### PR TITLE
Centered banner in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-![Logisim-evolution](src/main/resources/resources/logisim/img/logisim-evolution-logo.svg)
+<p align="center">
+  <a href="https://github.com/logisim-evolution/logisim-evolution">
+    <img src="src/main/resources/resources/logisim/img/logisim-evolution-logo.svg" alt="Logisim-evolution">
+  </a>
+</p>
 
 # Digital logic designer and simulator #
 


### PR DESCRIPTION
I prefer this style because, IMHO centered banners looks better and clicking the banner leads to the project and not to the source file.
(The second part can also be achieved with only MarkDown.)
But it uses HTML, what some people don't like in .md files.
What is your opinion?