### PR TITLE
Add SELECT_LOC to StdAttr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
   * Added TTL 74x139: dual 2-line to 4-lines decoders.
   * Fixed missing port on DotMatrix.
   * Combined `Select Location` from Plexers and `Gate Location` from Wiring to one attribute.
-    - Breaks backwards comparability for Transistors and Transmission Gates.
+    * Breaks backwards comparability for Transistors and Transmission Gates.
       When opening old .circ files, they will have the default `Select Location` ("Bottom/Left").
   * Replace DarkLaf with FlatLaf for better compatibility.
   * Adds "Rotate Left" context menu action.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
   * Added option to configure size of connection pin markers.
   * Added TTL 74x139: dual 2-line to 4-lines decoders.
   * Fixed missing port on DotMatrix.
+  * Combined `Select Location` from Plexers and `Gate Location` from Wiring to one attribute.
+    - Breaks backwards comparability for Transistors and Transmission Gates.
+      When opening old .circ files, they will have the default `Select Location` ("Bottom/Left").
   * Replace DarkLaf with FlatLaf for better compatibility.
   * Adds "Rotate Left" context menu action.
   * Display "Too few inputs for table" if Karnaugh Map has only 1 input.

--- a/src/main/java/com/cburch/logisim/instance/StdAttr.java
+++ b/src/main/java/com/cburch/logisim/instance/StdAttr.java
@@ -104,6 +104,16 @@ public interface StdAttr {
           new BitWidth[] {
             BitWidth.create(32), BitWidth.create(64)
           });
+  
+  AttributeOption GATE_TOP_LEFT =
+      new AttributeOption("tl", S.getter("stdGateTopLeftOption"));
+  AttributeOption GATE_BOTTOM_RIGHT =
+      new AttributeOption("br", S.getter("stdGateBottomRightOption"));
+  Attribute<AttributeOption> GATE =
+      Attributes.forOption(
+          "gate",
+          S.getter("stdGateAttr"),
+          new AttributeOption[] {GATE_TOP_LEFT, GATE_BOTTOM_RIGHT});
 
   Attribute<String> DUMMY = Attributes.forHidden();
 }

--- a/src/main/java/com/cburch/logisim/instance/StdAttr.java
+++ b/src/main/java/com/cburch/logisim/instance/StdAttr.java
@@ -105,15 +105,15 @@ public interface StdAttr {
             BitWidth.create(32), BitWidth.create(64)
           });
   
-  AttributeOption GATE_TOP_LEFT =
-      new AttributeOption("tl", S.getter("stdGateTopLeftOption"));
-  AttributeOption GATE_BOTTOM_RIGHT =
-      new AttributeOption("br", S.getter("stdGateBottomRightOption"));
-  Attribute<AttributeOption> GATE =
+  AttributeOption SELECT_BOTTOM_LEFT =
+      new AttributeOption("bl", S.getter("stdSelectBottomLeftOption"));
+  AttributeOption SELECT_TOP_RIGHT =
+      new AttributeOption("tr", S.getter("stdSelectTopRightOption"));
+  Attribute<AttributeOption> SELECT_LOC =
       Attributes.forOption(
-          "gate",
-          S.getter("stdGateAttr"),
-          new AttributeOption[] {GATE_TOP_LEFT, GATE_BOTTOM_RIGHT});
+          "selloc",
+          S.getter("stdSelectLocAttr"),
+          new AttributeOption[] {SELECT_BOTTOM_LEFT, SELECT_TOP_RIGHT});
 
   Attribute<String> DUMMY = Attributes.forHidden();
 }

--- a/src/main/java/com/cburch/logisim/std/io/DotMatrixBase.java
+++ b/src/main/java/com/cburch/logisim/std/io/DotMatrixBase.java
@@ -228,6 +228,7 @@ public abstract class DotMatrixBase extends InstanceFactory {
           getAttributeInputType(),
           getAttributeColumns(),
           getAttributeRows(),
+          StdAttr.SELECT_LOC,
           IoLibrary.ATTR_ON_COLOR,
           IoLibrary.ATTR_OFF_COLOR,
           ATTR_PERSIST,
@@ -243,6 +244,7 @@ public abstract class DotMatrixBase extends InstanceFactory {
           getAttributeItemColumn(),
           BitWidth.create(cols),
           BitWidth.create(rows),
+          StdAttr.SELECT_BOTTOM_LEFT,
           Color.GREEN,
           Color.gray,
           0,
@@ -326,6 +328,8 @@ public abstract class DotMatrixBase extends InstanceFactory {
   protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
     if (attr == StdAttr.LABEL_LOC) {
       instance.computeLabelTextField(Instance.AVOID_LEFT);
+    } else if (attr == StdAttr.SELECT_LOC) {
+        updatePorts(instance);
     } else if (attr == getAttributeRows()
         || attr == getAttributeColumns()
         || attr == getAttributeInputType()) {
@@ -450,22 +454,24 @@ public abstract class DotMatrixBase extends InstanceFactory {
     Object input = instance.getAttributeValue(getAttributeInputType());
     final var rows = instance.getAttributeValue(getAttributeRows()).getWidth();
     final var cols = instance.getAttributeValue(getAttributeColumns()).getWidth();
+    final var selectLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
     Port[] ps;
     if (input == getAttributeItemColumn()) {
       ps = new Port[cols];
       for (var i = 0; i < cols; i++) {
-        ps[i] = new Port(10 * i, 0, Port.INPUT, rows);
+        ps[i] = new Port(10 * i, selectLoc == StdAttr.SELECT_BOTTOM_LEFT ? 0 : rows * -10 * scaleY, Port.INPUT, rows);
       }
     } else if (input == getAttributeItemRow()) {
       ps = new Port[rows];
       for (var i = 0; i < rows; i++) {
-        ps[i] = new Port(0, 10 * i, Port.INPUT, cols);
+        ps[i] = new Port(selectLoc == StdAttr.SELECT_BOTTOM_LEFT ? 0 : cols * 10, 10 * i, Port.INPUT, cols);
       }
     } else {
       if (rows <= 1) {
         ps = new Port[] {new Port(0, 0, Port.INPUT, cols), new Port(10 * cols, 0, Port.INPUT, rows)};
       } else {
-        ps = new Port[] {new Port(0, 0, Port.INPUT, cols), new Port(0, 10, Port.INPUT, rows)};
+        final var dx = selectLoc == StdAttr.SELECT_BOTTOM_LEFT ? 0 : cols * 10;
+        ps = new Port[] {new Port(dx, 0, Port.INPUT, cols), new Port(dx, 10, Port.INPUT, rows)};
       }
     }
     instance.setPorts(ps);

--- a/src/main/java/com/cburch/logisim/std/io/DotMatrixBase.java
+++ b/src/main/java/com/cburch/logisim/std/io/DotMatrixBase.java
@@ -329,7 +329,7 @@ public abstract class DotMatrixBase extends InstanceFactory {
     if (attr == StdAttr.LABEL_LOC) {
       instance.computeLabelTextField(Instance.AVOID_LEFT);
     } else if (attr == StdAttr.SELECT_LOC) {
-        updatePorts(instance);
+      updatePorts(instance);
     } else if (attr == getAttributeRows()
         || attr == getAttributeColumns()
         || attr == getAttributeInputType()) {

--- a/src/main/java/com/cburch/logisim/std/io/extra/Buzzer.java
+++ b/src/main/java/com/cburch/logisim/std/io/extra/Buzzer.java
@@ -114,10 +114,25 @@ public class Buzzer extends InstanceFactory {
     super(_ID, S.getter("buzzerComponent"));
     setAttributes(
         new Attribute[]{
-            StdAttr.FACING, StdAttr.GATE, FREQUENCY_MEASURE, VOLUME_WIDTH, StdAttr.LABEL, StdAttr.LABEL_FONT,
-            WAVEFORM, CHANNEL, SMOOTH_LEVEL, SMOOTH_WIDTH
+            StdAttr.FACING,
+            StdAttr.SELECT_LOC,
+            FREQUENCY_MEASURE,
+            VOLUME_WIDTH,
+            StdAttr.LABEL,
+            StdAttr.LABEL_FONT,
+            WAVEFORM,
+            CHANNEL,
+            SMOOTH_LEVEL,
+            SMOOTH_WIDTH
         },
-        new Object[]{Direction.WEST, StdAttr.GATE_BOTTOM_RIGHT, Hz, BitWidth.create(7), "", StdAttr.DEFAULT_LABEL_FONT, Sine,
+        new Object[]{
+            Direction.WEST,
+            StdAttr.SELECT_BOTTOM_LEFT,
+            Hz,
+            BitWidth.create(7),
+            "",
+            StdAttr.DEFAULT_LABEL_FONT,
+            Sine,
             C_BOTH, 2, 2});
     setFacingAttribute(StdAttr.FACING);
     setIconName("buzzer.gif");
@@ -171,7 +186,7 @@ public class Buzzer extends InstanceFactory {
     if (attr == StdAttr.FACING) {
       instance.recomputeBounds();
       updateports(instance);
-    } else if (attr == VOLUME_WIDTH || attr == StdAttr.GATE) {
+    } else if (attr == VOLUME_WIDTH || attr == StdAttr.SELECT_LOC) {
       updateports(instance);
     } else if (attr == WAVEFORM || attr == CHANNEL || attr == SMOOTH_LEVEL || attr == SMOOTH_WIDTH) {
       instance.fireInvalidated();
@@ -270,15 +285,15 @@ public class Buzzer extends InstanceFactory {
     p[VOL].setToolTip(S.getter("buzzerVolume"));
     p[ENABLE] = new Port(0, 0, Port.INPUT, 1);
     p[ENABLE].setToolTip(S.getter("enableSound"));
-    Object gateLoc = instance.getAttributeValue(StdAttr.GATE);
+    Object gateLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
     var xPw = 20;
     var yPw = 20;
     if (facing == Direction.NORTH || facing == Direction.SOUTH) {
-      xPw *= gateLoc == StdAttr.GATE_TOP_LEFT ? -1 : 1;
+      xPw *= gateLoc == StdAttr.SELECT_BOTTOM_LEFT ? -1 : 1;
       yPw *= facing == Direction.SOUTH ? -1 : 1;
     } else {
       xPw *= facing == Direction.EAST ? -1 : 1;
-      yPw *= gateLoc == StdAttr.GATE_TOP_LEFT ? -1 : 1;
+      yPw *= gateLoc == StdAttr.SELECT_TOP_RIGHT ? -1 : 1;
     }
     p[PW] = new Port(xPw, yPw, Port.INPUT, 8);
     p[PW].setToolTip(S.getter("buzzerDutyCycle"));

--- a/src/main/java/com/cburch/logisim/std/io/extra/Buzzer.java
+++ b/src/main/java/com/cburch/logisim/std/io/extra/Buzzer.java
@@ -114,10 +114,10 @@ public class Buzzer extends InstanceFactory {
     super(_ID, S.getter("buzzerComponent"));
     setAttributes(
         new Attribute[]{
-            StdAttr.FACING, FREQUENCY_MEASURE, VOLUME_WIDTH, StdAttr.LABEL, StdAttr.LABEL_FONT,
+            StdAttr.FACING, StdAttr.GATE, FREQUENCY_MEASURE, VOLUME_WIDTH, StdAttr.LABEL, StdAttr.LABEL_FONT,
             WAVEFORM, CHANNEL, SMOOTH_LEVEL, SMOOTH_WIDTH
         },
-        new Object[]{Direction.WEST, Hz, BitWidth.create(7), "", StdAttr.DEFAULT_LABEL_FONT, Sine,
+        new Object[]{Direction.WEST, StdAttr.GATE_BOTTOM_RIGHT, Hz, BitWidth.create(7), "", StdAttr.DEFAULT_LABEL_FONT, Sine,
             C_BOTH, 2, 2});
     setFacingAttribute(StdAttr.FACING);
     setIconName("buzzer.gif");
@@ -171,7 +171,7 @@ public class Buzzer extends InstanceFactory {
     if (attr == StdAttr.FACING) {
       instance.recomputeBounds();
       updateports(instance);
-    } else if (attr == VOLUME_WIDTH) {
+    } else if (attr == VOLUME_WIDTH || attr == StdAttr.GATE) {
       updateports(instance);
     } else if (attr == WAVEFORM || attr == CHANNEL || attr == SMOOTH_LEVEL || attr == SMOOTH_WIDTH) {
       instance.fireInvalidated();
@@ -256,10 +256,10 @@ public class Buzzer extends InstanceFactory {
   }
 
   private void updateports(Instance instance) {
-    Direction dir = instance.getAttributeValue(StdAttr.FACING);
+    Direction facing = instance.getAttributeValue(StdAttr.FACING);
     byte VolumeWidth = (byte) instance.getAttributeValue(VOLUME_WIDTH).getWidth();
     Port[] p = new Port[4];
-    if (dir == Direction.EAST || dir == Direction.WEST) {
+    if (facing == Direction.EAST || facing == Direction.WEST) {
       p[FREQ] = new Port(0, -10, Port.INPUT, 14);
       p[VOL] = new Port(0, 10, Port.INPUT, VolumeWidth);
     } else {
@@ -270,12 +270,15 @@ public class Buzzer extends InstanceFactory {
     p[VOL].setToolTip(S.getter("buzzerVolume"));
     p[ENABLE] = new Port(0, 0, Port.INPUT, 1);
     p[ENABLE].setToolTip(S.getter("enableSound"));
+    Object gateLoc = instance.getAttributeValue(StdAttr.GATE);
     var xPw = 20;
     var yPw = 20;
-    if (dir == Direction.SOUTH) {
-      yPw = -20;
-    } else if (dir == Direction.EAST) {
-      xPw = -20;
+    if (facing == Direction.NORTH || facing == Direction.SOUTH) {
+      xPw *= gateLoc == StdAttr.GATE_TOP_LEFT ? -1 : 1;
+      yPw *= facing == Direction.SOUTH ? -1 : 1;
+    } else {
+      xPw *= facing == Direction.EAST ? -1 : 1;
+      yPw *= gateLoc == StdAttr.GATE_TOP_LEFT ? -1 : 1;
     }
     p[PW] = new Port(xPw, yPw, Port.INPUT, 8);
     p[PW].setToolTip(S.getter("buzzerDutyCycle"));

--- a/src/main/java/com/cburch/logisim/std/io/extra/Buzzer.java
+++ b/src/main/java/com/cburch/logisim/std/io/extra/Buzzer.java
@@ -285,15 +285,15 @@ public class Buzzer extends InstanceFactory {
     p[VOL].setToolTip(S.getter("buzzerVolume"));
     p[ENABLE] = new Port(0, 0, Port.INPUT, 1);
     p[ENABLE].setToolTip(S.getter("enableSound"));
-    Object gateLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
+    Object selectLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
     var xPw = 20;
     var yPw = 20;
     if (facing == Direction.NORTH || facing == Direction.SOUTH) {
-      xPw *= gateLoc == StdAttr.SELECT_BOTTOM_LEFT ? -1 : 1;
+      xPw *= selectLoc == StdAttr.SELECT_BOTTOM_LEFT ? -1 : 1;
       yPw *= facing == Direction.SOUTH ? -1 : 1;
     } else {
       xPw *= facing == Direction.EAST ? -1 : 1;
-      yPw *= gateLoc == StdAttr.SELECT_TOP_RIGHT ? -1 : 1;
+      yPw *= selectLoc == StdAttr.SELECT_TOP_RIGHT ? -1 : 1;
     }
     p[PW] = new Port(xPw, yPw, Port.INPUT, 8);
     p[PW].setToolTip(S.getter("buzzerDutyCycle"));

--- a/src/main/java/com/cburch/logisim/std/plexers/BitSelector.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/BitSelector.java
@@ -66,8 +66,8 @@ public class BitSelector extends InstanceFactory {
   public BitSelector() {
     super(_ID, S.getter("bitSelectorComponent"));
     setAttributes(
-        new Attribute[] {StdAttr.FACING, StdAttr.WIDTH, GROUP_ATTR},
-        new Object[] {Direction.EAST, BitWidth.create(8), BitWidth.ONE});
+        new Attribute[] {StdAttr.FACING, StdAttr.SELECT_LOC, StdAttr.WIDTH, GROUP_ATTR},
+        new Object[] {Direction.EAST, StdAttr.SELECT_BOTTOM_LEFT, BitWidth.create(8), BitWidth.ONE});
     setKeyConfigurator(
         JoinedConfigurator.create(
             new BitWidthConfigurator(GROUP_ATTR, 1, Value.MAX_WIDTH, 0),
@@ -109,7 +109,7 @@ public class BitSelector extends InstanceFactory {
     if (attr == StdAttr.FACING) {
       instance.recomputeBounds();
       updatePorts(instance);
-    } else if (attr == StdAttr.WIDTH || attr == GROUP_ATTR) {
+    } else if (attr == StdAttr.WIDTH || attr == GROUP_ATTR || attr == StdAttr.SELECT_LOC) {
       updatePorts(instance);
     }
   }
@@ -164,6 +164,7 @@ public class BitSelector extends InstanceFactory {
 
   private void updatePorts(Instance instance) {
     final var facing = instance.getAttributeValue(StdAttr.FACING);
+    final var selectLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
     final var data = instance.getAttributeValue(StdAttr.WIDTH);
     final var group = instance.getAttributeValue(GROUP_ATTR);
     var groups = (data.getWidth() + group.getWidth() - 1) / group.getWidth() - 1;
@@ -180,16 +181,28 @@ public class BitSelector extends InstanceFactory {
     Location selPt;
     if (facing == Direction.WEST) {
       inPt = Location.create(30, 0);
-      selPt = Location.create(10, 10);
+      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) 
+        selPt = Location.create(10, -10);
+      else
+        selPt = Location.create(10, 10);
     } else if (facing == Direction.NORTH) {
       inPt = Location.create(0, 30);
-      selPt = Location.create(-10, 10);
+      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) 
+        selPt = Location.create(-10, 10);
+      else
+        selPt = Location.create(10, 10);
     } else if (facing == Direction.SOUTH) {
       inPt = Location.create(0, -30);
-      selPt = Location.create(-10, -10);
+      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) 
+        selPt = Location.create(-10, -10);
+      else
+        selPt = Location.create(10, -10);
     } else {
       inPt = Location.create(-30, 0);
-      selPt = Location.create(-10, 10);
+      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) 
+        selPt = Location.create(-10, 10);
+      else
+        selPt = Location.create(-10, -10);
     }
 
     final var ps = new Port[3];

--- a/src/main/java/com/cburch/logisim/std/plexers/Decoder.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Decoder.java
@@ -64,7 +64,7 @@ public class Decoder extends InstanceFactory {
     setAttributes(
         new Attribute[] {
           StdAttr.FACING,
-          PlexersLibrary.ATTR_SELECT_LOC,
+          StdAttr.SELECT_LOC,
           PlexersLibrary.ATTR_SELECT,
           PlexersLibrary.ATTR_TRISTATE,
           PlexersLibrary.ATTR_DISABLED,
@@ -72,7 +72,7 @@ public class Decoder extends InstanceFactory {
         },
         new Object[] {
           Direction.EAST,
-          PlexersLibrary.SELECT_BOTTOM_LEFT,
+          StdAttr.SELECT_BOTTOM_LEFT,
           PlexersLibrary.DEFAULT_SELECT,
           PlexersLibrary.DEFAULT_TRISTATE,
           PlexersLibrary.DISABLED_ZERO,
@@ -114,12 +114,12 @@ public class Decoder extends InstanceFactory {
   @Override
   public Bounds getOffsetBounds(AttributeSet attrs) {
     final var facing = attrs.getValue(StdAttr.FACING);
-    final var selectLoc = attrs.getValue(PlexersLibrary.ATTR_SELECT_LOC);
+    final var selectLoc = attrs.getValue(StdAttr.SELECT_LOC);
     final var select = attrs.getValue(PlexersLibrary.ATTR_SELECT);
     final var outputs = 1 << select.getWidth();
     Bounds bds;
     var reversed = facing == Direction.WEST || facing == Direction.NORTH;
-    if (selectLoc == PlexersLibrary.SELECT_TOP_RIGHT) reversed = !reversed;
+    if (selectLoc == StdAttr.SELECT_TOP_RIGHT) reversed = !reversed;
     if (outputs == 2) {
       int y = reversed ? 0 : -40;
       bds = Bounds.create(-20, y - 5, 30, 40 + 10);
@@ -145,7 +145,7 @@ public class Decoder extends InstanceFactory {
 
   @Override
   protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
-    if (attr == StdAttr.FACING || attr == PlexersLibrary.ATTR_SELECT_LOC || attr == PlexersLibrary.ATTR_SELECT) {
+    if (attr == StdAttr.FACING || attr == StdAttr.SELECT_LOC || attr == PlexersLibrary.ATTR_SELECT) {
       instance.recomputeBounds();
       updatePorts(instance);
     } else if (attr == PlexersLibrary.ATTR_ENABLE) {
@@ -185,10 +185,10 @@ public class Decoder extends InstanceFactory {
     final var g = painter.getGraphics();
     final var bds = painter.getBounds();
     final var facing = painter.getAttributeValue(StdAttr.FACING);
-    Object selectLoc = painter.getAttributeValue(PlexersLibrary.ATTR_SELECT_LOC);
+    Object selectLoc = painter.getAttributeValue(StdAttr.SELECT_LOC);
     final var select = painter.getAttributeValue(PlexersLibrary.ATTR_SELECT);
     boolean enable = painter.getAttributeValue(PlexersLibrary.ATTR_ENABLE);
-    int selMult = selectLoc == PlexersLibrary.SELECT_TOP_RIGHT ? -1 : 1;
+    int selMult = selectLoc == StdAttr.SELECT_TOP_RIGHT ? -1 : 1;
     int outputs = 1 << select.getWidth();
 
     // draw stubs for select and enable ports
@@ -312,7 +312,7 @@ public class Decoder extends InstanceFactory {
 
   private void updatePorts(Instance instance) {
     final var facing = instance.getAttributeValue(StdAttr.FACING);
-    Object selectLoc = instance.getAttributeValue(PlexersLibrary.ATTR_SELECT_LOC);
+    Object selectLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
     final var select = instance.getAttributeValue(PlexersLibrary.ATTR_SELECT);
     final var enable = instance.getAttributeValue(PlexersLibrary.ATTR_ENABLE);
     var outputs = 1 << select.getWidth();
@@ -322,7 +322,7 @@ public class Decoder extends InstanceFactory {
       Location end1;
       if (facing == Direction.NORTH || facing == Direction.SOUTH) {
         int y = facing == Direction.NORTH ? -10 : 10;
-        if (selectLoc == PlexersLibrary.SELECT_TOP_RIGHT) {
+        if (selectLoc == StdAttr.SELECT_TOP_RIGHT) {
           end0 = Location.create(-30, y);
           end1 = Location.create(-10, y);
         } else {
@@ -331,7 +331,7 @@ public class Decoder extends InstanceFactory {
         }
       } else {
         int x = facing == Direction.WEST ? -10 : 10;
-        if (selectLoc == PlexersLibrary.SELECT_TOP_RIGHT) {
+        if (selectLoc == StdAttr.SELECT_TOP_RIGHT) {
           end0 = Location.create(x, 10);
           end1 = Location.create(x, 30);
         } else {
@@ -349,12 +349,12 @@ public class Decoder extends InstanceFactory {
       if (facing == Direction.NORTH || facing == Direction.SOUTH) {
         dy = facing == Direction.NORTH ? -20 : 20;
         ddy = 0;
-        dx = selectLoc == PlexersLibrary.SELECT_TOP_RIGHT ? -10 * outputs : 0;
+        dx = selectLoc == StdAttr.SELECT_TOP_RIGHT ? -10 * outputs : 0;
         ddx = 10;
       } else {
         dx = facing == Direction.WEST ? -20 : 20;
         ddx = 0;
-        dy = selectLoc == PlexersLibrary.SELECT_TOP_RIGHT ? 0 : -10 * outputs;
+        dy = selectLoc == StdAttr.SELECT_TOP_RIGHT ? 0 : -10 * outputs;
         ddy = 10;
       }
       for (var i = 0; i < outputs; i++) {

--- a/src/main/java/com/cburch/logisim/std/plexers/Demultiplexer.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Demultiplexer.java
@@ -65,7 +65,7 @@ public class Demultiplexer extends InstanceFactory {
     setAttributes(
         new Attribute[] {
           StdAttr.FACING,
-          PlexersLibrary.ATTR_SELECT_LOC,
+          StdAttr.SELECT_LOC,
           PlexersLibrary.ATTR_SELECT,
           StdAttr.WIDTH,
           PlexersLibrary.ATTR_TRISTATE,
@@ -74,7 +74,7 @@ public class Demultiplexer extends InstanceFactory {
         },
         new Object[] {
           Direction.EAST,
-          PlexersLibrary.SELECT_BOTTOM_LEFT,
+          StdAttr.SELECT_BOTTOM_LEFT,
           PlexersLibrary.DEFAULT_SELECT,
           BitWidth.ONE,
           PlexersLibrary.DEFAULT_TRISTATE,
@@ -145,7 +145,7 @@ public class Demultiplexer extends InstanceFactory {
 
   @Override
   protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
-    if (attr == StdAttr.FACING || attr == PlexersLibrary.ATTR_SELECT_LOC || attr == PlexersLibrary.ATTR_SELECT) {
+    if (attr == StdAttr.FACING || attr == StdAttr.SELECT_LOC || attr == PlexersLibrary.ATTR_SELECT) {
       instance.recomputeBounds();
       updatePorts(instance);
     } else if (attr == StdAttr.WIDTH || attr == PlexersLibrary.ATTR_ENABLE) {
@@ -192,8 +192,8 @@ public class Demultiplexer extends InstanceFactory {
     // draw select and enable inputs
     GraphicsUtil.switchToWidth(g, 3);
     final var vertical = facing == Direction.NORTH || facing == Direction.SOUTH;
-    Object selectLoc = painter.getAttributeValue(PlexersLibrary.ATTR_SELECT_LOC);
-    final var selMult = selectLoc == PlexersLibrary.SELECT_BOTTOM_LEFT ? 1 : -1;
+    Object selectLoc = painter.getAttributeValue(StdAttr.SELECT_LOC);
+    final var selMult = selectLoc == StdAttr.SELECT_BOTTOM_LEFT ? 1 : -1;
     final var dx = vertical ? selMult : 0;
     final var dy = vertical ? 0 : -selMult;
     if (outputs == 2) { // draw select wire
@@ -310,14 +310,14 @@ public class Demultiplexer extends InstanceFactory {
 
   private void updatePorts(Instance instance) {
     final var facing = instance.getAttributeValue(StdAttr.FACING);
-    Object selectLoc = instance.getAttributeValue(PlexersLibrary.ATTR_SELECT_LOC);
+    Object selectLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
     final var data = instance.getAttributeValue(StdAttr.WIDTH);
     final var select = instance.getAttributeValue(PlexersLibrary.ATTR_SELECT);
     final var enable = instance.getAttributeValue(PlexersLibrary.ATTR_ENABLE);
     var outputs = 1 << select.getWidth();
     final var ps = new Port[outputs + (enable ? 3 : 2)];
     Location sel;
-    int selMult = selectLoc == PlexersLibrary.SELECT_BOTTOM_LEFT ? 1 : -1;
+    int selMult = selectLoc == StdAttr.SELECT_BOTTOM_LEFT ? 1 : -1;
     if (outputs == 2) {
       Location end0;
       Location end1;

--- a/src/main/java/com/cburch/logisim/std/plexers/Multiplexer.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Multiplexer.java
@@ -92,14 +92,14 @@ public class Multiplexer extends InstanceFactory {
         new Attribute[] {
           StdAttr.FACING,
           PlexersLibrary.ATTR_SIZE,
-          PlexersLibrary.ATTR_SELECT_LOC,
+          StdAttr.SELECT_LOC,
           PlexersLibrary.ATTR_SELECT,
           StdAttr.WIDTH,
           PlexersLibrary.ATTR_DISABLED,
           PlexersLibrary.ATTR_ENABLE
         },
         new Object[] {
-          Direction.EAST, PlexersLibrary.SIZE_WIDE, PlexersLibrary.SELECT_BOTTOM_LEFT,
+          Direction.EAST, PlexersLibrary.SIZE_WIDE, StdAttr.SELECT_BOTTOM_LEFT,
           PlexersLibrary.DEFAULT_SELECT, BitWidth.ONE, PlexersLibrary.DISABLED_ZERO,
           PlexersLibrary.DEFAULT_ENABLE
         });
@@ -171,7 +171,7 @@ public class Multiplexer extends InstanceFactory {
   @Override
   protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
     if (attr == StdAttr.FACING
-        || attr == PlexersLibrary.ATTR_SELECT_LOC
+        || attr == StdAttr.SELECT_LOC
         || attr == PlexersLibrary.ATTR_SELECT
         || attr == PlexersLibrary.ATTR_SIZE) {
       instance.recomputeBounds();
@@ -210,8 +210,8 @@ public class Multiplexer extends InstanceFactory {
     // draw stubs for select/enable inputs that aren't on instance boundary
     GraphicsUtil.switchToWidth(g, 3);
     final var vertical = facing != Direction.NORTH && facing != Direction.SOUTH;
-    Object selectLoc = painter.getAttributeValue(PlexersLibrary.ATTR_SELECT_LOC);
-    final var selMult = selectLoc == PlexersLibrary.SELECT_BOTTOM_LEFT ? 1 : -1;
+    Object selectLoc = painter.getAttributeValue(StdAttr.SELECT_LOC);
+    final var selMult = selectLoc == StdAttr.SELECT_BOTTOM_LEFT ? 1 : -1;
     final var oddside = (vertical == (selMult < 0));
     int dx, dy;
     if (wide) {
@@ -312,8 +312,8 @@ public class Multiplexer extends InstanceFactory {
     final var wide = size == PlexersLibrary.SIZE_WIDE;
     final var dir = instance.getAttributeValue(StdAttr.FACING);
     final var vertical = dir != Direction.NORTH && dir != Direction.SOUTH;
-    Object selectLoc = instance.getAttributeValue(PlexersLibrary.ATTR_SELECT_LOC);
-    final var botLeft = selectLoc == PlexersLibrary.SELECT_BOTTOM_LEFT;
+    Object selectLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
+    final var botLeft = selectLoc == StdAttr.SELECT_BOTTOM_LEFT;
     final var selMult = botLeft ? 1 : -1;
     final var data = instance.getAttributeValue(StdAttr.WIDTH);
     final var select = instance.getAttributeValue(PlexersLibrary.ATTR_SELECT);

--- a/src/main/java/com/cburch/logisim/std/plexers/Multiplexer.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Multiplexer.java
@@ -312,7 +312,7 @@ public class Multiplexer extends InstanceFactory {
     final var wide = size == PlexersLibrary.SIZE_WIDE;
     final var dir = instance.getAttributeValue(StdAttr.FACING);
     final var vertical = dir != Direction.NORTH && dir != Direction.SOUTH;
-    Object selectLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
+    final var selectLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
     final var botLeft = selectLoc == StdAttr.SELECT_BOTTOM_LEFT;
     final var selMult = botLeft ? 1 : -1;
     final var data = instance.getAttributeValue(StdAttr.WIDTH);

--- a/src/main/java/com/cburch/logisim/std/plexers/PlexersLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/PlexersLibrary.java
@@ -142,17 +142,6 @@ public class PlexersLibrary extends Library {
   public static final Attribute<Boolean> ATTR_ENABLE =
       Attributes.forBoolean("enable", S.getter("plexerEnableAttr"));
   public static final Object DEFAULT_ENABLE = Boolean.FALSE;
-  static final AttributeOption SELECT_BOTTOM_LEFT =
-      new AttributeOption("bl", S.getter("plexerSelectBottomLeftOption"));
-
-  static final AttributeOption SELECT_TOP_RIGHT =
-      new AttributeOption("tr", S.getter("plexerSelectTopRightOption"));
-
-  static final Attribute<AttributeOption> ATTR_SELECT_LOC =
-      Attributes.forOption(
-          "selloc",
-          S.getter("plexerSelectLocAttr"),
-          new AttributeOption[] {SELECT_BOTTOM_LEFT, SELECT_TOP_RIGHT});
 
   public static final int DELAY = 3;
 

--- a/src/main/java/com/cburch/logisim/std/wiring/Transistor.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Transistor.java
@@ -79,8 +79,8 @@ public class Transistor extends InstanceFactory {
   public Transistor() {
     super(_ID, S.getter("transistorComponent"));
     setAttributes(
-        new Attribute[] {ATTR_TYPE, StdAttr.FACING, WiringLibrary.ATTR_GATE, StdAttr.WIDTH},
-        new Object[] {TYPE_P, Direction.EAST, WiringLibrary.GATE_TOP_LEFT, BitWidth.ONE});
+        new Attribute[] {ATTR_TYPE, StdAttr.FACING, StdAttr.GATE, StdAttr.WIDTH},
+        new Object[] {TYPE_P, Direction.EAST, StdAttr.GATE_TOP_LEFT, BitWidth.ONE});
     setFacingAttribute(StdAttr.FACING);
     setKeyConfigurator(new BitWidthConfigurator(StdAttr.WIDTH));
   }
@@ -137,12 +137,12 @@ public class Transistor extends InstanceFactory {
 
   private void drawInstance(InstancePainter painter, boolean isGhost) {
     Object type = painter.getAttributeValue(ATTR_TYPE);
-    Object powerLoc = painter.getAttributeValue(WiringLibrary.ATTR_GATE);
+    Object powerLoc = painter.getAttributeValue(StdAttr.GATE);
     Direction from = painter.getAttributeValue(StdAttr.FACING);
     Direction facing = painter.getAttributeValue(StdAttr.FACING);
     boolean flip =
         (facing == Direction.SOUTH || facing == Direction.WEST)
-            == (powerLoc == WiringLibrary.GATE_TOP_LEFT);
+            == (powerLoc == StdAttr.GATE_TOP_LEFT);
 
     int degrees = Direction.EAST.toDegrees() - from.toDegrees();
     double radians = Math.toRadians((degrees + 360) % 360);
@@ -217,8 +217,8 @@ public class Transistor extends InstanceFactory {
   @Override
   public Bounds getOffsetBounds(AttributeSet attrs) {
     Direction facing = attrs.getValue(StdAttr.FACING);
-    Object gateLoc = attrs.getValue(WiringLibrary.ATTR_GATE);
-    int delta = gateLoc == WiringLibrary.GATE_TOP_LEFT ? -20 : 0;
+    Object gateLoc = attrs.getValue(StdAttr.GATE);
+    int delta = gateLoc == StdAttr.GATE_TOP_LEFT ? -20 : 0;
     if (facing == Direction.NORTH) {
       return Bounds.create(delta, 0, 20, 40);
     } else if (facing == Direction.SOUTH) {
@@ -232,7 +232,7 @@ public class Transistor extends InstanceFactory {
 
   @Override
   protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
-    if (attr == StdAttr.FACING || attr == WiringLibrary.ATTR_GATE) {
+    if (attr == StdAttr.FACING || attr == StdAttr.GATE) {
       instance.recomputeBounds();
       updatePorts(instance);
     } else if (attr == StdAttr.WIDTH) {
@@ -279,10 +279,10 @@ public class Transistor extends InstanceFactory {
       dx = 1;
     }
 
-    Object powerLoc = instance.getAttributeValue(WiringLibrary.ATTR_GATE);
+    Object powerLoc = instance.getAttributeValue(StdAttr.GATE);
     boolean flip =
         (facing == Direction.SOUTH || facing == Direction.WEST)
-            == (powerLoc == WiringLibrary.GATE_TOP_LEFT);
+            == (powerLoc == StdAttr.GATE_TOP_LEFT);
 
     Port[] ports = new Port[3];
     ports[OUTPUT] = new Port(0, 0, Port.OUTPUT, StdAttr.WIDTH);

--- a/src/main/java/com/cburch/logisim/std/wiring/Transistor.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Transistor.java
@@ -79,8 +79,8 @@ public class Transistor extends InstanceFactory {
   public Transistor() {
     super(_ID, S.getter("transistorComponent"));
     setAttributes(
-        new Attribute[] {ATTR_TYPE, StdAttr.FACING, StdAttr.GATE, StdAttr.WIDTH},
-        new Object[] {TYPE_P, Direction.EAST, StdAttr.GATE_TOP_LEFT, BitWidth.ONE});
+        new Attribute[] {ATTR_TYPE, StdAttr.FACING, StdAttr.SELECT_LOC, StdAttr.WIDTH},
+        new Object[] {TYPE_P, Direction.EAST, StdAttr.SELECT_TOP_RIGHT, BitWidth.ONE});
     setFacingAttribute(StdAttr.FACING);
     setKeyConfigurator(new BitWidthConfigurator(StdAttr.WIDTH));
   }
@@ -137,12 +137,12 @@ public class Transistor extends InstanceFactory {
 
   private void drawInstance(InstancePainter painter, boolean isGhost) {
     Object type = painter.getAttributeValue(ATTR_TYPE);
-    Object powerLoc = painter.getAttributeValue(StdAttr.GATE);
+    Object powerLoc = painter.getAttributeValue(StdAttr.SELECT_LOC);
     Direction from = painter.getAttributeValue(StdAttr.FACING);
     Direction facing = painter.getAttributeValue(StdAttr.FACING);
     boolean flip =
-        (facing == Direction.SOUTH || facing == Direction.WEST)
-            == (powerLoc == StdAttr.GATE_TOP_LEFT);
+        (facing == Direction.NORTH || facing == Direction.WEST)
+            == (powerLoc == StdAttr.SELECT_TOP_RIGHT);
 
     int degrees = Direction.EAST.toDegrees() - from.toDegrees();
     double radians = Math.toRadians((degrees + 360) % 360);
@@ -217,22 +217,22 @@ public class Transistor extends InstanceFactory {
   @Override
   public Bounds getOffsetBounds(AttributeSet attrs) {
     Direction facing = attrs.getValue(StdAttr.FACING);
-    Object gateLoc = attrs.getValue(StdAttr.GATE);
-    int delta = gateLoc == StdAttr.GATE_TOP_LEFT ? -20 : 0;
+    Object gateLoc = attrs.getValue(StdAttr.SELECT_LOC);
+    int delta = gateLoc == StdAttr.SELECT_TOP_RIGHT ? 20 : 0;
     if (facing == Direction.NORTH) {
-      return Bounds.create(delta, 0, 20, 40);
+      return Bounds.create(-20 + delta, 0, 20, 40);
     } else if (facing == Direction.SOUTH) {
-      return Bounds.create(delta, -40, 20, 40);
+      return Bounds.create(-20 + delta, -40, 20, 40);
     } else if (facing == Direction.WEST) {
-      return Bounds.create(0, delta, 40, 20);
+      return Bounds.create(0, delta * -1, 40, 20);
     } else { // facing == Direction.EAST
-      return Bounds.create(-40, delta, 40, 20);
+      return Bounds.create(-40, delta * -1, 40, 20);
     }
   }
 
   @Override
   protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
-    if (attr == StdAttr.FACING || attr == StdAttr.GATE) {
+    if (attr == StdAttr.FACING || attr == StdAttr.SELECT_LOC) {
       instance.recomputeBounds();
       updatePorts(instance);
     } else if (attr == StdAttr.WIDTH) {
@@ -279,10 +279,10 @@ public class Transistor extends InstanceFactory {
       dx = 1;
     }
 
-    Object powerLoc = instance.getAttributeValue(StdAttr.GATE);
+    Object powerLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
     boolean flip =
-        (facing == Direction.SOUTH || facing == Direction.WEST)
-            == (powerLoc == StdAttr.GATE_TOP_LEFT);
+        (facing == Direction.NORTH || facing == Direction.WEST)
+            == (powerLoc == StdAttr.SELECT_TOP_RIGHT);
 
     Port[] ports = new Port[3];
     ports[OUTPUT] = new Port(0, 0, Port.OUTPUT, StdAttr.WIDTH);

--- a/src/main/java/com/cburch/logisim/std/wiring/TransmissionGate.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/TransmissionGate.java
@@ -68,8 +68,8 @@ public class TransmissionGate extends InstanceFactory {
     super(_ID, S.getter("transmissionGateComponent"));
     setIconName("transmis.gif");
     setAttributes(
-        new Attribute[] {StdAttr.FACING, WiringLibrary.ATTR_GATE, StdAttr.WIDTH},
-        new Object[] {Direction.EAST, WiringLibrary.GATE_TOP_LEFT, BitWidth.ONE});
+        new Attribute[] {StdAttr.FACING, StdAttr.GATE, StdAttr.WIDTH},
+        new Object[] {Direction.EAST, StdAttr.GATE_TOP_LEFT, BitWidth.ONE});
     setFacingAttribute(StdAttr.FACING);
     setKeyConfigurator(new BitWidthConfigurator(StdAttr.WIDTH));
   }
@@ -120,11 +120,11 @@ public class TransmissionGate extends InstanceFactory {
 
   private void drawInstance(InstancePainter painter, boolean isGhost) {
     Bounds bds = painter.getBounds();
-    Object powerLoc = painter.getAttributeValue(WiringLibrary.ATTR_GATE);
+    Object powerLoc = painter.getAttributeValue(StdAttr.GATE);
     Direction facing = painter.getAttributeValue(StdAttr.FACING);
     boolean flip =
         (facing == Direction.SOUTH || facing == Direction.WEST)
-            == (powerLoc == WiringLibrary.GATE_TOP_LEFT);
+            == (powerLoc == StdAttr.GATE_TOP_LEFT);
 
     int degrees = Direction.WEST.toDegrees() - facing.toDegrees();
     if (flip) degrees += 180;
@@ -199,7 +199,7 @@ public class TransmissionGate extends InstanceFactory {
 
   @Override
   protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
-    if (attr == StdAttr.FACING || attr == WiringLibrary.ATTR_GATE) {
+    if (attr == StdAttr.FACING || attr == StdAttr.GATE) {
       instance.recomputeBounds();
       updatePorts(instance);
     } else if (attr == StdAttr.WIDTH) {
@@ -236,10 +236,10 @@ public class TransmissionGate extends InstanceFactory {
       dx = 1;
     }
 
-    Object powerLoc = instance.getAttributeValue(WiringLibrary.ATTR_GATE);
+    Object powerLoc = instance.getAttributeValue(StdAttr.GATE);
     boolean flip =
         (facing == Direction.SOUTH || facing == Direction.WEST)
-            == (powerLoc == WiringLibrary.GATE_TOP_LEFT);
+            == (powerLoc == StdAttr.GATE_TOP_LEFT);
 
     Port[] ports = new Port[4];
     ports[OUTPUT] = new Port(0, 0, Port.OUTPUT, StdAttr.WIDTH);

--- a/src/main/java/com/cburch/logisim/std/wiring/TransmissionGate.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/TransmissionGate.java
@@ -68,8 +68,8 @@ public class TransmissionGate extends InstanceFactory {
     super(_ID, S.getter("transmissionGateComponent"));
     setIconName("transmis.gif");
     setAttributes(
-        new Attribute[] {StdAttr.FACING, StdAttr.GATE, StdAttr.WIDTH},
-        new Object[] {Direction.EAST, StdAttr.GATE_TOP_LEFT, BitWidth.ONE});
+        new Attribute[] {StdAttr.FACING, StdAttr.SELECT_LOC, StdAttr.WIDTH},
+        new Object[] {Direction.EAST, StdAttr.SELECT_TOP_RIGHT, BitWidth.ONE});
     setFacingAttribute(StdAttr.FACING);
     setKeyConfigurator(new BitWidthConfigurator(StdAttr.WIDTH));
   }
@@ -120,11 +120,11 @@ public class TransmissionGate extends InstanceFactory {
 
   private void drawInstance(InstancePainter painter, boolean isGhost) {
     Bounds bds = painter.getBounds();
-    Object powerLoc = painter.getAttributeValue(StdAttr.GATE);
+    Object powerLoc = painter.getAttributeValue(StdAttr.SELECT_LOC);
     Direction facing = painter.getAttributeValue(StdAttr.FACING);
     boolean flip =
-        (facing == Direction.SOUTH || facing == Direction.WEST)
-            == (powerLoc == StdAttr.GATE_TOP_LEFT);
+        (facing == Direction.NORTH || facing == Direction.WEST)
+            == (powerLoc == StdAttr.SELECT_TOP_RIGHT);
 
     int degrees = Direction.WEST.toDegrees() - facing.toDegrees();
     if (flip) degrees += 180;
@@ -199,7 +199,7 @@ public class TransmissionGate extends InstanceFactory {
 
   @Override
   protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
-    if (attr == StdAttr.FACING || attr == StdAttr.GATE) {
+    if (attr == StdAttr.FACING || attr == StdAttr.SELECT_LOC) {
       instance.recomputeBounds();
       updatePorts(instance);
     } else if (attr == StdAttr.WIDTH) {
@@ -236,10 +236,10 @@ public class TransmissionGate extends InstanceFactory {
       dx = 1;
     }
 
-    Object powerLoc = instance.getAttributeValue(StdAttr.GATE);
+    Object powerLoc = instance.getAttributeValue(StdAttr.SELECT_LOC);
     boolean flip =
-        (facing == Direction.SOUTH || facing == Direction.WEST)
-            == (powerLoc == StdAttr.GATE_TOP_LEFT);
+        (facing == Direction.NORTH || facing == Direction.WEST)
+            == (powerLoc == StdAttr.SELECT_TOP_RIGHT);
 
     Port[] ports = new Port[4];
     ports[OUTPUT] = new Port(0, 0, Port.OUTPUT, StdAttr.WIDTH);

--- a/src/main/java/com/cburch/logisim/std/wiring/WiringLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/WiringLibrary.java
@@ -31,9 +31,6 @@ package com.cburch.logisim.std.wiring;
 import static com.cburch.logisim.std.Strings.S;
 
 import com.cburch.logisim.circuit.SplitterFactory;
-import com.cburch.logisim.data.Attribute;
-import com.cburch.logisim.data.AttributeOption;
-import com.cburch.logisim.data.Attributes;
 import com.cburch.logisim.tools.AddTool;
 import com.cburch.logisim.tools.FactoryDescription;
 import com.cburch.logisim.tools.Library;
@@ -51,16 +48,6 @@ public class WiringLibrary extends Library {
    * Identifier value must MUST be unique string among all libraries.
    */
   public static final String _ID = "Wiring";
-
-  static final AttributeOption GATE_TOP_LEFT =
-      new AttributeOption("tl", S.getter("wiringGateTopLeftOption"));
-  static final AttributeOption GATE_BOTTOM_RIGHT =
-      new AttributeOption("br", S.getter("wiringGateBottomRightOption"));
-  static final Attribute<AttributeOption> ATTR_GATE =
-      Attributes.forOption(
-          "gate",
-          S.getter("wiringGateAttr"),
-          new AttributeOption[] {GATE_TOP_LEFT, GATE_BOTTOM_RIGHT});
 
   private static final Tool[] ADD_TOOLS = {
     new AddTool(SplitterFactory.instance),

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -710,6 +710,9 @@ stdLabelLocAttr = Label Location
 stdLabelVisibility = Label Visible
 stdLogisimEvolutionAppearance = Logisim-Evolution
 stdTriggerAttr = Trigger
+stdGateAttr = Gate Location
+stdGateBottomRightOption = Bottom/Right
+stdGateTopLeftOption = Top/Left
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +906,5 @@ noConnectionComponent = Do not connect
 powerComponent = Power
 transistorComponent = Transistor
 transmissionGateComponent = Transmission Gate
-wiringGateAttr = Gate Location
-wiringGateBottomRightOption = Bottom/Right
-wiringGateTopLeftOption = Top/Left
 wiringLibrary = Wiring
 input.output.extra = Input/Output Extra

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -710,9 +710,9 @@ stdLabelLocAttr = Label Location
 stdLabelVisibility = Label Visible
 stdLogisimEvolutionAppearance = Logisim-Evolution
 stdTriggerAttr = Trigger
-stdGateAttr = Gate Location
-stdGateBottomRightOption = Bottom/Right
-stdGateTopLeftOption = Top/Left
+stdSelectLocAttr = Select Location
+stdSelectBottomLeftOption = Bottom/Left
+stdSelectTopRightOption = Top/Right
 #
 # tcl/TclLibrary.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = Zero
 plexerEnableAttr = Include Enable?
 plexerLibrary = Plexers
 plexerSelectBitsAttr = Select Bits
-plexerSelectBottomLeftOption = Bottom/Left
-plexerSelectLocAttr = Select Location
-plexerSelectTopRightOption = Top/Right
 plexerThreeStateAttr = Three-state?
 priorityEncoderComponent = Priority Encoder
 #

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = Null
 plexerEnableAttr = Eingang freigeben?
 plexerLibrary = Auswahlschaltungen
 plexerSelectBitsAttr = Auswahlleitungen
-plexerSelectBottomLeftOption = Unten/Links
-plexerSelectLocAttr = Position der Eingänge
-plexerSelectTopRightOption = Oben/Rechts
 plexerThreeStateAttr = Threestate?
 priorityEncoderComponent = Prioritätsenkoder
 #
@@ -710,6 +707,9 @@ stdLabelLocAttr = Labelposition
 stdLabelVisibility = Etikett sichtbar
 stdLogisimEvolutionAppearance = Logisim-Entwicklung
 stdTriggerAttr = Trigger
+# ==> stdSelectLocAttr =
+# ==> stdSelectBottomLeftOption =
+# ==> stdSelectTopRightOption =
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +903,5 @@ noConnectionComponent = Nicht anschließen
 powerComponent = Versorgungsspannung
 transistorComponent = Transistor
 transmissionGateComponent = Übertragungsgatter
-wiringGateAttr = Position der Eingänge
-wiringGateBottomRightOption = Unten/Rechts
-wiringGateTopLeftOption = Oben/Links
 wiringLibrary = Verdrahtung
 # ==> input.output.extra =

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -707,9 +707,9 @@ stdLabelLocAttr = Labelposition
 stdLabelVisibility = Etikett sichtbar
 stdLogisimEvolutionAppearance = Logisim-Entwicklung
 stdTriggerAttr = Trigger
-# ==> stdSelectLocAttr =
-# ==> stdSelectBottomLeftOption =
-# ==> stdSelectTopRightOption =
+stdSelectLocAttr = Position der Eingänge
+stdSelectBottomLeftOption = Unten/Links
+stdSelectTopRightOption = Oben/Rechts
 #
 # tcl/TclLibrary.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = Μηδέν
 # ==> plexerEnableAttr =
 plexerLibrary = Πλέκτες/Κωδικοποιητές
 plexerSelectBitsAttr = Επιλογή Ψηφίων
-# ==> plexerSelectBottomLeftOption =
-# ==> plexerSelectLocAttr =
-# ==> plexerSelectTopRightOption =
 plexerThreeStateAttr = Τριών-Καταστάσεων?
 priorityEncoderComponent = Κωδικοποιητής Προτεραιότητας
 #
@@ -710,6 +707,9 @@ stdLabelFontAttr = Γραμματοσειρά Ετικέτας
 # ==> stdLabelVisibility =
 # ==> stdLogisimEvolutionAppearance =
 stdTriggerAttr = Σκανδαλισμός
+# ==> stdSelectLocAttr =
+# ==> stdSelectBottomLeftOption =
+# ==> stdSelectTopRightOption =
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +903,5 @@ groundComponent = Γείωση
 powerComponent = Ισχύς
 transistorComponent = Τρανζίστορ
 transmissionGateComponent = Πύλη Μετάδοσης
-wiringGateAttr = Θέση Πύλης
-wiringGateBottomRightOption = Κάτω/Δεξιά
-wiringGateTopLeftOption = Πάνω/Αριστερά
 wiringLibrary = Καλωδίωση
 # ==> input.output.extra =

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = Cero
 plexerEnableAttr = ¿Incluir Enable?
 plexerLibrary = Plexores
 plexerSelectBitsAttr = Bits de selección
-plexerSelectBottomLeftOption = Abajo/izquierda
-plexerSelectLocAttr = Posición de selección
-plexerSelectTopRightOption = Arriba/derecha
 plexerThreeStateAttr = ¿Tres estados?
 priorityEncoderComponent = Codificador de prioridad
 #
@@ -710,6 +707,9 @@ stdLabelFontAttr = Fuente de etiqueta
 stdLabelVisibility = Etiqueta visible
 # ==> stdLogisimEvolutionAppearance =
 stdTriggerAttr = Flanco
+# ==> stdSelectLocAttr =
+# ==> stdSelectBottomLeftOption =
+# ==> stdSelectTopRightOption =
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +903,5 @@ groundComponent = Tierra
 powerComponent = Alimentación
 transistorComponent = Transistor
 transmissionGateComponent = Puerta de transmisión
-wiringGateAttr = Posición de la puerta
-wiringGateBottomRightOption = Abajo/derecha
-wiringGateTopLeftOption = Arriba/izquierda
 wiringLibrary = Cableado
 # ==> input.output.extra =

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -707,9 +707,9 @@ stdLabelFontAttr = Fuente de etiqueta
 stdLabelVisibility = Etiqueta visible
 # ==> stdLogisimEvolutionAppearance =
 stdTriggerAttr = Flanco
-# ==> stdSelectLocAttr =
-# ==> stdSelectBottomLeftOption =
-# ==> stdSelectTopRightOption =
+stdSelectLocAttr = Posición de selección
+stdSelectBottomLeftOption = Abajo/izquierda
+stdSelectTopRightOption = Arriba/derecha
 #
 # tcl/TclLibrary.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -707,9 +707,9 @@ stdLabelLocAttr = Emplacement de l'étiquette
 stdLabelVisibility = Étiquette visible
 stdLogisimEvolutionAppearance = Logisim-Evolution
 stdTriggerAttr = Trigger
-# ==> stdSelectLocAttr =
-# ==> stdSelectBottomLeftOption =
-# ==> stdSelectTopRightOption =
+stdSelectLocAttr = Selectionner l'emplacement
+stdSelectBottomLeftOption = Fond/Gauche
+stdSelectTopRightOption = Haut/Droite
 #
 # tcl/TclLibrary.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = Zero
 plexerEnableAttr = Inclure l'activation ?
 plexerLibrary = De/Multiplexeurs,Encodeurs
 plexerSelectBitsAttr = Select Bits
-plexerSelectBottomLeftOption = Fond/Gauche
-plexerSelectLocAttr = Selectionner l'emplacement
-plexerSelectTopRightOption = Haut/Droite
 plexerThreeStateAttr = Trois états ?
 priorityEncoderComponent = Encodeur prioritaire
 #
@@ -710,6 +707,9 @@ stdLabelLocAttr = Emplacement de l'étiquette
 stdLabelVisibility = Étiquette visible
 stdLogisimEvolutionAppearance = Logisim-Evolution
 stdTriggerAttr = Trigger
+# ==> stdSelectLocAttr =
+# ==> stdSelectBottomLeftOption =
+# ==> stdSelectTopRightOption =
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +903,5 @@ noConnectionComponent = Ne pas connecter
 powerComponent = Alimentation
 transistorComponent = Transistor
 transmissionGateComponent = Porte de transmission
-wiringGateAttr = Position de la porte
-wiringGateBottomRightOption = Bas/droite
-wiringGateTopLeftOption = Haut/gauche
 wiringLibrary = Câblage
 input.output.extra = Entrée/Sortie (extra)

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = Zero
 plexerEnableAttr = Includere Abilitazione?
 plexerLibrary = Plexers
 plexerSelectBitsAttr = Bits di Selezione
-plexerSelectBottomLeftOption = Sotto/Sinistra
-plexerSelectLocAttr = Locazione Select
-plexerSelectTopRightOption = Sopra/Destra
 plexerThreeStateAttr = Three-state?
 priorityEncoderComponent = Encoder a Priorità
 #
@@ -710,6 +707,9 @@ stdLabelLocAttr = Posizione dell'etichetta
 stdLabelVisibility = Etichetta Visibile
 stdLogisimEvolutionAppearance = Logisim-Evoluzione
 stdTriggerAttr = Innesco
+# ==> stdSelectLocAttr =
+# ==> stdSelectBottomLeftOption =
+# ==> stdSelectTopRightOption =
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +903,5 @@ noConnectionComponent = Non collegare
 powerComponent = Alimentazione
 transistorComponent = Transistor
 transmissionGateComponent = Porta di Trasmissione
-wiringGateAttr = Posizione Porta
-wiringGateBottomRightOption = Sotto/Destra
-wiringGateTopLeftOption = Sopra/Sinistra
 wiringLibrary = Connessioni
 # ==> input.output.extra =

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -707,9 +707,9 @@ stdLabelLocAttr = Posizione dell'etichetta
 stdLabelVisibility = Etichetta Visibile
 stdLogisimEvolutionAppearance = Logisim-Evoluzione
 stdTriggerAttr = Innesco
-# ==> stdSelectLocAttr =
-# ==> stdSelectBottomLeftOption =
-# ==> stdSelectTopRightOption =
+stdSelectLocAttr = Locazione Select
+stdSelectBottomLeftOption = Sotto/Sinistra
+stdSelectTopRightOption = Sopra/Destra
 #
 # tcl/TclLibrary.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = ゼロ
 plexerEnableAttr = Include Enable?
 plexerLibrary = プレクサ
 plexerSelectBitsAttr = ビットの選択
-plexerSelectBottomLeftOption = 下/左
-plexerSelectLocAttr = 位置の選択
-plexerSelectTopRightOption = 上/右
 plexerThreeStateAttr = Three-state?
 priorityEncoderComponent = プライオリティ・エンコーダ
 #
@@ -710,6 +707,9 @@ stdLabelLocAttr = Label Location
 stdLabelVisibility = ラベルの視認
 stdLogisimEvolutionAppearance = Logisim-Evolution
 stdTriggerAttr = Trigger
+# ==> stdSelectLocAttr =
+# ==> stdSelectBottomLeftOption =
+# ==> stdSelectTopRightOption =
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +903,5 @@ noConnectionComponent = 接続なし
 powerComponent = パワー
 transistorComponent = トランジスタ
 transmissionGateComponent = トランスミッションゲート
-wiringGateAttr = Gate Location
-wiringGateBottomRightOption = 下/右
-wiringGateTopLeftOption = 上/左
 wiringLibrary = 配線
 # ==> input.output.extra =

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -707,9 +707,9 @@ stdLabelLocAttr = Label Location
 stdLabelVisibility = ラベルの視認
 stdLogisimEvolutionAppearance = Logisim-Evolution
 stdTriggerAttr = Trigger
-# ==> stdSelectLocAttr =
-# ==> stdSelectBottomLeftOption =
-# ==> stdSelectTopRightOption =
+stdSelectLocAttr = 位置の選択
+stdSelectBottomLeftOption = 下/左
+stdSelectTopRightOption = 上/右
 #
 # tcl/TclLibrary.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -707,9 +707,9 @@ stdLabelLocAttr = Plaats van het label
 stdLabelVisibility = Label zichtbaar
 stdLogisimEvolutionAppearance = Logisim-Evolutie
 stdTriggerAttr = Trigger
-# ==> stdSelectLocAttr =
-# ==> stdSelectBottomLeftOption =
-# ==> stdSelectTopRightOption =
+stdSelectLocAttr = Selecteer een locatie
+stdSelectBottomLeftOption = Bodem/Linkerzijde
+stdSelectTopRightOption = Boven/rechts
 #
 # tcl/TclLibrary.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = Nul
 plexerEnableAttr = Inclusief Enable?
 plexerLibrary = Plexers
 plexerSelectBitsAttr = Selecteer Bits
-plexerSelectBottomLeftOption = Bodem/Linkerzijde
-plexerSelectLocAttr = Selecteer een locatie
-plexerSelectTopRightOption = Boven/rechts
 plexerThreeStateAttr = Drie staten?
 priorityEncoderComponent = Voorrangsencoder
 #
@@ -710,6 +707,9 @@ stdLabelLocAttr = Plaats van het label
 stdLabelVisibility = Label zichtbaar
 stdLogisimEvolutionAppearance = Logisim-Evolutie
 stdTriggerAttr = Trigger
+# ==> stdSelectLocAttr =
+# ==> stdSelectBottomLeftOption =
+# ==> stdSelectTopRightOption =
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +903,5 @@ noConnectionComponent = Niet aansluiten
 powerComponent = Spanning
 transistorComponent = Transistor
 transmissionGateComponent = Transmissie Poort
-wiringGateAttr = Poort locatie
-wiringGateBottomRightOption = Onder/rechtsonder
-wiringGateTopLeftOption = Boven/links
 wiringLibrary = Bedrading
 # ==> input.output.extra =

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = Zero
 plexerEnableAttr = Dołączyć Enable?
 plexerLibrary = Pleksery
 plexerSelectBitsAttr = Wybór bitów
-plexerSelectBottomLeftOption = Bottom/LeftOption
-plexerSelectLocAttr = wybierz lokalizację
-plexerSelectTopRightOption = góra/prawa
 plexerThreeStateAttr = Trzy-Stany?
 priorityEncoderComponent = Priorytetowy koder
 #
@@ -710,6 +707,9 @@ stdLabelLocAttr = Lokalizacja etykiety
 stdLabelVisibility = Etykieta Widoczna
 stdLogisimEvolutionAppearance = Logisim-Evolution
 stdTriggerAttr = Trigger
+# ==> stdSelectLocAttr =
+# ==> stdSelectBottomLeftOption =
+# ==> stdSelectTopRightOption =
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +903,5 @@ noConnectionComponent = Nie podłączaj
 powerComponent = Moc
 transistorComponent = Tranzystor
 transmissionGateComponent = Brama transmisyjna
-wiringGateAttr = lokalizacja bramy
-wiringGateBottomRightOption = Dół/Prawo
-wiringGateTopLeftOption = Górna/lewa strona
 wiringLibrary = Okablowanie
 # ==> input.output.extra =

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -707,9 +707,9 @@ stdLabelLocAttr = Lokalizacja etykiety
 stdLabelVisibility = Etykieta Widoczna
 stdLogisimEvolutionAppearance = Logisim-Evolution
 stdTriggerAttr = Trigger
-# ==> stdSelectLocAttr =
+stdSelectLocAttr = wybierz lokalizację
 # ==> stdSelectBottomLeftOption =
-# ==> stdSelectTopRightOption =
+stdSelectTopRightOption = góra/prawa
 #
 # tcl/TclLibrary.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = Zero
 plexerEnableAttr = Incluir Enable?
 plexerLibrary = Plexers
 plexerSelectBitsAttr = Bits para seleção
-plexerSelectBottomLeftOption = Abaixo/Esquerda
-plexerSelectLocAttr = Selecionar posição
-plexerSelectTopRightOption = Acima/Direita
 plexerThreeStateAttr = Tri-state?
 priorityEncoderComponent = Codificador de prioridade
 #
@@ -710,6 +707,9 @@ stdLabelLocAttr = Localização da etiqueta
 stdLabelVisibility = Etiqueta Visível
 stdLogisimEvolutionAppearance = Logisim-Evolução
 stdTriggerAttr = Gatilho
+# ==> stdSelectLocAttr =
+# ==> stdSelectBottomLeftOption =
+# ==> stdSelectTopRightOption =
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +903,5 @@ noConnectionComponent = Não conectar
 powerComponent = Fonte
 transistorComponent = Transistor
 transmissionGateComponent = Porta de Transmissão
-wiringGateAttr = Posição
-wiringGateBottomRightOption = Embaixo/Direita
-wiringGateTopLeftOption = Em cima/Esquerda
 wiringLibrary = Conexão
 # ==> input.output.extra =

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -707,9 +707,9 @@ stdLabelLocAttr = Localização da etiqueta
 stdLabelVisibility = Etiqueta Visível
 stdLogisimEvolutionAppearance = Logisim-Evolução
 stdTriggerAttr = Gatilho
-# ==> stdSelectLocAttr =
-# ==> stdSelectBottomLeftOption =
-# ==> stdSelectTopRightOption =
+stdSelectLocAttr = Selecionar posição
+stdSelectBottomLeftOption = Abaixo/Esquerda
+stdSelectTopRightOption = Acima/Direita
 #
 # tcl/TclLibrary.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -681,9 +681,6 @@ plexerDisabledZero = Ноль
 plexerEnableAttr = Разрешающий вход?
 plexerLibrary = Плексоры
 plexerSelectBitsAttr = Выбирающие биты
-plexerSelectBottomLeftOption = Снизу/слева
-plexerSelectLocAttr = Положение выбирающего входа
-plexerSelectTopRightOption = Сверху/справа
 plexerThreeStateAttr = Три состояния?
 priorityEncoderComponent = Шифратор приоритетов
 #
@@ -710,6 +707,9 @@ stdLabelLocAttr = Местоположение этикетки
 stdLabelVisibility = Ярлык видимый
 stdLogisimEvolutionAppearance = Logisim-Эволюция
 stdTriggerAttr = Срабатывание
+# ==> stdSelectLocAttr =
+# ==> stdSelectBottomLeftOption =
+# ==> stdSelectTopRightOption =
 #
 # tcl/TclLibrary.java
 #
@@ -903,8 +903,5 @@ noConnectionComponent = Не подключайтесь
 powerComponent = Питание
 transistorComponent = Транзистор
 transmissionGateComponent = Передаточный вентиль
-wiringGateAttr = Положение затвора
-wiringGateBottomRightOption = Снизу/справа
-wiringGateTopLeftOption = Сверху/слева
 wiringLibrary = Проводка
 # ==> input.output.extra =

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -707,9 +707,9 @@ stdLabelLocAttr = Местоположение этикетки
 stdLabelVisibility = Ярлык видимый
 stdLogisimEvolutionAppearance = Logisim-Эволюция
 stdTriggerAttr = Срабатывание
-# ==> stdSelectLocAttr =
-# ==> stdSelectBottomLeftOption =
-# ==> stdSelectTopRightOption =
+stdSelectLocAttr = Положение выбирающего входа
+stdSelectBottomLeftOption = Снизу/слева
+stdSelectTopRightOption = Сверху/справа
 #
 # tcl/TclLibrary.java
 #


### PR DESCRIPTION
Add `SELECT_LOC` to StdAttr.
Changed all Plexers and Transistor/TransmissionGate to use the standard attribute.
Added the attribute to BitSelector, Buzzer and LedMatrix.

One downside is that the Transistor and TransmissionGate are not longer backwards compatible. 
The options changed from `Bottom/Right` and `Top/Left` to `Bottom/Left` and `Top/Right`.