### PR TITLE
Cleanup of component libraries

### DIFF
--- a/src/main/java/com/cburch/gray/Components.java
+++ b/src/main/java/com/cburch/gray/Components.java
@@ -61,6 +61,11 @@ public class Components extends Library {
     return "Gray Tools";
   }
 
+  /** Returns library name/id */
+  public String getName() {
+    return getClass().getName();
+  }
+
   /** Returns a list of all the tools available in this library. */
   @Override
   public List<AddTool> getTools() {

--- a/src/main/java/com/cburch/gray/Components.java
+++ b/src/main/java/com/cburch/gray/Components.java
@@ -66,8 +66,4 @@ public class Components extends Library {
   public List<AddTool> getTools() {
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/gray/Components.java
+++ b/src/main/java/com/cburch/gray/Components.java
@@ -35,40 +35,37 @@ import java.util.List;
 
 /** The library of components that the user can access. */
 public class Components extends Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "Components";
+
   /**
    * The list of all tools contained in this library. Technically, libraries contain tools, which is
    * a slightly more general concept than components; practically speaking, though, you'll most
    * often want to create AddTools for new components that can be added into the circuit.
    */
-  private final List<AddTool> tools;
-
-  /**
-   * Constructs an instance of this library. This constructor is how Logisim accesses first when it
-   * opens the JAR file: It looks for a no-arguments constructor method of the user-designated
-   * class.
-   */
-  public Components() {
-    tools =
-        Arrays.asList(
-            new AddTool(new GrayIncrementer()),
-            new AddTool(new SimpleGrayCounter()),
-            new AddTool(new GrayCounter()));
-  }
+  private List<AddTool> tools = null;
 
   /** Returns the name of the library that the user will see. */
   @Override
   public String getDisplayName() {
-    return "Gray Tools";
-  }
-
-  /** Returns library name/id */
-  public String getName() {
-    return getClass().getName();
+    return "Gray Tools";    // FIXME: hardcoded string
   }
 
   /** Returns a list of all the tools available in this library. */
   @Override
   public List<AddTool> getTools() {
+    if (tools == null) {
+      tools = Arrays.asList(
+        new AddTool(new GrayIncrementer()),
+        new AddTool(new SimpleGrayCounter()),
+        new AddTool(new GrayCounter()));
+    }
     return tools;
   }
 }

--- a/src/main/java/com/cburch/logisim/file/LoadedLibrary.java
+++ b/src/main/java/com/cburch/logisim/file/LoadedLibrary.java
@@ -174,6 +174,7 @@ public class LoadedLibrary extends Library implements LibraryEventSource {
     return base.getLibraries();
   }
 
+  @Override
   public boolean removeLibrary(String Name) {
     return base.removeLibrary(Name);
   }

--- a/src/main/java/com/cburch/logisim/file/LogisimFile.java
+++ b/src/main/java/com/cburch/logisim/file/LogisimFile.java
@@ -42,6 +42,7 @@ import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.proj.Projects;
+import com.cburch.logisim.std.base.Base;
 import com.cburch.logisim.tools.AddTool;
 import com.cburch.logisim.tools.Library;
 import com.cburch.logisim.tools.Tool;
@@ -281,7 +282,7 @@ public class LogisimFile extends Library implements LibraryEventSource, CircuitL
   }
 
   public void addLibrary(Library lib) {
-    if (!lib.getName().equals("Base")) {
+    if (!lib.getName().equals(Base._ID)) {
       for (Tool tool : lib.getTools()) {
         AddTool tool1 = (AddTool) tool;
         AttributeSet atrs = tool1.getAttributeSet();

--- a/src/main/java/com/cburch/logisim/file/XmlReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlReader.java
@@ -48,8 +48,11 @@ import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.base.Base;
+import com.cburch.logisim.std.gates.Gates;
 import com.cburch.logisim.std.wiring.Pin;
 import com.cburch.logisim.std.wiring.ProbeAttributes;
+import com.cburch.logisim.std.wiring.Wiring;
 import com.cburch.logisim.tools.Library;
 import com.cburch.logisim.tools.Tool;
 import com.cburch.logisim.util.InputEventUtil;
@@ -287,7 +290,7 @@ class XmlReader {
       }
       return known;
     }
-    
+
     void loadMap(Element board, String boardName, Circuit circ) {
       HashMap<String,CircuitMapInfo> map = new HashMap<>();
       for (Element cmap : XmlIterator.forChildElements(board, "mc")) {
@@ -1139,14 +1142,14 @@ class XmlReader {
       String label = libElt.getAttribute("name");
       if (desc == null) {
         // skip these tests
-      } else if (desc.equals("#Base")) {
+      } else if (desc.equals("#" + Base._ID)) {
         oldBaseElt = libElt;
         oldBaseLabel = label;
-      } else if (desc.equals("#Wiring")) {
+      } else if (desc.equals("#" + Wiring._ID)) {
         // Wiring library already in file. This shouldn't happen, but if
         // somehow it does, we don't want to add it again.
         return;
-      } else if (desc.equals("#Gates")) {
+      } else if (desc.equals("#" + Gates._ID)) {
         gatesElt = libElt;
         gatesLabel = label;
       }

--- a/src/main/java/com/cburch/logisim/file/XmlReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlReader.java
@@ -1172,17 +1172,17 @@ class XmlReader {
     if (oldBaseElt != null) {
       wiringLabel = oldBaseLabel;
       wiringElt = oldBaseElt;
-      wiringElt.setAttribute("desc", "#Wiring");
+      wiringElt.setAttribute("desc", "#" + Wiring._ID);
 
       newBaseLabel = "" + (maxLabel + 1);
       newBaseElt = doc.createElement("lib");
-      newBaseElt.setAttribute("desc", "#Base");
+      newBaseElt.setAttribute("desc", "#" + Base._ID);
       newBaseElt.setAttribute("name", newBaseLabel);
       root.insertBefore(newBaseElt, lastLibElt.getNextSibling());
     } else {
       wiringLabel = "" + (maxLabel + 1);
       wiringElt = doc.createElement("lib");
-      wiringElt.setAttribute("desc", "#Wiring");
+      wiringElt.setAttribute("desc", "#" + Wiring._ID);
       wiringElt.setAttribute("name", wiringLabel);
       root.insertBefore(wiringElt, lastLibElt.getNextSibling());
 

--- a/src/main/java/com/cburch/logisim/fpga/library/BFHPraktika.java
+++ b/src/main/java/com/cburch/logisim/fpga/library/BFHPraktika.java
@@ -36,6 +36,15 @@ import com.cburch.logisim.tools.Tool;
 import java.util.List;
 
 public class BFHPraktika extends Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "BFH-Praktika";
+
   private static final FactoryDescription[] DESCRIPTIONS = {
     new FactoryDescription("Binary_to_BCD_converter", S.getter("Bin2BCD"), "", bin2bcd.class),
     new FactoryDescription(
@@ -47,11 +56,6 @@ public class BFHPraktika extends Library {
   @Override
   public String getDisplayName() {
     return S.get("BFHMegaFunctions");
-  }
-
-  @Override
-  public String getName() {
-    return "BFH-Praktika";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/fpga/library/BFHPraktika.java
+++ b/src/main/java/com/cburch/logisim/fpga/library/BFHPraktika.java
@@ -63,8 +63,4 @@ public class BFHPraktika extends Library {
     }
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/fpga/library/BFHPraktika.java
+++ b/src/main/java/com/cburch/logisim/fpga/library/BFHPraktika.java
@@ -44,8 +44,6 @@ public class BFHPraktika extends Library {
 
   private List<Tool> tools = null;
 
-  public BFHPraktika() {}
-
   @Override
   public String getDisplayName() {
     return S.get("BFHMegaFunctions");

--- a/src/main/java/com/cburch/logisim/gui/start/Startup.java
+++ b/src/main/java/com/cburch/logisim/gui/start/Startup.java
@@ -49,6 +49,8 @@ import com.cburch.logisim.gui.test.TestBench;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.proj.ProjectActions;
+import com.cburch.logisim.std.base.Base;
+import com.cburch.logisim.std.gates.Gates;
 import com.cburch.logisim.util.ArgonXML;
 import com.cburch.logisim.util.LocaleManager;
 import com.cburch.logisim.util.MacCompatibility;
@@ -157,7 +159,7 @@ public class Startup implements AWTEventListener {
       startupTemp.doPrintFile(file);
     }
   }
-  
+
   private static int parseTtyFormat(String fmt)
   {
     switch (fmt) {
@@ -937,8 +939,8 @@ public class Startup implements AWTEventListener {
     }
     Loader templLoader = new Loader(monitor);
     int count =
-        templLoader.getBuiltin().getLibrary("Base").getTools().size()
-            + templLoader.getBuiltin().getLibrary("Gates").getTools().size();
+        templLoader.getBuiltin().getLibrary(Base._ID).getTools().size()
+            + templLoader.getBuiltin().getLibrary(Gates._ID).getTools().size();
     if (count < 0) {
       // this will never happen, but the optimizer doesn't know that...
       logger.error("FATAL ERROR - no components"); // OK

--- a/src/main/java/com/cburch/logisim/soc/Soc.java
+++ b/src/main/java/com/cburch/logisim/soc/Soc.java
@@ -42,7 +42,7 @@ import com.cburch.logisim.tools.Library;
 import com.cburch.logisim.tools.Tool;
 import java.util.List;
 
-public class Soc  extends Library {
+public class Soc extends Library {
 
   private static final FactoryDescription[] DESCRIPTIONS = {
     new FactoryDescription(

--- a/src/main/java/com/cburch/logisim/soc/Soc.java
+++ b/src/main/java/com/cburch/logisim/soc/Soc.java
@@ -80,8 +80,4 @@ public class Soc  extends Library {
     }
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/soc/Soc.java
+++ b/src/main/java/com/cburch/logisim/soc/Soc.java
@@ -44,6 +44,14 @@ import java.util.List;
 
 public class Soc extends Library {
 
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "Soc";
+
   private static final FactoryDescription[] DESCRIPTIONS = {
     new FactoryDescription(
         "Rv32im", S.getter("Rv32imComponent"), "Rv32im.gif", Rv32im_riscv.class),
@@ -66,11 +74,6 @@ public class Soc extends Library {
   @Override
   public String getDisplayName() {
     return S.get("socLibrary");
-  }
-
-  @Override
-  public String getName() {
-    return "Soc";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/Builtin.java
+++ b/src/main/java/com/cburch/logisim/std/Builtin.java
@@ -89,8 +89,4 @@ public class Builtin extends Library {
   public List<Tool> getTools() {
     return Collections.emptyList();
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/std/Builtin.java
+++ b/src/main/java/com/cburch/logisim/std/Builtin.java
@@ -52,24 +52,6 @@ import java.util.List;
 public class Builtin extends Library {
   private List<Library> libraries = null;
 
-  public Builtin() {
-    libraries =
-        Arrays.asList(
-            new Base(),
-            new Gates(),
-            new Wiring(),
-            new Plexers(),
-            new Arithmetic(),
-            new Memory(),
-            new Io(),
-            new TTL(),
-            new Hdl(),
-            new Tcl(),
-            new BFHPraktika(),
-            new ITA_IO(),
-            new Soc());
-  }
-
   @Override
   public String getDisplayName() {
     return S.get("builtinLibrary");
@@ -77,6 +59,22 @@ public class Builtin extends Library {
 
   @Override
   public List<Library> getLibraries() {
+    if (libraries == null) {
+      libraries = Arrays.asList(
+        new Base(),
+        new Gates(),
+        new Wiring(),
+        new Plexers(),
+        new Arithmetic(),
+        new Memory(),
+        new Io(),
+        new TTL(),
+        new Hdl(),
+        new Tcl(),
+        new BFHPraktika(),
+        new ITA_IO(),
+        new Soc());
+    }
     return libraries;
   }
 

--- a/src/main/java/com/cburch/logisim/std/Builtin.java
+++ b/src/main/java/com/cburch/logisim/std/Builtin.java
@@ -49,7 +49,19 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Library of built-in component libraries
+ */
 public class Builtin extends Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "Builtin";
+
   private List<Library> libraries = null;
 
   @Override
@@ -76,11 +88,6 @@ public class Builtin extends Library {
         new Soc());
     }
     return libraries;
-  }
-
-  @Override
-  public String getName() {
-    return "Builtin";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/arith/Arithmetic.java
+++ b/src/main/java/com/cburch/logisim/std/arith/Arithmetic.java
@@ -65,12 +65,8 @@ public class Arithmetic extends Library {
   @Override
   public List<Tool> getTools() {
     if (tools == null) {
-      tools = FactoryDescription.getTools(Arithmetic.class, DESCRIPTIONS);
+      tools = FactoryDescription.getTools(getClass(), DESCRIPTIONS);
     }
     return tools;
-  }
-
-  public boolean removeLibrary(String Name) {
-    return false;
   }
 }

--- a/src/main/java/com/cburch/logisim/std/arith/Arithmetic.java
+++ b/src/main/java/com/cburch/logisim/std/arith/Arithmetic.java
@@ -50,8 +50,6 @@ public class Arithmetic extends Library {
 
   private List<Tool> tools = null;
 
-  public Arithmetic() {}
-
   @Override
   public String getDisplayName() {
     return S.get("arithmeticLibrary");

--- a/src/main/java/com/cburch/logisim/std/arith/Arithmetic.java
+++ b/src/main/java/com/cburch/logisim/std/arith/Arithmetic.java
@@ -36,6 +36,15 @@ import com.cburch.logisim.tools.Tool;
 import java.util.List;
 
 public class Arithmetic extends Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "Arithmetic";
+
   private static final FactoryDescription[] DESCRIPTIONS = {
     new FactoryDescription("Adder", S.getter("adderComponent"), "adder.gif", Adder.class),
     new FactoryDescription("Subtractor", S.getter("subtractorComponent"), "subtractor.gif", Subtractor.class),
@@ -53,11 +62,6 @@ public class Arithmetic extends Library {
   @Override
   public String getDisplayName() {
     return S.get("arithmeticLibrary");
-  }
-
-  @Override
-  public String getName() {
-    return "Arithmetic";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/base/Base.java
+++ b/src/main/java/com/cburch/logisim/std/base/Base.java
@@ -59,7 +59,7 @@ public class Base extends Library {
         new TextTool(),
         new MenuTool());
     }
-  
+
   @Override
   public boolean contains(ComponentFactory querry) {
     return super.contains(querry) || (querry instanceof Text);
@@ -89,9 +89,4 @@ public class Base extends Library {
   public List<Tool> getTools() {
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
-
 }

--- a/src/main/java/com/cburch/logisim/std/base/Base.java
+++ b/src/main/java/com/cburch/logisim/std/base/Base.java
@@ -44,6 +44,15 @@ import java.util.Arrays;
 import java.util.List;
 
 public class Base extends Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "Base";
+
   private final List<Tool> tools;
   private final AddTool textAdder = new AddTool(Text.FACTORY);
   private final SelectTool selectTool = new SelectTool();
@@ -78,11 +87,6 @@ public class Base extends Library {
   @Override
   public String getDisplayName() {
     return S.get("baseLibrary");
-  }
-
-  @Override
-  public String getName() {
-    return "Base";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/gates/Gates.java
+++ b/src/main/java/com/cburch/logisim/std/gates/Gates.java
@@ -37,16 +37,20 @@ import java.util.Arrays;
 import java.util.List;
 
 public class Gates extends Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "Gates";
+
   private List<Tool> tools = null;
 
   @Override
   public String getDisplayName() {
     return S.get("gatesLibrary");
-  }
-
-  @Override
-  public String getName() {
-    return "Gates";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/gates/Gates.java
+++ b/src/main/java/com/cburch/logisim/std/gates/Gates.java
@@ -39,26 +39,6 @@ import java.util.List;
 public class Gates extends Library {
   private List<Tool> tools = null;
 
-  public Gates() {
-    tools =
-        Arrays.asList(
-            new Tool[] {
-              new AddTool(NotGate.FACTORY),
-              new AddTool(Buffer.FACTORY),
-              new AddTool(AndGate.FACTORY),
-              new AddTool(OrGate.FACTORY),
-              new AddTool(NandGate.FACTORY),
-              new AddTool(NorGate.FACTORY),
-              new AddTool(XorGate.FACTORY),
-              new AddTool(XnorGate.FACTORY),
-              new AddTool(OddParityGate.FACTORY),
-              new AddTool(EvenParityGate.FACTORY),
-              new AddTool(ControlledBuffer.FACTORY_BUFFER),
-              new AddTool(ControlledBuffer.FACTORY_INVERTER),
-              new AddTool(PLA.FACTORY)
-            });
-  }
-
   @Override
   public String getDisplayName() {
     return S.get("gatesLibrary");
@@ -71,6 +51,24 @@ public class Gates extends Library {
 
   @Override
   public List<Tool> getTools() {
+    if (tools == null) {
+      tools = Arrays.asList(
+        new Tool[] {
+          new AddTool(NotGate.FACTORY),
+          new AddTool(Buffer.FACTORY),
+          new AddTool(AndGate.FACTORY),
+          new AddTool(OrGate.FACTORY),
+          new AddTool(NandGate.FACTORY),
+          new AddTool(NorGate.FACTORY),
+          new AddTool(XorGate.FACTORY),
+          new AddTool(XnorGate.FACTORY),
+          new AddTool(OddParityGate.FACTORY),
+          new AddTool(EvenParityGate.FACTORY),
+          new AddTool(ControlledBuffer.FACTORY_BUFFER),
+          new AddTool(ControlledBuffer.FACTORY_INVERTER),
+          new AddTool(PLA.FACTORY)
+        });
+    }
     return tools;
   }
 }

--- a/src/main/java/com/cburch/logisim/std/gates/Gates.java
+++ b/src/main/java/com/cburch/logisim/std/gates/Gates.java
@@ -73,8 +73,4 @@ public class Gates extends Library {
   public List<Tool> getTools() {
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/std/hdl/Hdl.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/Hdl.java
@@ -38,6 +38,14 @@ import java.util.List;
 
 public class Hdl extends Library {
 
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "HDL-IP";
+
   private static final FactoryDescription[] DESCRIPTIONS = {
     new FactoryDescription("VHDL Entity", S.getter("vhdlComponent"), new ArithmeticIcon("VHDL"),
     		VhdlEntityComponent.class),
@@ -48,11 +56,6 @@ public class Hdl extends Library {
   @Override
   public String getDisplayName() {
     return S.get("hdlLibrary");
-  }
-
-  @Override
-  public String getName() {
-    return "HDL-IP";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/hdl/Hdl.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/Hdl.java
@@ -45,8 +45,6 @@ public class Hdl extends Library {
 
   private List<Tool> tools = null;
 
-  public Hdl() {}
-
   @Override
   public String getDisplayName() {
     return S.get("hdlLibrary");

--- a/src/main/java/com/cburch/logisim/std/hdl/Hdl.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/Hdl.java
@@ -64,8 +64,4 @@ public class Hdl extends Library {
     }
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/std/io/Io.java
+++ b/src/main/java/com/cburch/logisim/std/io/Io.java
@@ -41,6 +41,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Io extends Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "I/O";
+
   public static final Attribute<Color> ATTR_COLOR =
       Attributes.forColor("color", S.getter("ioColorAttr"));
   static final Attribute<Color> ATTR_ON_COLOR = Attributes.forColor("color", S.getter("ioOnColor"));
@@ -73,11 +82,6 @@ public class Io extends Library {
   @Override
   public String getDisplayName() {
     return S.get("ioLibrary");
-  }
-
-  @Override
-  public String getName() {
-    return "I/O";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/io/Io.java
+++ b/src/main/java/com/cburch/logisim/std/io/Io.java
@@ -91,8 +91,4 @@ public class Io extends Library {
     }
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/std/io/Io.java
+++ b/src/main/java/com/cburch/logisim/std/io/Io.java
@@ -70,8 +70,6 @@ public class Io extends Library {
 
   private List<Tool> tools = null;
 
-  public Io() {}
-
   @Override
   public String getDisplayName() {
     return S.get("ioLibrary");

--- a/src/main/java/com/cburch/logisim/std/io/extra/ITA_IO.java
+++ b/src/main/java/com/cburch/logisim/std/io/extra/ITA_IO.java
@@ -39,6 +39,14 @@ import java.util.List;
 
 public class ITA_IO extends Library {
 
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "Input/Output-Extra";
+
   private static final FactoryDescription[] DESCRIPTIONS = {
     new FactoryDescription("Switch", S.getter("switchComponent"), "switch.gif", Switch.class),
     new FactoryDescription("Buzzer", S.getter("buzzerComponent"), "buzzer.gif", Buzzer.class),
@@ -56,11 +64,6 @@ public class ITA_IO extends Library {
   @Override
   public String getDisplayName() {
     return S.get("input.output.extra");
-  }
-
-  @Override
-  public String getName() {
-    return "Input/Output-Extra";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/io/extra/ITA_IO.java
+++ b/src/main/java/com/cburch/logisim/std/io/extra/ITA_IO.java
@@ -64,12 +64,6 @@ public class ITA_IO extends Library {
   }
 
   @Override
-  public boolean removeLibrary(String name) {
-    // TODO Auto-generated method stub
-    return false;
-  }
-
-  @Override
   public List<? extends Tool> getTools() {
     if (tools == null) {
       List<Tool> ret = new ArrayList<>(ADD_TOOLS.length + DESCRIPTIONS.length);

--- a/src/main/java/com/cburch/logisim/std/memory/Memory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Memory.java
@@ -77,8 +77,4 @@ public class Memory extends Library {
     }
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/std/memory/Memory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Memory.java
@@ -58,8 +58,6 @@ public class Memory extends Library {
 
   private List<Tool> tools = null;
 
-  public Memory() {}
-
   @Override
   public String getDisplayName() {
     return S.get("memoryLibrary");

--- a/src/main/java/com/cburch/logisim/std/memory/Memory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Memory.java
@@ -36,6 +36,15 @@ import com.cburch.logisim.tools.Tool;
 import java.util.List;
 
 public class Memory extends Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "Memory";
+
   protected static final int DELAY = 5;
 
   private static final FactoryDescription[] DESCRIPTIONS = {
@@ -61,11 +70,6 @@ public class Memory extends Library {
   @Override
   public String getDisplayName() {
     return S.get("memoryLibrary");
-  }
-
-  @Override
-  public String getName() {
-    return "Memory";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/plexers/Plexers.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Plexers.java
@@ -45,6 +45,15 @@ import java.awt.Graphics;
 import java.util.List;
 
 public class Plexers extends Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "Plexers";
+
   static boolean contains(Location loc, Bounds bds, Direction facing) {
     if (bds.contains(loc, 1)) {
       int x = loc.getX();
@@ -166,11 +175,6 @@ public class Plexers extends Library {
   @Override
   public String getDisplayName() {
     return S.get("plexerLibrary");
-  }
-
-  @Override
-  public String getName() {
-    return "Plexers";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/plexers/Plexers.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Plexers.java
@@ -182,8 +182,4 @@ public class Plexers extends Library {
     }
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/std/plexers/Plexers.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Plexers.java
@@ -163,8 +163,6 @@ public class Plexers extends Library {
 
   private List<Tool> tools = null;
 
-  public Plexers() {}
-
   @Override
   public String getDisplayName() {
     return S.get("plexerLibrary");

--- a/src/main/java/com/cburch/logisim/std/tcl/Tcl.java
+++ b/src/main/java/com/cburch/logisim/std/tcl/Tcl.java
@@ -64,8 +64,4 @@ public class Tcl extends Library {
     }
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/std/tcl/Tcl.java
+++ b/src/main/java/com/cburch/logisim/std/tcl/Tcl.java
@@ -45,8 +45,6 @@ public class Tcl extends Library {
 
   private List<Tool> tools = null;
 
-  public Tcl() {}
-
   @Override
   public String getDisplayName() {
     return S.get("tclLibrary");

--- a/src/main/java/com/cburch/logisim/std/tcl/Tcl.java
+++ b/src/main/java/com/cburch/logisim/std/tcl/Tcl.java
@@ -37,6 +37,14 @@ import java.util.List;
 
 public class Tcl extends Library {
 
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "TCL";
+
   private static final FactoryDescription[] DESCRIPTIONS = {
     new FactoryDescription(
         "TclConsoleReds", S.getter("tclConsoleReds"), "tcl.gif", TclConsoleReds.class),
@@ -48,11 +56,6 @@ public class Tcl extends Library {
   @Override
   public String getDisplayName() {
     return S.get("tclLibrary");
-  }
-
-  @Override
-  public String getName() {
-    return "TCL";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/ttl/TTL.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/TTL.java
@@ -38,6 +38,15 @@ import com.cburch.logisim.tools.Tool;
 import java.util.List;
 
 public class TTL extends Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "TTL";
+
   private static final FactoryDescription[] DESCRIPTIONS = {
     new FactoryDescription("7400", S.getter("TTL7400"), "ttl.gif", Ttl7400.class),
     new FactoryDescription("7402", S.getter("TTL7402"), "ttl.gif", Ttl7402.class),
@@ -85,13 +94,6 @@ public class TTL extends Library {
       Attributes.forBoolean("ShowInternalStructure", S.getter("ShowInternalStructure"));
 
   private List<Tool> tools = null;
-
-  public TTL() {}
-
-  @Override
-  public String getName() {
-    return "TTL";
-  }
 
   @Override
   public List<? extends Tool> getTools() {

--- a/src/main/java/com/cburch/logisim/std/ttl/TTL.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/TTL.java
@@ -100,10 +100,4 @@ public class TTL extends Library {
     }
     return tools;
   }
-
-  @Override
-  public boolean removeLibrary(String name) {
-    // TODO Auto-generated method stub
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/std/wiring/Wiring.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Wiring.java
@@ -76,8 +76,6 @@ public class Wiring extends Library {
 
   private List<Tool> tools = null;
 
-  public Wiring() {}
-
   @Override
   public String getDisplayName() {
     return S.get("wiringLibrary");

--- a/src/main/java/com/cburch/logisim/std/wiring/Wiring.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Wiring.java
@@ -44,6 +44,14 @@ import java.util.List;
 
 public class Wiring extends Library {
 
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = "Wiring";
+
   static final AttributeOption GATE_TOP_LEFT =
       new AttributeOption("tl", S.getter("wiringGateTopLeftOption"));
   static final AttributeOption GATE_BOTTOM_RIGHT =
@@ -79,11 +87,6 @@ public class Wiring extends Library {
   @Override
   public String getDisplayName() {
     return S.get("wiringLibrary");
-  }
-
-  @Override
-  public String getName() {
-    return "Wiring";
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/wiring/Wiring.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Wiring.java
@@ -98,8 +98,4 @@ public class Wiring extends Library {
     }
     return tools;
   }
-
-  public boolean removeLibrary(String Name) {
-    return false;
-  }
 }

--- a/src/main/java/com/cburch/logisim/tools/AddTool.java
+++ b/src/main/java/com/cburch/logisim/tools/AddTool.java
@@ -56,6 +56,7 @@ import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Action;
 import com.cburch.logisim.proj.Dependencies;
 import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.base.Base;
 import com.cburch.logisim.std.gates.GateKeyboardModifier;
 import com.cburch.logisim.std.wiring.ProbeAttributes;
 import com.cburch.logisim.tools.key.KeyConfigurationEvent;
@@ -204,7 +205,7 @@ public class AddTool extends Tool implements Transferable,PropertyChangeListener
     if (afterAdd.equals(AppPreferences.ADD_AFTER_UNCHANGED)) {
       return null;
     } else { // switch to Edit Tool
-      Library base = proj.getLogisimFile().getLibrary("Base");
+      Library base = proj.getLogisimFile().getLibrary(Base._ID);
       if (base == null) {
         return null;
       } else {
@@ -421,7 +422,7 @@ public class AddTool extends Tool implements Transferable,PropertyChangeListener
               break;
             case KeyEvent.VK_ESCAPE:
               Project proj = canvas.getProject();
-              Library base = proj.getLogisimFile().getLibrary("Base");
+              Library base = proj.getLogisimFile().getLibrary(Base._ID);
               Tool next = (base == null) ? null : base.getTool("Edit Tool");
               if (next != null) {
                 proj.setTool(next);

--- a/src/main/java/com/cburch/logisim/tools/Library.java
+++ b/src/main/java/com/cburch/logisim/tools/Library.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 public abstract class Library {
   private boolean hidden = false;
-	
+
   public boolean contains(ComponentFactory query) {
     return indexOf(query) >= 0;
   }
@@ -65,7 +65,9 @@ public abstract class Library {
     return null;
   }
 
-  public abstract boolean removeLibrary(String name);
+  public boolean removeLibrary(String Name) {
+    return false;
+  }
 
   public String getName() {
     return getClass().getName();
@@ -97,11 +99,11 @@ public abstract class Library {
   public boolean isDirty() {
     return false;
   }
-  
+
   public boolean isHidden() {
-    return hidden;  
+    return hidden;
   }
-  
+
   public void setHidden() {
     hidden = true;
   }

--- a/src/main/java/com/cburch/logisim/tools/Library.java
+++ b/src/main/java/com/cburch/logisim/tools/Library.java
@@ -48,9 +48,17 @@ public abstract class Library {
     return false;
   }
 
+  /**
+   * Returns the name of the library that the user will see.
+   */
   public String getDisplayName() {
     return getName();
   }
+
+  /**
+   * Returns library name/id
+   */
+  abstract public String getName();
 
   public List<Library> getLibraries() {
     return Collections.emptyList();
@@ -69,10 +77,6 @@ public abstract class Library {
     return false;
   }
 
-  public String getName() {
-    return getClass().getName();
-  }
-
   public Tool getTool(String name) {
     for (Tool tool : getTools()) {
       if (tool.getName().equals(name)) {
@@ -82,6 +86,9 @@ public abstract class Library {
     return null;
   }
 
+  /**
+   * Returns a list of all the tools available in this library.
+   */
   public abstract List<? extends Tool> getTools();
 
   public int indexOf(ComponentFactory query) {

--- a/src/main/java/com/cburch/logisim/tools/Library.java
+++ b/src/main/java/com/cburch/logisim/tools/Library.java
@@ -83,7 +83,8 @@ public abstract class Library {
     } catch (Exception e) {
       e.printStackTrace();
     }
-    return null;
+
+    throw new NullPointerException("Missing _ID for " + getClass());
   }
 
   public List<Library> getLibraries() {

--- a/src/main/java/com/cburch/logisim/tools/Library.java
+++ b/src/main/java/com/cburch/logisim/tools/Library.java
@@ -29,10 +29,21 @@
 package com.cburch.logisim.tools;
 
 import com.cburch.logisim.comp.ComponentFactory;
+
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 
 public abstract class Library {
+
+  /**
+   * Unique identifier of the library, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all libraries.
+   */
+  public static final String _ID = null;
+
   private boolean hidden = false;
 
   public boolean contains(ComponentFactory query) {
@@ -56,9 +67,24 @@ public abstract class Library {
   }
 
   /**
-   * Returns library name/id
+   * Returns unique library identifier.
+   *
+   * As we want to have static _ID per library, generic
+   * implementation must look for it in the current instance
    */
-  abstract public String getName();
+  public String getName() {
+    try {
+      Field[] fields = getClass().getDeclaredFields();
+      for (int i = 0; i < fields.length; i++) {
+        if (fields[i].getName().equals("_ID")) {
+          return (String)fields[i].get(this);
+        }
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
 
   public List<Library> getLibraries() {
     return Collections.emptyList();
@@ -66,7 +92,7 @@ public abstract class Library {
 
   public Library getLibrary(String name) {
     for (Library lib : getLibraries()) {
-      if (lib.getName().equals(name)) {
+      if (name.equals(lib.getName())) {
         return lib;
       }
     }

--- a/src/main/java/com/cburch/logisim/tools/LibraryTools.java
+++ b/src/main/java/com/cburch/logisim/tools/LibraryTools.java
@@ -34,6 +34,8 @@ import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.file.LoadedLibrary;
 import com.cburch.logisim.file.LogisimFile;
 import com.cburch.logisim.gui.generic.OptionPane;
+import com.cburch.logisim.std.base.Base;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -67,7 +69,7 @@ public class LibraryTools {
 
   public static boolean BuildToolList(Library lib, HashMap<String, AddTool> Tools) {
     boolean ret = true;
-    if (!lib.getName().equals("Base")) {
+    if (!lib.getName().equals(Base._ID)) {
       for (Tool tool1 : lib.getTools()) {
         if (Tools.containsKey(tool1.getName().toUpperCase()))
           ret = false;


### PR DESCRIPTION
Changes:
* Removes redundant `removeLibrary()` implementations
* Removes empty constructors
* Introduces library static _ID field and reworks generic getName() to look for it to reduce redundant code and remove library references via library name hardcoded in referring code.