### PR TITLE
Made pins' tooltips more descriptive for 74161

### DIFF
--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl74161.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl74161.java
@@ -66,20 +66,20 @@ public class Ttl74161 extends AbstractTtlGate {
                 (byte) 16,
                 new byte[]{11, 12, 13, 14, 15},
                 new String[]{
-                        "nClear",
-                        "Clock",
-                        "A",
-                        "B",
-                        "C",
-                        "D",
-                        "ENP",
-                        "nLoad",
-                        "Ent",
-                        "QD",
-                        "QC",
-                        "QB",
-                        "QA",
-                        "RC0"
+                        "MR/CLR (Reset, active LOW)",
+                        "CP/CLK (Clock)",
+                        "D0/A",
+                        "D1/B",
+                        "D2/C",
+                        "D3/D",
+                        "CE/ENP (Count Enable)",
+                        "PE/LOAD (Parallel Enable, active LOW)",
+                        "CET/ENT (Count Enable Carry)",
+                        "Q0/QD",
+                        "Q1/QC",
+                        "A2/QB",
+                        "A3/QA",
+                        "TC/RC0 (Terminal Count)"
                 });
         super.setInstancePoker(Poker.class);
     }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl74161.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl74161.java
@@ -75,10 +75,10 @@ public class Ttl74161 extends AbstractTtlGate {
                         "CE/ENP (Count Enable)",
                         "PE/LOAD (Parallel Enable, active LOW)",
                         "CET/ENT (Count Enable Carry)",
-                        "Q0/QD",
-                        "Q1/QC",
-                        "A2/QB",
-                        "A3/QA",
+                        "Q3/QD",
+                        "Q2/QC",
+                        "A1/QB",
+                        "A0/QA",
                         "TC/RC0 (Terminal Count)"
                 });
         super.setInstancePoker(Poker.class);


### PR DESCRIPTION
Makes tooltips of 74161's pins to be more descriptive and also include naming used by NXP or Motorola, not just TI. 

Rationale: this came after discussion with one of my students, who complained that his life, as newbie in the field, would definitely be simpler if he could focus more on the assignment, instead of deciphering pin meanings. While this may looks like silly complaint for pros, I took a closer look how 74161 is represented here. It seems that current pins are labeled as it is present in i.e. Texas Instruments datasheet. However, if you get i.e. HC version of the IC from other vendors, they may not use the same names which apparently is a problem for newbies.  For example NXP ([sheet](https://pdf1.alldatasheet.com/datasheet-pdf/view/15545/PHILIPS/74HC161.html)) or Motorola ([sheet](https://html.alldatasheet.com/html-pdf/5675/MOTOROLA/74LS161/258/1/74LS161.html)) vs TI ([sheet](https://www.ti.com/product/SN74LS161A)) in table below:

PIN | NXP / Moto | TI | Desc
-- | -- | -- | --
1 | MR (LOW) | CLR (LOW)  | async master reset (active LOW)
2 | CP | CLK | clock input (LOW-to-HIGH, edge triggered)
3 | D0 | A  | data input
4 | D1 | B  | data input
5 | D2 | C  | data input
6 | D3 | D  | data input
7 | CEP | ENP  | count enable input
8 | GND | GND  | 
9 | PE (LOW) | LOAD (LOW)  | parallel enable input (active LOW)
10 | CET | ENT  | count enable carry input
11 | Q0 | QA  | Flip-flop output
12 | Q1 | QB  | Flip-flop output
13 | Q2 | QC  | Flip-flop output
14 | Q3 | QD  | Flip-flop output
15 | TC | RC0  | Terminal count output
16 | VCC | VCC  |

I do frankly admit that if you do not know them in advance, then TI's are more cryptic than others' and never liked them, so this PR mixes both worlds and adds descriptive info as well which shall help users, so if this type of changes is fine with you, I'd take a look at other supported ICs and update their tooltips as well. 

The only thing I do not fully like in my PR are pins 3-6 and 11-14. I am not sure having i.e. `Q0/QA` vs just `QA` or `Q0` adds any extra value, so this is something I still considering changing. Please let me know your thoughts.