### PR TITLE
Made checkstyle GHA use -dev suppression file

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -5,7 +5,7 @@
 #
 # Marcin Orlowski
 
-name: "Checkstyle"
+name: "Code style"
 on:
   push:
     # No need to run on push to "develop" as there should not be any direct pushes.
@@ -16,7 +16,7 @@ on:
 
 jobs:
   analyze_sources:
-    name: "Is there anything to lint?"
+    name: "Is there any Java source code to lint?"
     runs-on: ubuntu-latest
 
     outputs:
@@ -94,7 +94,10 @@ jobs:
         # Starting from 8.28, default checkstyle config looks for optional checkstyle-suppressions.xml
         # (See https://github.com/checkstyle/checkstyle/issues/6946) so we just need to link ours
         # (as it looks for it in CWD) and that should be sufficient.
-        ln -s config/checkstyle/suppressions.xml checkstyle-suppressions.xml
+        supp_file="config/checkstyle/suppressions-dev.xml"
+        # safe fall back to non-dev file if -dev version is removed
+        [[ -f "${supp_file}" ]] || supp_file="config/checkstyle/suppressions.xml"
+        ln -s "${supp_file}" checkstyle-suppressions.xml
 
         # Let's lint eventually...
         checkstyle -o "${REPORT_FILE}" -c "${CHECKS_FILE}" ${{ needs.analyze_sources.outputs.changed_files }}

--- a/config/checkstyle/suppressions-dev.xml
+++ b/config/checkstyle/suppressions-dev.xml
@@ -8,6 +8,7 @@
     <suppress checks="MissingJavadocType"/>
     <suppress checks="JavadocParagraph"/>
     <suppress checks="NeedBraces"/>
+    <suppress checks="LineLength"/>
 
     <suppress checks="LocalVariableName"/>
     <suppress checks="ParameterName"/>
@@ -26,7 +27,6 @@
     <suppress checks="SummaryJavadoc"/>
     <suppress checks="OverloadMethodsDeclarationOrder"/>
     <suppress checks="CustomImportOrder"/>
-    <suppress checks="LineLength"/>
     <suppress checks="SingleLineJavadoc"/>
     <suppress checks="FallThrough"/>
 

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -8,6 +8,7 @@
     <suppress checks="MissingJavadocType"/>
     <suppress checks="JavadocParagraph"/>
     <suppress checks="NeedBraces"/>
+    <suppress checks="LineLength"/>
 
     <!-- Auto-generated file. https://github.com/logisim-evolution/logisim-evolution/issues/563-->
 	<suppress id="VhdlSyntax" files="src/main/java/com/cburch/logisim/vhdl/syntax/VhdlSyntax.java"/>


### PR DESCRIPTION
Changed Checkstyle linter to use uppressions-dev.xml which in turn makes the linter less restrictive. This is unfortunately needed because our source code has still high number of issues and because linter now runs on every PR as GH action, it'd be really hard to submit anything "clear" right now as once you touched any "tainted" file, it'd be like opening pandora box for linter. And then if you'd decide to fix it all in your PR, your original change would get obscured by style fixes.

I also disabled LineLength check in general config as 100 chars limit is problematic.

This is redo of #783 