### PR TITLE
Display "Too few inputs for table" if Karnaugh Map has only 1 input

### DIFF
--- a/src/main/java/com/cburch/logisim/analyze/gui/KarnaughMapPanel.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/KarnaughMapPanel.java
@@ -219,7 +219,11 @@ public class KarnaughMapPanel extends JPanel
       message = S.get("karnaughNoOutputError");
     } else if (table.getInputColumnCount() > MAX_VARS) {
       message = S.get("karnaughTooManyInputsError");
-    } else if (table.getInputColumnCount() == 0) message = S.get("karnaughNoInputsError");
+    } else if (table.getInputColumnCount() == 0) {
+      message = S.get("karnaughNoInputsError");
+    } else if (table.getInputColumnCount() == 1) {
+      message = S.get("karnaughTooFewInputsError");
+    }
 
     if (message != null) {
       if (g == null) {
@@ -441,6 +445,7 @@ public class KarnaughMapPanel extends JPanel
 
   @Override
   public String getToolTipText(MouseEvent event) {
+    if (KMapArea == null) return null;
     TruthTable table = model.getTruthTable();
     int row = getRow(event);
     if (row < 0) return null;
@@ -501,6 +506,8 @@ public class KarnaughMapPanel extends JPanel
       message = S.get("karnaughTooManyInputsError");
     } else if (inputCount == 0) {
       message = S.get("karnaughNoInputsError");
+    } else if (inputCount == 1) {
+      message = S.get("karnaughTooFewInputsError");
     }
     if (message != null) {
       g.setFont(HeaderFont);

--- a/src/main/resources/resources/logisim/strings/analyze/analyze.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze.properties
@@ -120,6 +120,7 @@ openErrorTitle = Error Reading File
 #
 karnaughNoInputsError = No inputs available.
 karnaughNoOutputError = No output selected.
+karnaughTooFewInputsError = Too few inputs for table.
 karnaughTooManyInputsError = Too many inputs for table.
 NoSelectedKmapGroup = No group selected.
 SelectedKmapGroup = Selected group:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_de.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_de.properties
@@ -120,6 +120,7 @@ openErrorTitle = Fehler beim Lesen der Datei
 #
 karnaughNoInputsError = Keine Eingänge vorhanden.
 karnaughNoOutputError = Kein Ausgang ausgewählt.
+karnaughTooFewInputsError = Zu wenige Eingänge für die Tabelle.
 karnaughTooManyInputsError = Zu viele Eingänge für die Tabelle.
 NoSelectedKmapGroup = Keine Gruppe ausgewählt.
 SelectedKmapGroup = Ausgewählte Gruppe:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_el.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_el.properties
@@ -120,6 +120,7 @@ UsedSeperatorInFile = Επιλέξτε το χαρακτήρα διαχωρισ�
 #
 karnaughNoInputsError = Δεν υπάρχουν διαθέσιμες εισροές.
 karnaughNoOutputError = Καμία επιλεγμένη έξοδο.
+# ==> karnaughTooFewInputsError =
 karnaughTooManyInputsError = Πάρα πολλές είσοδοι για τον πίνακα.
 NoSelectedKmapGroup = Δεν επιλέχθηκε ομάδα.
 SelectedKmapGroup = Επιλεγμένη ομάδα:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_el.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_el.properties
@@ -120,7 +120,7 @@ UsedSeperatorInFile = Επιλέξτε το χαρακτήρα διαχωρισ�
 #
 karnaughNoInputsError = Δεν υπάρχουν διαθέσιμες εισροές.
 karnaughNoOutputError = Καμία επιλεγμένη έξοδο.
-# ==> karnaughTooFewInputsError =
+karnaughTooFewInputsError = Πολύ λίγες είσοδοι για τον πίνακα.
 karnaughTooManyInputsError = Πάρα πολλές είσοδοι για τον πίνακα.
 NoSelectedKmapGroup = Δεν επιλέχθηκε ομάδα.
 SelectedKmapGroup = Επιλεγμένη ομάδα:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_es.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_es.properties
@@ -120,6 +120,7 @@ openErrorTitle = Error al leer el archivo
 #
 karnaughNoInputsError = No hay entradas disponibles.
 karnaughNoOutputError = No hay salidas seleccionadas.
+karnaughTooFewInputsError = Muy pocas entradas por tabla.
 karnaughTooManyInputsError = Demasiadas entradas por tabla.
 NoSelectedKmapGroup = Ningún grupo seleccionado.
 SelectedKmapGroup = Grupo seleccionado:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_fr.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_fr.properties
@@ -120,6 +120,7 @@ openErrorTitle = Erreur de lecture du fichier
 #
 karnaughNoInputsError = Aucune entrée disponible.
 karnaughNoOutputError = Aucune entrée sélectionnée.
+karnaughTooFewInputsError = Trop peu d'entrées pour la table.
 karnaughTooManyInputsError = Trop d'entrées pour la table.
 NoSelectedKmapGroup = Aucun groupe sélectionné.
 SelectedKmapGroup = Groupe sélectionné :

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_it.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_it.properties
@@ -120,6 +120,7 @@ openErrorTitle = Errore di lettura del file
 #
 karnaughNoInputsError = Nessun ingresso disponibile.
 karnaughNoOutputError = Nessun output selezionato.
+karnaughTooFewInputsError = Troppo poco input per la tabella.
 karnaughTooManyInputsError = Troppi input per la tabella.
 NoSelectedKmapGroup = Nessun gruppo selezionato.
 SelectedKmapGroup = Gruppo selezionato:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_ja.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_ja.properties
@@ -120,6 +120,7 @@ openErrorTitle = ファイルの読み取りエラー
 #
 karnaughNoInputsError = 利用可能な入力がありません。
 karnaughNoOutputError = 選択された出力がありません。
+# ==> karnaughTooFewInputsError =
 karnaughTooManyInputsError = テーブルの入力が多すぎます。
 NoSelectedKmapGroup = 選択されたグループがありません。
 SelectedKmapGroup = 選択されたグループです:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_nl.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_nl.properties
@@ -120,6 +120,7 @@ openErrorTitle = Fout lezen van het bestand
 #
 karnaughNoInputsError = Geen invoer beschikbaar.
 karnaughNoOutputError = Geen uitgang geselecteerd.
+karnaughTooFewInputsError = Te weinig ingangen voor de tabel.
 karnaughTooManyInputsError = Te veel ingangen voor de tabel.
 NoSelectedKmapGroup = Geen groep geselecteerd.
 SelectedKmapGroup = Geselecteerde groep:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_pt.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_pt.properties
@@ -120,6 +120,7 @@ openErrorTitle = Arquivo de leitura de erros
 #
 karnaughNoInputsError = Não há entradas disponíveis.
 karnaughNoOutputError = Nenhuma saída selecionada.
+# ==> karnaughTooFewInputsError =
 karnaughTooManyInputsError = Entradas demais para a tabela.
 NoSelectedKmapGroup = Nenhum grupo selecionado.
 SelectedKmapGroup = Grupo selecionado:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_pt.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_pt.properties
@@ -120,7 +120,7 @@ openErrorTitle = Arquivo de leitura de erros
 #
 karnaughNoInputsError = Não há entradas disponíveis.
 karnaughNoOutputError = Nenhuma saída selecionada.
-# ==> karnaughTooFewInputsError =
+karnaughTooFewInputsError = Entradas demasiado poucas para a tabela.
 karnaughTooManyInputsError = Entradas demais para a tabela.
 NoSelectedKmapGroup = Nenhum grupo selecionado.
 SelectedKmapGroup = Grupo selecionado:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_ru.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_ru.properties
@@ -120,6 +120,7 @@ openErrorTitle = Файл считывания ошибок
 #
 karnaughNoInputsError = Входы недоступны.
 karnaughNoOutputError = Выход не выбран.
+# ==> karnaughTooFewInputsError =
 karnaughTooManyInputsError = Слишком много входов для таблицы.
 NoSelectedKmapGroup = Группа не выбрана.
 SelectedKmapGroup = Выбранная группа:

--- a/src/main/resources/resources/logisim/strings/analyze/analyze_ru.properties
+++ b/src/main/resources/resources/logisim/strings/analyze/analyze_ru.properties
@@ -120,7 +120,7 @@ openErrorTitle = Файл считывания ошибок
 #
 karnaughNoInputsError = Входы недоступны.
 karnaughNoOutputError = Выход не выбран.
-# ==> karnaughTooFewInputsError =
+karnaughTooFewInputsError = Слишком мало входов для таблицы.
 karnaughTooManyInputsError = Слишком много входов для таблицы.
 NoSelectedKmapGroup = Группа не выбрана.
 SelectedKmapGroup = Выбранная группа:


### PR DESCRIPTION
If there is only one input to a Karnaugh Map, then display the message "Too few inputs for table" instead.

A Karnaugh Map only makes sense if there are at least two inputs.

I have added this message string to the `analyze.properties` files for some languages, but left the placeholder `# ==> karnaughTooFewInputsError =` for the languages for which I have no idea of the translation.

Fixes #578