### PR TITLE
Do CI runs with JDK 16 instead of JDK 15

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,7 @@ jobs:
     
     strategy:
       matrix:
-        java-version: [ 11, 15 ]
+        java-version: [ 11, 16 ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Do CI runs with JDK 16 instead of JDK 15 in addition to JDK 11.