### PR TITLE
Added CheckStyle docs + corrected config

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ Once it is running without bugs on your local fork request a *Pull request* by:
 
 ## Code style
 
+Source code should follow "Google Java" code style (this is still work in progress), therefore Logisim-evolution
+comes with CheckStyle configuration that you can apply to ensure your contributions follows the standard as well.
+Please see [checkstyle/README.md](checkstyle/README.md) for more information how to use CheckStyle with Gradle
+or with InteliJ-IDEA.
+
 All of Logisim's Java files have been formatted using [`google-java-format`](https://github.com/google/google-java-format). If you are using [Eclipse](https://www.eclipse.org/), there is a [plugin](https://github.com/google/google-java-format#eclipse) available to enforce this formatting. If you are using [InteliJ IDEA](https://www.jetbrains.com/idea/), the corresponding plugin is available via its [Marketplace](https://plugins.jetbrains.com/plugin/8527-google-java-format).
 Code style to use is `Default Google java style`.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -302,11 +302,10 @@ tasks {
     // Checkstyles related tasks: "checkstylMain" and "checkstyleTest"
     checkstyle {
         // If you are going to upgrade checkstyle version ensure you are upgrading also
-        // XML config file to match. The simplest approach is to go project release page:
-        // https://github.com/checkstyle/checkstyle/releases and grab source archive for
-        // version of your choice and copy out "src/main/resources/google_checks.xml" here.
+        // XML config file to match or CheckStyle may fail to work. See `checkstyle/README.md`
+        // for details!
         toolVersion = "8.37"
-        configFile = file("${project.rootDir}/checkstyle/google_checks.xml")
+        configFile = file("${project.rootDir}/checkstyle/logisim.xml")
     }
     checkstyleMain {
         source = fileTree("src/main/java")

--- a/checkstyle/README.md
+++ b/checkstyle/README.md
@@ -1,0 +1,51 @@
+# Coding style #
+
+Logisim-evolution uses code style based on CheckStyle's `Google Java Style` (stored
+in `checkstyle/logisim.xml` file), with the following checks currently disabled:
+
+* "MissingJavadocMethod"
+* "NeedBraces
+
+# Using Logisim style with InteliJ #
+
+You can use our coding style with InteliJ's CheckStyle plugin:
+
+* Go to Settings -> Plugins,
+* Install "CheckStyle-IDEA" plugin (by Jamie Shiell) from Marketplace,
+* Open its settings (Tools -> Checkstyle)
+* Set correct "Checkstyle version" (see "toolVersion" in "gradle.build.kts" file)
+* Add new "Configuration file":
+  * Click "+"
+  * Set description to "Logisim-evolution"
+  * Select "Use a local Checkstyle file"
+  * Click "Browse" and locate "logisim.xml" in "checkstyle/" folder in Logisim source tree
+  * Enable "Store relative to project location"
+  * Click "Next"
+  * Click "Next" again on "Property" table.
+  * Click "Finish"
+* From now on you can run CheckStyle using "Checkstyle" command or directly from CheckStyle tab
+* Ensure "Rules:" shown in the scan result window read "Logisim-evolution"
+
+# Checking style with Gradle #
+
+CheckStyle is plugged into project's Gradle and exposes `checkstyleMain` and
+`checkstyleTest` tasks:
+
+```bash
+$ ./gradlew checkstyleMain
+```
+
+# Updating CheckStyle used by Gradle plugin #
+
+If you are going to change version of CheckStyle used by Gradle, the following steps
+must be taken care of:
+
+* Edit `build.gradle.kts` and bump `toolVersion` of `checkstyle` task config to desired version
+* Upgrade `checkstyle/logisim.xml` configuration. This is important, as certain versions of
+  CheckStyle introduces backward incompatible changes and older/different configs may not
+  work as expected or cause CheckStyle to fail completely. The simplest way to udpdate 
+  `logisim.xml` config is to go to CheckStyle GitHub project release page:
+  https://github.com/checkstyle/checkstyle/releases and grab source archive for that particular
+  version you set in `toolVersion`. Then get the original `src/main/resources/google_checks.xml`
+  file, disable (comment out) checks listed above and write as `logisim.xml`.
+

--- a/checkstyle/logisim.xml
+++ b/checkstyle/logisim.xml
@@ -70,10 +70,10 @@
       <property name="tokens"
                value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
     </module>
-    <module name="NeedBraces">
-      <property name="tokens"
-               value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
-    </module>
+<!--    <module name="NeedBraces">-->
+<!--      <property name="tokens"-->
+<!--               value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>-->
+<!--    </module>-->
     <module name="LeftCurly">
       <property name="tokens"
                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
@@ -321,13 +321,13 @@
       <property name="allowedAnnotations" value="Override, Test"/>
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
     </module>
-    <module name="MissingJavadocMethod">
-      <property name="scope" value="public"/>
-      <property name="minLineCount" value="2"/>
-      <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
-                                   COMPACT_CTOR_DEF"/>
-    </module>
+<!--    <module name="MissingJavadocMethod">-->
+<!--      <property name="scope" value="public"/>-->
+<!--      <property name="minLineCount" value="2"/>-->
+<!--      <property name="allowedAnnotations" value="Override, Test"/>-->
+<!--      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,-->
+<!--                                   COMPACT_CTOR_DEF"/>-->
+<!--    </module>-->
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
       <message key="name.invalidPattern"


### PR DESCRIPTION
This adds more info on how to use CheckStyle (either with Gradle or InteliJ). I also tweaked style a bit, disabling two "most popular" complains CheckStyle on my first cleanup of "util/" content, be it "MissingJavadocMethod" and "NeedBraces" as there's lot of one-liners without the curly braces. There're other complains too, but I will post more in #698 about that.