### PR TITLE
Small library labels cleanup

### DIFF
--- a/src/main/resources/resources/logisim/strings/soc/soc.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = Currently the memory ordering instructions are not impl
 # Soc.java
 #
 SocBusComponent = SoC bus simulator
-socLibrary = System On Chip
+socLibrary = System On a Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc.properties
@@ -205,7 +205,7 @@ JtagUartKeybReadEnable = Keyboard read enable
 JtagUartTtyClear = TTY clear
 JtagUartTtyData = TTY data
 JtagUartTtyWrite = TTY write data
-SocJtagUartComponent = Jtag Uart component
+SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc.properties
@@ -394,7 +394,7 @@ Rv32imMOINotImplmented = Currently the memory ordering instructions are not impl
 #
 # Soc.java
 #
-SocBusComponent = SOC bus simulator
+SocBusComponent = SoC bus simulator
 socLibrary = System On Chip
 #
 # util/AbstractAssembler.java

--- a/src/main/resources/resources/logisim/strings/soc/soc.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = Currently the memory ordering instructions are not impl
 # Soc.java
 #
 SocBusComponent = SOC bus simulator
-socLibrary = System On Chip components
+socLibrary = System On Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_de.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_de.properties
@@ -394,7 +394,7 @@ Rv32imMOINotImplmented = Derzeit sind die Anweisungen zur Speicherbestellung nic
 #
 # Soc.java
 #
-SocBusComponent = SOC-Bus-Simulator
+SocBusComponent = SoC-Bus-Simulator
 socLibrary = System On Chip
 #
 # util/AbstractAssembler.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_de.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_de.properties
@@ -205,7 +205,7 @@ JtagUartKeybReadEnable = Lesefreigabe der Tastatur
 JtagUartTtyClear = TTY klar
 JtagUartTtyData = TTY-Daten
 JtagUartTtyWrite = TTY schreibt Daten
-SocJtagUartComponent = Jtag Uart Komponente
+SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_de.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_de.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = Derzeit sind die Anweisungen zur Speicherbestellung nic
 # Soc.java
 #
 SocBusComponent = SOC-Bus-Simulator
-socLibrary = System On Chip Komponenten
+socLibrary = System On Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_de.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_de.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = Derzeit sind die Anweisungen zur Speicherbestellung nic
 # Soc.java
 #
 SocBusComponent = SoC-Bus-Simulator
-socLibrary = System On Chip
+socLibrary = System On a Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_es.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_es.properties
@@ -394,8 +394,8 @@ Rv32imMOINotImplmented = Actualmente las instrucciones para ordenar la memoria n
 #
 # Soc.java
 #
-SocBusComponent = Simulador de bus SOC
-socLibrary = System On Chip
+SocBusComponent = Simulador de bus SoC
+socLibrary = System On a Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_es.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_es.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = Actualmente las instrucciones para ordenar la memoria n
 # Soc.java
 #
 SocBusComponent = Simulador de bus SOC
-socLibrary = Componentes de System On Chip
+socLibrary = System On Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_fr.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_fr.properties
@@ -205,7 +205,7 @@ JtagUartKeybReadEnable = Activation de la lecture du clavier
 JtagUartTtyClear = ATS clair
 JtagUartTtyData = Données ATS
 JtagUartTtyWrite = Données d'écriture ATS
-SocJtagUartComponent = Jtag Uart composant
+SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_fr.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_fr.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = Actuellement, les instructions de commande de mémoire 
 # Soc.java
 #
 SocBusComponent = Simulateur de bus SOC
-socLibrary = Composants System On Chip
+socLibrary = System On Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_fr.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_fr.properties
@@ -394,8 +394,8 @@ Rv32imMOINotImplmented = Actuellement, les instructions de commande de mémoire 
 #
 # Soc.java
 #
-SocBusComponent = Simulateur de bus SOC
-socLibrary = System On Chip
+SocBusComponent = Simulateur de bus SoC
+socLibrary = System On a Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_it.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_it.properties
@@ -394,7 +394,7 @@ Rv32imMOINotImplmented = Attualmente le istruzioni per l'ordine di memoria non s
 #
 # Soc.java
 #
-SocBusComponent = Simulatore di bus SOC
+SocBusComponent = Simulatore di bus SoC
 socLibrary = Sistema su chip
 #
 # util/AbstractAssembler.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_it.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_it.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = Attualmente le istruzioni per l'ordine di memoria non s
 # Soc.java
 #
 SocBusComponent = Simulatore di bus SOC
-socLibrary = Componenti del sistema su chip
+socLibrary = Sistema su chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_ja.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_ja.properties
@@ -206,7 +206,7 @@ JtagUartKeybReadEnable = キーボードの読み取りを有効にする。
 JtagUartTtyClear = TTYクリア
 JtagUartTtyData = TTYデータ
 JtagUartTtyWrite = TTY書き込みデータ
-SocJtagUartComponent = Jtag Uartコンポーネント
+SocJtagUartComponent = JTAG UARTコンポーネント
 #
 # jtaguart/JtagUartAttributes.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_ja.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_ja.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = 現在、メモリ順序付け命令は実装されて�
 #
 # Soc.java
 #
-SocBusComponent = SOCバスシミュレータ
+SocBusComponent = SoCバスシミュレータ
 socLibrary = システム・オン・チップ・コンポーネント
 #
 # util/AbstractAssembler.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
@@ -394,7 +394,7 @@ Rv32imMOINotImplmented = Momenteel zijn de instructies voor het bestellen van he
 #
 # Soc.java
 #
-SocBusComponent = SOC-bussimulator
+SocBusComponent = SoC-bussimulator
 socLibrary = System on Chip
 #
 # util/AbstractAssembler.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = Momenteel zijn de instructies voor het bestellen van he
 # Soc.java
 #
 SocBusComponent = SoC-bussimulator
-socLibrary = System on Chip
+socLibrary = System On a Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = Momenteel zijn de instructies voor het bestellen van he
 # Soc.java
 #
 SocBusComponent = SOC-bussimulator
-socLibrary = System on chip componenten
+socLibrary = System on Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
@@ -205,7 +205,7 @@ JtagUartKeybReadEnable = Toetsenbord lezen inschakelen
 JtagUartTtyClear = TTY duidelijk
 JtagUartTtyData = TTY gegevens
 JtagUartTtyWrite = TTY gegevens schrijven
-SocJtagUartComponent = Jtag Uart component
+SocJtagUartComponent = Jtag UART
 #
 # jtaguart/JtagUartAttributes.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_pt.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_pt.properties
@@ -394,8 +394,8 @@ Rv32imMOINotImplmented = Atualmente as instruções de pedido de memória não e
 #
 # Soc.java
 #
-SocBusComponent = Simulador de barramento SOC
-socLibrary = Sistema On Chip
+SocBusComponent = Simulador de barramento SoC
+socLibrary = Sistema On a Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_pt.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_pt.properties
@@ -395,7 +395,7 @@ Rv32imMOINotImplmented = Atualmente as instruções de pedido de memória não e
 # Soc.java
 #
 SocBusComponent = Simulador de barramento SOC
-socLibrary = Componentes do Sistema On Chip
+socLibrary = Sistema On Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/soc/soc_ru.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_ru.properties
@@ -394,8 +394,8 @@ Rv32imMOINotImplmented = В настоящее время инструкции �
 #
 # Soc.java
 #
-SocBusComponent = симулятор шины SOC
-socLibrary = Компоненты System On Chip
+SocBusComponent = симулятор шины SoC
+socLibrary = System On a Chip
 #
 # util/AbstractAssembler.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -315,7 +315,7 @@ hexDigitDPTip = DecimalPoint: lights the decimal point
 # io/Io.java
 #
 buttonComponent = Button
-dipswitchComponent = Dip Switch
+dipswitchComponent = DIP Switch
 dotMatrixComponent = LED Matrix
 hexDigitComponent = Hex Digit Display
 ioActiveAttr = Active On High?

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -848,6 +848,6 @@ wiringGateAttr = Gate Location
 wiringGateBottomRightOption = Bottom/Right
 wiringGateTopLeftOption = Top/Left
 wiringLibrary = Wiring
-input.output.extra=Input/Output-Extra
+input.output.extra = Input/Output Extra
 
 

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -315,7 +315,7 @@ hexDigitDPTip = DecimalPoint: lights the decimal point
 # io/Io.java
 #
 buttonComponent = Button
-dipswitchComponent = Dip switch
+dipswitchComponent = Dip Switch
 dotMatrixComponent = LED Matrix
 hexDigitComponent = Hex Digit Display
 ioActiveAttr = Active On High?
@@ -328,7 +328,7 @@ joystickComponent = Joystick
 ledComponent = LED
 pioComponent = Port I/O
 repLBComponent = Reptar Local Bus
-RGBledComponent = RGBLED
+RGBledComponent = RGB LED
 sevenSegmentComponent = 7-Segment Display
 ttyComponent = TTY
 #

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -302,7 +302,7 @@ hexDigitDPTip = Dezimalpunkt: Leuchtet das Dezimalpunkt.
 # io/Io.java
 #
 buttonComponent = Taster
-dipswitchComponent = Dip-Schalter
+dipswitchComponent = DIP-Schalter
 dotMatrixComponent = LED-Matrix
 hexDigitComponent = Hexadezimale Anzeige
 ioActiveAttr = Eingeschaltet bei H-Signal?

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -315,7 +315,7 @@ joystickComponent = Joystick
 ledComponent = LED
 pioComponent = Port I/O
 repLBComponent = Reptar Lokaler Bus
-RGBledComponent = RGBLED
+RGBledComponent = RGB LED
 sevenSegmentComponent = 7-Segmentanzeige
 ttyComponent = Terminal
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -315,7 +315,7 @@ joystickComponent = Joystick
 ledComponent = LED
 pioComponent = Porta I/O
 repLBComponent = Autobus locale Reptar
-RGBledComponent = RGBLED
+RGBledComponent = RGB LED
 sevenSegmentComponent = Display a 7 segmenti
 ttyComponent = TTY
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -302,7 +302,7 @@ hexDigitDPTip = DecimalPoint: illumina la virgola decimale
 # io/Io.java
 #
 buttonComponent = Pulsante
-dipswitchComponent = Dip switch
+dipswitchComponent = DIP Switch
 dotMatrixComponent = Matrice di LED
 hexDigitComponent = Display esadecimale digitale
 ioActiveAttr = Attivo su livello alto?

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -302,7 +302,7 @@ hexDigitDPTip = DecimalPoint: 小数点を点灯します。
 # io/Io.java
 #
 buttonComponent = ボタン
-dipswitchComponent = Dip スイッチ
+dipswitchComponent = DIP スイッチ
 dotMatrixComponent = マトリックス型LED
 hexDigitComponent = 16進数ディスプレイ
 ioActiveAttr = Active On High?

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -315,7 +315,7 @@ joystickComponent = ジョイスティック
 ledComponent = LED
 pioComponent = ポート I/O
 repLBComponent = リピータローカルバス
-RGBledComponent = RGBLED
+RGBledComponent = RGB LED
 sevenSegmentComponent = 7セグメントディスプレイ
 ttyComponent = TTY
 #

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -313,7 +313,7 @@ hexDigitDPTip = DecimalPoint: licht de decimale komma op.
 # io/Io.java
 #
 buttonComponent = Knop
-dipswitchComponent = Dip switch
+dipswitchComponent = DIP Switch
 dotMatrixComponent = LED Matrix
 hexDigitComponent = Hexadecimale Digit Display
 ioActiveAttr = Actief op High?

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -326,7 +326,7 @@ joystickComponent = Joystick
 ledComponent = LED
 pioComponent = Poort I/O
 repLBComponent = Reptar lokale bus
-RGBledComponent = RGBLED
+RGBledComponent = RGB LED
 sevenSegmentComponent = 7-segmentdisplay
 ttyComponent = TTY
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -302,7 +302,7 @@ hexDigitDPTip = DecimalPoint: ilumina o ponto decimal
 # io/Io.java
 #
 buttonComponent = Botão
-dipswitchComponent = Dip switch
+dipswitchComponent = DIP Switch
 dotMatrixComponent = Matriz de LED
 hexDigitComponent = Display hexadecimal
 ioActiveAttr = Ativar em alto?


### PR DESCRIPTION
Library labels cleanup:
* Changed 'RGBLED' label to 'RGB LED'
* Ensured 'DIP' in 'DIP Switch' label is all upper-cased
* Shortened "System on Chip Components" label by dropping "Components" from it.
* Renamed "Input/Output-Extra" to "Input/Output Extra" 
* Ensured "System on a chip" abbrev. is spelled "SoC"
* Ensured JTAG and UART proper spelling
* Corrected full form of SoC to "System On a Chip"