### PR TITLE
Loop again rows by index in TruthTable::removeInput()

### DIFF
--- a/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
@@ -668,7 +668,7 @@ public class TruthTable {
         Row r = rows.get(i);
         if (r.inputs[index] == Entry.DONT_CARE)
           continue;
-        setDontCare(r, b, true, changed);
+        setDontCare(r, b, true, changed); // mutates row
       }
       int mask = b - 1; // _0000111
       ArrayList<Row> ret = new ArrayList<>(rows.size());

--- a/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
@@ -663,7 +663,9 @@ public class TruthTable {
       // force an Entry column of each row.input to 'x', then remove it
       int b = (1 << (oldCount - 1 - index)); // _0001000
       boolean[] changed = new boolean[columns.size()];
-      for (Row r : rows) {
+      // loop rows by index to avoid java.util.ConcurrentModificationException
+      for (int i = 0; i < rows.size(); ++i) {
+        Row r = rows.get(i);
         if (r.inputs[index] == Entry.DONT_CARE)
           continue;
         setDontCare(r, b, true, changed);


### PR DESCRIPTION
Thanks @simoc for diagnosing (again) the cause for issue #579! I reapplied your fix from commit 39c355 to `TruthTable::removeInput()`.

@zdimension: Feel free to suggest a better fix.

@BFH-ktt1: Might this warrant a hot fix release?