### PR TITLE
Configurable connection pin markers

### DIFF
--- a/src/main/java/com/cburch/logisim/comp/ComponentDrawContext.java
+++ b/src/main/java/com/cburch/logisim/comp/ComponentDrawContext.java
@@ -161,6 +161,28 @@ public class ComponentDrawContext {
     drawHandle(left, top);
   }
 
+
+  protected void drawPinMarker(int x, int y) {
+    final int defaultRadius = 4;
+    final int defaultOffset = 2;
+    final int mediumDotRadius = 6;
+    final int mediumDotOffset = 3;
+    final int bigDotRadius = 8;
+    final int bigDotOffset = 4;
+
+    String appearance = AppPreferences.PinAppearance.get();
+    int radius = defaultRadius;
+    int offset = defaultOffset;
+    if (appearance.equals(AppPreferences.PIN_APPEAR_DOT_MEDIUM)) {
+      radius = mediumDotRadius;
+      offset = mediumDotOffset;
+    } else if (appearance.equals(AppPreferences.PIN_APPEAR_DOT_BIG)) {
+      radius = bigDotRadius;
+      offset = bigDotOffset;
+    }
+    g.fillOval(x - offset, y - offset, radius, radius);
+  }
+
   public void drawPin(Component comp, int i) {
     EndData e = comp.getEnd(i);
     Location pt = e.getLocation();
@@ -171,7 +193,7 @@ public class ComponentDrawContext {
     } else {
       g.setColor(Color.BLACK);
     }
-    g.fillOval(pt.getX() - PIN_OFFS, pt.getY() - PIN_OFFS, PIN_RAD, PIN_RAD);
+    drawPinMarker(pt.getX(), pt.getY());
     g.setColor(curColor);
   }
 
@@ -188,7 +210,7 @@ public class ComponentDrawContext {
     } else {
       g.setColor(Color.BLACK);
     }
-    g.fillOval(x - PIN_OFFS, y - PIN_OFFS, PIN_RAD, PIN_RAD);
+    drawPinMarker(x, y);
     g.setColor(curColor);
     if (dir == Direction.EAST) {
       GraphicsUtil.drawText(g, label, x + 3, y, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
@@ -211,7 +233,7 @@ public class ComponentDrawContext {
       } else {
         g.setColor(Color.BLACK);
       }
-      g.fillOval(pt.getX() - PIN_OFFS, pt.getY() - PIN_OFFS, PIN_RAD, PIN_RAD);
+      drawPinMarker(pt.getX(), pt.getY());
     }
     g.setColor(curColor);
   }

--- a/src/main/java/com/cburch/logisim/comp/ComponentDrawContext.java
+++ b/src/main/java/com/cburch/logisim/comp/ComponentDrawContext.java
@@ -171,14 +171,17 @@ public class ComponentDrawContext {
     final int bigDotOffset = 4;
 
     String appearance = AppPreferences.PinAppearance.get();
-    int radius = defaultRadius;
-    int offset = defaultOffset;
+    int radius = 4;
+    int offset = 2;
     if (appearance.equals(AppPreferences.PIN_APPEAR_DOT_MEDIUM)) {
-      radius = mediumDotRadius;
-      offset = mediumDotOffset;
+      radius = 6;
+      offset = 3;
     } else if (appearance.equals(AppPreferences.PIN_APPEAR_DOT_BIG)) {
-      radius = bigDotRadius;
-      offset = bigDotOffset;
+      radius = 8;
+      offset = 4;
+    } else if (appearance.equals(AppPreferences.PIN_APPEAR_DOT_BIGGER)) {
+      radius = 10;
+      offset = 5;
     }
     g.fillOval(x - offset, y - offset, radius, radius);
   }

--- a/src/main/java/com/cburch/logisim/gui/prefs/LayoutOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/LayoutOptions.java
@@ -115,7 +115,8 @@ class LayoutOptions extends OptionsPanel {
             new PrefOption[] {
                   new PrefOption(AppPreferences.PIN_APPEAR_DOT_SMALL, S.getter("layoutPinAppearanceDotSmall")),
                   new PrefOption(AppPreferences.PIN_APPEAR_DOT_MEDIUM, S.getter("layoutPinAppearanceDotMedium")),
-                  new PrefOption(AppPreferences.PIN_APPEAR_DOT_BIG, S.getter("layoutPinAppearanceDotBig"))
+                  new PrefOption(AppPreferences.PIN_APPEAR_DOT_BIG, S.getter("layoutPinAppearanceDotBig")),
+                  new PrefOption(AppPreferences.PIN_APPEAR_DOT_BIGGER, S.getter("layoutPinAppearanceDotBigger"))
             });
 
 

--- a/src/main/java/com/cburch/logisim/gui/prefs/LayoutOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/LayoutOptions.java
@@ -31,21 +31,30 @@ package com.cburch.logisim.gui.prefs;
 import static com.cburch.logisim.gui.Strings.S;
 
 import com.cburch.logisim.circuit.RadixOption;
+import com.cburch.logisim.fpga.gui.ZoomSlider;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.proj.Projects;
 import com.cburch.logisim.util.TableLayout;
-import javax.swing.JPanel;
+
+import javax.swing.*;
+import java.util.prefs.PreferenceChangeEvent;
+import java.util.prefs.PreferenceChangeListener;
 
 class LayoutOptions extends OptionsPanel {
   private static final long serialVersionUID = 1L;
   private final PrefBoolean[] checks;
   private final PrefOptionList afterAdd;
   private final PrefOptionList DefaultAppear;
+  private final PrefOptionList PrefPinAppearance;
   private PrefOptionList radix1;
   private PrefOptionList radix2;
 
   public LayoutOptions(PreferencesFrame window) {
     super(window);
+
+    AppPreferences.getPrefs().addPreferenceChangeListener(new LayoutOptions.MyListener());
 
     checks =
         new PrefBoolean[] {
@@ -99,6 +108,17 @@ class LayoutOptions extends OptionsPanel {
                   StdAttr.APPEAR_EVOLUTION.toString(), StdAttr.APPEAR_EVOLUTION.getDisplayGetter())
             });
 
+    // How connection pins should be drawn like
+    PrefPinAppearance = new PrefOptionList(
+      AppPreferences.PinAppearance,
+        S.getter("layoutPinAppearance"),
+            new PrefOption[] {
+                  new PrefOption(AppPreferences.PIN_APPEAR_DOT_SMALL, S.getter("layoutPinAppearanceDotSmall")),
+                  new PrefOption(AppPreferences.PIN_APPEAR_DOT_MEDIUM, S.getter("layoutPinAppearanceDotMedium")),
+                  new PrefOption(AppPreferences.PIN_APPEAR_DOT_BIG, S.getter("layoutPinAppearanceDotBig"))
+            });
+
+
     JPanel panel = new JPanel(new TableLayout(2));
     panel.add(DefaultAppear.getJLabel());
     panel.add(DefaultAppear.getJComboBox());
@@ -108,6 +128,8 @@ class LayoutOptions extends OptionsPanel {
     panel.add(radix1.getJComboBox());
     panel.add(radix2.getJLabel());
     panel.add(radix2.getJComboBox());
+    panel.add(PrefPinAppearance.getJLabel());
+    panel.add(PrefPinAppearance.getJComboBox());
 
     setLayout(new TableLayout(1));
     for (PrefBoolean check : checks) {
@@ -136,4 +158,20 @@ class LayoutOptions extends OptionsPanel {
     afterAdd.localeChanged();
     DefaultAppear.localeChanged();
   }
+
+
+  private static class MyListener implements PreferenceChangeListener {
+    @Override
+    public void preferenceChange(PreferenceChangeEvent evt) {
+      boolean update = false;
+      if (evt.getKey().equals(AppPreferences.PinAppearance.getIdentifier())) {
+        update = true;
+      }
+      if (update) {
+        for (Project proj : Projects.getOpenProjects()) proj.getFrame().repaint();
+      }
+    }
+  }
+
+
 }

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -455,11 +455,11 @@ public class AppPreferences {
   private static Template emptyTemplate = null;
   private static Template customTemplate = null;
   private static File customTemplateFile = null;
-  
+
   public static int getIconSize() {
     return getScaled(IconSize);
   }
-  
+
   public static int getIconBorder() {
     return getScaled(IconBorder);
   }
@@ -579,8 +579,17 @@ public class AppPreferences {
           new PrefMonitorStringOpts(
               "afterAdd", new String[] {ADD_AFTER_EDIT, ADD_AFTER_UNCHANGED}, ADD_AFTER_EDIT));
 
-  public static final PrefMonitor<String> POKE_WIRE_RADIX1;
 
+  public static final String PIN_APPEAR_DOT_SMALL = "dot-small";
+  public static final String PIN_APPEAR_DOT_MEDIUM = "dot-medium";
+  public static final String PIN_APPEAR_DOT_BIG = "dot-big";
+  public static final PrefMonitor<String> PinAppearance =
+    create(new PrefMonitorStringOpts("pinAppearance",
+            new String[] {PIN_APPEAR_DOT_SMALL, PIN_APPEAR_DOT_MEDIUM, PIN_APPEAR_DOT_BIG},
+            PIN_APPEAR_DOT_SMALL));
+
+
+  public static final PrefMonitor<String> POKE_WIRE_RADIX1;
   public static final PrefMonitor<String> POKE_WIRE_RADIX2;
 
   static {
@@ -601,7 +610,7 @@ public class AppPreferences {
 
   public static final PrefMonitor<Boolean> Memory_Startup_Unknown =
       create(new PrefMonitorBoolean("MemStartUnknown", false));
-  
+
   // Simulation preferences
   public static final PrefMonitor<Integer> TRUE_COLOR =
       create(new PrefMonitorInt("SimTrueColor",0x0000D200));
@@ -667,7 +676,7 @@ public class AppPreferences {
 	      create(new PrefMonitorInt("KMAPColor15",0xAAFFC3));
   public static final PrefMonitor<Integer> KMAP16_COLOR =
 	      create(new PrefMonitorInt("KMAPColor16",0xF032E6));
-  
+
   // FPGA commander colors
   public static final PrefMonitor<Integer> FPGA_DEFINE_COLOR =
           create(new PrefMonitorInt("FPGADefineColor", 0xFF0000));
@@ -758,7 +767,7 @@ public class AppPreferences {
               ((!GraphicsEnvironment.isHeadless())
                   ? Toolkit.getDefaultToolkit().getScreenSize().height
                   : 0)));
-  
+
   public static void resetWindow() {
 	  WINDOW_MAIN_SPLIT.set(0.251);
 	  WINDOW_LEFT_SPLIT.set(0.51);

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -583,9 +583,10 @@ public class AppPreferences {
   public static final String PIN_APPEAR_DOT_SMALL = "dot-small";
   public static final String PIN_APPEAR_DOT_MEDIUM = "dot-medium";
   public static final String PIN_APPEAR_DOT_BIG = "dot-big";
+  public static final String PIN_APPEAR_DOT_BIGGER = "dot-bigger";
   public static final PrefMonitor<String> PinAppearance =
     create(new PrefMonitorStringOpts("pinAppearance",
-            new String[] {PIN_APPEAR_DOT_SMALL, PIN_APPEAR_DOT_MEDIUM, PIN_APPEAR_DOT_BIG},
+            new String[] {PIN_APPEAR_DOT_SMALL, PIN_APPEAR_DOT_MEDIUM, PIN_APPEAR_DOT_BIG, PIN_APPEAR_DOT_BIGGER},
             PIN_APPEAR_DOT_SMALL));
 
 

--- a/src/main/java/com/cburch/logisim/tools/AddTool.java
+++ b/src/main/java/com/cburch/logisim/tools/AddTool.java
@@ -162,7 +162,7 @@ public class AddTool extends Tool implements Transferable,PropertyChangeListener
       AppPreferences.NEW_INPUT_OUTPUT_SHAPES.addPropertyChangeListener(this);
     }
   }
-  
+
   @Override
   public void registerParent(java.awt.Component parent) {
     ComponentFactory fac = getFactory();
@@ -732,7 +732,7 @@ public class AddTool extends Tool implements Transferable,PropertyChangeListener
       return this.description.equals(o.description);
     }
   }
-  
+
   public static final DataFlavor dataFlavor;
   static {
     DataFlavor f = null;

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -550,6 +550,10 @@ layoutRadix2 = Second radix when wire poked:
 layoutShowTips = Show component tips
 layoutTitle = Layout
 layoutUseNewInputOutputSymbols = Use new input and output shapes
+layoutPinAppearance = Draw connection pins as:
+layoutPinAppearanceDotSmall = Small dot
+layoutPinAppearanceDotMedium = Medium dot
+layoutPinAppearanceDotBig = Big dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -554,6 +554,7 @@ layoutPinAppearance = Draw connection pins as:
 layoutPinAppearanceDotSmall = Small dot
 layoutPinAppearanceDotMedium = Medium dot
 layoutPinAppearanceDotBig = Big dot
+layoutPinAppearanceDotBigger = Bigger dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -494,6 +494,10 @@ layoutRadix2 = Zweite Basis wenn Leitung angeklickt wird
 layoutShowTips = Bauteiletipps anzeigen
 layoutTitle = Layouteditor
 layoutUseNewInputOutputSymbols = Neue Ein- und Ausgabeformen verwenden
+# ==> layoutPinAppearance = Draw connection pins as:
+# ==> layoutPinAppearanceDotSmall = Small dot
+# ==> layoutPinAppearanceDotMedium = Medium dot
+# ==> layoutPinAppearanceDotBig = Big dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -498,6 +498,7 @@ layoutUseNewInputOutputSymbols = Neue Ein- und Ausgabeformen verwenden
 # ==> layoutPinAppearanceDotSmall = Small dot
 # ==> layoutPinAppearanceDotMedium = Medium dot
 # ==> layoutPinAppearanceDotBig = Big dot
+# ==> layoutPinAppearanceDotBigger = Bigger dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -494,6 +494,10 @@ layoutRadix2 = Δεύτερο αριθμητικό σύστημα όταν δρ�
 layoutShowTips = Εμφάνιση συμβουλών στοιχείου
 layoutTitle = Διάταξη
 # ==> layoutUseNewInputOutputSymbols = 
+# ==> layoutPinAppearance = Draw connection pins as:
+# ==> layoutPinAppearanceDotSmall = Small dot
+# ==> layoutPinAppearanceDotMedium = Medium dot
+# ==> layoutPinAppearanceDotBig = Big dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -498,6 +498,7 @@ layoutTitle = Διάταξη
 # ==> layoutPinAppearanceDotSmall = Small dot
 # ==> layoutPinAppearanceDotMedium = Medium dot
 # ==> layoutPinAppearanceDotBig = Big dot
+# ==> layoutPinAppearanceDotBigger = Bigger dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -494,6 +494,10 @@ layoutRadix2 = Segunda base a usar cuando se inserta un cable:
 layoutShowTips = Mostrar consejos de componente
 layoutTitle = Área de trabajo
 layoutUseNewInputOutputSymbols = Utilizar nuevas formas de entrada y salida.
+# ==> layoutPinAppearance = Draw connection pins as:
+# ==> layoutPinAppearanceDotSmall = Small dot
+# ==> layoutPinAppearanceDotMedium = Medium dot
+# ==> layoutPinAppearanceDotBig = Big dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -498,6 +498,7 @@ layoutUseNewInputOutputSymbols = Utilizar nuevas formas de entrada y salida.
 # ==> layoutPinAppearanceDotSmall = Small dot
 # ==> layoutPinAppearanceDotMedium = Medium dot
 # ==> layoutPinAppearanceDotBig = Big dot
+# ==> layoutPinAppearanceDotBigger = Bigger dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -499,6 +499,10 @@ layoutRadix2 = Deuxième base quand le câble est poussé :
 layoutShowTips = Montrer les astuces du composant
 layoutTitle = présentation
 layoutUseNewInputOutputSymbols = Utiliser les nouveaux symboles d'entrée et de sortie
+# ==> layoutPinAppearance = Draw connection pins as:
+# ==> layoutPinAppearanceDotSmall = Small dot
+# ==> layoutPinAppearanceDotMedium = Medium dot
+# ==> layoutPinAppearanceDotBig = Big dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -503,6 +503,7 @@ layoutUseNewInputOutputSymbols = Utiliser les nouveaux symboles d'entrée et de 
 # ==> layoutPinAppearanceDotSmall = Small dot
 # ==> layoutPinAppearanceDotMedium = Medium dot
 # ==> layoutPinAppearanceDotBig = Big dot
+# ==> layoutPinAppearanceDotBigger = Bigger dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -498,6 +498,7 @@ layoutUseNewInputOutputSymbols = Utilizzare nuove forme di ingresso e di uscita
 # ==> layoutPinAppearanceDotSmall = Small dot
 # ==> layoutPinAppearanceDotMedium = Medium dot
 # ==> layoutPinAppearanceDotBig = Big dot
+# ==> layoutPinAppearanceDotBigger = Bigger dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -494,6 +494,10 @@ layoutRadix2 = Secondo numero quando filo cliccato:
 layoutShowTips = Mostra suggerimento componenti
 layoutTitle = Layout
 layoutUseNewInputOutputSymbols = Utilizzare nuove forme di ingresso e di uscita
+# ==> layoutPinAppearance = Draw connection pins as:
+# ==> layoutPinAppearanceDotSmall = Small dot
+# ==> layoutPinAppearanceDotMedium = Medium dot
+# ==> layoutPinAppearanceDotBig = Big dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -494,6 +494,10 @@ layoutRadix2 = ワイヤが突かれたときの2番目の基数:
 layoutShowTips = コンポーネントのヒントを表示
 layoutTitle = レイアウト
 layoutUseNewInputOutputSymbols = 新しい入力および出力図形を使用する
+# ==> layoutPinAppearance = Draw connection pins as:
+# ==> layoutPinAppearanceDotSmall = Small dot
+# ==> layoutPinAppearanceDotMedium = Medium dot
+# ==> layoutPinAppearanceDotBig = Big dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -498,6 +498,7 @@ layoutUseNewInputOutputSymbols = 新しい入力および出力図形を使用�
 # ==> layoutPinAppearanceDotSmall = Small dot
 # ==> layoutPinAppearanceDotMedium = Medium dot
 # ==> layoutPinAppearanceDotBig = Big dot
+# ==> layoutPinAppearanceDotBigger = Bigger dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -553,6 +553,7 @@ layoutUseNewInputOutputSymbols = Nieuwe invoer- en uitvoervormen gebruiken
 # ==> layoutPinAppearanceDotSmall = Small dot
 # ==> layoutPinAppearanceDotMedium = Medium dot
 # ==> layoutPinAppearanceDotBig = Big dot
+# ==> layoutPinAppearanceDotBigger = Bigger dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -549,6 +549,10 @@ layoutRadix2 = Tweede talstelsel wanneer een speld op de draad wordt aangesloten
 layoutShowTips = Toon tips voor onderdelen
 layoutTitle = Lay-out
 layoutUseNewInputOutputSymbols = Nieuwe invoer- en uitvoervormen gebruiken
+# ==> layoutPinAppearance = Draw connection pins as:
+# ==> layoutPinAppearanceDotSmall = Small dot
+# ==> layoutPinAppearanceDotMedium = Medium dot
+# ==> layoutPinAppearanceDotBig = Big dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -498,6 +498,7 @@ layoutUseNewInputOutputSymbols = Usar novas formas de entrada e saída
 # ==> layoutPinAppearanceDotSmall = Small dot
 # ==> layoutPinAppearanceDotMedium = Medium dot
 # ==> layoutPinAppearanceDotBig = Big dot
+# ==> layoutPinAppearanceDotBigger = Bigger dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -494,6 +494,10 @@ layoutRadix2 = Segunda base de numeração quando conexão for testada:
 layoutShowTips = Mostrar dicas sobre componente
 layoutTitle = Layout
 layoutUseNewInputOutputSymbols = Usar novas formas de entrada e saída
+# ==> layoutPinAppearance = Draw connection pins as:
+# ==> layoutPinAppearanceDotSmall = Small dot
+# ==> layoutPinAppearanceDotMedium = Medium dot
+# ==> layoutPinAppearanceDotBig = Big dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -498,6 +498,7 @@ layoutUseNewInputOutputSymbols = Использование новых форм 
 # ==> layoutPinAppearanceDotSmall = Small dot
 # ==> layoutPinAppearanceDotMedium = Medium dot
 # ==> layoutPinAppearanceDotBig = Big dot
+# ==> layoutPinAppearanceDotBigger = Bigger dot
 #
 # prefs/PreferencesFrame.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -494,6 +494,10 @@ layoutRadix2 = Второе основание при нажатии на про
 layoutShowTips = Показывать подсказки для компонентов
 layoutTitle = Чертёж
 layoutUseNewInputOutputSymbols = Использование новых форм входа и выхода
+# ==> layoutPinAppearance = Draw connection pins as:
+# ==> layoutPinAppearanceDotSmall = Small dot
+# ==> layoutPinAppearanceDotMedium = Medium dot
+# ==> layoutPinAppearanceDotBig = Big dot
 #
 # prefs/PreferencesFrame.java
 #


### PR DESCRIPTION
Currently size of connection markers are too small and hard to see, especially when using i.e 4K monitors or zooming the circuit out. This PR adds configuration option (in `Preferences->Layout`) to set appearance of connection pin markers. Currently 4 sizes are available: "Small dot" (current appearance), "medium dot" (x1.5), "big dot" (x2) and "bigger dot" (x2.5), which looks as follow:

At zoom 100%:

![zoom100](https://user-images.githubusercontent.com/8041294/121103945-469aba80-c801-11eb-9733-c4d1e001a9b5.png)

At zoom 80%

![zoom80](https://user-images.githubusercontent.com/8041294/121103981-54e8d680-c801-11eb-9c94-faa5f0a0ccca.png)
