### PR TITLE
Removed ZoomText label

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/generic/ZoomControl.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ZoomControl.java
@@ -59,11 +59,10 @@ import javax.swing.JPanel;
 import javax.swing.JSlider;
 import javax.swing.SwingConstants;
 
-public class ZoomControl extends JPanel implements LocaleListener {
+public class ZoomControl extends JPanel {
   private static final long serialVersionUID = 1L;
   private final ZoomLabel label;
   private final JSlider slider;
-  private final JLabel zoomText;
   private final GridIcon grid;
   private final Canvas canvas;
   private final JButton plus;
@@ -90,8 +89,6 @@ public class ZoomControl extends JPanel implements LocaleListener {
     zoom.add(label, BorderLayout.CENTER);
     zoom.add(plus, BorderLayout.EAST);
     zoom.add(slider, BorderLayout.SOUTH);
-    zoomText = new JLabel(S.get("ZoomText"), SwingConstants.CENTER);
-    zoom.add(zoomText, BorderLayout.NORTH);
 
     this.add(zoom, BorderLayout.NORTH);
 
@@ -108,7 +105,6 @@ public class ZoomControl extends JPanel implements LocaleListener {
     model.addPropertyChangeListener(ZoomModel.SHOW_GRID, grid);
     model.addPropertyChangeListener(ZoomModel.ZOOM, sliderModel);
     model.addPropertyChangeListener(ZoomModel.ZOOM, label);
-    LocaleManager.addLocaleListener(this);
   }
 
   private int nearestZoomOption() {
@@ -177,7 +173,6 @@ public class ZoomControl extends JPanel implements LocaleListener {
         label.setEnabled(false);
         plus.setEnabled(false);
         minus.setEnabled(false);
-        zoomText.setEnabled(false);
       } else {
         slider.setEnabled(true);
         ZoomButton.setEnabled(true);
@@ -185,7 +180,6 @@ public class ZoomControl extends JPanel implements LocaleListener {
         label.setEnabled(true);
         plus.setEnabled(true);
         minus.setEnabled(true);
-        zoomText.setEnabled(true);
         sliderModel = new SliderModel(model);
         slider.setModel(sliderModel);
         grid.update();
@@ -197,11 +191,6 @@ public class ZoomControl extends JPanel implements LocaleListener {
         label.setText(zoomString());
       }
     }
-  }
-
-  @Override
-  public void localeChanged() {
-    zoomText.setText(S.get("ZoomText"));
   }
 
   private class GridIcon extends JComponent implements MouseListener, PropertyChangeListener {

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -109,7 +109,6 @@ attributeDialogTitle = Select Value
 # generic/ZoomControl.java
 #
 zoomShowGrid = Toggle whether grid is shown
-ZoomText = Zoom and grid control:
 #
 # hex/Clip.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -57,7 +57,6 @@ attributeDialogTitle = Wert auswählen
 # generic/ZoomControl.java
 #
 zoomShowGrid = Gitternetz umschalten
-ZoomText = Zoom- und Rasterkontrolle:
 #
 # hex/Clip.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -57,7 +57,6 @@ attributeDialogTitle = Επιλογή Τιμής
 # generic/ZoomControl.java
 #
 zoomShowGrid = Εναλλαγή εμφάνισης πλέγματος
-# ==> ZoomText =
 #
 # hex/Clip.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -57,7 +57,6 @@ attributeDialogTitle = Seleccionar valor
 # generic/ZoomControl.java
 #
 zoomShowGrid = Activar o desactivar cuadrícula
-ZoomText = Control de zoom y cuadrícula:
 #
 # hex/Clip.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -57,7 +57,6 @@ attributeDialogTitle = Sélectionner une valeur
 # generic/ZoomControl.java
 #
 zoomShowGrid = Changer l'affichage de la grille
-ZoomText = Zoom et contrôle de la grille :
 #
 # hex/Clip.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -57,7 +57,6 @@ attributeDialogTitle = Seleziona Valore
 # generic/ZoomControl.java
 #
 zoomShowGrid = Attiva se la griglia è mostrata
-ZoomText = Zoom e controllo della griglia:
 #
 # hex/Clip.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -57,7 +57,6 @@ attributeDialogTitle = 選択値
 # generic/ZoomControl.java
 #
 zoomShowGrid = グリッドを表示するかどうかを切り替える
-ZoomText = ズームとグリッドコントロール:
 #
 # hex/Clip.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -107,7 +107,6 @@ attributeDialogTitle = Selecteer waarde
 # generic/ZoomControl.java
 #
 zoomShowGrid = Selecteer of grid wordt weergegeven.
-ZoomText = Zoom en grid instelling:
 #
 # hex/Clip.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -57,7 +57,6 @@ attributeDialogTitle = Selecionar valor
 # generic/ZoomControl.java
 #
 zoomShowGrid = Alternar se grade em uso
-ZoomText = Zoom e controle de grade:
 #
 # hex/Clip.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -57,7 +57,6 @@ attributeDialogTitle = Выбор значения
 # generic/ZoomControl.java
 #
 zoomShowGrid = Переключить отображение сетки
-ZoomText = управление масштабированием:
 #
 # hex/Clip.java
 #


### PR DESCRIPTION
Removed ZoomText label from ZoomControl panel as it just occupied screen state adding no additional long term value justifying its permanent presence.