### PR TITLE
Adds support for non-localizable options

### DIFF
--- a/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUartAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUartAttributes.java
@@ -55,29 +55,21 @@ public class JtagUartAttributes  extends AbstractAttributeSet {
     }
   }
 
-  public static final AttributeOption OPT_8 = new AttributeOption("8", S.getter("JtagSize8"));
-  public static final AttributeOption OPT_16 = new AttributeOption("16", S.getter("JtagSize16"));
-  public static final AttributeOption OPT_32 = new AttributeOption("32", S.getter("JtagSize32"));
-  public static final AttributeOption OPT_64 = new AttributeOption("64", S.getter("JtagSize64"));
-  public static final AttributeOption OPT_128 = new AttributeOption("128", S.getter("JtagSize128"));
-  public static final AttributeOption OPT_256 = new AttributeOption("256", S.getter("JtagSize256"));
-  public static final AttributeOption OPT_512 = new AttributeOption("512", S.getter("JtagSize512"));
-  public static final AttributeOption OPT_1024 =
-      new AttributeOption("1024", S.getter("JtagSize1024"));
-  public static final AttributeOption OPT_2048 =
-      new AttributeOption("2048", S.getter("JtagSize2048"));
-  public static final AttributeOption OPT_4096 =
-      new AttributeOption("4096", S.getter("JtagSize4096"));
-  public static final AttributeOption OPT_8192 =
-      new AttributeOption("8192", S.getter("JtagSize8192"));
-  public static final AttributeOption OPT_16384 =
-      new AttributeOption("16384", S.getter("JtagSize16384"));
-  public static final AttributeOption OPT_32768 =
-      new AttributeOption("32768", S.getter("JtagSize32768"));
-  public static final AttributeOption[] SIZE_ARRAY =
-      new AttributeOption[] {
-        OPT_8, OPT_16, OPT_32, OPT_64, OPT_128, OPT_256, OPT_512, OPT_1024, OPT_2048, OPT_4096,
-        OPT_8192, OPT_16384, OPT_32768
+  public static final AttributeOption OPT_8 = new AttributeOption("8", S.fixedString("8"));
+  public static final AttributeOption OPT_16 = new AttributeOption("16", S.fixedString("16"));
+  public static final AttributeOption OPT_32 = new AttributeOption("32", S.fixedString("32"));
+  public static final AttributeOption OPT_64 = new AttributeOption("64", S.fixedString("64"));
+  public static final AttributeOption OPT_128 = new AttributeOption("128", S.fixedString("128"));
+  public static final AttributeOption OPT_256 = new AttributeOption("256", S.fixedString("256"));
+  public static final AttributeOption OPT_512 = new AttributeOption("512", S.fixedString("512"));
+  public static final AttributeOption OPT_1024 = new AttributeOption("1024", S.fixedString("1KB"));
+  public static final AttributeOption OPT_2048 = new AttributeOption("2048", S.fixedString("2KB"));
+  public static final AttributeOption OPT_4096 = new AttributeOption("4096", S.fixedString("4KB"));
+  public static final AttributeOption OPT_8192 = new AttributeOption("8192", S.fixedString("8KB"));
+  public static final AttributeOption OPT_16384 = new AttributeOption("16384", S.fixedString("16KB"));
+  public static final AttributeOption OPT_32768 = new AttributeOption("32768", S.fixedString("32KB"));
+  public static final AttributeOption[] SIZE_ARRAY = new AttributeOption[] {
+        OPT_8, OPT_16, OPT_32, OPT_64, OPT_128, OPT_256, OPT_512, OPT_1024, OPT_2048, OPT_4096, OPT_8192, OPT_16384, OPT_32768
       };
 
   public static final Attribute<Integer> START_ADDRESS =

--- a/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUartAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUartAttributes.java
@@ -68,8 +68,10 @@ public class JtagUartAttributes  extends AbstractAttributeSet {
   public static final AttributeOption OPT_8192 = new AttributeOption("8192", S.fixedString("8KB"));
   public static final AttributeOption OPT_16384 = new AttributeOption("16384", S.fixedString("16KB"));
   public static final AttributeOption OPT_32768 = new AttributeOption("32768", S.fixedString("32KB"));
-  public static final AttributeOption[] SIZE_ARRAY = new AttributeOption[] {
-        OPT_8, OPT_16, OPT_32, OPT_64, OPT_128, OPT_256, OPT_512, OPT_1024, OPT_2048, OPT_4096, OPT_8192, OPT_16384, OPT_32768
+  public static final AttributeOption[] SIZE_ARRAY =
+      new AttributeOption[] {
+        OPT_8, OPT_16, OPT_32, OPT_64, OPT_128, OPT_256, OPT_512, OPT_1024, OPT_2048, OPT_4096,
+        OPT_8192, OPT_16384, OPT_32768
       };
 
   public static final Attribute<Integer> START_ADDRESS =

--- a/src/main/java/com/cburch/logisim/soc/vga/VgaAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/vga/VgaAttributes.java
@@ -92,7 +92,8 @@ public class VgaAttributes extends AbstractAttributeSet {
   @SuppressWarnings("serial")
   public static final ArrayList<AttributeOption> MODES = new ArrayList<>() {{
       this.addAll(Arrays.asList(MODE_ARRAY));
-  }};
+    }
+  };
 
   private static final List<Attribute<?>> ATTRIBUTES =
       Arrays.asList(

--- a/src/main/java/com/cburch/logisim/soc/vga/VgaAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/vga/VgaAttributes.java
@@ -68,22 +68,22 @@ public class VgaAttributes extends AbstractAttributeSet {
   public static final int MODE_800_600_MASK = 8;
   public static final int MODE_1024_768_MASK = 16;
 
-  public static final AttributeOption OPT_160_120 = new AttributeOption("160x120", S.getter("VgaMode160x120"));
-  public static final AttributeOption OPT_320_240 = new AttributeOption("320x240", S.getter("VgaMode320x240"));
-  public static final AttributeOption OPT_640_480 = new AttributeOption("640x480", S.getter("VgaMode640x480"));
-  public static final AttributeOption OPT_800_600 = new AttributeOption("800x600", S.getter("VgaMode800x600"));
-  public static final AttributeOption OPT_1024_768 = new AttributeOption("1024x768", S.getter("VgaMode1024x768"));
+  public static final AttributeOption OPT_160_120 = new AttributeOption("160x120", S.fixedString("160x120"));
+  public static final AttributeOption OPT_320_240 = new AttributeOption("320x240", S.fixedString("320x240"));
+  public static final AttributeOption OPT_640_480 = new AttributeOption("640x480", S.fixedString("640x480"));
+  public static final AttributeOption OPT_800_600 = new AttributeOption("800x600", S.fixedString("800x600"));
+  public static final AttributeOption OPT_1024_768 = new AttributeOption("1024x768", S.fixedString("1024x768"));
   public static final AttributeOption[] MODE_ARRAY = new AttributeOption[] {OPT_160_120, OPT_320_240, OPT_640_480, OPT_800_600, OPT_1024_768};
 
   public static final Attribute<VgaState> VGA_STATE = new VgaStateAttribute();
   public static final Attribute<Integer> START_ADDRESS = Attributes.forHexInteger("StartAddress", S.getter("VgaStartAddress"));
   public static final Attribute<Integer> BUFFER_ADDRESS = Attributes.forHexInteger("BufferAddress", S.getter("VgaBufferAddress"));
   public static final Attribute<AttributeOption> MODE = Attributes.forOption("DisplayMode", S.getter("VgaInitialDisplayMode"), MODE_ARRAY);
-  public static final Attribute<Boolean> SOFT_160_120 = Attributes.forBoolean("soft160x120", S.getter("VgaSoft160x120"));
-  public static final Attribute<Boolean> SOFT_320_240 = Attributes.forBoolean("soft320x240", S.getter("VgaSoft320x240"));
-  public static final Attribute<Boolean> SOFT_640_480 = Attributes.forBoolean("soft640x480", S.getter("VgaSoft640x480"));
-  public static final Attribute<Boolean> SOFT_800_600 = Attributes.forBoolean("soft800x600", S.getter("VgaSoft800x600"));
-  public static final Attribute<Boolean> SOFT_1024_768 = Attributes.forBoolean("soft1024x768", S.getter("VgaSoft1024x768"));
+  public static final Attribute<Boolean> SOFT_160_120 = Attributes.forBoolean("soft160x120", S.getter("VgaSoftMode", "160x120"));
+  public static final Attribute<Boolean> SOFT_320_240 = Attributes.forBoolean("soft320x240", S.getter("VgaSoftMode", "320x240"));
+  public static final Attribute<Boolean> SOFT_640_480 = Attributes.forBoolean("soft640x480", S.getter("VgaSoftMode", "640x480"));
+  public static final Attribute<Boolean> SOFT_800_600 = Attributes.forBoolean("soft800x600", S.getter("VgaSoftMode", "800x600"));
+  public static final Attribute<Boolean> SOFT_1024_768 = Attributes.forBoolean("soft1024x768", S.getter("VgaSoftMode", "1024x768"));
 
   private Font labelFont = StdAttr.DEFAULT_LABEL_FONT;
   private Boolean labelVisible = true;

--- a/src/main/java/com/cburch/logisim/util/LocaleManager.java
+++ b/src/main/java/com/cburch/logisim/util/LocaleManager.java
@@ -58,6 +58,25 @@ public class LocaleManager {
     }
   }
 
+  /**
+   * Always returns "fixed" value. Implements StringGetter interface
+   * to let this class be used for i.e. settings for which there's no
+   * point of providing localizable strings (i.e. screen resolutsions,
+   * or plain numeric values), thus using LocaleGetter is an overkill.
+   */
+  private static class FixedString implements StringGetter {
+    final String value;
+
+    FixedString(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return this.value;
+    }
+  }
+
   /* kwalsh  >> */
   private static class LocaleFormatterWithString extends LocaleGetter {
     final String arg;
@@ -346,6 +365,10 @@ public class LocaleManager {
 
   public StringGetter getter(String key, StringGetter arg) {
     return new LocaleFormatterWithGetter(this, key, arg);
+  }
+
+  public StringGetter fixedString(String value) {
+    return new FixedString(value);
   }
 
   private void loadDefault() {

--- a/src/main/resources/resources/logisim/strings/soc/soc.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc.properties
@@ -209,19 +209,6 @@ SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #
-JtagSize1024 = 1k
-JtagSize128 = 128
-JtagSize16 = 16
-JtagSize16384 = 16k
-JtagSize2048 = 2k
-JtagSize256 = 256
-JtagSize32 = 32
-JtagSize32768 = 32k
-JtagSize4096 = 4k
-JtagSize512 = 512
-JtagSize64 = 64
-JtagSize8 = 8
-JtagSize8192 = 8k
 JtagUartReadIrqThreshold = Read IRQ threshold
 JtagUartWriteIrqThreshold = Write IRQ threshold
 UartJtagREADFifoSize = Read FIFO size:

--- a/src/main/resources/resources/logisim/strings/soc/soc.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc.properties
@@ -457,16 +457,7 @@ SocVgaComponent = VGA screen
 #
 VgaBufferAddress = Pixel buffer Address:
 VgaInitialDisplayMode = Initial mode:
-VgaMode1024x768 = 1024x768
-VgaMode160x120 = 160x120
-VgaMode320x240 = 320x240
-VgaMode640x480 = 640x480
-VgaMode800x600 = 800x600
-VgaSoft1024x768 = Software 1024x768:
-VgaSoft160x120 = Software 160x120:
-VgaSoft320x240 = Software 320x240:
-VgaSoft640x480 = Software 640x480:
-VgaSoft800x600 = Software 800x600:
+VgaSoftMode = Software %s:
 VgaStartAddress = Base address:
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_de.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_de.properties
@@ -209,19 +209,6 @@ SocJtagUartComponent = Jtag Uart Komponente
 #
 # jtaguart/JtagUartAttributes.java
 #
-JtagSize1024 = 1k
-JtagSize128 = 128
-JtagSize16 = 16
-JtagSize16384 = 16k
-JtagSize2048 = 2k
-JtagSize256 = 256
-JtagSize32 = 32
-JtagSize32768 = 32k
-JtagSize4096 = 4k
-JtagSize512 = 512
-JtagSize64 = 64
-JtagSize8 = 8
-JtagSize8192 = 8k
 JtagUartReadIrqThreshold = IRQ-Schwellenwert lesen
 JtagUartWriteIrqThreshold = IRQ-Schwellenwert schreiben
 UartJtagREADFifoSize = FIFO-Größe lesen:

--- a/src/main/resources/resources/logisim/strings/soc/soc_de.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_de.properties
@@ -457,16 +457,7 @@ SocVgaComponent = VGA-Bildschirm
 #
 VgaBufferAddress = Pixelpuffer Adresse:
 VgaInitialDisplayMode = Anfangsmodus:
-VgaMode1024x768 = 1024x768
-VgaMode160x120 = 160x120
-VgaMode320x240 = 320x240
-VgaMode640x480 = 640x480
-VgaMode800x600 = 800x600
-VgaSoft1024x768 = Software 1024x768:
-VgaSoft160x120 = Software 160x120:
-VgaSoft320x240 = Software 320x240:
-VgaSoft640x480 = Software 640x480:
-VgaSoft800x600 = Software 800x600:
+VgaSoftMode = Software %s:
 VgaStartAddress = Basisadresse:
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_el.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_el.properties
@@ -457,16 +457,7 @@
 #
 # ==> VgaBufferAddress =
 # ==> VgaInitialDisplayMode =
-# ==> VgaMode1024x768 =
-# ==> VgaMode160x120 =
-# ==> VgaMode320x240 =
-# ==> VgaMode640x480 =
-# ==> VgaMode800x600 =
-# ==> VgaSoft1024x768 =
-# ==> VgaSoft160x120 =
-# ==> VgaSoft320x240 =
-# ==> VgaSoft640x480 =
-# ==> VgaSoft800x600 =
+# ==> VgaSoftMode =
 # ==> VgaStartAddress =
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_el.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_el.properties
@@ -209,19 +209,6 @@
 #
 # jtaguart/JtagUartAttributes.java
 #
-# ==> JtagSize1024 =
-# ==> JtagSize128 =
-# ==> JtagSize16 =
-# ==> JtagSize16384 =
-# ==> JtagSize2048 =
-# ==> JtagSize256 =
-# ==> JtagSize32 =
-# ==> JtagSize32768 =
-# ==> JtagSize4096 =
-# ==> JtagSize512 =
-# ==> JtagSize64 =
-# ==> JtagSize8 =
-# ==> JtagSize8192 =
 # ==> JtagUartReadIrqThreshold =
 # ==> JtagUartWriteIrqThreshold =
 # ==> UartJtagREADFifoSize =

--- a/src/main/resources/resources/logisim/strings/soc/soc_es.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_es.properties
@@ -209,19 +209,6 @@ SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #
-JtagSize1024 = 1k
-JtagSize128 = 128
-JtagSize16 = 16
-JtagSize16384 = 16k
-JtagSize2048 = 2k
-JtagSize256 = 256
-JtagSize32 = 32
-JtagSize32768 = 32k
-JtagSize4096 = 4k
-JtagSize512 = 512
-JtagSize64 = 64
-JtagSize8 = 8
-JtagSize8192 = 8k
 JtagUartReadIrqThreshold = Leer umbral de IRQ
 JtagUartWriteIrqThreshold = Escribir umbral IRQ
 UartJtagREADFifoSize = Leer el tamaño FIFO:

--- a/src/main/resources/resources/logisim/strings/soc/soc_es.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_es.properties
@@ -457,16 +457,7 @@ SocVgaComponent = Pantalla VGA
 #
 VgaBufferAddress = Dirección del búfer de píxeles:
 VgaInitialDisplayMode = Modo inicial:
-VgaMode1024x768 = 1024x768
-VgaMode160x120 = 160x120
-VgaMode320x240 = 320x240
-VgaMode640x480 = 640x480
-VgaMode800x600 = 800x600
-VgaSoft1024x768 = Software 1024x768:
-VgaSoft160x120 = Software 160x120:
-VgaSoft320x240 = Software 320x240:
-VgaSoft640x480 = Software 640x480:
-VgaSoft800x600 = Software 800x600:
+VgaSoftMode = Software %s:
 VgaStartAddress = Dirección de la base:
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_fr.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_fr.properties
@@ -457,16 +457,7 @@ SocVgaComponent = écran VGA
 #
 VgaBufferAddress = Adresse du tampon de pixels :
 VgaInitialDisplayMode = Mode initial :
-VgaMode1024x768 = 1024x768
-VgaMode160x120 = 160x120
-VgaMode320x240 = 320x240
-VgaMode640x480 = 640x480
-VgaMode800x600 = 800x600
-VgaSoft1024x768 = Logiciel 1024x768 :
-VgaSoft160x120 = Logiciel 160x120 :
-VgaSoft320x240 = Logiciel 320x240 :
-VgaSoft640x480 = Logiciel 640x480 :
-VgaSoft800x600 = Logiciel 800x600 :
+VgaSoftMode = Logiciel %s :
 VgaStartAddress = Adresse de base :
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_fr.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_fr.properties
@@ -209,19 +209,6 @@ SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #
-JtagSize1024 = 1k
-JtagSize128 = 128
-JtagSize16 = 16
-JtagSize16384 = 16k
-JtagSize2048 = 2k
-JtagSize256 = 256
-JtagSize32 = 32
-JtagSize32768 = 32k
-JtagSize4096 = 4k
-JtagSize512 = 512
-JtagSize64 = 64
-JtagSize8 = 8
-JtagSize8192 = 8k
 JtagUartReadIrqThreshold = Lecture du seuil IRQ
 JtagUartWriteIrqThreshold = Écriture du seuil d'IRQ
 UartJtagREADFifoSize = Taille de lecture FIFO :

--- a/src/main/resources/resources/logisim/strings/soc/soc_it.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_it.properties
@@ -209,19 +209,6 @@ SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #
-JtagSize1024 = 1k
-JtagSize128 = 128
-JtagSize16 = 16
-JtagSize16384 = 16k
-JtagSize2048 = 2k
-JtagSize256 = 256
-JtagSize32 = 32
-JtagSize32768 = 32k
-JtagSize4096 = 4k
-JtagSize512 = 512
-JtagSize64 = 64
-JtagSize8 = 8
-JtagSize8192 = 8k
 JtagUartReadIrqThreshold = Leggere la soglia IRQ
 JtagUartWriteIrqThreshold = Scrivi soglia IRQ
 UartJtagREADFifoSize = Leggi il formato FIFO:

--- a/src/main/resources/resources/logisim/strings/soc/soc_it.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_it.properties
@@ -457,16 +457,7 @@ SocVgaComponent = Schermo VGA
 #
 VgaBufferAddress = Pixel buffer Indirizzo:
 VgaInitialDisplayMode = Modalità iniziale:
-VgaMode1024x768 = 1024x768
-VgaMode160x120 = 160x120
-VgaMode320x240 = 320x240
-VgaMode640x480 = 640x480
-VgaMode800x600 = 800x600
-VgaSoft1024x768 = Software 1024x768:
-VgaSoft160x120 = Software 160x120:
-VgaSoft320x240 = Software 320x240:
-VgaSoft640x480 = Software 640x480:
-VgaSoft800x600 = Software 800x600:
+VgaSoftMode = Software %s:
 VgaStartAddress = Indirizzo di base:
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_ja.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_ja.properties
@@ -457,16 +457,7 @@ SocVgaComponent = VGAスクリーン
 #
 VgaBufferAddress = ピクセルバッファのアドレス:
 VgaInitialDisplayMode = 初期モード:
-VgaMode1024x768 = 1024x768
-VgaMode160x120 = 160x120
-VgaMode320x240 = 320x240
-VgaMode640x480 = 640x480
-VgaMode800x600 = 800x600
-VgaSoft1024x768 = Software 1024x768:
-VgaSoft160x120 = Software 160x120:
-VgaSoft320x240 = Software 320x240:
-VgaSoft640x480 = Software 640x480:
-VgaSoft800x600 = Software 800x600:
+#VgaSoftMode = Software %s:
 VgaStartAddress = ベースアドレス:
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_ja.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_ja.properties
@@ -209,19 +209,6 @@ SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #
-JtagSize1024 = 1k
-JtagSize128 = 128
-JtagSize16 = 16
-JtagSize16384 = 16k
-JtagSize2048 = 2k
-JtagSize256 = 256
-JtagSize32 = 32
-JtagSize32768 = 32k
-JtagSize4096 = 4k
-JtagSize512 = 512
-JtagSize64 = 64
-JtagSize8 = 8
-JtagSize8192 = 8k
 JtagUartReadIrqThreshold = 読み取りIRQしきい値
 JtagUartWriteIrqThreshold = IRQしきい値を書き込む
 UartJtagREADFifoSize = 読み出しFIFOサイズ:

--- a/src/main/resources/resources/logisim/strings/soc/soc_ja.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_ja.properties
@@ -444,7 +444,7 @@ SocVgaComponent = VGAスクリーン
 #
 VgaBufferAddress = ピクセルバッファのアドレス:
 VgaInitialDisplayMode = 初期モード:
-#VgaSoftMode = Software %s:
+# ==> VgaSoftMode = Software %s:
 VgaStartAddress = ベースアドレス:
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
@@ -457,16 +457,7 @@ SocVgaComponent = VGA-scherm
 #
 VgaBufferAddress = Pixelbuffer Adres:
 VgaInitialDisplayMode = Initiële modus:
-VgaMode1024x768 = 1024x768
-VgaMode160x120 = 160x120
-VgaMode320x240 = 320x240
-VgaMode640x480 = 640x480
-VgaMode800x600 = 800x600
-VgaSoft1024x768 = Software 1024x768:
-VgaSoft160x120 = Software 160x120:
-VgaSoft320x240 = Software 320x240:
-VgaSoft640x480 = Software 640x480:
-VgaSoft800x600 = Software 800x600x600:
+VgaSoftMode = Software %s:
 VgaStartAddress = Basis adres:
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_nl.properties
@@ -209,19 +209,6 @@ SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #
-JtagSize1024 = 1k
-JtagSize128 = 128
-JtagSize16 = 16
-JtagSize16384 = 16k
-JtagSize2048 = 2k
-JtagSize256 = 256
-JtagSize32 = 32
-JtagSize32768 = 32k
-JtagSize4096 = 4k
-JtagSize512 = 512
-JtagSize64 = 64
-JtagSize8 = 8
-JtagSize8192 = 8k
 JtagUartReadIrqThreshold = IRQ-drempel lezen
 JtagUartWriteIrqThreshold = IRQ-drempel schrijven
 UartJtagREADFifoSize = Lees de FIFO grootte:

--- a/src/main/resources/resources/logisim/strings/soc/soc_pl.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_pl.properties
@@ -209,19 +209,6 @@ SocJtagUartComponent = składnik Jtag Uart
 #
 # jtaguart/JtagUartAttributes.java
 #
-JtagSize1024 = 1k
-JtagSize128 = 128
-JtagSize16 = 16
-JtagSize16384 = 16k
-JtagSize2048 = 2k
-JtagSize256 = 256
-JtagSize32 = 32
-JtagSize32768 = 32k
-JtagSize4096 = 4k
-JtagSize512 = 512
-JtagSize64 = 64
-JtagSize8 = 8
-JtagSize8192 = 8k
 JtagUartReadIrqThreshold = Próg odczytu IRQ
 JtagUartWriteIrqThreshold = Próg zapisu IRQ
 UartJtagREADFifoSize = Odczytaj rozmiar FIFO:

--- a/src/main/resources/resources/logisim/strings/soc/soc_pl.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_pl.properties
@@ -457,16 +457,7 @@ SocVgaComponent = ekran VGA
 #
 VgaBufferAddress = Adres bufora pikseli:
 VgaInitialDisplayMode = Tryb początkowy:
-VgaMode1024x768 = 1024x768
-VgaMode160x120 = 160x120
-VgaMode320x240 = 320x240
-VgaMode640x480 = 640x480
-VgaMode800x600 = 800x600
-VgaSoft1024x768 = Oprogramowanie 1024x768:
-VgaSoft160x120 = Oprogramowanie 160x120:
-VgaSoft320x240 = Oprogramowanie 320x240:
-VgaSoft640x480 = Oprogramowanie 640x480:
-VgaSoft800x600 = Oprogramowanie 800x600:
+VgaSoftMode = Programowe %s:
 VgaStartAddress = Adres bazowy:
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_pt.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_pt.properties
@@ -209,19 +209,6 @@ SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #
-JtagSize1024 = 1k
-JtagSize128 = 128
-JtagSize16 = 16
-JtagSize16384 = 16k
-JtagSize2048 = 2k
-JtagSize256 = 256
-JtagSize32 = 32
-JtagSize32768 = 32k
-JtagSize4096 = 4k
-JtagSize512 = 512
-JtagSize64 = 64
-JtagSize8 = 8
-JtagSize8192 = 8k
 JtagUartReadIrqThreshold = Ler limiar IRQ
 JtagUartWriteIrqThreshold = Escrever o limiar IRQ
 UartJtagREADFifoSize = Ler tamanho FIFO:

--- a/src/main/resources/resources/logisim/strings/soc/soc_pt.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_pt.properties
@@ -457,16 +457,7 @@ SocVgaComponent = Tela VGA
 #
 VgaBufferAddress = Endereço do buffer de pixels:
 VgaInitialDisplayMode = Modo inicial:
-VgaMode1024x768 = 1024x768
-VgaMode160x120 = 160x120
-VgaMode320x240 = 320x240
-VgaMode640x480 = 640x480
-VgaMode800x600 = 800x600
-VgaSoft1024x768 = Software 1024x768:
-VgaSoft160x120 = Software 160x120:
-VgaSoft320x240 = Software 320x240:
-VgaSoft640x480 = Software 640x480:
-VgaSoft800x600 = Software 800x600:
+VgaSoftMode = Software %s:
 VgaStartAddress = Endereço base:
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_ru.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_ru.properties
@@ -457,16 +457,7 @@ SocVgaComponent = экран VGA
 #
 VgaBufferAddress = Адрес буфера пикселей Адрес:
 VgaInitialDisplayMode = Исходный режим:
-VgaMode1024x768 = 1024x768
-VgaMode160x120 = 160x120
-VgaMode320x240 = 320x240
-VgaMode640x480 = 640x480
-VgaMode800x600 = 800x600
-VgaSoft1024x768 = Программное обеспечение 1024x768:
-VgaSoft160x120 = Программное обеспечение 160x120:
-VgaSoft320x240 = Программное обеспечение 320x240:
-VgaSoft640x480 = Программное обеспечение 640x480:
-VgaSoft800x600 = Программное обеспечение 800x600:
+VgaSoftMode = Программное %s:
 VgaStartAddress = Базовый адрес:
 #
 # vga/VgaMenu.java

--- a/src/main/resources/resources/logisim/strings/soc/soc_ru.properties
+++ b/src/main/resources/resources/logisim/strings/soc/soc_ru.properties
@@ -209,19 +209,6 @@ SocJtagUartComponent = JTAG UART
 #
 # jtaguart/JtagUartAttributes.java
 #
-JtagSize1024 = 1k
-JtagSize128 = 128
-JtagSize16 = 16
-JtagSize16384 = 16k
-JtagSize2048 = 2k
-JtagSize256 = 256
-JtagSize32 = 32
-JtagSize32768 = 32k
-JtagSize4096 = 4k
-JtagSize512 = 512
-JtagSize64 = 64
-JtagSize8 = 8
-JtagSize8192 = 8k
 JtagUartReadIrqThreshold = Считывание порога IRQ
 JtagUartWriteIrqThreshold = Запись порогового значения IRQ
 UartJtagREADFifoSize = Читайте размер FIFO:


### PR DESCRIPTION
Adds support for non-localizable options and removes a few elements from localization strings. The rationale: our localizations lag for most of the languages and files are massive. Certain elements like i.e. screen resolutions (`800x600` or element capacity) can be currently made non-translatable with no harm, and benefit of reducing number of localization entries.