### PR TITLE
Reworked GHA to use recent Checkstyle JAR

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -5,7 +5,7 @@
 #
 # Marcin Orlowski
 
-name: "Code style JAR"
+name: "Code style"
 on:
   push:
     # No need to run on push to "develop" as there should not be any direct pushes.

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -66,9 +66,6 @@ jobs:
     # such instead of installing packaged version via apt.
 
     steps:
-    - name: foo
-      run: java -version
-
     - name: "Checkout sources"
       uses: actions/checkout@v2
 
@@ -100,6 +97,7 @@ jobs:
 
         # Let's lint eventually...
         echo "*********************************************************"
+        java -version
         echo "Linting using $(java -jar "${JAR}" --version)"
         java -jar "${JAR}" -o "${REPORT_FILE}" -c "${CHECKS_FILE}" ${{ needs.analyze_sources.outputs.changed_files }}
 

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -5,7 +5,7 @@
 #
 # Marcin Orlowski
 
-name: "Code style"
+name: "Code style JAR"
 on:
   push:
     # No need to run on push to "develop" as there should not be any direct pushes.
@@ -66,8 +66,8 @@ jobs:
     # such instead of installing packaged version via apt.
 
     steps:
-    - name: "Install packages..."
-      run: sudo apt-get install checkstyle unzip libcommons-cli-java
+    - name: foo
+      run: java -version
 
     - name: "Checkout sources"
       uses: actions/checkout@v2
@@ -76,20 +76,19 @@ jobs:
       # We need bash here as java-wrappers.sh may not work with other shells.
       shell: bash
       run: |
-        echo "Using $(checkstyle --version)"
+        VERSION="8.44"
+        JAR="checkstyle-${VERSION}-all.jar"
+        URL="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${VERSION}/${JAR}"
 
+        echo "Downloading ${JAR}..."
+        wget --quiet "${URL}"
+
+        # Extracting config file for possible manipulations.
         declare -r REPORT_FILE="output.txt"
         declare -r CHECKS_FILE="google_checks.xml"
 
-        # Find where checkstyle.jar lives and get built-in google_checks.xml config out of it.
-        source /usr/lib/java-wrappers/java-wrappers.sh
-        locate_jar checkstyle
-        if [[ -z "${found_jar}" ]]; then
-          echo "checkstyle.jar not found."
-          exit 100
-        fi
-
-        unzip -d . "${found_jar}" "${CHECKS_FILE}"
+        # Extract built-in config file.
+        unzip -qq -d . "${JAR}" "${CHECKS_FILE}"
 
         # Starting from 8.28, default checkstyle config looks for optional checkstyle-suppressions.xml
         # (See https://github.com/checkstyle/checkstyle/issues/6946) so we just need to link ours
@@ -100,7 +99,9 @@ jobs:
         ln -s "${supp_file}" checkstyle-suppressions.xml
 
         # Let's lint eventually...
-        checkstyle -o "${REPORT_FILE}" -c "${CHECKS_FILE}" ${{ needs.analyze_sources.outputs.changed_files }}
+        echo "*********************************************************"
+        echo "Linting using $(java -jar "${JAR}" --version)"
+        java -jar "${JAR}" -o "${REPORT_FILE}" -c "${CHECKS_FILE}" ${{ needs.analyze_sources.outputs.changed_files }}
 
         # Plain output always contains "Starting audit..." and "Audit done." lines. Let's remove them.
         sed -i 's/^Starting audit...$//; s/^Audit done.$//' "${REPORT_FILE}"


### PR DESCRIPTION
Reworked GHA to use recent Checkstyle version from JAR so we can have any version we like instead of relying on Ubuntu packaged version.

Ticket: #796