### PR TITLE
Fixed hex paste to work with 64 bit

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/hex/HexFile.java
+++ b/src/main/java/com/cburch/logisim/gui/hex/HexFile.java
@@ -1470,9 +1470,9 @@ public class HexFile {
       while ((word = nextWord()) != null) {
         int i = 0, n = word.length();
         if (n >= 2 && (word.startsWith("0x") || word.startsWith("0X"))) i += 2;
-        int v = 0;
+        long v = 0;
         for (; i < n; i++) {
-          int d;
+          long d;
           try {
             d = hex2int(word.charAt(i));
           } catch (NumberFormatException e) {


### PR DESCRIPTION
If you paste a sequence of hex words into a 64 bit ROM using the hex editor in the current develop version, it only takes 32 bits worth (sign extended to the full 64 bits). This PR fixes this problem so the paste works correctly for all 64 bits.