### PR TITLE
Finish reapplication of code to fix reading of memory values from .circ files

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/hex/HexFile.java
+++ b/src/main/java/com/cburch/logisim/gui/hex/HexFile.java
@@ -1326,7 +1326,7 @@ public class HexFile {
         try {
           rleValue = Long.parseUnsignedLong(hexWord, 16);
         } catch (NumberFormatException e) {
-          try {            
+          try {
             rleValue = Long.parseLong(hexWord, 16);
           } catch (NumberFormatException f) {
             warn("\"%s\" is not valid hex data.", hexWord);
@@ -1337,7 +1337,7 @@ public class HexFile {
           rleCount = 1;
         } else {
           try {
-            rleValue = Long.parseUnsignedLong(word.substring(0), star);
+            rleCount = Long.parseUnsignedLong(word.substring(0, star));
           } catch (NumberFormatException e) {
             warn("\"%s\" is not valid (base-10 decimal) count.", word.substring(0, star));
             continue;


### PR DESCRIPTION
The reason the redo of my fix failed my tests is that a line was changed. That line was supposed to parse a base 10 unsigned count from the format "count*hexvalue". This PR returns it to the original submission.

This PR solves issue #674.