### PR TITLE
changed APP_URL

### DIFF
--- a/src/main/java/com/cburch/logisim/Main.java
+++ b/src/main/java/com/cburch/logisim/Main.java
@@ -93,7 +93,8 @@ public class Main {
   public static final LogisimVersion VERSION = new LogisimVersion(3, 5, 0);
   public static final int COPYRIGHT_YEAR = 2021;
   public static final String APP_DISPLAY_NAME = APP_NAME + " v" + VERSION;
-  public static final String APP_URL = "https://github.com/logisim-evolution/";
+  public static final String APP_URL = "https://github.com/logisim-evolution/logisim-evolution";
+  public static final String ORG_URL = "https://github.com/logisim-evolution/";
 
   public static boolean ANALYZE = true;
   public static boolean headless = false;

--- a/src/main/java/com/cburch/logisim/gui/start/AboutCredits.java
+++ b/src/main/java/com/cburch/logisim/gui/start/AboutCredits.java
@@ -62,7 +62,7 @@ class AboutCredits extends JComponent {
     lines
         .title(Main.APP_DISPLAY_NAME)
         .h2("Copyright \u00A9" + Main.COPYRIGHT_YEAR + " " + Main.APP_NAME + " developers")
-        .url(Main.APP_URL)
+        .url(Main.ORG_URL)
         .space()
         .h1(S.get("creditsRoleFork"))
         .text("College of the Holy Cross")


### PR DESCRIPTION
dbe5d352dbf907884a9708256e98563982504dc1 changed `APP_URL` to point tho the organization on GitHub instead of the project itself.
The reasoning was:
> The main intent I made `APP_URL` pointing to the organization is to make it shorter. It also avoids, confusing to some, "duplicated" `logisim-evolution` part.

\- @MarcinOrlowski in [PR 846](https://github.com/logisim-evolution/logisim-evolution/pull/846#discussion_r681929239)

At that point, `APP_URL` was only used for the`Project Website` button and in `About`. Having a shorter URL made sense in the `About` window.

But now it gets used in places where the full URL makes more sense (#846 will use it in multiple places).
Especially if we consider that the organization will have multiple repositories in the near future (E.g. #600,  #743).

Having `ORG_URL` may be redundant since it is almost the same string. (I only created it so that the short URL can still be used.)
This could change in future when the website is coming.