### PR TITLE
Remove animated icons

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   analyze_sources:
-    name: "Is there anything to lint?"
+    name: "Is there any Java source code to lint?"
     runs-on: ubuntu-latest
 
     outputs:
@@ -94,7 +94,10 @@ jobs:
         # Starting from 8.28, default checkstyle config looks for optional checkstyle-suppressions.xml
         # (See https://github.com/checkstyle/checkstyle/issues/6946) so we just need to link ours
         # (as it looks for it in CWD) and that should be sufficient.
-        ln -s config/checkstyle/suppressions.xml checkstyle-suppressions.xml
+        supp_file="config/checkstyle/suppressions-dev.xml"
+        # safe fall back to non-dev file if -dev version is removed
+        [[ -f "${supp_file}" ]] || supp_file="config/checkstyle/suppressions.xml"
+        ln -s "${supp_file}" checkstyle-suppressions.xml
 
         # Let's lint eventually...
         checkstyle -o "${REPORT_FILE}" -c "${CHECKS_FILE}" ${{ needs.analyze_sources.outputs.changed_files }}

--- a/config/checkstyle/suppressions-dev.xml
+++ b/config/checkstyle/suppressions-dev.xml
@@ -8,6 +8,7 @@
     <suppress checks="MissingJavadocType"/>
     <suppress checks="JavadocParagraph"/>
     <suppress checks="NeedBraces"/>
+    <suppress checks="LineLength"/>
 
     <suppress checks="LocalVariableName"/>
     <suppress checks="ParameterName"/>
@@ -26,7 +27,6 @@
     <suppress checks="SummaryJavadoc"/>
     <suppress checks="OverloadMethodsDeclarationOrder"/>
     <suppress checks="CustomImportOrder"/>
-    <suppress checks="LineLength"/>
     <suppress checks="SingleLineJavadoc"/>
     <suppress checks="FallThrough"/>
 

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -8,6 +8,7 @@
     <suppress checks="MissingJavadocType"/>
     <suppress checks="JavadocParagraph"/>
     <suppress checks="NeedBraces"/>
+    <suppress checks="LineLength"/>
 
     <!-- Auto-generated file. https://github.com/logisim-evolution/logisim-evolution/issues/563-->
 	<suppress id="VhdlSyntax" files="src/main/java/com/cburch/logisim/vhdl/syntax/VhdlSyntax.java"/>

--- a/src/main/java/com/cburch/draw/icons/DrawCurveIcon.java
+++ b/src/main/java/com/cburch/draw/icons/DrawCurveIcon.java
@@ -28,58 +28,33 @@
 
 package com.cburch.draw.icons;
 
-import com.cburch.logisim.gui.icons.AnimatedIcon;
+import com.cburch.logisim.gui.icons.BaseIcon;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.geom.GeneralPath;
 
-public class DrawCurveIcon extends AnimatedIcon {
-
-  private int states = 5;
+public class DrawCurveIcon extends BaseIcon {
 
   @Override
-  @SuppressWarnings("fallthrough")
-  protected void paintIcon(Graphics2D g2) {
-    int wh = scale(3);
-    g2.setStroke(new BasicStroke(scale(1)));
-    g2.setColor(Color.GRAY);
-    switch (states) {
-      case 5:
-      case 4:
-        g2.drawRect(scale(9), scale(0), wh, wh);
-        // fall through
-      case 3:
-        g2.setStroke(new BasicStroke(scale(2)));
-        if (states > 4) {
-          g2.setColor(Color.BLUE.darker());
-          GeneralPath p = new GeneralPath();
-          p.moveTo(scale(1), scale(5));
-          p.quadTo(scale(10), scale(1), scale(14), scale(14));
-          g2.draw(p);
-        } else {
-          g2.setColor(Color.DARK_GRAY);
-          g2.drawLine(scale(1), scale(6), scale(14), scale(14));
-        }
-        // fall through
-      case 2:
-        g2.setColor(Color.GRAY);
-        g2.setStroke(new BasicStroke(scale(1)));
-        g2.drawRect(scale(13), scale(13), wh, wh);
-        // fall through
-      case 1:
-        g2.drawRect(scale(0), scale(5), wh, wh);
-    }
-  }
+  protected void paintIcon(Graphics2D gfx) {
+    final var wh = scale(3);
+    gfx.setStroke(new BasicStroke(scale(1)));
+    gfx.setColor(Color.GRAY);
 
-  @Override
-  public void animationUpdate() {
-    states++;
-    states %= 6;
-  }
+    gfx.drawRect(scale(9), scale(0), wh, wh);
 
-  @Override
-  public void resetToStatic() {
-    states = 5;
+    gfx.setStroke(new BasicStroke(scale(2)));
+    gfx.setColor(Color.BLUE.darker());
+
+    final var p = new GeneralPath();
+    p.moveTo(scale(1), scale(5));
+    p.quadTo(scale(10), scale(1), scale(14), scale(14));
+    gfx.draw(p);
+
+    gfx.setColor(Color.GRAY);
+    gfx.setStroke(new BasicStroke(scale(1)));
+    gfx.drawRect(scale(13), scale(13), wh, wh);
+    gfx.drawRect(scale(0), scale(5), wh, wh);
   }
 }

--- a/src/main/java/com/cburch/draw/icons/DrawLineIcon.java
+++ b/src/main/java/com/cburch/draw/icons/DrawLineIcon.java
@@ -28,45 +28,29 @@
 
 package com.cburch.draw.icons;
 
-import com.cburch.logisim.gui.icons.AnimatedIcon;
+import com.cburch.logisim.gui.icons.BaseIcon;
 import com.cburch.logisim.prefs.AppPreferences;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 
-public class DrawLineIcon extends AnimatedIcon {
-
-  private int state = 3;
+public class DrawLineIcon extends BaseIcon {
 
   @Override
-  @SuppressWarnings("fallthrough")
-  protected void paintIcon(Graphics2D g2) {
-    g2.setColor(Color.GRAY);
-    g2.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
-    int wh = AppPreferences.getScaled(3);
-    switch (state) {
-      case 3:
-        g2.setStroke(new BasicStroke(scale(2)));
-        g2.setColor(Color.BLUE.darker());
-        g2.drawLine(scale(1), scale(14), scale(14), scale(1));
-        // fall through
-      case 2:
-        g2.setColor(Color.GRAY);
-        g2.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
-        g2.drawRect(scale(13), 0, wh, wh);
-        // fall through
-      case 1:
-        g2.drawRect(0, scale(13), wh, wh);
-    }
+  protected void paintIcon(Graphics2D gfx) {
+    gfx.setColor(Color.GRAY);
+    gfx.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
+    final var wh = AppPreferences.getScaled(3);
+
+    gfx.setStroke(new BasicStroke(scale(2)));
+    gfx.setColor(Color.BLUE.darker());
+    gfx.drawLine(scale(1), scale(14), scale(14), scale(1));
+
+    gfx.setColor(Color.GRAY);
+    gfx.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
+    gfx.drawRect(scale(13), 0, wh, wh);
+
+    gfx.drawRect(0, scale(13), wh, wh);
   }
 
-  @Override
-  public void animationUpdate() {
-    state = (state + 1) & 3;
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = 3;
-  }
 }

--- a/src/main/java/com/cburch/draw/icons/DrawPolylineIcon.java
+++ b/src/main/java/com/cburch/draw/icons/DrawPolylineIcon.java
@@ -28,53 +28,42 @@
 
 package com.cburch.draw.icons;
 
-import com.cburch.logisim.gui.icons.AnimatedIcon;
+import com.cburch.logisim.gui.icons.BaseIcon;
 import com.cburch.logisim.prefs.AppPreferences;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.geom.GeneralPath;
 
-public class DrawPolylineIcon extends AnimatedIcon {
+public class DrawPolylineIcon extends BaseIcon {
 
   private static final int[] points = {1, 14, 1, 1, 7, 8, 13, 4, 10, 13};
-  private boolean closed = false;
-  private int state = points.length;
+  private boolean isPolylineClosed = false;
 
   public DrawPolylineIcon(boolean closed) {
-    this.closed = closed;
+    this.isPolylineClosed = closed;
   }
 
   @Override
-  protected void paintIcon(Graphics2D g2) {
-    g2.setStroke(new BasicStroke(AppPreferences.getScaled(2)));
-    g2.setColor(Color.BLUE.darker());
-    GeneralPath p = new GeneralPath();
-    p.moveTo(AppPreferences.getScaled(points[0]), AppPreferences.getScaled(points[1]));
-    for (int i = 2; i < state - 1; i += 2)
+  protected void paintIcon(Graphics2D gfx) {
+    gfx.setStroke(new BasicStroke(AppPreferences.getScaled(2)));
+    gfx.setColor(Color.BLUE.darker());
+    final var p = new GeneralPath();
+    var i = 0;
+    p.moveTo(AppPreferences.getScaled(points[i++]), AppPreferences.getScaled(points[i++]));
+    for (; i < points.length - 1; i += 2) {
       p.lineTo(AppPreferences.getScaled(points[i]), AppPreferences.getScaled(points[i + 1]));
-    if (closed && state == points.length) p.closePath();
-    g2.draw(p);
-    g2.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
-    g2.setColor(Color.GRAY);
-    int wh = AppPreferences.getScaled(3);
-    for (int i = 0; i <= state - 1; i += 2)
-      g2.drawRect(
+    }
+    if (isPolylineClosed) p.closePath();
+    gfx.draw(p);
+    gfx.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
+    gfx.setColor(Color.GRAY);
+    final var wh = AppPreferences.getScaled(3);
+    for (i = 0; i <= points.length - 1; i += 2)
+      gfx.drawRect(
           AppPreferences.getScaled(points[i] - 1),
           AppPreferences.getScaled(points[i + 1] - 1),
           wh,
           wh);
-  }
-
-  @Override
-  public void animationUpdate() {
-    state++;
-    if (state == 2) state++;
-    state %= (points.length + 1);
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = points.length;
   }
 }

--- a/src/main/java/com/cburch/draw/icons/DrawShapeIcon.java
+++ b/src/main/java/com/cburch/draw/icons/DrawShapeIcon.java
@@ -28,51 +28,56 @@
 
 package com.cburch.draw.icons;
 
-import com.cburch.logisim.gui.icons.AnimatedIcon;
+import com.cburch.logisim.gui.icons.BaseIcon;
 import com.cburch.logisim.prefs.AppPreferences;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 
-public class DrawShapeIcon extends AnimatedIcon {
+public class DrawShapeIcon extends BaseIcon {
 
   public static final int RECTANGLE = 0;
-  public static final int ROUNDEDRECTANGLE = 1;
+  public static final int ROUNDED_RECTANGLE = 1;
   public static final int ELIPSE = 2;
+
   private static final int[] points = {3, 2, 8, 4, 14, 8};
-  private final int type;
-  private int state;
+  private final int shapeType;
 
   public DrawShapeIcon(int type) {
-    this.type = type;
-    state = 3;
+    this.shapeType = type;
   }
 
   @Override
-  protected void paintIcon(Graphics2D g2) {
-    if (state == 0) return;
-    g2.setStroke(new BasicStroke(AppPreferences.getScaled(2)));
-    g2.setColor(Color.BLUE.darker());
-    int x = scale(1);
-    int y = scale(3);
-    int width = scale(points[(state - 1) * 2]);
-    int height = scale(points[(state - 1) * 2 + 1]);
-    if (type == RECTANGLE) g2.drawRect(x, y, width, height);
-    else if (type == ROUNDEDRECTANGLE) g2.drawRoundRect(x, y, width, height, y, y);
-    else g2.drawOval(x, y, width, height);
-    g2.setColor(Color.GRAY);
-    g2.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
-    g2.drawRect(0, y - x, y, y);
-    g2.drawRect(width - x, y + height - x, y, y);
+  protected void paintIcon(Graphics2D gfx) {
+    final var state = 3;
+
+    gfx.setStroke(new BasicStroke(AppPreferences.getScaled(2)));
+    final var x = scale(1);
+    final var y = scale(3);
+    final var width = scale(points[(state - 1) * 2]);
+    final var height = scale(points[(state - 1) * 2 + 1]);
+
+    switch (shapeType) {
+      case RECTANGLE:
+        gfx.setColor(Color.BLUE.darker());
+        gfx.drawRect(x, y, width, height);
+        break;
+      case ROUNDED_RECTANGLE:
+        gfx.setColor(Color.RED.darker());
+        // FIXME: rounded rect shape looks almost as regular rectangle on smaller zoom factor
+        gfx.drawRoundRect(x, y, width, height, y, y);
+        break;
+      case ELIPSE:
+      default:
+        gfx.setColor(Color.BLUE);
+        gfx.drawOval(x, y, width, height);
+        break;
+    }
+
+    gfx.setColor(Color.GRAY);
+    gfx.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
+    gfx.drawRect(0, y - x, y, y);
+    gfx.drawRect(width - x, y + height - x, y, y);
   }
 
-  @Override
-  public void animationUpdate() {
-    state = (state + 1) & 3;
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = 3;
-  }
 }

--- a/src/main/java/com/cburch/draw/tools/RoundRectangleTool.java
+++ b/src/main/java/com/cburch/draw/tools/RoundRectangleTool.java
@@ -68,6 +68,6 @@ public class RoundRectangleTool extends RectangularTool {
 
   @Override
   public Icon getIcon() {
-    return new DrawShapeIcon(DrawShapeIcon.ROUNDEDRECTANGLE);
+    return new DrawShapeIcon(DrawShapeIcon.ROUNDED_RECTANGLE);
   }
 }

--- a/src/main/java/com/cburch/logisim/fpga/data/IOComponentTypes.java
+++ b/src/main/java/com/cburch/logisim/fpga/data/IOComponentTypes.java
@@ -31,7 +31,7 @@ package com.cburch.logisim.fpga.data;
 import static com.cburch.logisim.fpga.Strings.S;
 
 import com.cburch.logisim.std.io.DipSwitch;
-import com.cburch.logisim.std.io.RGBLed;
+import com.cburch.logisim.std.io.RgbLed;
 import com.cburch.logisim.std.io.ReptarLocalBus;
 import java.util.EnumSet;
 
@@ -140,7 +140,7 @@ public enum IOComponentTypes {
       case SevenSegment:
         return com.cburch.logisim.std.io.SevenSegment.getOutputLabel(id);
       case RGBLED:
-        return RGBLed.getLabel(id);
+        return RgbLed.getLabel(id);
       case LocalBus:
         return ReptarLocalBus.getOutputLabel(id);
       default:

--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceToolbarModel.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceToolbarModel.java
@@ -51,8 +51,7 @@ class AppearanceToolbarModel extends AbstractToolbarModel implements PropertyCha
   private final Canvas canvas;
   private final List<ToolbarItem> items;
 
-  public AppearanceToolbarModel(
-      AbstractTool selectTool, ShowStateTool ssTool, Canvas canvas, DrawingAttributeSet attrs) {
+  public AppearanceToolbarModel(AbstractTool selectTool, ShowStateTool showStateTool, Canvas canvas, DrawingAttributeSet attrs) {
     this.canvas = canvas;
 
     AbstractTool[] tools = {
@@ -67,11 +66,11 @@ class AppearanceToolbarModel extends AbstractToolbarModel implements PropertyCha
       new PolyTool(true, attrs),
     };
 
-    ArrayList<ToolbarItem> rawItems = new ArrayList<>();
-    for (AbstractTool tool : tools) {
+    final var rawItems = new ArrayList<ToolbarItem>();
+    for (final var tool : tools) {
       rawItems.add(new ToolbarToolItem(tool));
     }
-    rawItems.add(ssTool);
+    rawItems.add(showStateTool);
     items = Collections.unmodifiableList(rawItems);
     canvas.addPropertyChangeListener(Canvas.TOOL_PROPERTY, this);
   }
@@ -105,6 +104,7 @@ class AppearanceToolbarModel extends AbstractToolbarModel implements PropertyCha
     }
   }
 
+  @Override
   public void propertyChange(PropertyChangeEvent e) {
     String prop = e.getPropertyName();
     if (Canvas.TOOL_PROPERTY.equals(prop)) {

--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceView.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceView.java
@@ -58,10 +58,10 @@ public class AppearanceView {
 
   public AppearanceView() {
     attrs = new DrawingAttributeSet();
-    SelectTool selectTool = new SelectTool();
+    final var selectTool = new SelectTool();
     canvas = new AppearanceCanvas(selectTool);
     canvasPane = new CanvasPane(canvas);
-    ShowStateTool ssTool = new ShowStateTool(this, canvas, attrs);
+    final var ssTool = new ShowStateTool(this, canvas, attrs);
     toolbarModel = new AppearanceToolbarModel(selectTool, ssTool, canvas, attrs);
     zoomModel =
         new BasicZoomModel(
@@ -84,7 +84,7 @@ public class AppearanceView {
   }
 
   public AttrTableDrawManager getAttrTableDrawManager(AttrTable table) {
-    AttrTableDrawManager ret = attrTableManager;
+    var ret = attrTableManager;
     if (ret == null) {
       ret = new AttrTableDrawManager(canvas, table, attrs);
       attrTableManager = ret;

--- a/src/main/java/com/cburch/logisim/gui/appear/LayoutThumbnail.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/LayoutThumbnail.java
@@ -28,7 +28,6 @@
 
 package com.cburch.logisim.gui.appear;
 
-import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.CircuitState;
 import com.cburch.logisim.circuit.appear.AppearancePort;
 import com.cburch.logisim.circuit.appear.DynamicElement;
@@ -37,7 +36,7 @@ import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.std.io.Led;
-import com.cburch.logisim.std.io.RGBLed;
+import com.cburch.logisim.std.io.RgbLed;
 import com.cburch.logisim.std.wiring.Pin;
 import com.cburch.logisim.util.GraphicsUtil;
 import java.awt.Color;
@@ -126,7 +125,7 @@ public class LayoutThumbnail extends JComponent {
           int y = b.getY();
           int w = b.getWidth();
           int h = b.getHeight();
-          if (elt.getFactory() instanceof Led || elt.getFactory() instanceof RGBLed) {
+          if (elt.getFactory() instanceof Led || elt.getFactory() instanceof RgbLed) {
             gfxCopy.drawOval(x, y, w, h);
           } else {
             gfxCopy.drawRect(x, y, w, h);

--- a/src/main/java/com/cburch/logisim/gui/icons/AbstractIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/AbstractIcon.java
@@ -28,45 +28,9 @@
 
 package com.cburch.logisim.gui.icons;
 
-import com.cburch.logisim.prefs.AppPreferences;
-import java.awt.BasicStroke;
-import java.awt.Component;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import javax.swing.Icon;
+/**
+ * @deprecated Extend BaseIcon class instead.
+ */
+public abstract class AbstractIcon extends BaseIcon {
 
-public abstract class AbstractIcon implements Icon {
-
-  public static int scale(int v) {
-    return AppPreferences.getScaled(v);
-  }
-
-  public static double scale(double v) {
-    return AppPreferences.getScaled(v);
-  }
-
-  public static float scale(float v) {
-    return AppPreferences.getScaled(v);
-  }
-
-  @Override
-  public void paintIcon(Component c, Graphics g, int x, int y) {
-    Graphics2D g2 = (Graphics2D) g.create();
-    g2.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
-    g2.translate(x, y);
-    paintIcon(g2);
-    g2.dispose();
-  }
-
-  protected abstract void paintIcon(Graphics2D g2);
-
-  @Override
-  public int getIconWidth() {
-    return AppPreferences.getIconSize();
-  }
-
-  @Override
-  public int getIconHeight() {
-    return AppPreferences.getIconSize();
-  }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/AbstractIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/AbstractIcon.java
@@ -29,6 +29,8 @@
 package com.cburch.logisim.gui.icons;
 
 /**
+ * Base class for animated icons.
+ *
  * @deprecated Extend BaseIcon class instead.
  */
 public abstract class AbstractIcon extends BaseIcon {

--- a/src/main/java/com/cburch/logisim/gui/icons/AnimatedIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/AnimatedIcon.java
@@ -37,6 +37,9 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import javax.swing.Icon;
 
+/**
+ * @deprecated AnimatedIcon class is deprecated and will be removed in next release. Icons MUST now extend AbstractIcon class.
+ */
 public abstract class AnimatedIcon implements Icon, AnimationListener {
 
   public AnimatedIcon() {

--- a/src/main/java/com/cburch/logisim/gui/icons/AnimationTimer.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/AnimationTimer.java
@@ -84,15 +84,21 @@ public class AnimationTimer extends TimerTask implements PropertyChangeListener 
   }
 
   /**
+   * AnimationListener.
+   *
    * @deprecated AnimatedIcon class is deprecated and will be removed in next release.
    */
   public interface AnimationListener {
     /**
+     * animationUpdate.
+     *
      * @deprecated AnimatedIcon class is deprecated and will be removed in next release.
      */
     void animationUpdate();
 
     /**
+     * resetToStatic.
+     *
      * @deprecated AnimatedIcon class is deprecated and will be removed in next release.
      */
     void resetToStatic();

--- a/src/main/java/com/cburch/logisim/gui/icons/AnimationTimer.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/AnimationTimer.java
@@ -83,9 +83,18 @@ public class AnimationTimer extends TimerTask implements PropertyChangeListener 
     }
   }
 
+  /**
+   * @deprecated AnimatedIcon class is deprecated and will be removed in next release.
+   */
   public interface AnimationListener {
+    /**
+     * @deprecated AnimatedIcon class is deprecated and will be removed in next release.
+     */
     void animationUpdate();
 
+    /**
+     * @deprecated AnimatedIcon class is deprecated and will be removed in next release.
+     */
     void resetToStatic();
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/AppearEditIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/AppearEditIcon.java
@@ -34,7 +34,7 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.geom.GeneralPath;
 
-public class AppearEditIcon extends AbstractIcon {
+public class AppearEditIcon extends BaseIcon {
 
   private final int[] tip = {0, 14, 1, 15, 0, 15};
   private final int[] body = {0, 13, 13, 0, 15, 2, 2, 15};

--- a/src/main/java/com/cburch/logisim/gui/icons/ArithmeticIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ArithmeticIcon.java
@@ -34,7 +34,7 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
 
-public class ArithmeticIcon extends AbstractIcon {
+public class ArithmeticIcon extends BaseIcon {
 
   private final String opp;
   private boolean invalid;

--- a/src/main/java/com/cburch/logisim/gui/icons/BaseIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/BaseIcon.java
@@ -33,25 +33,50 @@ import java.awt.BasicStroke;
 import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import javax.swing.Icon;
 
-public abstract class BaseIcon implements Icon {
+public abstract class BaseIcon implements javax.swing.Icon {
 
-  public static int scale(int v) {
-    return AppPreferences.getScaled(v);
+  /**
+   * Returns value scaled by user selected scaling zoom-factor (Window->Zoom Factor).
+   *
+   * @param val Value to scale by user selected zoom-factor.
+   * @return Returns scaled value.
+   */
+  public int scale(int val) {
+    return AppPreferences.getScaled(val);
   }
 
-  public static double scale(double v) {
-    return AppPreferences.getScaled(v);
+  /**
+   * Returns value scaled by user selected scaling zoom-factor (Window->Zoom Factor).
+   *
+   * @param val Value to scale by user selected zoom-factor.
+   * @return Returns scaled value.
+   */
+  public double scale(double val) {
+    return AppPreferences.getScaled(val);
   }
 
-  public static float scale(float v) {
-    return AppPreferences.getScaled(v);
+  /**
+   * Returns value scaled by user selected scaling zoom-factor (Window->Zoom Factor).
+   *
+   * @param val Value to scale by user selected zoom-factor.
+   * @return Returns scaled value.
+   */
+  public float scale(float val) {
+    return AppPreferences.getScaled(val);
   }
 
+  /**
+   * Paints the icon image.
+   *
+   * @param comp Component
+   * @param gfx Instance of java.awt.Graphics
+   * @param x Starting X coordinate.
+   * @param y Starting Y coordinate.
+   */
   @Override
-  public void paintIcon(Component c, Graphics g, int x, int y) {
-    Graphics2D g2 = (Graphics2D) g.create();
+  public void paintIcon(Component comp, Graphics gfx, int x, int y) {
+    Graphics2D g2 = (Graphics2D) gfx.create();
     g2.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
     g2.translate(x, y);
     paintIcon(g2);
@@ -60,11 +85,21 @@ public abstract class BaseIcon implements Icon {
 
   protected abstract void paintIcon(Graphics2D g2);
 
+  /**
+   * Calculates icon width to match current user zoom scale factor.
+   *
+   * @return Icon width as calculated according to user zoom scale factor.
+   */
   @Override
   public int getIconWidth() {
     return AppPreferences.getIconSize();
   }
 
+  /**
+   * Calculates icon height to match current user zoom scale factor.
+   *
+   * @return Icon width as calculated according to user zoom scale factor.
+   */
   @Override
   public int getIconHeight() {
     return AppPreferences.getIconSize();

--- a/src/main/java/com/cburch/logisim/gui/icons/BaseIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/BaseIcon.java
@@ -28,36 +28,45 @@
 
 package com.cburch.logisim.gui.icons;
 
-import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.prefs.AppPreferences;
-import java.awt.Color;
+import java.awt.BasicStroke;
+import java.awt.Component;
+import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.geom.GeneralPath;
+import javax.swing.Icon;
 
-public class FatArrowIcon extends BaseIcon {
+public abstract class BaseIcon implements Icon {
 
-  private static final int[] points = {2, 7, 7, 2, 12, 7, 9, 7, 9, 12, 5, 12, 5, 7};
-  private final Direction dir;
+  public static int scale(int v) {
+    return AppPreferences.getScaled(v);
+  }
 
-  public FatArrowIcon(Direction dir) {
-    this.dir = dir;
+  public static double scale(double v) {
+    return AppPreferences.getScaled(v);
+  }
+
+  public static float scale(float v) {
+    return AppPreferences.getScaled(v);
   }
 
   @Override
-  protected void paintIcon(Graphics2D g2) {
-    g2.translate(AppPreferences.getScaled(7), AppPreferences.getScaled(7));
-    if (dir.equals(Direction.WEST)) g2.rotate((6 * Math.PI) / 4);
-    else if (dir.equals(Direction.SOUTH)) g2.rotate(Math.PI);
-    else if (dir.equals(Direction.EAST)) g2.rotate(Math.PI / 2);
-    g2.translate(-AppPreferences.getScaled(7), -AppPreferences.getScaled(7));
-    g2.setColor(Color.blue);
-    GeneralPath path = new GeneralPath();
-    path.moveTo(AppPreferences.getScaled(points[0]), AppPreferences.getScaled(points[1]));
-    for (int i = 2; i < points.length; i += 2)
-      path.lineTo(AppPreferences.getScaled(points[i]), AppPreferences.getScaled(points[i + 1]));
-    path.closePath();
-    g2.fill(path);
-    g2.setColor(Color.blue.darker());
-    g2.draw(path);
+  public void paintIcon(Component c, Graphics g, int x, int y) {
+    Graphics2D g2 = (Graphics2D) g.create();
+    g2.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
+    g2.translate(x, y);
+    paintIcon(g2);
+    g2.dispose();
+  }
+
+  protected abstract void paintIcon(Graphics2D g2);
+
+  @Override
+  public int getIconWidth() {
+    return AppPreferences.getIconSize();
+  }
+
+  @Override
+  public int getIconHeight() {
+    return AppPreferences.getIconSize();
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/ButtonIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ButtonIcon.java
@@ -28,55 +28,29 @@
 
 package com.cburch.logisim.gui.icons;
 
-import com.cburch.logisim.data.Value;
-import com.cburch.logisim.util.StringGetter;
 import java.awt.Color;
-import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
 
-public class ButtonIcon extends AnimatedIcon {
-
-  private int state = 0;
-  private int index = 0;
-  private StringGetter name = null;
-
-  public ButtonIcon() {}
-
-  public ButtonIcon(StringGetter sg) {
-    name = sg;
-    index = 0;
-  }
-
-  @Override
-  public void animationUpdate() {
-    state = (state + 1) & 3;
-    if (name != null) {
-      index = (index + 1) % name.toString().length();
-    }
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = 0;
-    index = 0;
-  }
+public class ButtonIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {
-    int wh = scale(12);
-    int x = scale(state);
-    int y = scale(11) + scale(state);
-    int[] xpos = {x, x + wh, scale(14), scale(3)};
-    int[] ypos = {y, y, scale(14), scale(14)};
+    final int state = 0;
+
+    final var wh = scale(12);
+    var x = scale(state);
+    var y = scale(11) + scale(state);
+    final int[] xpos = {x, x + wh, scale(14), scale(3)};
+    final int[] ypos = {y, y, scale(14), scale(14)};
     g2.setColor(Color.LIGHT_GRAY);
     g2.fillPolygon(xpos, ypos, 4);
     g2.setColor(Color.BLACK);
     g2.drawPolygon(xpos, ypos, 4);
     x = wh + scale(state);
     y = scale(state);
-    int[] xpos1 = {x, x, scale(14), scale(14)};
-    int[] ypos1 = {y, y + wh, scale(14), scale(3)};
+    final int[] xpos1 = {x, x, scale(14), scale(14)};
+    final int[] ypos1 = {y, y + wh, scale(14), scale(3)};
     g2.setColor(Color.LIGHT_GRAY);
     g2.fillPolygon(xpos1, ypos1, 4);
     g2.setColor(Color.BLACK);
@@ -85,21 +59,12 @@ public class ButtonIcon extends AnimatedIcon {
     g2.fillRect(scale(state), scale(state), wh, wh);
     g2.setColor(Color.BLACK);
     g2.drawRect(scale(state), scale(state), wh, wh);
-    if (name == null) {
-      g2.setColor(state == 3 ? Value.TRUE_COLOR : Value.FALSE_COLOR);
-      g2.fillOval(scale(13), scale(7), scale(3), scale(3));
-      g2.drawOval(scale(13), scale(7), scale(3), scale(3));
-    } else {
-      String s = name.toString();
-      if (index >= s.length()) index = 0;
-      Font f = g2.getFont().deriveFont((float) wh);
-      TextLayout t = new TextLayout(s.substring(index, index + 1), f, g2.getFontRenderContext());
-      g2.setColor(Color.BLUE);
-      float center = scale(state) + wh / 2;
-      t.draw(
-          g2,
-          center - (float) t.getBounds().getCenterX(),
-          center - (float) t.getBounds().getCenterY());
-    }
+
+    final var s = "B";
+    final var f = g2.getFont().deriveFont((float) wh);
+    final var t = new TextLayout(s, f, g2.getFontRenderContext());
+    g2.setColor(Color.BLUE);
+    final var center = scale(state) + wh / 2;
+    t.draw(g2, center - (float) t.getBounds().getCenterX(), center - (float) t.getBounds().getCenterY());
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/CompileIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/CompileIcon.java
@@ -32,32 +32,28 @@ import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.util.GraphicsUtil;
 import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Font;
 import java.awt.Graphics2D;
 
-public class CompileIcon extends AbstractIcon {
+public class CompileIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {
-    int[] page = new int[] {0, 0, 0, 15, 15, 15, 15, 5, 10, 5, 10, 0, 15, 5, 10, 0, 0, 0};
+    final var page = new int[] {0, 0, 0, 15, 15, 15, 15, 5, 10, 5, 10, 0, 15, 5, 10, 0, 0, 0};
     g2.setColor(Color.BLACK);
     g2.setStroke(new BasicStroke(AppPreferences.getScaled(1F)));
-    int[] xpos = new int[9];
-    int[] ypos = new int[9];
-    for (int i = 0; i < 9; i++) {
+    final var xpos = new int[9];
+    final var ypos = new int[9];
+    for (var i = 0; i < 9; i++) {
       xpos[i] = AppPreferences.getScaled(page[i * 2]);
       ypos[i] = AppPreferences.getScaled(page[i * 2 + 1]);
     }
     g2.drawPolygon(xpos, ypos, 9);
-    Font f = g2.getFont();
+    final var f = g2.getFont();
     g2.setFont(f.deriveFont(AppPreferences.getScaled(4F)));
     g2.setColor(Color.BLUE);
-    GraphicsUtil.drawCenteredText(
-        g2, "j r9", AppPreferences.getScaled(7), AppPreferences.getScaled(3));
-    GraphicsUtil.drawCenteredText(
-        g2, "nop", AppPreferences.getScaled(7), AppPreferences.getScaled(7));
+    GraphicsUtil.drawCenteredText(g2, "j r9", AppPreferences.getScaled(7), AppPreferences.getScaled(3));
+    GraphicsUtil.drawCenteredText(g2, "nop", AppPreferences.getScaled(7), AppPreferences.getScaled(7));
     g2.setColor(Color.MAGENTA);
-    GraphicsUtil.drawCenteredText(
-        g2, "101..", AppPreferences.getScaled(7), AppPreferences.getScaled(11));
+    GraphicsUtil.drawCenteredText(g2, "101..", AppPreferences.getScaled(7), AppPreferences.getScaled(11));
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/DipswitchIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/DipswitchIcon.java
@@ -33,58 +33,29 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
 
-public class DipswitchIcon extends AnimatedIcon {
-
-  private int state = 0;
-
-  @Override
-  public void animationUpdate() {
-    state = (state + 1) & 3;
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = 0;
-  }
+public class DipswitchIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {
     g2.setColor(Color.BLUE);
     g2.fillRect(0, 0, getIconWidth(), getIconHeight());
-    final int w = scale(8);
-    final int h = scale(5);
+    final var w = scale(8);
+    final var h = scale(5);
     g2.setColor(Color.WHITE);
     Font f = g2.getFont().deriveFont((float) (getIconWidth() / 2.5));
     TextLayout t = new TextLayout("1", f, g2.getFontRenderContext());
-    t.draw(
-        g2,
+    t.draw(g2,
         (float) ((3 * getIconWidth()) / 4 - t.getBounds().getCenterX()),
         (float) (getIconHeight() / 4 - t.getBounds().getCenterY()));
     t = new TextLayout("2", f, g2.getFontRenderContext());
-    t.draw(
-        g2,
+    t.draw(g2,
         (float) ((3 * getIconWidth()) / 4 - t.getBounds().getCenterX()),
         (float) ((3 * getIconHeight()) / 4 - t.getBounds().getCenterY()));
     g2.fillRect(scale(2), scale(2), w, h);
     g2.fillRect(scale(2), scale(9), w, h);
     g2.setColor(Color.gray);
-    int x1;
-    int x2;
-    switch (state) {
-      case 0:
-        x1 = x2 = scale(2);
-        break;
-      case 1:
-        x1 = scale(2) + w >> 1;
-        x2 = scale(2);
-        break;
-      case 3:
-        x2 = scale(2) + w >> 1;
-        x1 = scale(2);
-        break;
-      default:
-        x1 = x2 = scale(2) + w >> 1;
-    }
+    final var x1 = scale(2) + w >> 1;
+    final var x2 = scale(2);
     g2.fillRect(x1, scale(2), w >> 1, h);
     g2.fillRect(x2, scale(9), w >> 1, h);
   }

--- a/src/main/java/com/cburch/logisim/gui/icons/FlipFlopIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/FlipFlopIcon.java
@@ -36,7 +36,7 @@ import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
 import java.awt.geom.GeneralPath;
 
-public class FlipFlopIcon extends AbstractIcon {
+public class FlipFlopIcon extends BaseIcon {
 
   public static final int D_FLIPFLOP = 0;
   public static final int T_FLIPFLOP = 1;

--- a/src/main/java/com/cburch/logisim/gui/icons/FlipFlopIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/FlipFlopIcon.java
@@ -31,7 +31,6 @@ package com.cburch.logisim.gui.icons;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.prefs.AppPreferences;
 import java.awt.Color;
-import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
 import java.awt.geom.GeneralPath;
@@ -52,13 +51,16 @@ public class FlipFlopIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {
-    if (AppPreferences.getDefaultAppearance().equals(StdAttr.APPEAR_CLASSIC)) paintClassicIcon(g2);
-    else paintEvolutionIcon(g2);
+    if (AppPreferences.getDefaultAppearance().equals(StdAttr.APPEAR_CLASSIC)) {
+      paintClassicIcon(g2);
+    } else {
+      paintEvolutionIcon(g2);
+    }
   }
 
   private void paintClassicIcon(Graphics2D g2) {
     g2.drawRect(scale(2), scale(2), scale(12), scale(12));
-    String str = "";
+    var str = "";
     switch (type) {
       case D_FLIPFLOP:
         str = "D";
@@ -75,13 +77,13 @@ public class FlipFlopIcon extends BaseIcon {
       case REGISTER:
         str = "00";
         break;
+      default:
+        // do nothing. Should not really happen.
+        break;
     }
-    Font f = g2.getFont().deriveFont((float) ((double) AppPreferences.getIconSize() / 2.1));
-    TextLayout l = new TextLayout(str, f, g2.getFontRenderContext());
-    l.draw(
-        g2,
-        (float) (getIconWidth() / 2 - l.getBounds().getCenterX()),
-        (float) (getIconHeight() / 2 - l.getBounds().getCenterY()));
+    final var f = g2.getFont().deriveFont((float) ((double) AppPreferences.getIconSize() / 2.1));
+    final var l = new TextLayout(str, f, g2.getFontRenderContext());
+    l.draw(g2, (float) (getIconWidth() / 2 - l.getBounds().getCenterX()), (float) (getIconHeight() / 2 - l.getBounds().getCenterY()));
   }
 
   private void paintEvolutionIcon(Graphics2D g2) {
@@ -92,14 +94,15 @@ public class FlipFlopIcon extends BaseIcon {
     g2.drawRect(scale(4), 0, scale(8), scale(16));
     g2.drawLine(scale(0), scale(3), scale(4), scale(3));
     g2.drawLine(scale(12), scale(3), scale(15), scale(3));
-    if (type == JK_FLIPFLOP || type == SR_FLIPFLOP)
+    if (type == JK_FLIPFLOP || type == SR_FLIPFLOP) {
       g2.drawLine(scale(0), scale(7), scale(4), scale(7));
+    }
     g2.drawLine(scale(0), scale(12), scale(4), scale(12));
-    int[] xp = {scale(4), scale(7), scale(4)};
-    int[] yp = {scale(11), scale(12), scale(13)};
+    final int[] xp = {scale(4), scale(7), scale(4)};
+    final int[] yp = {scale(11), scale(12), scale(13)};
     g2.drawPolygon(xp, yp, 3);
     g2.drawOval(scale(12), scale(10), scale(4), scale(4));
-    GeneralPath p = new GeneralPath();
+    final var p = new GeneralPath();
     switch (type) {
       case D_FLIPFLOP:
         p.moveTo(scale(7), scale(5));
@@ -133,19 +136,22 @@ public class FlipFlopIcon extends BaseIcon {
         p.quadTo(scale(9), scale(7), scale(7), scale(8));
         p.lineTo(scale(8), scale(9));
         break;
+      default:
+        // do nothing. Should not really happen.
+        break;
     }
     g2.draw(p);
   }
 
   private void paintRegisterIcon(Graphics2D g2) {
-    for (int i = 2; i >= 0; i--) {
+    for (var i = 2; i >= 0; i--) {
       g2.setColor(Color.WHITE);
       g2.fillRect(scale((i + 1) * 2), scale(4 - i * 2), scale(8), scale(12));
       g2.setColor(Color.BLACK);
       g2.drawRect(scale((i + 1) * 2), scale(4 - i * 2), scale(8), scale(12));
     }
-    int[] xp = {scale(2), scale(5), scale(2)};
-    int[] yp = {scale(11), scale(12), scale(13)};
+    final int[] xp = {scale(2), scale(5), scale(2)};
+    final int[] yp = {scale(11), scale(12), scale(13)};
     g2.drawPolygon(xp, yp, 3);
     g2.drawLine(scale(0), scale(12), scale(2), scale(12));
     g2.fillRect(0, scale(5), scale(2), scale(2));

--- a/src/main/java/com/cburch/logisim/gui/icons/HdlIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/HdlIcon.java
@@ -35,7 +35,7 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
 
-public class HdlIcon extends AbstractIcon {
+public class HdlIcon extends BaseIcon {
 
   private final String type;
 

--- a/src/main/java/com/cburch/logisim/gui/icons/JoystickIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/JoystickIcon.java
@@ -32,19 +32,9 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 
-public class JoystickIcon extends AnimatedIcon {
+public class JoystickIcon extends BaseIcon {
 
-  private int state = 0;
-
-  @Override
-  public void animationUpdate() {
-    state = (state + 1) % 6;
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = 0;
-  }
+  private int state = 1;
 
   @Override
   protected void paintIcon(Graphics2D g2) {
@@ -52,18 +42,15 @@ public class JoystickIcon extends AnimatedIcon {
     int[] xpos = {0, scale(6), scale(4), scale(2)};
     int[] ypos = {scale(13), scale(13), scale(15), scale(15)};
     g2.fillPolygon(xpos, ypos, 4);
-    for (int i = 0; i < 4; i++) xpos[i] += scale(10);
-    g2.fillPolygon(xpos, ypos, 4);
-    if ((state & 1) == 0) {
-      g2.setColor(Color.RED);
-      g2.fillRect(scale(2), scale(9), scale(4), scale(2));
+    for (int i = 0; i < 4; i++) {
+      xpos[i] += scale(10);
     }
-    int xbase = scale(9);
-    int ybase = scale(11);
-    int[] xcerc = {scale(9), scale(13), scale(9), scale(5), scale(2), scale(5)};
-    int[] ycerc = {scale(2), scale(3), scale(2), scale(3), scale(5), scale(3)};
-    int xtop = xcerc[state];
-    int ytop = ycerc[state];
+    g2.fillPolygon(xpos, ypos, 4);
+
+    final int xbase = scale(9);
+    final int ybase = scale(11);
+    var xtop = scale(13);
+    var ytop = scale(3);
     g2.setStroke(new BasicStroke(scale(2)));
     g2.setColor(Color.BLACK);
     g2.drawLine(xtop, ytop, xbase, ybase);

--- a/src/main/java/com/cburch/logisim/gui/icons/KeyboardIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/KeyboardIcon.java
@@ -28,51 +28,43 @@
 
 package com.cburch.logisim.gui.icons;
 
-import com.cburch.logisim.prefs.AppPreferences;
-import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.font.TextLayout;
 
-public class LEDIcon extends AnimatedIcon {
-
-  private final boolean isRgb;
-  private int showstate;
-
-  public LEDIcon(boolean isRgb) {
-    super();
-    this.isRgb = isRgb;
-    showstate = -1;
-  }
+public class KeyboardIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {
-    int xy = AppPreferences.getScaled(2);
-    int wh = AppPreferences.getScaled(12);
-    int r = (showstate & 1) == 1 ? 255 : 0;
-    int g = (showstate & 2) == 2 ? 255 : 0;
-    int b = (showstate & 4) == 4 ? 255 : 0;
-    Color c = (showstate >= 0) ? new Color(r, g, b) : Color.RED;
-    g2.setColor(c);
-    g2.fillOval(xy, xy, wh, wh);
-    if (isRgb && showstate < 0) {
-      g2.setColor(Color.GREEN);
-      g2.fillArc(xy, xy, wh, wh, 0, 120);
-      g2.setColor(Color.BLUE);
-      g2.fillArc(xy, xy, wh, wh, 120, 120);
-    }
+    final int state = 0;
+
+    final var wh = scale(12);
+    var x = scale(state);
+    var y = scale(11) + scale(state);
+    final int[] xpos = {x, x + wh, scale(14), scale(3)};
+    final int[] ypos = {y, y, scale(14), scale(14)};
+    g2.setColor(Color.LIGHT_GRAY);
+    g2.fillPolygon(xpos, ypos, 4);
     g2.setColor(Color.BLACK);
-    g2.setStroke(new BasicStroke(AppPreferences.getScaled(2)));
-    g2.drawOval(xy, xy, wh, wh);
-  }
+    g2.drawPolygon(xpos, ypos, 4);
+    x = wh + scale(state);
+    y = scale(state);
+    final int[] xpos1 = {x, x, scale(14), scale(14)};
+    final int[] ypos1 = {y, y + wh, scale(14), scale(3)};
+    g2.setColor(Color.LIGHT_GRAY);
+    g2.fillPolygon(xpos1, ypos1, 4);
+    g2.setColor(Color.BLACK);
+    g2.drawPolygon(xpos1, ypos1, 4);
+    g2.setColor(Color.WHITE);
+    g2.fillRect(scale(state), scale(state), wh, wh);
+    g2.setColor(Color.BLACK);
+    g2.drawRect(scale(state), scale(state), wh, wh);
 
-  @Override
-  public void animationUpdate() {
-    showstate++;
-    showstate %= isRgb ? 8 : 2;
-  }
-
-  @Override
-  public void resetToStatic() {
-    showstate = -1;
+    final var s = "K";
+    final var f = g2.getFont().deriveFont((float) wh);
+    final var t = new TextLayout(s, f, g2.getFontRenderContext());
+    g2.setColor(Color.BLUE);
+    final var center = scale(state) + wh / 2;
+    t.draw(g2, center - (float) t.getBounds().getCenterX(), center - (float) t.getBounds().getCenterY());
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/LedBarIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/LedBarIcon.java
@@ -22,50 +22,19 @@ package com.cburch.logisim.gui.icons;
 import java.awt.Color;
 import java.awt.Graphics2D;
 
-public class LedBarIcon extends AnimatedIcon {
-
-  private int state = 0;
-
-  @Override
-  public void animationUpdate() {
-    state = (state + 1) % 4;
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = 0;
-  }
+public class LedBarIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {
     g2.setColor(Color.DARK_GRAY);
     g2.fillRect(0, 0, getIconWidth(), getIconHeight());
 
-    Color col1;
-    Color col2;
-    switch (state) {
-      case 0:
-        col1 = Color.gray;
-        col2 = Color.gray;
-        break;
-      case 1:
-        col1 = Color.green;
-        col2 = Color.gray;
-        break;
-      case 3:
-        col1 = Color.gray;
-        col2 = Color.green;
-        break;
-      case 4:
-      default:
-        col1 = Color.green;
-        col2 = Color.green;
-        break;
-    }
+    final var col1 = Color.green;
+    final var col2 = Color.gray;
 
-    int y = scale(2);
-    int h = scale(12);
-    int w = scale(5);
+    final var y = scale(2);
+    final var h = scale(12);
+    final var w = scale(5);
     g2.setColor(col1);
     g2.fillRect(scale(2), y, w, h);
     g2.setColor(col2);

--- a/src/main/java/com/cburch/logisim/gui/icons/LedIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/LedIcon.java
@@ -28,38 +28,37 @@
 
 package com.cburch.logisim.gui.icons;
 
+import com.cburch.logisim.prefs.AppPreferences;
+import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
-import java.util.concurrent.ThreadLocalRandom;
 
-public class DiceIcon extends AnimatedIcon {
+public class LedIcon extends BaseIcon {
 
-  private int state = ThreadLocalRandom.current().nextInt(0, 6);
+  private final boolean isRgb;
 
-  @Override
-  public void animationUpdate() {
-    state = ThreadLocalRandom.current().nextInt(0, 6);
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = ThreadLocalRandom.current().nextInt(0, 6);
+  public LedIcon(boolean isRgb) {
+    super();
+    this.isRgb = isRgb;
   }
 
   @Override
   protected void paintIcon(Graphics2D g2) {
+    int xy = AppPreferences.getScaled(2);
+    int wh = AppPreferences.getScaled(12);
+    if (isRgb) {
+      g2.setColor(Color.GREEN);
+      g2.fillArc(xy, xy, wh, wh, 0, 120);
+      g2.setColor(Color.RED);
+      g2.fillArc(xy, xy, wh, wh, 120, 120);
+      g2.setColor(Color.BLUE);
+      g2.fillArc(xy, xy, wh, wh, 240, 120);
+    } else {
+      g2.setColor(Color.RED);
+      g2.fillOval(xy, xy, wh, wh);
+    }
     g2.setColor(Color.BLACK);
-    g2.drawRoundRect(0, 0, scale(16), scale(16), scale(5), scale(5));
-    if (state == 1 || state > 2) g2.fillOval(scale(2), scale(2), scale(3), scale(3));
-    if (state == 5) {
-      g2.fillOval(scale(2), scale(6), scale(3), scale(3));
-      g2.fillOval(scale(10), scale(6), scale(3), scale(3));
-    }
-    if (state == 0 || state == 4 || state == 2) g2.fillOval(scale(6), scale(6), scale(3), scale(3));
-    if (state > 1) {
-      g2.fillOval(scale(2), scale(10), scale(3), scale(3));
-      g2.fillOval(scale(10), scale(2), scale(3), scale(3));
-    }
-    if (state > 2 || state == 1) g2.fillOval(scale(10), scale(10), scale(3), scale(3));
+    g2.setStroke(new BasicStroke(AppPreferences.getScaled(2)));
+    g2.drawOval(xy, xy, wh, wh);
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/LedMatrixIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/LedMatrixIcon.java
@@ -45,7 +45,7 @@ public class LedMatrixIcon extends BaseIcon {
     final var yint = 1;
     for (var i = 0; i < 4; i++)
       for (var j = 0; j < 4; j++) {
-        g2.setColor((i == xint) && (j == yint) ? Color.GREEN.darker() : Color.GREEN.brighter().brighter());
+        g2.setColor((i == xint) && (j == yint) ? Color.RED.darker() : Color.GREEN.darker());
         g2.fillOval(scale(2 + i * 3), scale(2 + j * 3), scale(3), scale(3));
       }
   }

--- a/src/main/java/com/cburch/logisim/gui/icons/LedMatrixIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/LedMatrixIcon.java
@@ -32,32 +32,7 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 
-public class LedMatrixIcon extends AnimatedIcon {
-
-  private double dirX = 0.7;
-  private double dirY = 1;
-  private double x = 2;
-  private double y = 1;
-
-  @Override
-  public void animationUpdate() {
-    x += dirX;
-    if (x < 0 || x > 3.5) {
-      dirX = -dirX;
-      x += 2 * dirX;
-    }
-    y += dirY;
-    if (y < 0 || y > 3.5) {
-      dirY = -dirY;
-      y += 2 * dirY;
-    }
-  }
-
-  @Override
-  public void resetToStatic() {
-    x = 2;
-    y = 1;
-  }
+public class LedMatrixIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {
@@ -66,12 +41,11 @@ public class LedMatrixIcon extends AnimatedIcon {
     g2.fillRect(0, 0, scale(16), scale(16));
     g2.setColor(Color.BLACK);
     g2.drawRect(0, 0, scale(16), scale(16));
-    int xint = (int) x;
-    int yint = (int) y;
-    for (int i = 0; i < 4; i++)
-      for (int j = 0; j < 4; j++) {
-        g2.setColor(
-            (i == xint) && (j == yint) ? Color.GREEN.darker() : Color.GREEN.brighter().brighter());
+    final var xint = 2;
+    final var yint = 1;
+    for (var i = 0; i < 4; i++)
+      for (var j = 0; j < 4; j++) {
+        g2.setColor((i == xint) && (j == yint) ? Color.GREEN.darker() : Color.GREEN.brighter().brighter());
         g2.fillOval(scale(2 + i * 3), scale(2 + j * 3), scale(3), scale(3));
       }
   }

--- a/src/main/java/com/cburch/logisim/gui/icons/OpenSaveIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/OpenSaveIcon.java
@@ -56,8 +56,8 @@ public class OpenSaveIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {
-    var discCol = myType == FILE_SAVE_AS ? Color.GRAY : Color.BLUE;
-    Bounds bds = getScaled(2, 2, 12, 12);
+    final var discCol = myType == FILE_SAVE_AS ? Color.GRAY : Color.BLUE;
+    var bds = getScaled(2, 2, 12, 12);
     g2.setColor(discCol);
     g2.fillRect(bds.getX(), bds.getY(), bds.getWidth(), bds.getHeight());
     g2.setColor(Color.YELLOW);
@@ -91,6 +91,9 @@ public class OpenSaveIcon extends BaseIcon {
           ypoints[i] = AppPreferences.getScaled(Arrowdown[i * 2 + 1]);
         }
         g2.fillPolygon(xpoints, ypoints, 7);
+        break;
+      default:
+        // do nothing. should not really happen.
         break;
     }
   }

--- a/src/main/java/com/cburch/logisim/gui/icons/OpenSaveIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/OpenSaveIcon.java
@@ -33,7 +33,7 @@ import com.cburch.logisim.prefs.AppPreferences;
 import java.awt.Color;
 import java.awt.Graphics2D;
 
-public class OpenSaveIcon extends AbstractIcon {
+public class OpenSaveIcon extends BaseIcon {
 
   public static final int FILE_OPEN = 0;
   public static final int FILE_SAVE = 1;

--- a/src/main/java/com/cburch/logisim/gui/icons/PlexerIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/PlexerIcon.java
@@ -32,7 +32,7 @@ import com.cburch.logisim.data.Value;
 import java.awt.BasicStroke;
 import java.awt.Graphics2D;
 
-public class PlexerIcon extends AbstractIcon {
+public class PlexerIcon extends BaseIcon {
 
   private static final int[] xpos = {4, 4, 10, 10};
   private static final int[] ypos = {0, 14, 9, 5};

--- a/src/main/java/com/cburch/logisim/gui/icons/ProjectAddIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ProjectAddIcon.java
@@ -37,7 +37,7 @@ import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
 import java.awt.geom.GeneralPath;
 
-public class ProjectAddIcon extends AbstractIcon {
+public class ProjectAddIcon extends BaseIcon {
 
   private static final int[] points = {
     2, 6, 6, 6, 6, 2, 9, 2, 9, 6, 13, 6, 13, 9, 9, 9, 9, 13, 6, 13, 6, 9, 2, 9

--- a/src/main/java/com/cburch/logisim/gui/icons/RandomIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/RandomIcon.java
@@ -29,40 +29,28 @@
 package com.cburch.logisim.gui.icons;
 
 import java.awt.Color;
-import java.awt.Font;
 import java.awt.Graphics2D;
-import java.awt.font.TextLayout;
+import java.util.concurrent.ThreadLocalRandom;
 
-public class CounterIcon extends BaseIcon {
-
-  private int state = 1;
+public class RandomIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {
+    // zero count, so 4 means 5 on a dice face.
+    final int state = 4;
+
     g2.setColor(Color.BLACK);
-    g2.fillRect(scale(1), 0, scale(6), scale(16));
-    g2.fillRect(scale(9), 0, scale(6), scale(16));
-    g2.drawRect(scale(1), 0, scale(6), scale(16));
-    g2.drawRect(scale(9), 0, scale(6), scale(16));
-    Font f = g2.getFont().deriveFont(scale((float) 6));
-    int tens = state / 10;
-    int ones = state % 10;
-    g2.setColor(Color.WHITE);
-    for (int i = -1; i < 2; i++) {
-      int val = Math.abs((ones + i) % 10);
-      char c = (char) ('0' + val);
-      TextLayout t = new TextLayout(Character.toString(c), f, g2.getFontRenderContext());
-      float x = scale((float) 11.5) - (float) t.getBounds().getCenterX();
-      float y = scale((float) (8.5 + i * 7)) - (float) t.getBounds().getCenterY();
-      t.draw(g2, x, y);
+    g2.drawRoundRect(0, 0, scale(16), scale(16), scale(5), scale(5));
+    if (state == 1 || state > 2) g2.fillOval(scale(2), scale(2), scale(3), scale(3));
+    if (state == 5) {
+      g2.fillOval(scale(2), scale(6), scale(3), scale(3));
+      g2.fillOval(scale(10), scale(6), scale(3), scale(3));
     }
-    for (int i = -1; i < 2; i++) {
-      int val = Math.abs((tens + i) % 10);
-      char c = (char) ('0' + val);
-      TextLayout t = new TextLayout(Character.toString(c), f, g2.getFontRenderContext());
-      float x = scale((float) 3.5) - (float) t.getBounds().getCenterX();
-      float y = scale((float) (8.5 + i * 7)) - (float) t.getBounds().getCenterY();
-      t.draw(g2, x, y);
+    if (state == 0 || state == 4 || state == 2) g2.fillOval(scale(6), scale(6), scale(3), scale(3));
+    if (state > 1) {
+      g2.fillOval(scale(2), scale(10), scale(3), scale(3));
+      g2.fillOval(scale(10), scale(2), scale(3), scale(3));
     }
+    if (state > 2 || state == 1) g2.fillOval(scale(10), scale(10), scale(3), scale(3));
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/RunIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/RunIcon.java
@@ -32,7 +32,7 @@ import com.cburch.logisim.prefs.AppPreferences;
 import java.awt.Color;
 import java.awt.Graphics2D;
 
-public class RunIcon extends AbstractIcon {
+public class RunIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {

--- a/src/main/java/com/cburch/logisim/gui/icons/SelectIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/SelectIcon.java
@@ -31,7 +31,7 @@ package com.cburch.logisim.gui.icons;
 import com.cburch.logisim.prefs.AppPreferences;
 import java.awt.Graphics2D;
 
-public class SelectIcon extends AbstractIcon {
+public class SelectIcon extends BaseIcon {
 
   public static void paint(Graphics2D g2) {
     int[] xp = {3, 3, 7, 10, 11, 9, 14};

--- a/src/main/java/com/cburch/logisim/gui/icons/SevenSegmentIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/SevenSegmentIcon.java
@@ -33,30 +33,18 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 
-public class SevenSegmentIcon extends AnimatedIcon {
+public class SevenSegmentIcon extends BaseIcon {
 
   private final boolean isHexDisplay;
-  private int state;
 
   public SevenSegmentIcon(boolean isHexDisplay) {
     this.isHexDisplay = isHexDisplay;
-    state = (isHexDisplay) ? -1 : 3;
-  }
-
-  @Override
-  public void animationUpdate() {
-    state++;
-    state %= isHexDisplay ? 16 : 10;
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = isHexDisplay ? -1 : 3;
   }
 
   @Override
   protected void paintIcon(Graphics2D g2) {
-    int segson = HexDigit.getSegs(state);
+    // see HexDigit.getSegs()
+    int segson = HexDigit.getSegs(isHexDisplay ? 10 : 7);
     g2.setStroke(new BasicStroke(scale(2)));
     g2.setColor(Color.WHITE);
     g2.fillRect(scale(2), 0, scale(10), scale(16));

--- a/src/main/java/com/cburch/logisim/gui/icons/ShifterIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ShifterIcon.java
@@ -32,42 +32,29 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
-import java.util.concurrent.ThreadLocalRandom;
 
-public class ShifterIcon extends AnimatedIcon {
+public class ShifterIcon extends BaseIcon {
 
-  private int state = -1;
-
-  @Override
-  public void animationUpdate() {
-    state >>= 1;
-    int val = ThreadLocalRandom.current().nextInt(0, 2) << 2;
-    state = (state | val) & 7;
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = -1;
-  }
-
+  private int state = 2;
 
   @Override
   protected void paintIcon(Graphics2D g2) {
-    StringBuilder s = new StringBuilder();
-    if (state < 0) s.append("\u25b6" + "\u25b6" + "\u25b6");
-    else {
+    final var s = new StringBuilder();
+    if (state < 0) {
+      s.append("\u25b6" + "\u25b6" + "\u25b6");
+    } else {
       int mask = 4;
       while (mask > 0) {
         s.append((state & mask) == 0 ? "0" : "1");
         mask >>= 1;
       }
     }
-    Font f = g2.getFont().deriveFont(scale((float) 6)).deriveFont(Font.BOLD);
+    final var f = g2.getFont().deriveFont(scale((float) 6)).deriveFont(Font.BOLD);
     g2.setColor(Color.BLACK);
     g2.drawRect(0, scale(4), scale(16), scale(8));
-    TextLayout t = new TextLayout(s.toString(), f, g2.getFontRenderContext());
-    float x = scale((float) 8) - (float) t.getBounds().getCenterX();
-    float y = scale((float) 8) - (float) t.getBounds().getCenterY();
+    final var t = new TextLayout(s.toString(), f, g2.getFontRenderContext());
+    final var x = scale((float) 8) - (float) t.getBounds().getCenterX();
+    final var y = scale((float) 8) - (float) t.getBounds().getCenterY();
     t.draw(g2, x, y);
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/ShowStateIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ShowStateIcon.java
@@ -31,57 +31,41 @@ package com.cburch.logisim.gui.icons;
 import com.cburch.logisim.prefs.AppPreferences;
 import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
 
-public class ShowStateIcon extends AnimatedIcon {
+public class ShowStateIcon extends BaseIcon {
 
   private final boolean pressed;
-  private int state;
 
   public ShowStateIcon(boolean pressed) {
     this.pressed = pressed;
-    state = 5;
   }
 
   @Override
-  protected void paintIcon(Graphics2D g2) {
-    g2.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
+  protected void paintIcon(Graphics2D gfx) {
+    gfx.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
     if (pressed) {
-      g2.setColor(Color.MAGENTA.brighter().brighter().brighter());
-      g2.fillRect(0, 0, getIconWidth(), getIconHeight());
+      gfx.setColor(Color.MAGENTA.brighter().brighter().brighter());
+      gfx.fillRect(0, 0, getIconWidth(), getIconHeight());
     }
-    g2.setColor(Color.BLACK);
-    g2.drawRect(0, 0, getIconWidth(), getIconHeight() / 2);
-    Font f = g2.getFont().deriveFont((float) getIconWidth() / (float) 2);
-    StringBuilder str = new StringBuilder(Integer.toBinaryString(state));
-    while (str.length() < 3) {
-      str.insert(0, "0");
-    }
-    TextLayout l = new TextLayout(str.toString(), f, g2.getFontRenderContext());
-    l.draw(
-        g2,
-        (float) ((double) getIconWidth() / 2.0 - l.getBounds().getCenterX()),
-        (float) ((double) getIconHeight() / 4.0 - l.getBounds().getCenterY()));
-    int wh = AppPreferences.getScaled(AppPreferences.IconSize / 2 - AppPreferences.IconBorder);
-    int offset = AppPreferences.getScaled(AppPreferences.IconBorder);
-    g2.setColor((state & 4) != 0 ? Color.RED : Color.DARK_GRAY);
-    g2.fillOval(offset, offset + getIconHeight() / 2, wh, wh);
-    g2.setColor((state & 1) != 0 ? Color.GREEN : Color.DARK_GRAY);
-    g2.fillOval(offset + getIconWidth() / 2, offset + getIconHeight() / 2, wh, wh);
-    g2.setColor(Color.BLACK);
-    g2.drawOval(offset, offset + getIconHeight() / 2, wh, wh);
-    g2.drawOval(offset + getIconWidth() / 2, offset + getIconHeight() / 2, wh, wh);
-  }
-
-  @Override
-  public void animationUpdate() {
-    state = (state + 1) & 7;
-  }
-
-  @Override
-  public void resetToStatic() {
-    state = 5;
+    gfx.setColor(Color.BLACK);
+    gfx.drawRect(0, 0, getIconWidth(), getIconHeight() / 2);
+    final var font = gfx.getFont().deriveFont((float) getIconWidth() / (float) 2);
+    final var textLayout = new TextLayout("101", font, gfx.getFontRenderContext());
+    textLayout.draw(
+        gfx,
+        (float) ((double) getIconWidth() / 2.0 - textLayout.getBounds().getCenterX()),
+        (float) ((double) getIconHeight() / 4.0 - textLayout.getBounds().getCenterY()));
+    final var iconBorder = AppPreferences.IconBorder;
+    final var wh = AppPreferences.getScaled(AppPreferences.IconSize / 2 - iconBorder);
+    final var offset = AppPreferences.getScaled(iconBorder);
+    gfx.setColor(Color.RED);
+    gfx.fillOval(offset, offset + getIconHeight() / 2, wh, wh);
+    gfx.setColor(Color.GREEN);
+    gfx.fillOval(offset + getIconWidth() / 2, offset + getIconHeight() / 2, wh, wh);
+    gfx.setColor(Color.BLACK);
+    gfx.drawOval(offset, offset + getIconHeight() / 2, wh, wh);
+    gfx.drawOval(offset + getIconWidth() / 2, offset + getIconHeight() / 2, wh, wh);
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/SimulationIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/SimulationIcon.java
@@ -32,7 +32,7 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 
-public class SimulationIcon extends AbstractIcon {
+public class SimulationIcon extends BaseIcon {
 
   public static final int SIM_PLAY = 0;
   public static final int SIM_PAUSE = 1;

--- a/src/main/java/com/cburch/logisim/gui/icons/SimulationIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/SimulationIcon.java
@@ -55,13 +55,13 @@ public class SimulationIcon extends BaseIcon {
   @Override
   @SuppressWarnings("fallthrough")
   protected void paintIcon(Graphics2D g2) {
-    int wh = getIconWidth() - scale(1);
+    final var wh = getIconWidth() - scale(1);
     g2.setStroke(new BasicStroke(scale(1)));
     g2.setColor(currentType > SIM_STEP ? Color.LIGHT_GRAY : Color.WHITE);
     g2.fillOval(0, 0, wh, wh);
     if (currentType > SIM_STEP) {
       g2.setColor(Color.WHITE);
-      int wh1 = wh - scale(4);
+      final var wh1 = wh - scale(4);
       g2.fillOval(scale(2), scale(2), wh1, wh1);
       g2.setStroke(new BasicStroke(scale(2)));
       g2.setColor(Color.BLACK);
@@ -80,8 +80,8 @@ public class SimulationIcon extends BaseIcon {
         g2.drawRect(scale(10), scale(3), scale(1), scale(10));
         // fall through
       case SIM_PLAY:
-        int[] xpos = {scale(6), scale(10), scale(6)};
-        int[] ypos = {scale(3), scale(8), scale(13)};
+        final int[] xpos = {scale(6), scale(10), scale(6)};
+        final int[] ypos = {scale(3), scale(8), scale(13)};
         g2.setColor(Color.GREEN.brighter());
         g2.fillPolygon(xpos, ypos, 3);
         g2.setColor(Color.GREEN.darker());
@@ -99,8 +99,8 @@ public class SimulationIcon extends BaseIcon {
         g2.setStroke(new BasicStroke(scale(2)));
         g2.setColor(Color.MAGENTA.darker().darker());
         g2.drawArc(0, 0, wh, wh, -135, -180);
-        int[] x1 = {scale(10), scale(14), scale(14)};
-        int[] y1 = {(wh) / 4, (wh) / 4, (wh) / 4 - scale(4)};
+        final int[] x1 = {scale(10), scale(14), scale(14)};
+        final int[] y1 = {(wh) / 4, (wh) / 4, (wh) / 4 - scale(4)};
         g2.fillPolygon(x1, y1, 3);
         g2.drawPolygon(x1, y1, 3);
         // fall through
@@ -108,14 +108,14 @@ public class SimulationIcon extends BaseIcon {
         g2.setStroke(new BasicStroke(scale(2)));
         g2.setColor(Color.MAGENTA);
         g2.drawArc(0, 0, wh, wh, 45, -180);
-        int[] x = {scale(3), scale(7), scale(3)};
-        int[] y = {(3 * wh) / 4, (3 * wh) / 4, (3 * wh) / 4 + scale(4)};
+        final int[] x = {scale(3), scale(7), scale(3)};
+        final int[] y = {(3 * wh) / 4, (3 * wh) / 4, (3 * wh) / 4 + scale(4)};
         g2.fillPolygon(x, y, 3);
         g2.drawPolygon(x, y, 3);
         break;
       case SIM_ENABLE:
-        int[] x0 = {scale(6), scale(10), scale(6)};
-        int[] y0 = {scale(8), scale(12), scale(15)};
+        final int[] x0 = {scale(6), scale(10), scale(6)};
+        final int[] y0 = {scale(8), scale(12), scale(15)};
         g2.setColor(Color.GREEN.darker());
         g2.fillPolygon(x0, y0, 3);
         g2.setColor(Color.GREEN.darker().darker().darker());
@@ -126,6 +126,10 @@ public class SimulationIcon extends BaseIcon {
         g2.setColor(Color.RED.darker().darker());
         g2.drawLine(scale(6), scale(9), scale(6), scale(14));
         g2.drawLine(scale(10), scale(9), scale(10), scale(14));
+      default:
+        // Do nothing. Should not really happen.
+        // FIXME: we should have assert to ensure that!
+        break;
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/TextIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/TextIcon.java
@@ -34,7 +34,7 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
 
-public class TextIcon extends AbstractIcon {
+public class TextIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {

--- a/src/main/java/com/cburch/logisim/gui/icons/TreeIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/TreeIcon.java
@@ -34,7 +34,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.GeneralPath;
 
-public class TreeIcon extends AbstractIcon {
+public class TreeIcon extends BaseIcon {
 
   private final Rectangle paper =
       new Rectangle(

--- a/src/main/java/com/cburch/logisim/gui/icons/TtyIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/TtyIcon.java
@@ -34,20 +34,9 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.font.TextLayout;
 
-public class TtyIcon extends AnimatedIcon {
+public class TtyIcon extends BaseIcon {
 
-  private static final String display = "__Hello World!__";
-  private int index = 0;
-
-  @Override
-  public void animationUpdate() {
-    index = (index + 1) % (display.length() - 2);
-  }
-
-  @Override
-  public void resetToStatic() {
-    index = 0;
-  }
+  private static final String display = "Hello World!";
 
   @Override
   protected void paintIcon(Graphics2D g2) {
@@ -55,13 +44,9 @@ public class TtyIcon extends AnimatedIcon {
     g2.fillRoundRect(0, scale(3), scale(16), scale(10), scale(3), scale(3));
     g2.setColor(Color.BLACK);
     g2.drawRoundRect(0, scale(3), scale(16), scale(10), scale(3), scale(3));
-    Font f = Tty.DEFAULT_FONT.deriveFont(scale((float) 5)).deriveFont(Font.BOLD);
-    TextLayout t =
-        new TextLayout(display.substring(index, index + 3), f, g2.getFontRenderContext());
+    final var f = Tty.DEFAULT_FONT.deriveFont(scale((float) 5)).deriveFont(Font.BOLD);
+    final var t = new TextLayout(display.substring(0, 3), f, g2.getFontRenderContext());
     g2.setColor(Color.yellow);
-    t.draw(
-        g2,
-        (float) (getIconWidth() / 2 - t.getBounds().getCenterX()),
-        (float) (getIconHeight() / 2 - t.getBounds().getCenterY()));
+    t.draw(g2, (float) (getIconWidth() / 2 - t.getBounds().getCenterX()), (float) (getIconHeight() / 2 - t.getBounds().getCenterY()));
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/icons/ZoomIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ZoomIcon.java
@@ -34,7 +34,7 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.geom.GeneralPath;
 
-public class ZoomIcon extends AbstractIcon {
+public class ZoomIcon extends BaseIcon {
 
   public static final int ZOOMIN = 0;
   public static final int ZOOMOUT = 1;

--- a/src/main/java/com/cburch/logisim/gui/prefs/ColorChooserButton.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/ColorChooserButton.java
@@ -29,7 +29,7 @@
 package com.cburch.logisim.gui.prefs;
 
 import com.bric.colorpicker.ColorPickerDialog;
-import com.cburch.logisim.gui.icons.AbstractIcon;
+import com.cburch.logisim.gui.icons.BaseIcon;
 import com.cburch.logisim.prefs.PrefMonitor;
 import java.awt.Color;
 import java.awt.Frame;

--- a/src/main/java/com/cburch/logisim/gui/prefs/ColorChooserButton.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/ColorChooserButton.java
@@ -70,7 +70,7 @@ public class ColorChooserButton extends JButton implements PropertyChangeListene
     }
   }
 
-  private class ColorIcon extends AbstractIcon {
+  private class ColorIcon extends BaseIcon {
     @Override
     protected void paintIcon(Graphics2D g2) {
       g2.setColor(new Color(myMonitor.get()));

--- a/src/main/java/com/cburch/logisim/std/io/IoLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/io/IoLibrary.java
@@ -69,7 +69,7 @@ public class IoLibrary extends Library {
     new FactoryDescription(Keyboard.class, S.getter("keyboardComponent"), "keyboard.gif"),
     new FactoryDescription(Led.class, S.getter("ledComponent"), "led.gif"),
     new FactoryDescription(LedBar.class, S.getter("ioLedBarComponent"), "ledlightbar.gif"),
-    new FactoryDescription(RGBLed.class, S.getter("RGBledComponent"), "rgbled.gif"),
+    new FactoryDescription(RgbLed.class, S.getter("RGBledComponent"), "rgbled.gif"),
     new FactoryDescription(SevenSegment.class, S.getter("sevenSegmentComponent"), "7seg.gif"),
     new FactoryDescription(HexDigit.class, S.getter("hexDigitComponent"), "hexdig.gif"),
     new FactoryDescription(DotMatrix.class, S.getter("dotMatrixComponent"), "dotmat.gif"),
@@ -95,6 +95,7 @@ public class IoLibrary extends Library {
     return tools;
   }
 
+  @Override
   public boolean removeLibrary(String Name) {
     return false;
   }

--- a/src/main/java/com/cburch/logisim/std/io/Keyboard.java
+++ b/src/main/java/com/cburch/logisim/std/io/Keyboard.java
@@ -179,6 +179,7 @@ public class Keyboard extends InstanceFactory {
 
   private static final Font DEFAULT_FONT = new Font("monospaced", Font.PLAIN, 12);
 
+  @SuppressWarnings("checkstyle:IllegalTokenText")
   private static final char FORM_FEED = '\u000c'; // control-L
 
   private static final Attribute<Integer> ATTR_BUFFER =

--- a/src/main/java/com/cburch/logisim/std/io/Keyboard.java
+++ b/src/main/java/com/cburch/logisim/std/io/Keyboard.java
@@ -37,6 +37,7 @@ import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.data.Value;
 import com.cburch.logisim.gui.icons.ButtonIcon;
+import com.cburch.logisim.gui.icons.KeyboardIcon;
 import com.cburch.logisim.instance.InstanceFactory;
 import com.cburch.logisim.instance.InstancePainter;
 import com.cburch.logisim.instance.InstancePoker;
@@ -189,7 +190,7 @@ public class Keyboard extends InstanceFactory {
         new Attribute[] {ATTR_BUFFER, StdAttr.EDGE_TRIGGER},
         new Object[] {32, StdAttr.TRIG_RISING});
     setOffsetBounds(Bounds.create(0, -15, WIDTH, HEIGHT));
-    setIcon(new ButtonIcon(S.getter("keyboardComponent")));
+    setIcon(new KeyboardIcon());
     setInstancePoker(Poker.class);
 
     final var ps = new Port[5];

--- a/src/main/java/com/cburch/logisim/std/io/Keyboard.java
+++ b/src/main/java/com/cburch/logisim/std/io/Keyboard.java
@@ -180,7 +180,7 @@ public class Keyboard extends InstanceFactory {
   private static final Font DEFAULT_FONT = new Font("monospaced", Font.PLAIN, 12);
 
   @SuppressWarnings("checkstyle:IllegalTokenText")
-  private static final char FORM_FEED = '\u000c'; // control-L
+  private static final char FORM_FEED = 12; // control-L (LINE FEED)
 
   private static final Attribute<Integer> ATTR_BUFFER =
       Attributes.forIntegerRange("buflen", S.getter("keybBufferLengthAttr"), 1, 256);

--- a/src/main/java/com/cburch/logisim/std/io/Keyboard.java
+++ b/src/main/java/com/cburch/logisim/std/io/Keyboard.java
@@ -291,7 +291,7 @@ public class Keyboard extends InstanceFactory {
         py[2] = y1 + 3;
         g.drawPolyline(px, py, 3);
       } else if (key == '\n') {
-        int y1 = ys - 3;
+        final var y1 = ys - 3;
         px[0] = w1;
         py[0] = ys - asc;
         px[1] = w1;

--- a/src/main/java/com/cburch/logisim/std/io/Led.java
+++ b/src/main/java/com/cburch/logisim/std/io/Led.java
@@ -39,7 +39,7 @@ import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.data.Value;
 import com.cburch.logisim.fpga.data.ComponentMapInformationContainer;
-import com.cburch.logisim.gui.icons.LEDIcon;
+import com.cburch.logisim.gui.icons.LedIcon;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.instance.InstanceDataSingleton;
 import com.cburch.logisim.instance.InstanceFactory;
@@ -109,7 +109,7 @@ public class Led extends InstanceFactory implements DynamicElementProvider {
           new ComponentMapInformationContainer(0, 1, 0)
         });
     setFacingAttribute(StdAttr.FACING);
-    setIcon(new LEDIcon(false));
+    setIcon(new LedIcon(false));
     setKeyConfigurator(new DirectionConfigurator(StdAttr.LABEL_LOC, KeyEvent.ALT_DOWN_MASK));
     setPorts(new Port[] {new Port(0, 0, Port.INPUT, 1)});
     setInstanceLogger(Logger.class);
@@ -195,6 +195,7 @@ public class Led extends InstanceFactory implements DynamicElementProvider {
     return true;
   }
 
+  @Override
   public DynamicElement createDynamicElement(int x, int y, DynamicElement.Path path) {
     return new LedShape(x, y, path);
   }

--- a/src/main/java/com/cburch/logisim/std/io/RGBLed.java
+++ b/src/main/java/com/cburch/logisim/std/io/RGBLed.java
@@ -39,7 +39,7 @@ import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.data.Value;
 import com.cburch.logisim.fpga.data.ComponentMapInformationContainer;
-import com.cburch.logisim.gui.icons.LEDIcon;
+import com.cburch.logisim.gui.icons.LedIcon;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.instance.InstanceDataSingleton;
 import com.cburch.logisim.instance.InstanceFactory;
@@ -51,7 +51,6 @@ import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.tools.key.DirectionConfigurator;
 import com.cburch.logisim.util.GraphicsUtil;
 import java.awt.Color;
-import java.awt.Graphics;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 
@@ -129,7 +128,7 @@ public class RGBLed extends InstanceFactory implements DynamicElementProvider {
           new ComponentMapInformationContainer(0, 3, 0, null, getLabels(), null)
         });
     setFacingAttribute(StdAttr.FACING);
-    setIcon(new LEDIcon(true));
+    setIcon(new LedIcon(true));
     setKeyConfigurator(new DirectionConfigurator(StdAttr.LABEL_LOC, KeyEvent.ALT_DOWN_MASK));
     setInstanceLogger(Logger.class);
   }
@@ -250,6 +249,7 @@ public class RGBLed extends InstanceFactory implements DynamicElementProvider {
     return true;
   }
 
+  @Override
   public DynamicElement createDynamicElement(int x, int y, DynamicElement.Path path) {
     return new RGBLedShape(x, y, path);
   }

--- a/src/main/java/com/cburch/logisim/std/io/RGBLed.java
+++ b/src/main/java/com/cburch/logisim/std/io/RGBLed.java
@@ -65,6 +65,7 @@ public class RGBLed extends InstanceFactory implements DynamicElementProvider {
 
   public static class Logger extends InstanceLogger {
     static final BitWidth bitwidth = BitWidth.create(3);
+
     @Override
     public String getLogName(InstanceState state, Object option) {
       return state.getAttributeValue(StdAttr.LABEL);
@@ -136,7 +137,10 @@ public class RGBLed extends InstanceFactory implements DynamicElementProvider {
   private void updatePorts(Instance instance) {
     final var facing = instance.getAttributeValue(StdAttr.FACING);
     final var ps = new Port[3];
-    int cx = 0, cy = 0, dx = 0, dy = 0;
+    int cx = 0;
+    int cy = 0;
+    int dx = 0;
+    int dy = 0;
     if (facing == Direction.NORTH) {
       cy = 10;
       dx = 10;

--- a/src/main/java/com/cburch/logisim/std/io/RGBLedShape.java
+++ b/src/main/java/com/cburch/logisim/std/io/RGBLedShape.java
@@ -62,9 +62,9 @@ public class RGBLedShape extends LedShape {
       var summ = (data == null ? 0 : (Integer) data.getValue());
       final var mask = activ ? 0 : 7;
       summ ^= mask;
-      final var red = ((summ >> RGBLed.RED) & 1) * 0xFF;
-      final var green = ((summ >> RGBLed.GREEN) & 1) * 0xFF;
-      final var blue = ((summ >> RGBLed.BLUE) & 1) * 0xFF;
+      final var red = ((summ >> RgbLed.RED) & 1) * 0xFF;
+      final var green = ((summ >> RgbLed.GREEN) & 1) * 0xFF;
+      final var blue = ((summ >> RgbLed.BLUE) & 1) * 0xFF;
       g.setColor(new Color(red, green, blue));
       g.fillOval(x, y, w, h);
       g.setColor(Color.darkGray);

--- a/src/main/java/com/cburch/logisim/std/io/RgbLed.java
+++ b/src/main/java/com/cburch/logisim/std/io/RgbLed.java
@@ -54,7 +54,7 @@ import java.awt.Color;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 
-public class RGBLed extends InstanceFactory implements DynamicElementProvider {
+public class RgbLed extends InstanceFactory implements DynamicElementProvider {
   /**
    * Unique identifier of the tool, used as reference in project files.
    * Do NOT change as it will prevent project files from loading.
@@ -105,7 +105,7 @@ public class RGBLed extends InstanceFactory implements DynamicElementProvider {
   public static final int GREEN = 1;
   public static final int BLUE = 2;
 
-  public RGBLed() {
+  public RgbLed() {
     super(_ID, S.getter("RGBledComponent"));
     setAttributes(
         new Attribute[] {

--- a/src/main/java/com/cburch/logisim/std/memory/Random.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Random.java
@@ -107,11 +107,11 @@ public class Random extends InstanceFactory {
       oldReset = Value.UNKNOWN;
     }
 
-    public void PropagateReset(Value Reset, Object seed) {
-      if (oldReset == Value.FALSE && Reset == Value.TRUE) {
+    private void propagateReset(Value reset, Object seed) {
+      if (oldReset == Value.FALSE && reset == Value.TRUE) {
         resetValue = getRandomSeed(seed);
       }
-      oldReset = Reset;
+      oldReset = reset;
     }
 
     public void reset(Object seed) {
@@ -237,7 +237,7 @@ public class Random extends InstanceFactory {
     }
   }
 
-  private void DrawControl(InstancePainter painter, int xpos, int ypos, int NrOfBits) {
+  private void drawControl(InstancePainter painter, int xpos, int ypos, int nrOfBits) {
     final var g = painter.getGraphics();
     GraphicsUtil.switchToWidth(g, 2);
     g.drawLine(xpos + 10, ypos, xpos + 70, ypos);
@@ -247,7 +247,7 @@ public class Random extends InstanceFactory {
     g.drawLine(xpos + 60, ypos + 60, xpos + 70, ypos + 60);
     g.drawLine(xpos + 20, ypos + 60, xpos + 20, ypos + 70);
     g.drawLine(xpos + 60, ypos + 60, xpos + 60, ypos + 70);
-    final var Name = "RNG" + NrOfBits;
+    final var Name = "RNG" + nrOfBits;
     GraphicsUtil.drawText(g, Name, xpos + 40, ypos + 8, GraphicsUtil.H_CENTER, GraphicsUtil.V_CENTER);
     g.drawLine(xpos, ypos + 30, xpos + 10, ypos + 30);
     GraphicsUtil.drawText(g, "R", xpos + 20, ypos + 30, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
@@ -266,12 +266,12 @@ public class Random extends InstanceFactory {
     GraphicsUtil.switchToWidth(g, 1);
   }
 
-  private void DrawData(InstancePainter painter, int xpos, int ypos, int NrOfBits, int Value) {
+  private void drawData(InstancePainter painter, int xpos, int ypos, int nrOfBits, int value) {
     final var g = painter.getGraphics();
     GraphicsUtil.switchToWidth(g, 2);
     g.drawRect(xpos, ypos, 80, 20);
     if (painter.getShowState()) {
-      final var str = StringUtil.toHexString(NrOfBits, Value);
+      final var str = StringUtil.toHexString(nrOfBits, value);
       GraphicsUtil.drawCenteredText(g, str, xpos + 40, ypos + 10);
     }
     painter.drawPort(OUT);
@@ -338,8 +338,8 @@ public class Random extends InstanceFactory {
     final var width = widthVal == null ? 8 : widthVal.getWidth();
 
     painter.drawLabel();
-    DrawControl(painter, x, y, width);
-    DrawData(painter, x, y + 70, width, val);
+    drawControl(painter, x, y, width);
+    drawData(painter, x, y + 70, width, val);
   }
 
   @Override
@@ -372,7 +372,7 @@ public class Random extends InstanceFactory {
     Object triggerType = state.getAttributeValue(StdAttr.EDGE_TRIGGER);
     final var triggered = data.updateClock(state.getPortValue(CK), triggerType);
 
-    data.PropagateReset(state.getPortValue(RST), state.getAttributeValue(ATTR_SEED));
+    data.propagateReset(state.getPortValue(RST), state.getAttributeValue(ATTR_SEED));
     if (state.getPortValue(RST) == Value.TRUE) {
       data.reset(state.getAttributeValue(ATTR_SEED));
     } else if (triggered && state.getPortValue(NXT) != Value.FALSE) {

--- a/src/main/java/com/cburch/logisim/std/memory/Random.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Random.java
@@ -39,7 +39,7 @@ import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.data.Value;
 import com.cburch.logisim.fpga.designrulecheck.NetlistComponent;
-import com.cburch.logisim.gui.icons.DiceIcon;
+import com.cburch.logisim.gui.icons.RandomIcon;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.instance.InstanceData;
 import com.cburch.logisim.instance.InstanceFactory;
@@ -173,7 +173,7 @@ public class Random extends InstanceFactory {
     setKeyConfigurator(new BitWidthConfigurator(StdAttr.WIDTH));
 
     setOffsetBounds(Bounds.create(0, 0, 80, 90));
-    setIcon(new DiceIcon());
+    setIcon(new RandomIcon());
     setInstanceLogger(Logger.class);
   }
 


### PR DESCRIPTION
Animated icon removal. I tried to keep the static icon drawn in the state that looked best (from all its frames). `AnimatedIcon` class is still supported but is now marked deprecated for future removal.