### PR TITLE
Fix gradle build, change mac .dmg name to lower case, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,25 +70,37 @@ include the Java runtime and do not require it to be installed separately:
 * `logisim-evolution_<version>-1_amd64.deb`: Debian package (also suitable for Ubuntu and derivatives),
 * `logisim-evolution-<version>-1.x86_64.rpm`: Package for Fedora/Redhat/CentOS/SuSE Linux distributions,
 * `logisim-evolution-<version>.msi`: Installer package for Microsoft Windows,
-* `Logisim-evolution-<version>.dmg`: macOS package. Note that `Logisim-evolution` may also be installed
+* `logisim-evolution-<version>.dmg`: macOS package. Note that `Logisim-evolution` may also be installed
   using [MacPorts](https://www.macports.org/) (by typing `sudo port install logisim-evolution`)
   or via [Homebrew](https://brew.sh/) (by typing `brew install --cask logisim-evolution`).
 
 The Java JAR [`logisim-evolution-<version>-all.jar`](https://github.com/logisim-evolution/logisim-evolution/releases)
 is also available and can be run on any system with a supported Java runtime installed.
 
+**Note for macOS users**:
+The Logisim-evolution.app is not code-signed.
+The first time you launch it, you should do so by ctrl- or right-clicking the app and selecting `Open`,
+ which will give you a panel that allows you to open it.
+Depending on your security settings, you may also get a panel asking if you wish to allow it to accept network connections.
+You can click `Deny`.
+
 ### Nightly builds ###
 
-We also offer builds based on current state of [develop](https://github.com/logisim-evolution/logisim-evolution/tree/develop)
-branch, which are created everyday at midnight [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
+We also offer builds based on the current state of the
+[develop](https://github.com/logisim-evolution/logisim-evolution/tree/develop) branch.
+If the develop branch has been changed,
+a new `Nightly build` is created at midnight [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
-To get nightly downloads, please [click here](https://github.com/logisim-evolution/logisim-evolution/actions/workflows/nightly.yml)
-and browse to the last successful run of "Nightly build" (should be on top). Note, that due to Github internals,
-all files are provided as ZIP archives. You must unpack unpack downloaded binary prior run or installation.
+Note that these builds may be unstable since the develop branch is a work in progress.
+
+To get nightly downloads, please
+[click here](https://github.com/logisim-evolution/logisim-evolution/actions/workflows/nightly.yml)
+and browse to the last successful run of `Nightly build`, which should be on top. Note that due to Github internals,
+all files are provided as ZIP archives. You must unzip the downloaded file to get the package for installation.
 
 Please share your experience in [Discussions](https://github.com/logisim-evolution/logisim-evolution/discussions)
-or [open a ticket](https://github.com/logisim-evolution/logisim-evolution/issues) if you found a bug or have improvement
-idea.
+or [open a ticket](https://github.com/logisim-evolution/logisim-evolution/issues)
+if you found a bug or have suggestions for improvement.
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,62 +5,62 @@ import kotlin.collections.ArrayList
 import kotlin.collections.mapOf
 
 plugins {
-    checkstyle
-    id("com.github.ben-manes.versions") version "0.38.0"
-    java
-    application
-    id("com.github.johnrengelman.shadow") version "7.0.0"
+  checkstyle
+  id("com.github.ben-manes.versions") version "0.38.0"
+  java
+  application
+  id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 application {
-    mainClass.set("com.cburch.logisim.Main")
+  mainClass.set("com.cburch.logisim.Main")
 }
 
 dependencies {
-    implementation("org.hamcrest:hamcrest:2.2")
-    implementation("javax.help:javahelp:2.0.05")
-    implementation("com.fifesoft:rsyntaxtextarea:3.1.2")
-    implementation("net.sf.nimrod:nimrod-laf:1.2")
-    implementation("org.drjekyll:colorpicker:1.3")
-    implementation("org.drjekyll:fontchooser:2.4")
-    implementation("at.swimmesberger:swingx-core:1.6.8")
-    implementation("org.scijava:swing-checkbox-tree:1.0.2")
-    implementation("org.slf4j:slf4j-api:1.7.30")
-    implementation("org.slf4j:slf4j-simple:1.7.30")
-    implementation("com.formdev:flatlaf:1.2")
+  implementation("org.hamcrest:hamcrest:2.2")
+  implementation("javax.help:javahelp:2.0.05")
+  implementation("com.fifesoft:rsyntaxtextarea:3.1.2")
+  implementation("net.sf.nimrod:nimrod-laf:1.2")
+  implementation("org.drjekyll:colorpicker:1.3")
+  implementation("org.drjekyll:fontchooser:2.4")
+  implementation("at.swimmesberger:swingx-core:1.6.8")
+  implementation("org.scijava:swing-checkbox-tree:1.0.2")
+  implementation("org.slf4j:slf4j-api:1.7.30")
+  implementation("org.slf4j:slf4j-simple:1.7.30")
+  implementation("com.formdev:flatlaf:1.2")
 
-    // NOTE: Be aware of reported issues with Eclipse and Batik
-    // See: https://github.com/logisim-evolution/logisim-evolution/issues/709
-    // implementation("org.apache.xmlgraphics:batik-swing:1.14")
+  // NOTE: Be aware of reported issues with Eclipse and Batik
+  // See: https://github.com/logisim-evolution/logisim-evolution/issues/709
+  // implementation("org.apache.xmlgraphics:batik-swing:1.14")
 
-    testImplementation("org.junit.vintage:junit-vintage-engine:5.7.1")
+  testImplementation("org.junit.vintage:junit-vintage-engine:5.7.1")
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_14
-    targetCompatibility = JavaVersion.VERSION_14
+  sourceCompatibility = JavaVersion.VERSION_14
+  targetCompatibility = JavaVersion.VERSION_14
 }
 
 task<Jar>("sourcesJar") {
-    group = "build"
-    description = "Creates a source jar archive."
-    dependsOn.add("classes")
-    classifier = "src"
+  group = "build"
+  description = "Creates a source jar archive."
+  dependsOn.add("classes")
+  classifier = "src"
 
-    from(sourceSets.main.get().allSource)
+  from(sourceSets.main.get().allSource)
 }
 
 extra.apply {
-   val df = SimpleDateFormat("yyyy")
-   val year = df.format(Date())
-   val javaHome = System.getProperty("java.home") ?: throw GradleException("java.home is not set")
-   val cmd = javaHome + File.separator + "bin" + File.separator + "jpackage"
-   val jPackageCmd = if (cmd.contains(" ")) "\"" + cmd + "\"" else cmd
-   val parameters = ArrayList<String>(Arrays.asList(
+  val df = SimpleDateFormat("yyyy")
+  val year = df.format(Date())
+  val javaHome = System.getProperty("java.home") ?: throw GradleException("java.home is not set")
+  val cmd = javaHome + File.separator + "bin" + File.separator + "jpackage"
+  val jPackageCmd = if (cmd.contains(" ")) "\"" + cmd + "\"" else cmd
+  val parameters = ArrayList<String>(Arrays.asList(
       jPackageCmd,
       "--input", "$buildDir/libs",
       "--main-class", "com.cburch.logisim.Main",
@@ -68,258 +68,262 @@ extra.apply {
       "--app-version", project.version as String,
       "--copyright", "Copyright © 2001–" + year + " Carl Burch, BFH, HEIG-VD, HEPIA, Holy Cross, et al.",
       "--dest", "$buildDir/dist"
-   ))
-   val linuxParameters = ArrayList<String>(Arrays.asList(
+  ))
+  val linuxParameters = ArrayList<String>(Arrays.asList(
       "--name", project.name,
       "--file-associations", "$projectDir/support/jpackage/linux/file.jpackage",
       "--icon", "$projectDir/support/jpackage/linux/logisim-icon-128.png",
       "--install-dir", "/opt",
       "--linux-shortcut"
-   ))
-   set("sharedParameters", parameters)
-   set("linuxParameters", linuxParameters)
-   set("jPackageCmd", jPackageCmd)
-   val projectName = project.name as String
-   val projectVersion = project.version as String
-   val uppercaseProjectName = projectName.substring(0,1).toUpperCase() + projectName.substring(1)
-   set("uppercaseProjectName", uppercaseProjectName)
-   set("appDirname", "$buildDir/dist/" + uppercaseProjectName + ".app")
-   set("dmgFilename", "$buildDir/dist/" + projectName + "-" + projectVersion + ".dmg")
-   set("rpmFilename", "$buildDir/dist/" + projectName + "-" + projectVersion + "-1.x86_64.rpm")
-   set("debFilename", "$buildDir/dist/" + projectName + "_" + projectVersion + "-1_amd64.deb")
-   set("msiFilename", "$buildDir/dist/" + projectName + "-" + projectVersion + ".msi")
+  ))
+  set("sharedParameters", parameters)
+  set("linuxParameters", linuxParameters)
+  set("jPackageCmd", jPackageCmd)
+  val projectName = project.name as String
+  val projectVersion = project.version as String
+  val uppercaseProjectName = projectName.substring(0,1).toUpperCase() + projectName.substring(1)
+  set("uppercaseProjectName", uppercaseProjectName)
+  set("appDirname", "$buildDir/dist/" + uppercaseProjectName + ".app")
+  set("dmgFilename", "$buildDir/dist/" + projectName + "-" + projectVersion + ".dmg")
+  set("rpmFilename", "$buildDir/dist/" + projectName + "-" + projectVersion + "-1.x86_64.rpm")
+  set("debFilename", "$buildDir/dist/" + projectName + "_" + projectVersion + "-1_amd64.deb")
+  set("msiFilename", "$buildDir/dist/" + projectName + "-" + projectVersion + ".msi")
 }
 
 tasks.register("createDistDir") {
-   group = "build"
-   description = "Creates the directory for distribution"
-   dependsOn("shadowJar")
-   inputs.dir("$buildDir/libs")
-   outputs.dir("$buildDir/dist")
-   doLast {
-      if (File("$buildDir/libs").list().count() != 1) {
-         throw GradleException("$buildDir/libs should just contain a single shadowjar file.")
-      }
-      val folder = File("$buildDir/dist")
-      if (!folder.exists() && !folder.mkdirs()) {
-         throw GradleException("Unable to create directory \"$buildDir/dist\"")
-      }
-   }
+  group = "build"
+  description = "Creates the directory for distribution"
+  dependsOn("shadowJar")
+  inputs.dir("$buildDir/libs")
+  outputs.dir("$buildDir/dist")
+  doLast {
+    if (File("$buildDir/libs").list().count() != 1) {
+      throw GradleException("$buildDir/libs should just contain a single shadowjar file.")
+    }
+    val folder = File("$buildDir/dist")
+    if (!folder.exists() && !folder.mkdirs()) {
+      throw GradleException("Unable to create directory \"$buildDir/dist\"")
+    }
+  }
 }
 
 tasks.register("createDeb") {
-   group = "build"
-   description = "Makes the Linux platform specific packages"
-   dependsOn("shadowJar", "createDistDir")
-   inputs.dir("$buildDir/libs")
-   inputs.dir("$projectDir/support/jpackage/linux")
-   outputs.file(ext.get("debFilename") as String)
-   doLast {
-      if (OperatingSystem.current().isLinux) {
-         val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
-         parameters.addAll(ext.get("linuxParameters") as ArrayList<String>)
-         val processBuilder1 = ProcessBuilder()
-         processBuilder1.command(parameters)
-         val process1 = processBuilder1.start()
-         if (process1.waitFor() != 0) {
-            throw GradleException("Error while creating deb package")
-         }
+  group = "build"
+  description = "Makes the Linux platform specific packages"
+  dependsOn("shadowJar", "createDistDir")
+  inputs.dir("$buildDir/libs")
+  inputs.dir("$projectDir/support/jpackage/linux")
+  outputs.file(ext.get("debFilename") as String)
+  doLast {
+    if (OperatingSystem.current().isLinux) {
+      val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
+      parameters.addAll(ext.get("linuxParameters") as ArrayList<String>)
+      val processBuilder1 = ProcessBuilder()
+      processBuilder1.command(parameters)
+      val process1 = processBuilder1.start()
+      if (process1.waitFor() != 0) {
+        throw GradleException("Error while creating deb package")
       }
-   }
+    }
+  }
 }
 
 tasks.register("createRpm") {
-   group = "build"
-   description = "Makes the Linux platform specific packages"
-   dependsOn("shadowJar", "createDistDir")
-   inputs.dir("$buildDir/libs")
-   inputs.dir("$projectDir/support/jpackage/linux")
-   outputs.file(ext.get("rpmFilename") as String)
-   doLast {
-      if (OperatingSystem.current().isLinux) {
-         val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
-         parameters.addAll(ext.get("linuxParameters") as ArrayList<String>)
-         parameters.addAll(Arrays.asList(
-            "--type", "rpm"
-         ))
-         val processBuilder2 = ProcessBuilder()
-         processBuilder2.command(parameters)
-         val process2 = processBuilder2.start()
-         if (process2.waitFor() != 0) {
-            throw GradleException("Error while creating rpm package")
-         }
+  group = "build"
+  description = "Makes the Linux platform specific packages"
+  dependsOn("shadowJar", "createDistDir")
+  inputs.dir("$buildDir/libs")
+  inputs.dir("$projectDir/support/jpackage/linux")
+  outputs.file(ext.get("rpmFilename") as String)
+  doLast {
+    if (OperatingSystem.current().isLinux) {
+      val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
+      parameters.addAll(ext.get("linuxParameters") as ArrayList<String>)
+      parameters.addAll(Arrays.asList(
+          "--type", "rpm"
+      ))
+      val processBuilder2 = ProcessBuilder()
+      processBuilder2.command(parameters)
+      val process2 = processBuilder2.start()
+      if (process2.waitFor() != 0) {
+        throw GradleException("Error while creating rpm package")
       }
-   }
+    }
+  }
 }
 
 tasks.register("createMsi") {
-   group = "build"
-   description = "Makes the Windows platform specific package"
-   dependsOn("shadowJar", "createDistDir")
-   inputs.dir("$buildDir/libs")
-   inputs.dir("$projectDir/support/jpackage/windows")
-   outputs.file(ext.get("msiFilename") as String)
-   doLast {
-      if (OperatingSystem.current().isWindows) {
-         val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
-         parameters.addAll(Arrays.asList(
-            "--name", project.name,
-            "--file-associations", "$projectDir/support/jpackage/windows/file.jpackage",
-            "--icon", "$projectDir/support/jpackage/windows/Logisim-evolution.ico",
-            "--type", "msi",
-            "--win-menu-group", "logisim",
-            "--win-shortcut",
-            "--win-dir-chooser",
-            "--win-menu"
-         ))
-         val processBuilder1 = ProcessBuilder()
-         processBuilder1.command(parameters)
-         val process1 = processBuilder1.start()
-         if (process1.waitFor() != 0) {
-            throw GradleException("Error while creating msi package")
-         }
+  group = "build"
+  description = "Makes the Windows platform specific package"
+  dependsOn("shadowJar", "createDistDir")
+  inputs.dir("$buildDir/libs")
+  inputs.dir("$projectDir/support/jpackage/windows")
+  outputs.file(ext.get("msiFilename") as String)
+  doLast {
+    if (OperatingSystem.current().isWindows) {
+      val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
+      parameters.addAll(Arrays.asList(
+          "--name", project.name,
+          "--file-associations", "$projectDir/support/jpackage/windows/file.jpackage",
+          "--icon", "$projectDir/support/jpackage/windows/Logisim-evolution.ico",
+          "--type", "msi",
+          "--win-menu-group", "logisim",
+          "--win-shortcut",
+          "--win-dir-chooser",
+          "--win-menu"
+      ))
+      val processBuilder1 = ProcessBuilder()
+      processBuilder1.command(parameters)
+      val process1 = processBuilder1.start()
+      if (process1.waitFor() != 0) {
+        throw GradleException("Error while creating msi package")
       }
-   }
+    }
+  }
 }
 
 tasks.register("createApp") {
-   group = "build"
-   description = "Makes the Mac application"
-   dependsOn("shadowJar", "createDistDir")
-   inputs.dir("$buildDir/libs")
-   inputs.dir("$projectDir/support/jpackage/macos")
-   outputs.dir(ext.get("appDirname") as String)
-   doLast {
-      if (OperatingSystem.current().isMacOsX) {
-         val appDirname = ext.get("appDirname") as String
-         delete(appDirname)
-         val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
-         parameters.addAll(Arrays.asList(
-            "--name", ext.get("uppercaseProjectName") as String,
-            "--file-associations", "$projectDir/support/jpackage/macos/file.jpackage",
-            "--icon", "$projectDir/support/jpackage/macos/Logisim-evolution.icns",
-            "--type", "app-image"
-         ))
-         val processBuilder1 = ProcessBuilder()
-         processBuilder1.command(parameters)
-         val process1 = processBuilder1.start()
-         if (process1.waitFor() != 0) {
-            throw GradleException("Error while creating app directory")
-         }
-         val pListFilename = "$appDirname/Contents/Info.plist"
-         val parameters2 = ArrayList<String>(Arrays.asList(
-            "awk", "/Unknown/{sub(/Unknown/,\"public.app-category.education\")};{print >\"$buildDir/dist/Info.plist\"};/NSHighResolutionCapable/{print \"  <string>true</string>\" >\"$buildDir/dist/Info.plist\"; print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"$buildDir/dist/Info.plist\"}",
-            pListFilename
-         ))
-         val processBuilder2 = ProcessBuilder()
-         processBuilder2.command(parameters2)
-         val process2 = processBuilder2.start()
-         if (process2.waitFor() != 0) {
-            throw GradleException("Error while patching Info.plist")
-         }
-         val parameters3 = ArrayList<String>(Arrays.asList(
-            "mv", "$buildDir/dist/Info.plist", pListFilename
-         ))
-         val processBuilder3 = ProcessBuilder()
-         processBuilder3.command(parameters3)
-         val process3 = processBuilder3.start()
-         if (process3.waitFor() != 0) {
-            throw GradleException("Error while moving Info.plist into app")
-         }
-         val parameters4 = ArrayList<String>(Arrays.asList(
-            "codesign", "--remove-signature", appDirname
-         ))
-         val processBuilder4 = ProcessBuilder()
-         processBuilder4.command(parameters4)
-         val process4 = processBuilder4.start()
-         if (process4.waitFor() != 0) {
-            throw GradleException("Error while executing codesign --remove-signature")
-         }
+  group = "build"
+  description = "Makes the Mac application"
+  dependsOn("shadowJar", "createDistDir")
+  inputs.dir("$buildDir/libs")
+  inputs.dir("$projectDir/support/jpackage/macos")
+  outputs.dir(ext.get("appDirname") as String)
+  doLast {
+    if (OperatingSystem.current().isMacOsX) {
+      val appDirname = ext.get("appDirname") as String
+      delete(appDirname)
+      val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
+      parameters.addAll(Arrays.asList(
+          "--name", ext.get("uppercaseProjectName") as String,
+          "--file-associations", "$projectDir/support/jpackage/macos/file.jpackage",
+          "--icon", "$projectDir/support/jpackage/macos/Logisim-evolution.icns",
+          "--type", "app-image"
+      ))
+      val processBuilder1 = ProcessBuilder()
+      processBuilder1.command(parameters)
+      val process1 = processBuilder1.start()
+      if (process1.waitFor() != 0) {
+        throw GradleException("Error while creating app directory")
       }
-   }
+      val pListFilename = "$appDirname/Contents/Info.plist"
+      val parameters2 = ArrayList<String>(Arrays.asList(
+          "awk",
+          "/Unknown/{sub(/Unknown/,\"public.app-category.education\")};"
+              + "{print >\"$buildDir/dist/Info.plist\"};"
+              + "/NSHighResolutionCapable/{"
+                  + "print \"  <string>true</string>\" >\"$buildDir/dist/Info.plist\";"
+                  + "print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"$buildDir/dist/Info.plist\""
+              + "}",
+          pListFilename
+      ))
+      val processBuilder2 = ProcessBuilder()
+      processBuilder2.command(parameters2)
+      val process2 = processBuilder2.start()
+      if (process2.waitFor() != 0) {
+        throw GradleException("Error while patching Info.plist")
+      }
+      val parameters3 = ArrayList<String>(Arrays.asList(
+          "mv", "$buildDir/dist/Info.plist", pListFilename
+      ))
+      val processBuilder3 = ProcessBuilder()
+      processBuilder3.command(parameters3)
+      val process3 = processBuilder3.start()
+      if (process3.waitFor() != 0) {
+        throw GradleException("Error while moving Info.plist into app")
+      }
+      val parameters4 = ArrayList<String>(Arrays.asList(
+          "codesign", "--remove-signature", appDirname
+      ))
+      val processBuilder4 = ProcessBuilder()
+      processBuilder4.command(parameters4)
+      val process4 = processBuilder4.start()
+      if (process4.waitFor() != 0) {
+        throw GradleException("Error while executing codesign --remove-signature")
+      }
+    }
+  }
 }
 
 tasks.register("createDmg") {
-   group = "build"
-   description = "Makes the Mac dmg package"
-   dependsOn("createApp")
-   inputs.dir(ext.get("appDirname") as String)
-   outputs.file(ext.get("dmgFilename") as String)
-   doLast {
-      if (OperatingSystem.current().isMacOsX) {
-         val parameters1 = ArrayList<String>(Arrays.asList(
-            ext.get("jPackageCmd") as String,
-            "--type", "dmg",
-            "--app-image", ext.get("appDirname") as String,
-            "--name", project.name as String,
-            "--app-version", project.version as String,
-            "--dest", "$buildDir/dist"
-         ))
-         val processBuilder1 = ProcessBuilder()
-         processBuilder1.command(parameters1)
-         val process1 = processBuilder1.start()
-         if (process1.waitFor() != 0) {
-            throw GradleException("Error while creating dmg package")
-         }
+  group = "build"
+  description = "Makes the Mac dmg package"
+  dependsOn("createApp")
+  inputs.dir(ext.get("appDirname") as String)
+  outputs.file(ext.get("dmgFilename") as String)
+  doLast {
+    if (OperatingSystem.current().isMacOsX) {
+      val parameters1 = ArrayList<String>(Arrays.asList(
+          ext.get("jPackageCmd") as String,
+          "--type", "dmg",
+          "--app-image", ext.get("appDirname") as String,
+          "--name", project.name as String,
+          "--app-version", project.version as String,
+          "--dest", "$buildDir/dist"
+      ))
+      val processBuilder1 = ProcessBuilder()
+      processBuilder1.command(parameters1)
+      val process1 = processBuilder1.start()
+      if (process1.waitFor() != 0) {
+        throw GradleException("Error while creating dmg package")
       }
-   }
+    }
+  }
 }
 
 tasks.register("jpackage") {
-   group = "build"
-   description = "Makes the platform specific packages for the current platform"
-   dependsOn("createDeb", "createRpm", "createMsi", "createDmg")
+  group = "build"
+  description = "Makes the platform specific packages for the current platform"
+  dependsOn("createDeb", "createRpm", "createMsi", "createDmg")
 }
 
 tasks {
-    compileJava {
-        options.compilerArgs = listOf("-Xlint:deprecation", "-Xlint:unchecked", "-Xlint:fallthrough")
-    }
-    compileTestJava {
-        options.compilerArgs = listOf("-Xlint:deprecation", "-Xlint:unchecked", "-Xlint:fallthrough")
-    }
-    jar {
-        manifest {
-            attributes.putAll(mapOf(
-                    "Implementation-Title" to name,
-                    "Implementation-Version" to archiveVersion
-            ))
-        }
-
-        from(".") {
-            include("LICENSE")
-            include("README.md")
-        }
-    }
-    shadowJar {
-        from(".") {
-            include("LICENSE")
-            include("README.md")
-        }
+  compileJava {
+    options.compilerArgs = listOf("-Xlint:deprecation", "-Xlint:unchecked", "-Xlint:fallthrough")
+  }
+  compileTestJava {
+    options.compilerArgs = listOf("-Xlint:deprecation", "-Xlint:unchecked", "-Xlint:fallthrough")
+  }
+  jar {
+    manifest {
+      attributes.putAll(mapOf(
+          "Implementation-Title" to name,
+          "Implementation-Version" to archiveVersion
+      ))
     }
 
-    // Checkstyles related tasks: "checkstylMain" and "checkstyleTest"
-    checkstyle {
-        // Checkstyle version to use
-        toolVersion = "8.43"
-
-        // let's use google_checks.xml config provided with Checkstyle.
-        // https://stackoverflow.com/a/67513272/1235698
-        val archive = configurations.checkstyle.get().resolve().filter {
-          it.name.startsWith("checkstyle")
-        }
-        config = resources.text.fromArchiveEntry(archive, "google_checks.xml")
-
-        // FIXME there should be cleaner way of using custom suppression config with built-in style
-        // https://stackoverflow.com/a/64703619/1235698
-        System.setProperty( "org.checkstyle.google.suppressionfilter.config", "$projectDir/config/checkstyle/suppressions.xml")
+    from(".") {
+      include("LICENSE")
+      include("README.md")
     }
-    checkstyleMain {
-        source = fileTree("src/main/java")
+  }
+  shadowJar {
+    from(".") {
+      include("LICENSE")
+      include("README.md")
     }
-    checkstyleTest {
-        source = fileTree("src/test/java")
-    }
+  }
 
+  // Checkstyles related tasks: "checkstylMain" and "checkstyleTest"
+  checkstyle {
+    // Checkstyle version to use
+    toolVersion = "8.43"
+
+    // let's use google_checks.xml config provided with Checkstyle.
+    // https://stackoverflow.com/a/67513272/1235698
+    val archive = configurations.checkstyle.get().resolve().filter {
+      it.name.startsWith("checkstyle")
+    }
+    config = resources.text.fromArchiveEntry(archive, "google_checks.xml")
+
+    // FIXME there should be cleaner way of using custom suppression config with built-in style
+    // https://stackoverflow.com/a/64703619/1235698
+    System.setProperty( "org.checkstyle.google.suppressionfilter.config", "$projectDir/config/checkstyle/suppressions.xml")
+  }
+  checkstyleMain {
+    source = fileTree("src/main/java")
+  }
+  checkstyleTest {
+    source = fileTree("src/test/java")
+  }
 }
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,17 +62,17 @@ extra.apply {
   val jPackageCmd = if (cmd.contains(" ")) "\"" + cmd + "\"" else cmd
   val parameters = ArrayList<String>(Arrays.asList(
       jPackageCmd,
-      "--input", "$buildDir/libs",
+      "--input", "${buildDir}/libs",
       "--main-class", "com.cburch.logisim.Main",
       "--main-jar", "${project.name}-${project.version}-all.jar",
       "--app-version", project.version as String,
       "--copyright", "Copyright © 2001–" + year + " Carl Burch, BFH, HEIG-VD, HEPIA, Holy Cross, et al.",
-      "--dest", "$buildDir/dist"
+      "--dest", "${buildDir}/dist"
   ))
   val linuxParameters = ArrayList<String>(Arrays.asList(
       "--name", project.name,
-      "--file-associations", "$projectDir/support/jpackage/linux/file.jpackage",
-      "--icon", "$projectDir/support/jpackage/linux/logisim-icon-128.png",
+      "--file-associations", "${projectDir}/support/jpackage/linux/file.jpackage",
+      "--icon", "${projectDir}/support/jpackage/linux/logisim-icon-128.png",
       "--install-dir", "/opt",
       "--linux-shortcut"
   ))
@@ -81,26 +81,26 @@ extra.apply {
   set("jPackageCmd", jPackageCmd)
   val uppercaseProjectName = project.name.substring(0,1).toUpperCase() + project.name.substring(1)
   set("uppercaseProjectName", uppercaseProjectName)
-  set("appDirName", "$buildDir/dist/$uppercaseProjectName.app")
-  set("dmgFilename", "$buildDir/dist/${project.name}-${project.version}.dmg")
-  set("rpmFilename", "$buildDir/dist/${project.name}-${project.version}-1.x86_64.rpm")
-  set("debFilename", "$buildDir/dist/${project.name}_${project.version}-1_amd64.deb")
-  set("msiFilename", "$buildDir/dist/${project.name}-${project.version}.msi")
+  set("appDirName", "${buildDir}/dist/${uppercaseProjectName}.app")
+  set("dmgFilename", "${buildDir}/dist/${project.name}-${project.version}.dmg")
+  set("rpmFilename", "${buildDir}/dist/${project.name}-${project.version}-1.x86_64.rpm")
+  set("debFilename", "${buildDir}/dist/${project.name}_${project.version}-1_amd64.deb")
+  set("msiFilename", "${buildDir}/dist/${project.name}-${project.version}.msi")
 }
 
 tasks.register("createDistDir") {
   group = "build"
   description = "Creates the directory for distribution"
   dependsOn("shadowJar")
-  inputs.dir("$buildDir/libs")
-  outputs.dir("$buildDir/dist")
+  inputs.dir("${buildDir}/libs")
+  outputs.dir("${buildDir}/dist")
   doLast {
-    if (File("$buildDir/libs").list().count() != 1) {
-      throw GradleException("$buildDir/libs should just contain a single shadowJar file.")
+    if (File("${buildDir}/libs").list().count() != 1) {
+      throw GradleException("${buildDir}/libs should just contain a single shadowJar file.")
     }
-    val folder = File("$buildDir/dist")
+    val folder = File("${buildDir}/dist")
     if (!folder.exists() && !folder.mkdirs()) {
-      throw GradleException("Unable to create directory \"$buildDir/dist\"")
+      throw GradleException("Unable to create directory \"${buildDir}/dist\"")
     }
   }
 }
@@ -109,8 +109,8 @@ tasks.register("createDeb") {
   group = "build"
   description = "Makes the Linux platform specific packages"
   dependsOn("shadowJar", "createDistDir")
-  inputs.dir("$buildDir/libs")
-  inputs.dir("$projectDir/support/jpackage/linux")
+  inputs.dir("${buildDir}/libs")
+  inputs.dir("${projectDir}/support/jpackage/linux")
   outputs.file(ext.get("debFilename"))
   doLast {
     if (OperatingSystem.current().isLinux) {
@@ -130,8 +130,8 @@ tasks.register("createRpm") {
   group = "build"
   description = "Makes the Linux platform specific packages"
   dependsOn("shadowJar", "createDistDir")
-  inputs.dir("$buildDir/libs")
-  inputs.dir("$projectDir/support/jpackage/linux")
+  inputs.dir("${buildDir}/libs")
+  inputs.dir("${projectDir}/support/jpackage/linux")
   outputs.file(ext.get("rpmFilename"))
   doLast {
     if (OperatingSystem.current().isLinux) {
@@ -154,16 +154,16 @@ tasks.register("createMsi") {
   group = "build"
   description = "Makes the Windows platform specific package"
   dependsOn("shadowJar", "createDistDir")
-  inputs.dir("$buildDir/libs")
-  inputs.dir("$projectDir/support/jpackage/windows")
+  inputs.dir("${buildDir}/libs")
+  inputs.dir("${projectDir}/support/jpackage/windows")
   outputs.file(ext.get("msiFilename"))
   doLast {
     if (OperatingSystem.current().isWindows) {
       val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
       parameters.addAll(Arrays.asList(
           "--name", project.name,
-          "--file-associations", "$projectDir/support/jpackage/windows/file.jpackage",
-          "--icon", "$projectDir/support/jpackage/windows/Logisim-evolution.ico",
+          "--file-associations", "${projectDir}/support/jpackage/windows/file.jpackage",
+          "--icon", "${projectDir}/support/jpackage/windows/Logisim-evolution.ico",
           "--type", "msi",
           "--win-menu-group", "logisim",
           "--win-shortcut",
@@ -184,8 +184,8 @@ tasks.register("createApp") {
   group = "build"
   description = "Makes the Mac application"
   dependsOn("shadowJar", "createDistDir")
-  inputs.dir("$buildDir/libs")
-  inputs.dir("$projectDir/support/jpackage/macos")
+  inputs.dir("${buildDir}/libs")
+  inputs.dir("${projectDir}/support/jpackage/macos")
   outputs.dir(ext.get("appDirName"))
   doLast {
     if (OperatingSystem.current().isMacOsX) {
@@ -194,8 +194,8 @@ tasks.register("createApp") {
       val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
       parameters.addAll(Arrays.asList(
           "--name", ext.get("uppercaseProjectName") as String,
-          "--file-associations", "$projectDir/support/jpackage/macos/file.jpackage",
-          "--icon", "$projectDir/support/jpackage/macos/Logisim-evolution.icns",
+          "--file-associations", "${projectDir}/support/jpackage/macos/file.jpackage",
+          "--icon", "${projectDir}/support/jpackage/macos/Logisim-evolution.icns",
           "--type", "app-image"
       ))
       val processBuilder1 = ProcessBuilder()
@@ -204,14 +204,14 @@ tasks.register("createApp") {
       if (process1.waitFor() != 0) {
         throw GradleException("Error while creating the .app directory")
       }
-      val pListFilename = "$appDirName/Contents/Info.plist"
+      val pListFilename = "${appDirName}/Contents/Info.plist"
       val parameters2 = ArrayList<String>(Arrays.asList(
           "awk",
           "/Unknown/{sub(/Unknown/,\"public.app-category.education\")};"
-              + "{print >\"$buildDir/dist/Info.plist\"};"
+              + "{print >\"${buildDir}/dist/Info.plist\"};"
               + "/NSHighResolutionCapable/{"
-                  + "print \"  <string>true</string>\" >\"$buildDir/dist/Info.plist\";"
-                  + "print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"$buildDir/dist/Info.plist\""
+                  + "print \"  <string>true</string>\" >\"${buildDir}/dist/Info.plist\";"
+                  + "print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"${buildDir}/dist/Info.plist\""
               + "}",
           pListFilename
       ))
@@ -222,7 +222,7 @@ tasks.register("createApp") {
         throw GradleException("Error while patching Info.plist")
       }
       val parameters3 = ArrayList<String>(Arrays.asList(
-          "mv", "$buildDir/dist/Info.plist", pListFilename
+          "mv", "${buildDir}/dist/Info.plist", pListFilename
       ))
       val processBuilder3 = ProcessBuilder()
       processBuilder3.command(parameters3)
@@ -257,7 +257,7 @@ tasks.register("createDmg") {
           "--app-image", ext.get("appDirName") as String,
           "--name", project.name as String,
           "--app-version", project.version as String,
-          "--dest", "$buildDir/dist"
+          "--dest", "${buildDir}/dist"
       ))
       val processBuilder1 = ProcessBuilder()
       processBuilder1.command(parameters1)
@@ -316,7 +316,7 @@ tasks {
 
     // FIXME there should be cleaner way of using custom suppression config with built-in style
     // https://stackoverflow.com/a/64703619/1235698
-    System.setProperty( "org.checkstyle.google.suppressionfilter.config", "$projectDir/config/checkstyle/suppressions.xml")
+    System.setProperty( "org.checkstyle.google.suppressionfilter.config", "${projectDir}/config/checkstyle/suppressions.xml")
   }
   checkstyleMain {
     source = fileTree("src/main/java")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,10 +83,10 @@ extra.apply {
    val projectVersion = project.version as String
    val uppercaseProjectName = projectName.substring(0,1).toUpperCase() + projectName.substring(1)
    set("uppercaseProjectName", uppercaseProjectName)
-   set("appDirname", "$buildDir/dist/" + projectName + ".app")
+   set("appDirname", "$buildDir/dist/" + uppercaseProjectName + ".app")
    set("dmgFilename", "$buildDir/dist/" + projectName + "-" + projectVersion + ".dmg")
    set("rpmFilename", "$buildDir/dist/" + projectName + "-" + projectVersion + "-1.x86_64.rpm")
-   set("debFilename", "$buildDir/dist/" + projectName + "-" + projectVersion + "-1_amd64.deb")
+   set("debFilename", "$buildDir/dist/" + projectName + "_" + projectVersion + "-1_amd64.deb")
    set("msiFilename", "$buildDir/dist/" + projectName + "-" + projectVersion + ".msi")
 }
 
@@ -193,10 +193,9 @@ tasks.register("createApp") {
       if (OperatingSystem.current().isMacOsX) {
          val appDirname = ext.get("appDirname") as String
          delete(appDirname)
-         val appName = ext.get("uppercaseProjectName") as String
          val parameters = ArrayList<String>(ext.get("sharedParameters") as ArrayList<String>)
          parameters.addAll(Arrays.asList(
-            "--name", appName,
+            "--name", ext.get("uppercaseProjectName") as String,
             "--file-associations", "$projectDir/support/jpackage/macos/file.jpackage",
             "--icon", "$projectDir/support/jpackage/macos/Logisim-evolution.icns",
             "--type", "app-image"
@@ -207,7 +206,7 @@ tasks.register("createApp") {
          if (process1.waitFor() != 0) {
             throw GradleException("Error while creating app directory")
          }
-         val plistfilename = "$buildDir/dist/" + appName + ".app/Contents/Info.plist"
+         val plistfilename = appDirname + "/Contents/Info.plist"
          val parameters2 = ArrayList<String>(Arrays.asList(
             "awk", "/Unknown/{sub(/Unknown/,\"public.app-category.education\")};{print >\"$buildDir/dist/Info.plist\"};/NSHighResolutionCapable/{print \"  <string>true</string>\" >\"$buildDir/dist/Info.plist\"; print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"$buildDir/dist/Info.plist\"}",
             plistfilename
@@ -248,12 +247,11 @@ tasks.register("createDmg") {
    outputs.file(ext.get("dmgFilename") as String)
    doLast {
       if (OperatingSystem.current().isMacOsX) {
-         val appName = ext.get("uppercaseProjectName") as String
          val parameters1 = ArrayList<String>(Arrays.asList(
             ext.get("jpackagecmd") as String,
             "--type", "dmg",
-            "--app-image", "$buildDir" + File.separator + "dist" + File.separator +  appName + ".app",
-            "--name", appName,
+            "--app-image", ext.get("appDirname") as String,
+            "--name", project.name as String,
             "--app-version", project.version as String,
             "--dest", "$buildDir/dist"
          ))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,9 +59,9 @@ extra.apply {
    val year = df.format(Date())
    val javaHome = System.getProperty("java.home") ?: throw GradleException("java.home is not set")
    val cmd = javaHome + File.separator + "bin" + File.separator + "jpackage"
-   val jpackagecmd = if (cmd.contains(" ")) "\"" + cmd + "\"" else cmd
+   val jPackageCmd = if (cmd.contains(" ")) "\"" + cmd + "\"" else cmd
    val parameters = ArrayList<String>(Arrays.asList(
-      jpackagecmd,
+      jPackageCmd,
       "--input", "$buildDir/libs",
       "--main-class", "com.cburch.logisim.Main",
       "--main-jar", project.name + '-' + project.version + "-all.jar",
@@ -78,7 +78,7 @@ extra.apply {
    ))
    set("sharedParameters", parameters)
    set("linuxParameters", linuxParameters)
-   set("jpackagecmd", jpackagecmd)
+   set("jPackageCmd", jPackageCmd)
    val projectName = project.name as String
    val projectVersion = project.version as String
    val uppercaseProjectName = projectName.substring(0,1).toUpperCase() + projectName.substring(1)
@@ -206,10 +206,10 @@ tasks.register("createApp") {
          if (process1.waitFor() != 0) {
             throw GradleException("Error while creating app directory")
          }
-         val plistfilename = appDirname + "/Contents/Info.plist"
+         val pListFilename = "$appDirname/Contents/Info.plist"
          val parameters2 = ArrayList<String>(Arrays.asList(
             "awk", "/Unknown/{sub(/Unknown/,\"public.app-category.education\")};{print >\"$buildDir/dist/Info.plist\"};/NSHighResolutionCapable/{print \"  <string>true</string>\" >\"$buildDir/dist/Info.plist\"; print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"$buildDir/dist/Info.plist\"}",
-            plistfilename
+            pListFilename
          ))
          val processBuilder2 = ProcessBuilder()
          processBuilder2.command(parameters2)
@@ -218,7 +218,7 @@ tasks.register("createApp") {
             throw GradleException("Error while patching Info.plist")
          }
          val parameters3 = ArrayList<String>(Arrays.asList(
-            "mv", "$buildDir/dist/Info.plist", plistfilename
+            "mv", "$buildDir/dist/Info.plist", pListFilename
          ))
          val processBuilder3 = ProcessBuilder()
          processBuilder3.command(parameters3)
@@ -248,7 +248,7 @@ tasks.register("createDmg") {
    doLast {
       if (OperatingSystem.current().isMacOsX) {
          val parameters1 = ArrayList<String>(Arrays.asList(
-            ext.get("jpackagecmd") as String,
+            ext.get("jPackageCmd") as String,
             "--type", "dmg",
             "--app-image", ext.get("appDirname") as String,
             "--name", project.name as String,


### PR DESCRIPTION
This PR does the following:

Fixes the gradle build problem noted in #827.

Changes the macOS .dmg package name to lowercase, but leaves the .app name as uppercase so the user interface is not changed. Closes #821.

Updates the README to change the case of the dmg.

Updates the README to add a note for macOS users regarding the initial permission to run and the possible firewall question about internet access as discussed in #747.

Improves other English in the README.

I also added a commit to indent the build.gradle.kts file to 2 spaces. It was inconsistent.

Could @maehne and @MarcinOrlowski  please review.