### PR TITLE
Tweaked checkstyle GH Action

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -94,7 +94,10 @@ jobs:
         # Starting from 8.28, default checkstyle config looks for optional checkstyle-suppressions.xml
         # (See https://github.com/checkstyle/checkstyle/issues/6946) so we just need to link ours
         # (as it looks for it in CWD) and that should be sufficient.
-        ln -s config/checkstyle/suppressions.xml checkstyle-suppressions.xml
+        supp_file="config/checkstyle/suppressions-dev.xml"
+        # safe fall back to non-dev file if -dev version is removed
+        [[ -f "${supp_file}" ]] || supp_file="config/checkstyle/suppressions.xml"
+        ln -s "${supp_file}" checkstyle-suppressions.xml
 
         # Let's lint eventually...
         checkstyle -o "${REPORT_FILE}" -c "${CHECKS_FILE}" ${{ needs.analyze_sources.outputs.changed_files }}

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   analyze_sources:
-    name: "Is there anything to lint?"
+    name: "Is there any Java source code to lint?"
     runs-on: ubuntu-latest
 
     outputs:

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -5,7 +5,7 @@
 #
 # Marcin Orlowski
 
-name: "Checkstyle"
+name: "Code style"
 on:
   push:
     # No need to run on push to "develop" as there should not be any direct pushes.

--- a/config/checkstyle/suppressions-dev.xml
+++ b/config/checkstyle/suppressions-dev.xml
@@ -8,6 +8,7 @@
     <suppress checks="MissingJavadocType"/>
     <suppress checks="JavadocParagraph"/>
     <suppress checks="NeedBraces"/>
+    <suppress checks="LineLength"/>
 
     <suppress checks="LocalVariableName"/>
     <suppress checks="ParameterName"/>
@@ -26,7 +27,6 @@
     <suppress checks="SummaryJavadoc"/>
     <suppress checks="OverloadMethodsDeclarationOrder"/>
     <suppress checks="CustomImportOrder"/>
-    <suppress checks="LineLength"/>
     <suppress checks="SingleLineJavadoc"/>
     <suppress checks="FallThrough"/>
 

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -8,6 +8,7 @@
     <suppress checks="MissingJavadocType"/>
     <suppress checks="JavadocParagraph"/>
     <suppress checks="NeedBraces"/>
+    <suppress checks="LineLength"/>
 
     <!-- Auto-generated file. https://github.com/logisim-evolution/logisim-evolution/issues/563-->
 	<suppress id="VhdlSyntax" files="src/main/java/com/cburch/logisim/vhdl/syntax/VhdlSyntax.java"/>

--- a/src/main/java/com/cburch/logisim/fpga/data/IOComponentTypes.java
+++ b/src/main/java/com/cburch/logisim/fpga/data/IOComponentTypes.java
@@ -31,7 +31,7 @@ package com.cburch.logisim.fpga.data;
 import static com.cburch.logisim.fpga.Strings.S;
 
 import com.cburch.logisim.std.io.DipSwitch;
-import com.cburch.logisim.std.io.RGBLed;
+import com.cburch.logisim.std.io.RgbLed;
 import com.cburch.logisim.std.io.ReptarLocalBus;
 import java.util.EnumSet;
 
@@ -140,7 +140,7 @@ public enum IOComponentTypes {
       case SevenSegment:
         return com.cburch.logisim.std.io.SevenSegment.getOutputLabel(id);
       case RGBLED:
-        return RGBLed.getLabel(id);
+        return RgbLed.getLabel(id);
       case LocalBus:
         return ReptarLocalBus.getOutputLabel(id);
       default:

--- a/src/main/java/com/cburch/logisim/gui/appear/LayoutThumbnail.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/LayoutThumbnail.java
@@ -28,7 +28,6 @@
 
 package com.cburch.logisim.gui.appear;
 
-import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.CircuitState;
 import com.cburch.logisim.circuit.appear.AppearancePort;
 import com.cburch.logisim.circuit.appear.DynamicElement;
@@ -37,7 +36,7 @@ import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.std.io.Led;
-import com.cburch.logisim.std.io.RGBLed;
+import com.cburch.logisim.std.io.RgbLed;
 import com.cburch.logisim.std.wiring.Pin;
 import com.cburch.logisim.util.GraphicsUtil;
 import java.awt.Color;
@@ -126,7 +125,7 @@ public class LayoutThumbnail extends JComponent {
           int y = b.getY();
           int w = b.getWidth();
           int h = b.getHeight();
-          if (elt.getFactory() instanceof Led || elt.getFactory() instanceof RGBLed) {
+          if (elt.getFactory() instanceof Led || elt.getFactory() instanceof RgbLed) {
             gfxCopy.drawOval(x, y, w, h);
           } else {
             gfxCopy.drawRect(x, y, w, h);

--- a/src/main/java/com/cburch/logisim/gui/icons/SimulationIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/SimulationIcon.java
@@ -55,13 +55,13 @@ public class SimulationIcon extends AbstractIcon {
   @Override
   @SuppressWarnings("fallthrough")
   protected void paintIcon(Graphics2D g2) {
-    int wh = getIconWidth() - scale(1);
+    final var wh = getIconWidth() - scale(1);
     g2.setStroke(new BasicStroke(scale(1)));
     g2.setColor(currentType > SIM_STEP ? Color.LIGHT_GRAY : Color.WHITE);
     g2.fillOval(0, 0, wh, wh);
     if (currentType > SIM_STEP) {
       g2.setColor(Color.WHITE);
-      int wh1 = wh - scale(4);
+      final var wh1 = wh - scale(4);
       g2.fillOval(scale(2), scale(2), wh1, wh1);
       g2.setStroke(new BasicStroke(scale(2)));
       g2.setColor(Color.BLACK);
@@ -80,8 +80,8 @@ public class SimulationIcon extends AbstractIcon {
         g2.drawRect(scale(10), scale(3), scale(1), scale(10));
         // fall through
       case SIM_PLAY:
-        int[] xpos = {scale(6), scale(10), scale(6)};
-        int[] ypos = {scale(3), scale(8), scale(13)};
+        final int[] xpos = {scale(6), scale(10), scale(6)};
+        final int[] ypos = {scale(3), scale(8), scale(13)};
         g2.setColor(Color.GREEN.brighter());
         g2.fillPolygon(xpos, ypos, 3);
         g2.setColor(Color.GREEN.darker());
@@ -99,8 +99,8 @@ public class SimulationIcon extends AbstractIcon {
         g2.setStroke(new BasicStroke(scale(2)));
         g2.setColor(Color.MAGENTA.darker().darker());
         g2.drawArc(0, 0, wh, wh, -135, -180);
-        int[] x1 = {scale(10), scale(14), scale(14)};
-        int[] y1 = {(wh) / 4, (wh) / 4, (wh) / 4 - scale(4)};
+        final int[] x1 = {scale(10), scale(14), scale(14)};
+        final int[] y1 = {(wh) / 4, (wh) / 4, (wh) / 4 - scale(4)};
         g2.fillPolygon(x1, y1, 3);
         g2.drawPolygon(x1, y1, 3);
         // fall through
@@ -108,14 +108,14 @@ public class SimulationIcon extends AbstractIcon {
         g2.setStroke(new BasicStroke(scale(2)));
         g2.setColor(Color.MAGENTA);
         g2.drawArc(0, 0, wh, wh, 45, -180);
-        int[] x = {scale(3), scale(7), scale(3)};
-        int[] y = {(3 * wh) / 4, (3 * wh) / 4, (3 * wh) / 4 + scale(4)};
+        final int[] x = {scale(3), scale(7), scale(3)};
+        final int[] y = {(3 * wh) / 4, (3 * wh) / 4, (3 * wh) / 4 + scale(4)};
         g2.fillPolygon(x, y, 3);
         g2.drawPolygon(x, y, 3);
         break;
       case SIM_ENABLE:
-        int[] x0 = {scale(6), scale(10), scale(6)};
-        int[] y0 = {scale(8), scale(12), scale(15)};
+        final int[] x0 = {scale(6), scale(10), scale(6)};
+        final int[] y0 = {scale(8), scale(12), scale(15)};
         g2.setColor(Color.GREEN.darker());
         g2.fillPolygon(x0, y0, 3);
         g2.setColor(Color.GREEN.darker().darker().darker());
@@ -126,6 +126,10 @@ public class SimulationIcon extends AbstractIcon {
         g2.setColor(Color.RED.darker().darker());
         g2.drawLine(scale(6), scale(9), scale(6), scale(14));
         g2.drawLine(scale(10), scale(9), scale(10), scale(14));
+      default:
+        // Do nothing. Should not really happen.
+        // FIXME: we should have assert to ensure that!
+        break;
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/std/io/IoLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/io/IoLibrary.java
@@ -69,7 +69,7 @@ public class IoLibrary extends Library {
     new FactoryDescription(Keyboard.class, S.getter("keyboardComponent"), "keyboard.gif"),
     new FactoryDescription(Led.class, S.getter("ledComponent"), "led.gif"),
     new FactoryDescription(LedBar.class, S.getter("ioLedBarComponent"), "ledlightbar.gif"),
-    new FactoryDescription(RGBLed.class, S.getter("RGBledComponent"), "rgbled.gif"),
+    new FactoryDescription(RgbLed.class, S.getter("RGBledComponent"), "rgbled.gif"),
     new FactoryDescription(SevenSegment.class, S.getter("sevenSegmentComponent"), "7seg.gif"),
     new FactoryDescription(HexDigit.class, S.getter("hexDigitComponent"), "hexdig.gif"),
     new FactoryDescription(DotMatrix.class, S.getter("dotMatrixComponent"), "dotmat.gif"),
@@ -95,6 +95,7 @@ public class IoLibrary extends Library {
     return tools;
   }
 
+  @Override
   public boolean removeLibrary(String Name) {
     return false;
   }

--- a/src/main/java/com/cburch/logisim/std/io/RGBLedShape.java
+++ b/src/main/java/com/cburch/logisim/std/io/RGBLedShape.java
@@ -62,9 +62,9 @@ public class RGBLedShape extends LedShape {
       var summ = (data == null ? 0 : (Integer) data.getValue());
       final var mask = activ ? 0 : 7;
       summ ^= mask;
-      final var red = ((summ >> RGBLed.RED) & 1) * 0xFF;
-      final var green = ((summ >> RGBLed.GREEN) & 1) * 0xFF;
-      final var blue = ((summ >> RGBLed.BLUE) & 1) * 0xFF;
+      final var red = ((summ >> RgbLed.RED) & 1) * 0xFF;
+      final var green = ((summ >> RgbLed.GREEN) & 1) * 0xFF;
+      final var blue = ((summ >> RgbLed.BLUE) & 1) * 0xFF;
       g.setColor(new Color(red, green, blue));
       g.fillOval(x, y, w, h);
       g.setColor(Color.darkGray);

--- a/src/main/java/com/cburch/logisim/std/io/RgbLed.java
+++ b/src/main/java/com/cburch/logisim/std/io/RgbLed.java
@@ -55,7 +55,7 @@ import java.awt.Graphics;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 
-public class RGBLed extends InstanceFactory implements DynamicElementProvider {
+public class RgbLed extends InstanceFactory implements DynamicElementProvider {
   /**
    * Unique identifier of the tool, used as reference in project files.
    * Do NOT change as it will prevent project files from loading.
@@ -66,6 +66,7 @@ public class RGBLed extends InstanceFactory implements DynamicElementProvider {
 
   public static class Logger extends InstanceLogger {
     static final BitWidth bitwidth = BitWidth.create(3);
+
     @Override
     public String getLogName(InstanceState state, Object option) {
       return state.getAttributeValue(StdAttr.LABEL);
@@ -105,7 +106,7 @@ public class RGBLed extends InstanceFactory implements DynamicElementProvider {
   public static final int GREEN = 1;
   public static final int BLUE = 2;
 
-  public RGBLed() {
+  public RgbLed() {
     super(_ID, S.getter("RGBledComponent"));
     setAttributes(
         new Attribute[] {
@@ -137,7 +138,10 @@ public class RGBLed extends InstanceFactory implements DynamicElementProvider {
   private void updatePorts(Instance instance) {
     final var facing = instance.getAttributeValue(StdAttr.FACING);
     final var ps = new Port[3];
-    int cx = 0, cy = 0, dx = 0, dy = 0;
+    var cx = 0;
+    var cy = 0;
+    var dx = 0;
+    var dy = 0;
     if (facing == Direction.NORTH) {
       cy = 10;
       dx = 10;
@@ -250,6 +254,7 @@ public class RGBLed extends InstanceFactory implements DynamicElementProvider {
     return true;
   }
 
+  @Override
   public DynamicElement createDynamicElement(int x, int y, DynamicElement.Path path) {
     return new RGBLedShape(x, y, path);
   }


### PR DESCRIPTION
Changed Checkstyle linter to use `uppressions-dev.xml` which in turn makes the linter less restrictive. This is unfortunately needed because our source code has still high number of issues and because linter now runs on every PR as GH action, it'd be really hard to submit anything "clear" right now as once you touched any "tainted" file, it'd be like opening pandora box for linter. And then if you'd decide to fix it all in your PR, your original change would get obscured by style fixes. 

I also disabled `LineLength` check in general config as 100 chars limit is problematic.