### PR TITLE
Selection messages reworked

### DIFF
--- a/src/main/java/com/cburch/draw/gui/AttrTableSelectionModel.java
+++ b/src/main/java/com/cburch/draw/gui/AttrTableSelectionModel.java
@@ -78,7 +78,7 @@ class AttrTableSelectionModel extends AttributeSetTableModel implements Selectio
     } else if (commonClass == null) {
       return S.get("selectionVarious", "" + totalCount);
     } else if (commonCount == 1) {
-      return S.get("selectionOne", firstObject.getDisplayNameAndLabel());
+      return firstObject.getDisplayNameAndLabel();
     } else {
       return S.get("selectionMultiple", firstObject.getDisplayName(), "" + commonCount);
     }

--- a/src/main/java/com/cburch/logisim/gui/main/AttrTableSelectionModel.java
+++ b/src/main/java/com/cburch/logisim/gui/main/AttrTableSelectionModel.java
@@ -126,10 +126,13 @@ class AttrTableSelectionModel extends AttributeSetTableModel implements Selectio
       }
     } else if (factoryCount == 1) {
       setInstance(factory);
-      if (label != null && label.length() > 0)
-        return S.get("selectionOne", factory.getDisplayName()) + " \"" + label + "\"";
-      else if (loc != null) return S.get("selectionOne", factory.getDisplayName() + " " + loc);
-      else return S.get("selectionOne", factory.getDisplayName());
+      if (label != null && label.length() > 0) {
+        return factory.getDisplayName() + " \"" + label + "\"";
+      } else if (loc != null) {
+        return factory.getDisplayName() + " " + loc;
+      } else {
+        return factory.getDisplayName();
+      }
     } else {
       setInstance(factory);
       return S.get("selectionMultiple", factory.getDisplayName(), "" + factoryCount);
@@ -138,6 +141,7 @@ class AttrTableSelectionModel extends AttributeSetTableModel implements Selectio
 
   //
   // Selection.Listener methods
+  @Override
   public void selectionChanged(Event event) {
     fireTitleChanged();
     if (!frame.getEditorView().equals(Frame.EDIT_APPEARANCE)) {

--- a/src/main/java/com/cburch/logisim/gui/main/AttrTableToolModel.java
+++ b/src/main/java/com/cburch/logisim/gui/main/AttrTableToolModel.java
@@ -59,7 +59,7 @@ public class AttrTableToolModel extends AttributeSetTableModel {
 
   @Override
   public String getTitle() {
-    return S.get("toolAttrTitle", tool.getDisplayName());
+    return tool.getDisplayName();
   }
 
   public Tool getTool() {

--- a/src/main/resources/resources/logisim/strings/draw/draw.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw.properties
@@ -46,8 +46,6 @@ actionTranslate = Move %s
 #
 # Used if user selects multiple component of the same type
 selectionMultiple = %s × %s
-# Used if user selects just one component
-selectionOne = %s
 # USed when user selects multiple various components
 selectionVarious = Various items × %s
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw.properties
@@ -44,9 +44,12 @@ actionTranslate = Move %s
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = Selection: %s × %s
-selectionOne = Selection: %s
-selectionVarious = Selection: Various items × %s
+# Used if user selects multiple component of the same type
+selectionMultiple = %s × %s
+# Used if user selects just one component
+selectionOne = %s
+# USed when user selects multiple various components
+selectionVarious = Various items × %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_de.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_de.properties
@@ -45,7 +45,6 @@ actionTranslate = %s verschieben
 # gui/AttrTableSelectionModel.java
 #
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Verschiedene Artikel × %s
 #
 # shapes/Curve.java

--- a/src/main/resources/resources/logisim/strings/draw/draw_de.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_de.properties
@@ -44,9 +44,9 @@ actionTranslate = %s verschieben
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = Auswahl: %s × %s
-selectionOne = Auswahl: %s
-selectionVarious = Auswahl: Verschiedene Artikel × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Verschiedene Artikel × %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_el.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_el.properties
@@ -44,9 +44,9 @@ actionTranslate = Μετακίνηση %s
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = Επιλογή: %s × %s
-selectionOne = Επιλογή: %s
-selectionVarious = Επιλογή: Διάφορα αντικείμενα × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Διάφορα αντικείμενα × %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_el.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_el.properties
@@ -45,7 +45,6 @@ actionTranslate = Μετακίνηση %s
 # gui/AttrTableSelectionModel.java
 #
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Διάφορα αντικείμενα × %s
 #
 # shapes/Curve.java

--- a/src/main/resources/resources/logisim/strings/draw/draw_es.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_es.properties
@@ -44,9 +44,9 @@ actionTranslate = Mover %s
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = Selección: %s × %s
-selectionOne = Selección: %s
-selectionVarious = Selección: varios elementos × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Varios elementos × %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_es.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_es.properties
@@ -45,7 +45,6 @@ actionTranslate = Mover %s
 # gui/AttrTableSelectionModel.java
 #
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Varios elementos × %s
 #
 # shapes/Curve.java

--- a/src/main/resources/resources/logisim/strings/draw/draw_fr.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_fr.properties
@@ -44,9 +44,9 @@ actionTranslate = Déplacer %s
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = Sélection : %s × %s
-selectionOne = Sélection : %s
-selectionVarious = Sélection : différents éléments × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Différents éléments × %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_fr.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_fr.properties
@@ -45,7 +45,6 @@ actionTranslate = Déplacer %s
 # gui/AttrTableSelectionModel.java
 #
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Différents éléments × %s
 #
 # shapes/Curve.java

--- a/src/main/resources/resources/logisim/strings/draw/draw_it.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_it.properties
@@ -45,7 +45,6 @@ actionTranslate = Sposta %s
 # gui/AttrTableSelectionModel.java
 #
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Elementi vari× %s
 #
 # shapes/Curve.java

--- a/src/main/resources/resources/logisim/strings/draw/draw_it.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_it.properties
@@ -44,9 +44,9 @@ actionTranslate = Sposta %s
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = Selezione: %s × %s
-selectionOne = Selezione: %s
-selectionVarious = Selezione: Elementi vari× %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Elementi vari× %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_ja.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_ja.properties
@@ -45,7 +45,6 @@ actionTranslate = %sを移動
 # gui/AttrTableSelectionModel.java
 #
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = 各種項目 × %s
 #
 # shapes/Curve.java

--- a/src/main/resources/resources/logisim/strings/draw/draw_ja.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_ja.properties
@@ -44,9 +44,9 @@ actionTranslate = %sを移動
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = 選択範囲: %s × %s
-selectionOne = 選択範囲: %s
-selectionVarious = 選択範囲: 各種項目 × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = 各種項目 × %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_nl.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_nl.properties
@@ -45,7 +45,6 @@ actionTranslate = Verplaatsing %s
 # gui/AttrTableSelectionModel.java
 #
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Diverse artikelen × %s
 #
 # shapes/Curve.java

--- a/src/main/resources/resources/logisim/strings/draw/draw_nl.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_nl.properties
@@ -44,9 +44,9 @@ actionTranslate = Verplaatsing %s
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = Selectie: %s u00D7 %s
-selectionOne = Selectie: %s
-selectionVarious = Selectie: Diverse artikelen u00D7 %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Diverse artikelen × %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_pl.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_pl.properties
@@ -44,9 +44,9 @@ actionTranslate = Przenieś %s
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = Zaznaczenie: %s × %s
-selectionOne = Zaznaczenie: %s
-selectionVarious = Zaznaczenie: Różne przedmioty × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Różne elementy × %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_pl.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_pl.properties
@@ -45,7 +45,6 @@ actionTranslate = Przenieś %s
 # gui/AttrTableSelectionModel.java
 #
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Różne elementy × %s
 #
 # shapes/Curve.java

--- a/src/main/resources/resources/logisim/strings/draw/draw_pt.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_pt.properties
@@ -45,7 +45,6 @@ actionTranslate = Mover %s
 # gui/AttrTableSelectionModel.java
 #
 selectionMultiple = %s x %s
-selectionOne = %s
 selectionVarious = itens variados x %s
 #
 # shapes/Curve.java

--- a/src/main/resources/resources/logisim/strings/draw/draw_pt.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_pt.properties
@@ -44,9 +44,9 @@ actionTranslate = Mover %s
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = Seleção: %s x %s
-selectionOne = Seleção: %s
-selectionVarious = Seleção: itens variados x %s
+selectionMultiple = %s x %s
+selectionOne = %s
+selectionVarious = itens variados x %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_ru.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_ru.properties
@@ -44,9 +44,9 @@ actionTranslate = Переместить %s
 #
 # gui/AttrTableSelectionModel.java
 #
-selectionMultiple = Выделение: %s × %s
-selectionOne = Выделение: %s
-selectionVarious = Выделение: Различные элементы × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Различные элементы × %s
 #
 # shapes/Curve.java
 #

--- a/src/main/resources/resources/logisim/strings/draw/draw_ru.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_ru.properties
@@ -45,7 +45,6 @@ actionTranslate = Переместить %s
 # gui/AttrTableSelectionModel.java
 #
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Различные элементы × %s
 #
 # shapes/Curve.java

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -197,9 +197,9 @@ changeAttributeAction = Change Attribute
 #
 hdlAttrTitle = VHDL Entity: %s
 selectionAttributeAction = Change Selection Attribute
-selectionMultiple = Selection: %s × %s
-selectionOne = Selection: %s
-selectionVarious = Selection: Various items × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Various items × %s
 #
 # main/AttrTableToolModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -198,7 +198,6 @@ changeAttributeAction = Change Attribute
 hdlAttrTitle = VHDL Entity: %s
 selectionAttributeAction = Change Selection Attribute
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Various items × %s
 #
 # main/AttrTableToolModel.java

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -200,10 +200,6 @@ selectionAttributeAction = Change Selection Attribute
 selectionMultiple = %s × %s
 selectionVarious = Various items × %s
 #
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = Tool: %s
-#
 # main/Canvas.java
 #
 canvasExceptionError = Simulation halted by internal error

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -198,7 +198,6 @@ changeAttributeAction = Attribut ändern
 hdlAttrTitle = VHDL-Einheit: %s
 selectionAttributeAction = Ändere Auswahleigenschaften
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Diverse Elemente × %s
 #
 # main/AttrTableToolModel.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -200,10 +200,6 @@ selectionAttributeAction = Ändere Auswahleigenschaften
 selectionMultiple = %s × %s
 selectionVarious = Diverse Elemente × %s
 #
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = Werkzeug: %s
-#
 # main/Canvas.java
 #
 canvasExceptionError = Simulation aufgrund eines internen Fehlers angehalten

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -197,9 +197,9 @@ changeAttributeAction = Attribut ändern
 #
 hdlAttrTitle = VHDL-Einheit: %s
 selectionAttributeAction = Ändere Auswahleigenschaften
-selectionMultiple = Auswahl: %s × %s
-selectionOne = Auswahl: %s
-selectionVarious = Auswahl: Diverse Elemente × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Diverse Elemente × %s
 #
 # main/AttrTableToolModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -197,9 +197,9 @@ changeAttributeAction = Αλλαγή Ιδιότητας
 #
 # ==> hdlAttrTitle =
 selectionAttributeAction = Αλλαγή Ιδιότητας Επιλογής
-selectionMultiple = Επιλογή: %s × %s
-selectionOne = Επιλογή: %s
-selectionVarious = Επιλογή: Διάφορα αντικείμενα × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Διάφορα αντικείμενα × %s
 #
 # main/AttrTableToolModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -198,7 +198,6 @@ changeAttributeAction = Αλλαγή Ιδιότητας
 # ==> hdlAttrTitle =
 selectionAttributeAction = Αλλαγή Ιδιότητας Επιλογής
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Διάφορα αντικείμενα × %s
 #
 # main/AttrTableToolModel.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -200,10 +200,6 @@ selectionAttributeAction = Αλλαγή Ιδιότητας Επιλογής
 selectionMultiple = %s × %s
 selectionVarious = Διάφορα αντικείμενα × %s
 #
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = Εργαλείο: %s
-#
 # main/Canvas.java
 #
 canvasExceptionError = Η προσομοίωση σταμάτησε λόγω εσωτερικού σφάλματος

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -197,9 +197,9 @@ changeAttributeAction = Cambiar atributo
 #
 hdlAttrTitle = Entidad VHDL: %s
 selectionAttributeAction = Cambiar atributo de la selección
-selectionMultiple = Selección: %s × %s
-selectionOne = Selección: %s
-selectionVarious = Selección: varios elementos × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Varios elementos × %s
 #
 # main/AttrTableToolModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -200,10 +200,6 @@ selectionAttributeAction = Cambiar atributo de la selección
 selectionMultiple = %s × %s
 selectionVarious = Varios elementos × %s
 #
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = Herramienta: %s
-#
 # main/Canvas.java
 #
 canvasExceptionError = Simulación detenida debido a error interno

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -198,7 +198,6 @@ changeAttributeAction = Cambiar atributo
 hdlAttrTitle = Entidad VHDL: %s
 selectionAttributeAction = Cambiar atributo de la selección
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Varios elementos × %s
 #
 # main/AttrTableToolModel.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -198,7 +198,6 @@ changeAttributeAction = Changer un attribut
 hdlAttrTitle = Entité VHDL : %s
 selectionAttributeAction = Changer l'attribut sélectionné
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Différents éléments × %s
 #
 # main/AttrTableToolModel.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -200,10 +200,6 @@ selectionAttributeAction = Changer l'attribut sélectionné
 selectionMultiple = %s × %s
 selectionVarious = Différents éléments × %s
 #
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = Outil : %s
-#
 # main/Canvas.java
 #
 canvasExceptionError = Simulation stoppée par une erreur interne

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -197,9 +197,9 @@ changeAttributeAction = Changer un attribut
 #
 hdlAttrTitle = Entité VHDL : %s
 selectionAttributeAction = Changer l'attribut sélectionné
-selectionMultiple = Sélection : %s × %s
-selectionOne = Sélection : %s
-selectionVarious = Sélection : différents éléments × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Différents éléments × %s
 #
 # main/AttrTableToolModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -197,9 +197,9 @@ changeAttributeAction = Cambia Attributo
 #
 hdlAttrTitle = VHDL Entità: %s
 selectionAttributeAction = modifica attributo
-selectionMultiple = Selezione: %s × %s
-selectionOne = Selezione: %s
-selectionVarious = Selezione: Elementi vari × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Elementi vari × %s
 #
 # main/AttrTableToolModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -200,10 +200,6 @@ selectionAttributeAction = modifica attributo
 selectionMultiple = %s × %s
 selectionVarious = Elementi vari × %s
 #
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = Strumento: %s
-#
 # main/Canvas.java
 #
 canvasExceptionError = Simulazione alterata da un errore interno

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -198,7 +198,6 @@ changeAttributeAction = Cambia Attributo
 hdlAttrTitle = VHDL Entità: %s
 selectionAttributeAction = modifica attributo
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Elementi vari × %s
 #
 # main/AttrTableToolModel.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -198,7 +198,6 @@ changeAttributeAction = 属性の変更
 hdlAttrTitle = VHDL エンティティ: %s
 selectionAttributeAction = 選択属性の変更
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = 各種項目 × %s
 #
 # main/AttrTableToolModel.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -197,9 +197,9 @@ changeAttributeAction = 属性の変更
 #
 hdlAttrTitle = VHDL エンティティ: %s
 selectionAttributeAction = 選択属性の変更
-selectionMultiple = 選択範囲: %s × %s
-selectionOne = 選択範囲: %s
-selectionVarious = 選択範囲: 各種項目 × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = 各種項目 × %s
 #
 # main/AttrTableToolModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -200,10 +200,6 @@ selectionAttributeAction = 選択属性の変更
 selectionMultiple = %s × %s
 selectionVarious = 各種項目 × %s
 #
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = ツール: %s
-#
 # main/Canvas.java
 #
 canvasExceptionError = 内部エラーによりシミュレーションが停止しました。

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -198,7 +198,6 @@ changeAttributeAction = Verander Attribuut
 hdlAttrTitle = VHDL Entiteit: %s
 selectionAttributeAction = Wijzig selectie-attribuut Wijzig selectie-attribuut
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Diverse artikelen × %s
 #
 # main/AttrTableToolModel.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -200,10 +200,6 @@ selectionAttributeAction = Wijzig selectie-attribuut Wijzig selectie-attribuut
 selectionMultiple = %s × %s
 selectionVarious = Diverse artikelen × %s
 #
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = Gereedschap: %s
-#
 # main/Canvas.java
 #
 canvasExceptionError = Simulatie gestopt door een interne fout

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -197,9 +197,9 @@ changeAttributeAction = Verander Attribuut
 #
 hdlAttrTitle = VHDL Entiteit: %s
 selectionAttributeAction = Wijzig selectie-attribuut Wijzig selectie-attribuut
-selectionMultiple = Selectie: %s u00d7 %s
-selectionOne = Selectie: %s
-selectionVarious = Selectie: Diverse artikelen u00d7 %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Diverse artikelen × %s
 #
 # main/AttrTableToolModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -198,7 +198,6 @@ changeAttributeAction = Zmiana atrybutu
 hdlAttrTitle = Instancja VHDL: %s
 selectionAttributeAction = Zmień atrybut zaznaczenia
 selectionMultiple = %s × %s
-# ==> selectionOne =
 # ==> selectionVarious =
 #
 # main/AttrTableToolModel.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -198,11 +198,6 @@ changeAttributeAction = Zmiana atrybutu
 hdlAttrTitle = Instancja VHDL: %s
 selectionAttributeAction = Zmień atrybut zaznaczenia
 selectionMultiple = %s × %s
-# ==> selectionVarious =
-#
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = Narzędzie: %s
 #
 # main/Canvas.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -197,7 +197,7 @@ changeAttributeAction = Zmiana atrybutu
 #
 hdlAttrTitle = Instancja VHDL: %s
 selectionAttributeAction = Zmień atrybut zaznaczenia
-selectionMultiple = Zaznaczenie: %s × %s
+selectionMultiple = %s × %s
 # ==> selectionOne =
 # ==> selectionVarious =
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -200,10 +200,6 @@ selectionAttributeAction = Mudar atributo de seleção
 selectionMultiple = %s × %s
 selectionVarious = itens variados × %s
 #
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = Ferramenta: %s
-#
 # main/Canvas.java
 #
 canvasExceptionError = Simulação suspensa por erro interno

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -198,7 +198,6 @@ changeAttributeAction = Alterar atributo
 hdlAttrTitle = Entidade VHDL: %s
 selectionAttributeAction = Mudar atributo de seleção
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = itens variados × %s
 #
 # main/AttrTableToolModel.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -197,9 +197,9 @@ changeAttributeAction = Alterar atributo
 #
 hdlAttrTitle = Entidade VHDL: %s
 selectionAttributeAction = Mudar atributo de seleção
-selectionMultiple = Seleção: %s × %s
-selectionOne = Seleção: %s
-selectionVarious = Seleção: itens variados × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = itens variados × %s
 #
 # main/AttrTableToolModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -197,9 +197,9 @@ changeAttributeAction = Изменить атрибут
 #
 hdlAttrTitle = VHDL Организация: %s
 selectionAttributeAction = Изменить атрибут выделения
-selectionMultiple = Выделение: %s × %s
-selectionOne = Выделение: %s
-selectionVarious = Выделение: Различные элементы × %s
+selectionMultiple = %s × %s
+selectionOne = %s
+selectionVarious = Различные элементы × %s
 #
 # main/AttrTableToolModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -200,10 +200,6 @@ selectionAttributeAction = Изменить атрибут выделения
 selectionMultiple = %s × %s
 selectionVarious = Различные элементы × %s
 #
-# main/AttrTableToolModel.java
-#
-toolAttrTitle = Инструмент: %s
-#
 # main/Canvas.java
 #
 canvasExceptionError = Моделирование остановлено из-за внутренней ошибки

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -198,7 +198,6 @@ changeAttributeAction = Изменить атрибут
 hdlAttrTitle = VHDL Организация: %s
 selectionAttributeAction = Изменить атрибут выделения
 selectionMultiple = %s × %s
-selectionOne = %s
 selectionVarious = Различные элементы × %s
 #
 # main/AttrTableToolModel.java


### PR DESCRIPTION
This PR reworks messages shown when user adds or selects components on the canvas. It removes "Selection:" prefix from all the `selectionXXX` strings (from all language versions) as this prefix is on real use and just wastes screen space. The same for "Tool:" prefix of `toolAttrTitle` string. It also removes `selectionOne` string completely as after the above change the only sane form of `selectionOne` is `%s` hence no point of having it at all.