### PR TITLE
Restored previous path filtering to build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,67 +9,16 @@ on:
     # No need to run on push to "develop" as there should not be any direct pushes.
     # master is left just for emergency cases.
     branches: [ master ]
+    paths:
+    - src/**
   pull_request:
     branches: [ master, develop ]
+    paths:
+    - src/**
 
 jobs:
-
-  # I intentionally do not use "paths:" (as part of "push:"), i.e.
-  #
-  # on:
-  #   push:
-  #     branches: [ master ]
-  #     paths:
-  #     - src/**
-  #
-  # It's because that can cause confusion why there's no build action triggered on specific
-  # PR, so to avoid this this action is intentionally always triggered, but it will skip
-  # building process if nothing has changed in specified paths (sources).
-  #
-  analyze_sources:
-    name: "Need to build the application?"
-    runs-on: ubuntu-latest
-
-    outputs:
-      run_build: ${{ steps.diff_check.outputs.run_build }}
-
-    steps:
-    # https://github.com/marketplace/actions/checkout
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 2
-
-    - name: "CHECKING IF BUILD STEP SHOULD RUN..."
-      id: diff_check
-      run: |
-        git diff --name-only HEAD^ HEAD > changes.txt
-        found=""
-        while IFS= read -r file; do
-          if [[ "${file}" == src/* ]]; then
-            found="YES"
-            break
-          fi
-        done < changes.txt
-        if [[ "${found}" == "YES" ]]; then
-          echo "Sources affected. Will try to build it."
-          echo "::set-output name=run_build::true"
-        else
-          # Let's make the "Nah" result stand out in the logs.
-          echo "************************************************************"
-          echo "**                                                        **"
-          echo "**  NO NEED TO BUILD THE APPLICATION. BUILD STEP SKIPPED  **"
-          echo "**                                                        **"
-          echo "**  No changes in 'src/' folders detected.                **"
-          echo "**                                                        **"
-          echo "************************************************************"
-          echo "::set-output name=run_build::false"
-        fi
-
   build:
     name: "Building application"
-
-    needs: analyze_sources
-    if: needs.analyze_sources.diff_check.output.run_build == 'true'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
I restored previous approach that was silently skipping the action if no `src/**` changed as git's diff based conditional I implemented seems to have hiccups for ATM unknown reasons and do not trigger the build as expected under some circumstances. So until I fix that let's have it run the old way.