### PR TITLE
A bug fix for the issues reported in #826

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,11 @@
   * Canvas Zoom controls new offer wider range of zoom and three level of granularity.
   * Added predefined quick zoom buttons.
   * Tons of code cleanup and internal improvements.
+  * Added duplicated component placement on same location refusal
+  * Fixed pin duplication on load in case a custom apearance is used for a circuit
+  * Added LED-array support for FPGA-boards
+  * Improved partial placement on FPGA-boards for multi-pin components
+  * Fixed several small bugs
 
 * v3.5.0 (2021-05-25)
   * Many code-cleanups, bug fixes and again the chronogram.

--- a/src/main/java/com/cburch/draw/model/AbstractCanvasObject.java
+++ b/src/main/java/com/cburch/draw/model/AbstractCanvasObject.java
@@ -168,7 +168,7 @@ public abstract class AbstractCanvasObject implements AttributeSet, CanvasObject
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return true;
+    return attr.isToSave();
   }
 
   @Override

--- a/src/main/java/com/cburch/draw/tools/DrawingAttributeSet.java
+++ b/src/main/java/com/cburch/draw/tools/DrawingAttributeSet.java
@@ -146,7 +146,7 @@ public class DrawingAttributeSet implements AttributeSet, Cloneable {
   }
 
   public boolean isToSave(Attribute<?> attr) {
-    return true;
+    return attr.isToSave();
   }
 
   public void removeAttributeListener(AttributeListener l) {

--- a/src/main/java/com/cburch/logisim/circuit/Circuit.java
+++ b/src/main/java/com/cburch/logisim/circuit/Circuit.java
@@ -817,7 +817,24 @@ public class Circuit {
   }
 
   public boolean hasConflict(Component comp) {
-    return wires.points.hasConflict(comp);
+    return wires.points.hasConflict(comp) || isDoubleMapped(comp);
+  }
+  
+  private boolean isDoubleMapped(Component comp) {
+    final var loc = comp.getLocation();
+    final var existing = wires.points.getNonWires(loc);
+    for (final var existingComp : existing)
+      if (existingComp.getFactory().equals(comp.getFactory())) {
+        /* we make an exception for the pin in case we have an input placed on an output */
+        if (comp.getFactory() instanceof Pin) {
+          final var dir1 = comp.getAttributeSet().getValue(Pin.ATTR_TYPE);
+          final var dir2 = existingComp.getAttributeSet().getValue(Pin.ATTR_TYPE);
+          if (dir1 == dir2) return true;
+        } else { 
+          return true;
+        }
+      }
+    return false;
   }
 
   public boolean isConnected(Location loc, Component ignore) {

--- a/src/main/java/com/cburch/logisim/circuit/Circuit.java
+++ b/src/main/java/com/cburch/logisim/circuit/Circuit.java
@@ -823,7 +823,7 @@ public class Circuit {
   private boolean isDoubleMapped(Component comp) {
     final var loc = comp.getLocation();
     final var existing = wires.points.getNonWires(loc);
-    for (final var existingComp : existing)
+    for (final var existingComp : existing) {
       if (existingComp.getFactory().equals(comp.getFactory())) {
         /* we make an exception for the pin in case we have an input placed on an output */
         if (comp.getFactory() instanceof Pin) {
@@ -834,6 +834,7 @@ public class Circuit {
           return true;
         }
       }
+    }
     return false;
   }
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
@@ -264,7 +264,7 @@ public class CircuitAttributes extends AbstractAttributeSet {
       if (aStatic == attr)
         return false;
     }
-    return true;
+    return attr.isToSave();
   }
 
   void setPinInstances(Instance[] value) {

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearancePort.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearancePort.java
@@ -46,7 +46,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 public class AppearancePort extends AppearanceElement {
-  private static final int INPUT_RADIUS = 4;
+  public static final int INPUT_RADIUS = 4;
   private static final int OUTPUT_RADIUS = 5;
   private static final int MINOR_RADIUS = 2;
   public static final Color COLOR = Color.BLUE;

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearancePort.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearancePort.java
@@ -46,7 +46,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 public class AppearancePort extends AppearanceElement {
-  public static final int INPUT_RADIUS = 4;
+  private static final int INPUT_RADIUS = 4;
   private static final int OUTPUT_RADIUS = 5;
   private static final int MINOR_RADIUS = 2;
   public static final Color COLOR = Color.BLUE;
@@ -56,6 +56,10 @@ public class AppearancePort extends AppearanceElement {
   public AppearancePort(Location location, Instance pin) {
     super(location);
     this.pin = pin;
+  }
+  
+  public static boolean isInputAppearance(int radius) {
+    return radius == INPUT_RADIUS;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
@@ -81,7 +81,7 @@ public class AppearanceSvgReader {
     return new pinInfo(loc, inst);
   }
   
-  public static AbstractCanvasObject createShape( Element elt, List<pinInfo> pins, Circuit circuit) {
+  public static AbstractCanvasObject createShape(Element elt, List<pinInfo> pins, Circuit circuit) {
     final var name = elt.getTagName();
     if (name.equals("circ-anchor") || name.equals("circ-origin")) {
       final var loc = getLocation(elt);
@@ -98,7 +98,7 @@ public class AppearanceSvgReader {
       for (final var pin : pins) {
         if (pin.pinIsAlreadyUsed()) continue;
         if (pin.getPinLocation().equals(pinLoc)) {
-          final var isInputPin = ((Pin)pin.getPinInstance().getFactory()).isInputPin(pin.getPinInstance());
+          final var isInputPin = ((Pin) pin.getPinInstance().getFactory()).isInputPin(pin.getPinInstance());
           final var isInputRef = isInputPinReference(elt);
           if (isInputPin == isInputRef) {
             pin.setPinIsUsed();

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
@@ -43,31 +43,72 @@ import com.cburch.logisim.std.io.SevenSegmentShape;
 import com.cburch.logisim.std.io.TtyShape;
 import com.cburch.logisim.std.memory.CounterShape;
 import com.cburch.logisim.std.memory.RegisterShape;
-import java.util.Map;
+import com.cburch.logisim.std.wiring.Pin;
+
+import java.util.List;
 import org.w3c.dom.Element;
 
 public class AppearanceSvgReader {
-  public static AbstractCanvasObject createShape(
-      Element elt, Map<Location, Instance> pins, Circuit circuit) {
-    String name = elt.getTagName();
+  public static class pinInfo {
+    private final Location myLocation;
+    private final Instance myInstance;
+    private Boolean isMapped;
+    
+    public pinInfo(Location loc, Instance inst) {
+      myLocation = loc;
+      myInstance = inst;
+      isMapped = false;
+    }
+    
+    public Boolean pinIsAlreadyUsed() {
+      return isMapped;
+    }
+    
+    public Location getPinLocation() {
+      return myLocation;
+    }
+    
+    public Instance getPinInstance() {
+      return myInstance;
+    }
+    
+    public void setPinIsUsed() {
+      isMapped = true;
+    }
+  }
+  
+  public static pinInfo getPinInfo(Location loc, Instance inst) {
+    return new pinInfo(loc, inst);
+  }
+  
+  public static AbstractCanvasObject createShape( Element elt, List<pinInfo> pins, Circuit circuit) {
+    final var name = elt.getTagName();
     if (name.equals("circ-anchor") || name.equals("circ-origin")) {
-      Location loc = getLocation(elt);
-      AbstractCanvasObject ret = new AppearanceAnchor(loc);
+      final var loc = getLocation(elt);
+      final var ret = new AppearanceAnchor(loc);
       if (elt.hasAttribute("facing")) {
-        Direction facing = Direction.parse(elt.getAttribute("facing"));
+        final var facing = Direction.parse(elt.getAttribute("facing"));
         ret.setValue(AppearanceAnchor.FACING, facing);
       }
       return ret;
     } else if (name.equals("circ-port")) {
-      Location loc = getLocation(elt);
-      String[] pinStr = elt.getAttribute("pin").split(",");
-      Location pinLoc =
-          Location.create(Integer.parseInt(pinStr[0].trim()), Integer.parseInt(pinStr[1].trim()));
-      Instance pin = pins.get(pinLoc);
-      if (pin == null) return null;
-      return new AppearancePort(loc, pin);
+      final var loc = getLocation(elt);
+      final var pinStr = elt.getAttribute("pin").split(",");
+      final var pinLoc = Location.create(Integer.parseInt(pinStr[0].trim()), Integer.parseInt(pinStr[1].trim()));
+      for (final var pin : pins) {
+        if (pin.pinIsAlreadyUsed()) continue;
+        if (pin.getPinLocation().equals(pinLoc)) {
+          final var isInputPin = ((Pin)pin.getPinInstance().getFactory()).isInputPin(pin.getPinInstance());
+          final var isInputRef = isInputPinReference(elt);
+          if (isInputPin == isInputRef) {
+            pin.setPinIsUsed();
+            return new AppearancePort(loc, pin.getPinInstance()); 
+          }
+        }
+      }
+      return null; 
     } else if (name.startsWith("visible-")) {
-      String pathstr = elt.getAttribute("path");
+      final var pathstr = elt.getAttribute("path");
       if (pathstr == null || pathstr.length() == 0) return null;
       DynamicElement.Path path;
       try {
@@ -76,9 +117,9 @@ public class AppearanceSvgReader {
         System.out.println(e.getMessage());
         return null;
       }
-      int x = (int) Double.parseDouble(elt.getAttribute("x").trim());
-      int y = (int) Double.parseDouble(elt.getAttribute("y").trim());
-      DynamicElement shape = getDynamicElement(name, path, x, y);
+      final var x = (int) Double.parseDouble(elt.getAttribute("x").trim());
+      final var y = (int) Double.parseDouble(elt.getAttribute("y").trim());
+      final var shape = getDynamicElement(name, path, x, y);
       if (shape == null) {
         return null;
       }
@@ -117,6 +158,12 @@ public class AppearanceSvgReader {
       default:
         return null;
     }
+  }
+  
+  private static Boolean isInputPinReference(Element elt) {
+    final var w = Double.parseDouble(elt.getAttribute("width"));
+    final var radius = (int) Math.round(w / 2.0);
+    return radius == AppearancePort.INPUT_RADIUS;
   }
 
   private static Location getLocation(Element elt) {

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
@@ -161,8 +161,8 @@ public class AppearanceSvgReader {
   }
   
   private static Boolean isInputPinReference(Element elt) {
-    final var w = Double.parseDouble(elt.getAttribute("width"));
-    final var radius = (int) Math.round(w / 2.0);
+    final var width = Double.parseDouble(elt.getAttribute("width"));
+    final var radius = (int) Math.round(width / 2.0);
     return radius == AppearancePort.INPUT_RADIUS;
   }
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
@@ -52,16 +52,16 @@ public class AppearanceSvgReader {
   public static class pinInfo {
     private final Location myLocation;
     private final Instance myInstance;
-    private Boolean isMapped;
+    private Boolean pinIsUsed;
     
     public pinInfo(Location loc, Instance inst) {
       myLocation = loc;
       myInstance = inst;
-      isMapped = false;
+      pinIsUsed = false;
     }
     
     public Boolean pinIsAlreadyUsed() {
-      return isMapped;
+      return pinIsUsed;
     }
     
     public Location getPinLocation() {
@@ -73,7 +73,7 @@ public class AppearanceSvgReader {
     }
     
     public void setPinIsUsed() {
-      isMapped = true;
+      pinIsUsed = true;
     }
   }
   
@@ -163,7 +163,7 @@ public class AppearanceSvgReader {
   private static Boolean isInputPinReference(Element elt) {
     final var width = Double.parseDouble(elt.getAttribute("width"));
     final var radius = (int) Math.round(width / 2.0);
-    return radius == AppearancePort.INPUT_RADIUS;
+    return AppearancePort.isInputAppearance(radius);
   }
 
   private static Location getLocation(Element elt) {

--- a/src/main/java/com/cburch/logisim/data/AbstractAttributeSet.java
+++ b/src/main/java/com/cburch/logisim/data/AbstractAttributeSet.java
@@ -105,7 +105,7 @@ public abstract class AbstractAttributeSet implements Cloneable, AttributeSet {
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return true;
+    return attr.isToSave();
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/data/Attribute.java
+++ b/src/main/java/com/cburch/logisim/data/Attribute.java
@@ -85,6 +85,10 @@ public abstract class Attribute<V> {
   public boolean isHidden() {
     return hidden;
   }
+  
+  public boolean isToSave() {
+    return true;
+  }
 
   @Override
   public String toString() {

--- a/src/main/java/com/cburch/logisim/data/AttributeSets.java
+++ b/src/main/java/com/cburch/logisim/data/AttributeSets.java
@@ -196,7 +196,7 @@ public class AttributeSets {
 
         @Override
         public boolean isToSave(Attribute<?> attr) {
-          return true;
+          return attr.isToSave();
         }
 
         @Override

--- a/src/main/java/com/cburch/logisim/data/Attributes.java
+++ b/src/main/java/com/cburch/logisim/data/Attributes.java
@@ -70,6 +70,11 @@ public class Attributes {
     public ComponentMapInformationContainer parse(String value) {
       return null;
     }
+    
+    @Override
+    public boolean isToSave() {
+      return false;
+    }
 
     @Override
     public boolean isHidden() {

--- a/src/main/java/com/cburch/logisim/file/XmlReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlReader.java
@@ -41,7 +41,6 @@ import com.cburch.logisim.comp.Component;
 import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.data.AttributeDefaultProvider;
 import com.cburch.logisim.data.AttributeSet;
-import com.cburch.logisim.data.Location;
 import com.cburch.logisim.fpga.data.BoardRectangle;
 import com.cburch.logisim.fpga.data.MapComponent;
 import com.cburch.logisim.gui.generic.OptionPane;
@@ -66,7 +65,6 @@ import com.cburch.logisim.tools.TextTool;
 import com.cburch.logisim.tools.Tool;
 import com.cburch.logisim.tools.WiringTool;
 import com.cburch.logisim.util.InputEventUtil;
-import com.cburch.logisim.util.StringUtil;
 import com.cburch.logisim.vhdl.base.VhdlContent;
 import java.io.File;
 import java.io.IOException;
@@ -342,10 +340,10 @@ class XmlReader {
     }
 
     void loadAppearance(Element appearElt, XmlReader.CircuitData circData, String context) {
-      final var pins = new HashMap<Location, Instance>();
+      final var pins = new ArrayList<AppearanceSvgReader.pinInfo>();
       for (final var comp : circData.knownComponents.values()) {
         if (comp.getFactory() == Pin.FACTORY) {
-          pins.put(comp.getLocation(), Instance.getInstanceFor(comp));
+          pins.add(AppearanceSvgReader.getPinInfo(comp.getLocation(), Instance.getInstanceFor(comp)));
         }
       }
 

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -51,7 +51,6 @@ import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -101,11 +100,6 @@ class XmlWriter {
     if (a == null) return -1;
     if (b == null) return 1;
     return a.compareTo(b);
-    //for (var i = 0; i < Math.min(a.length(), b.length()); i++) {
-    //  if (a.charAt(i) != b.charAt(i))
-    //    return a.charAt(i) - b.charAt(i);
-    //}
-    //return a.length() - b.length();
   }
   
   static final void swap(Node top, Node node1, Node node2) {

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -143,10 +143,10 @@ class XmlWriter {
     //   - wire(s)
     if (name.equals("appear")) return; // do not sort the appearance section, we do not have to go down 
     if (n > 1 && !name.equals("project") && !name.equals("lib") && !name.equals("toolbar")) {
-      for (var i = 0; i < n-1; i++)
-        for (var j = 0; j < n - i - 1 ; j++) {
+      for (var i = 0; i < n - 1; i++)
+        for (var j = 0; j < n - i - 1; j++) {
           final var node1 = children.item(j);
-          final var node2 = children.item(j+1);
+          final var node2 = children.item(j + 1);
           swap(top, node1, node2);
         }
     }

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -102,30 +102,30 @@ class XmlWriter {
     return a.compareTo(b);
   }
   
-  static final void swap(Node top, Node node1, Node node2) {
-    final var na = node1.getNodeName();
-    final var nb = node2.getNodeName();
-    var c = stringCompare(na, nb);
-    if (c > 0) {
-      top.insertBefore(node2, node1);
-    } else if (c < 0) return;
-    final var ma = attrsToString(node1.getAttributes());
-    final var mb = attrsToString(node2.getAttributes());
-    c = stringCompare(ma, mb);
-    if (c > 0) {
-      top.insertBefore(node2, node1);
-    } else if (c < 0) return;
-    final var va = node1.getNodeValue();
-    final var vb = node2.getNodeValue();
-    c = stringCompare(va, vb);
-    if (c > 0) {
-      top.insertBefore(node2, node1);
+  static final void swap(Node top, Node nodeA, Node nodeB) {
+    final var na = nodeA.getNodeName();
+    final var nb = nodeB.getNodeName();
+    var compare = stringCompare(na, nb);
+    if (compare > 0) {
+      top.insertBefore(nodeB, nodeA);
+    } else if (compare < 0) return;
+    final var ma = attrsToString(nodeA.getAttributes());
+    final var mb = attrsToString(nodeB.getAttributes());
+    compare = stringCompare(ma, mb);
+    if (compare > 0) {
+      top.insertBefore(nodeB, nodeA);
+    } else if (compare < 0) return;
+    final var va = nodeA.getNodeValue();
+    final var vb = nodeB.getNodeValue();
+    compare = stringCompare(va, vb);
+    if (compare > 0) {
+      top.insertBefore(nodeB, nodeA);
     }
   }
 
   static void sort(Node top) {
     final var children = top.getChildNodes();
-    final var n = children.getLength();
+    final var nrChildren = children.getLength();
     final var name = top.getNodeName();
     // project (contains ordered elements, do not sort)
     // - main
@@ -142,16 +142,16 @@ class XmlWriter {
     //   - comp(s)
     //   - wire(s)
     if (name.equals("appear")) return; // do not sort the appearance section, we do not have to go down 
-    if (n > 1 && !name.equals("project") && !name.equals("lib") && !name.equals("toolbar")) {
-      for (var i = 0; i < n - 1; i++)
-        for (var j = 0; j < n - i - 1; j++) {
-          final var node1 = children.item(j);
-          final var node2 = children.item(j + 1);
-          swap(top, node1, node2);
+    if (nrChildren > 1 && !name.equals("project") && !name.equals("lib") && !name.equals("toolbar")) {
+      for (var bubbleLoop1 = 0; bubbleLoop1 < nrChildren - 1; bubbleLoop1++)
+        for (var bubbleLoop2 = 0; bubbleLoop2 < nrChildren - bubbleLoop1 - 1; bubbleLoop2++) {
+          final var nodeA = children.item(bubbleLoop2);
+          final var nodeB = children.item(bubbleLoop2 + 1);
+          swap(top, nodeA, nodeB);
         }
     }
-    for (var i = 0; i < n; i++) {
-      sort(children.item(i));
+    for (var childId = 0; childId < nrChildren; childId++) {
+      sort(children.item(childId));
     }
   }
 

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -103,21 +103,21 @@ class XmlWriter {
   }
   
   static final void swap(Node top, Node nodeA, Node nodeB) {
-    final var na = nodeA.getNodeName();
-    final var nb = nodeB.getNodeName();
-    var compare = stringCompare(na, nb);
+    final var nameNodeA = nodeA.getNodeName();
+    final var nameNodeB = nodeB.getNodeName();
+    var compare = stringCompare(nameNodeA, nameNodeB);
     if (compare > 0) {
       top.insertBefore(nodeB, nodeA);
     } else if (compare < 0) return;
-    final var ma = attrsToString(nodeA.getAttributes());
-    final var mb = attrsToString(nodeB.getAttributes());
-    compare = stringCompare(ma, mb);
+    final var nameAttributesNodeA = attrsToString(nodeA.getAttributes());
+    final var nameAttributesNodeB = attrsToString(nodeB.getAttributes());
+    compare = stringCompare(nameAttributesNodeA, nameAttributesNodeB);
     if (compare > 0) {
       top.insertBefore(nodeB, nodeA);
     } else if (compare < 0) return;
-    final var va = nodeA.getNodeValue();
-    final var vb = nodeB.getNodeValue();
-    compare = stringCompare(va, vb);
+    final var nameNodeValueNodeA = nodeA.getNodeValue();
+    final var nameNodeValueNodeB = nodeB.getNodeValue();
+    compare = stringCompare(nameNodeValueNodeA, nameNodeValueNodeB);
     if (compare > 0) {
       top.insertBefore(nodeB, nodeA);
     }
@@ -125,7 +125,7 @@ class XmlWriter {
 
   static void sort(Node top) {
     final var children = top.getChildNodes();
-    final var nrChildren = children.getLength();
+    final var childrenCount = children.getLength();
     final var name = top.getNodeName();
     // project (contains ordered elements, do not sort)
     // - main
@@ -142,15 +142,15 @@ class XmlWriter {
     //   - comp(s)
     //   - wire(s)
     if (name.equals("appear")) return; // do not sort the appearance section, we do not have to go down 
-    if (nrChildren > 1 && !name.equals("project") && !name.equals("lib") && !name.equals("toolbar")) {
-      for (var bubbleLoop1 = 0; bubbleLoop1 < nrChildren - 1; bubbleLoop1++)
-        for (var bubbleLoop2 = 0; bubbleLoop2 < nrChildren - bubbleLoop1 - 1; bubbleLoop2++) {
+    if (childrenCount > 1 && !name.equals("project") && !name.equals("lib") && !name.equals("toolbar")) {
+      for (var bubbleLoop1 = 0; bubbleLoop1 < childrenCount - 1; bubbleLoop1++)
+        for (var bubbleLoop2 = 0; bubbleLoop2 < childrenCount - bubbleLoop1 - 1; bubbleLoop2++) {
           final var nodeA = children.item(bubbleLoop2);
           final var nodeB = children.item(bubbleLoop2 + 1);
           swap(top, nodeA, nodeB);
         }
     }
-    for (var childId = 0; childId < nrChildren; childId++) {
+    for (var childId = 0; childId < childrenCount; childId++) {
       sort(children.item(childId));
     }
   }

--- a/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUartAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUartAttributes.java
@@ -119,7 +119,7 @@ public class JtagUartAttributes  extends AbstractAttributeSet {
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return attr != JTAG_STATE;
+    return attr.isToSave() && attr != JTAG_STATE;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/soc/memory/SocMemoryAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/memory/SocMemoryAttributes.java
@@ -113,7 +113,7 @@ public class SocMemoryAttributes extends AbstractAttributeSet {
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return attr != SOCMEM_STATE;
+    return attr.isToSave() && attr != SOCMEM_STATE;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2Attributes.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2Attributes.java
@@ -124,7 +124,7 @@ public class Nios2Attributes extends AbstractAttributeSet {
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return attr != NIOS2_STATE;
+    return attr.isToSave() && attr != NIOS2_STATE;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/soc/pio/PioAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/pio/PioAttributes.java
@@ -172,7 +172,7 @@ public class PioAttributes extends AbstractAttributeSet {
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return attr != PIO_STATE;
+    return attr.isToSave() && attr != PIO_STATE;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imAttributes.java
@@ -120,7 +120,7 @@ public class RV32imAttributes extends AbstractAttributeSet {
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return attr != RV32IM_STATE;
+    return attr.isToSave() && attr != RV32IM_STATE;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/soc/vga/VgaAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/vga/VgaAttributes.java
@@ -134,7 +134,7 @@ public class VgaAttributes extends AbstractAttributeSet {
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return attr != VGA_STATE;
+    return attr.isToSave() && attr != VGA_STATE;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/hdl/VhdlEntityAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/VhdlEntityAttributes.java
@@ -146,6 +146,6 @@ public class VhdlEntityAttributes extends AbstractAttributeSet {
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return attr != VhdlSimConstants.SIM_NAME_ATTR;
+    return attr.isToSave() && attr != VhdlSimConstants.SIM_NAME_ATTR;
   }
 }

--- a/src/main/java/com/cburch/logisim/std/wiring/PinAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/PinAttributes.java
@@ -88,7 +88,7 @@ class PinAttributes extends ProbeAttributes {
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return attr != ATTR_DUMMY;
+    return attr.isToSave() && attr != ATTR_DUMMY;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/tools/AddTool.java
+++ b/src/main/java/com/cburch/logisim/tools/AddTool.java
@@ -554,13 +554,13 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
 
         for (var x = 0; x < matrix.getNrOfXCopies(); x++) {
           for (var y = 0; y < matrix.getNrOfYCopies(); y++) {
-            final var loc = Location.create( e.getX() + matrix.GetDeltaX() * x
-                , e.getY() + matrix.GetDeltaY() * y);
+            final var loc = Location.create(e.getX() + matrix.GetDeltaX() * x,
+                e.getY() + matrix.GetDeltaY() * y);
             final var attrsCopy = (AttributeSet) attrs.clone();
             if (matrix.GetLabel() != null) {
               if (MatrixPlace)
-                attrsCopy.setValue(StdAttr.LABEL, AutoLabler.getMatrixLabel(canvas.getCircuit()
-                    , source, matrix.GetLabel(), x, y));
+                attrsCopy.setValue(StdAttr.LABEL, AutoLabler.getMatrixLabel(canvas.getCircuit(),
+                    source, matrix.GetLabel(), x, y));
               else {
                 attrsCopy.setValue(StdAttr.LABEL, matrix.GetLabel());
               }

--- a/src/main/java/com/cburch/logisim/tools/AddTool.java
+++ b/src/main/java/com/cburch/logisim/tools/AddTool.java
@@ -554,34 +554,32 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
 
         for (var x = 0; x < matrix.getNrOfXCopies(); x++) {
           for (var y = 0; y < matrix.getNrOfYCopies(); y++) {
-            final var loc = Location.create(
-                    e.getX() + matrix.GetDeltaX() * x, e.getY() + matrix.GetDeltaY() * y);
+            final var loc = Location.create( e.getX() + matrix.GetDeltaX() * x
+                , e.getY() + matrix.GetDeltaY() * y);
             final var attrsCopy = (AttributeSet) attrs.clone();
             if (matrix.GetLabel() != null) {
               if (MatrixPlace)
-                attrsCopy.setValue(
-                    StdAttr.LABEL,
-                    AutoLabler.getMatrixLabel(
-                        canvas.getCircuit(), source, matrix.GetLabel(), x, y));
+                attrsCopy.setValue(StdAttr.LABEL, AutoLabler.getMatrixLabel(canvas.getCircuit()
+                    , source, matrix.GetLabel(), x, y));
               else {
                 attrsCopy.setValue(StdAttr.LABEL, matrix.GetLabel());
               }
             }
-            final var c = source.createComponent(loc, attrsCopy);
+            final var comp = source.createComponent(loc, attrsCopy);
 
-            if (circ.hasConflict(c)) {
+            if (circ.hasConflict(comp)) {
               canvas.setErrorMessage(S.getter("exclusiveError"));
               return;
             }
 
-            final var bds = c.getBounds(g);
+            final var bds = comp.getBounds(g);
             if (bds.getX() < 0 || bds.getY() < 0) {
               canvas.setErrorMessage(S.getter("negativeCoordError"));
               return;
             }
 
-            mutation.add(c);
-            added.add(c);
+            mutation.add(comp);
+            added.add(comp);
           }
         }
         final var action = mutation.toAction(S.getter("addComponentAction", factory.getDisplayGetter()));

--- a/src/main/java/com/cburch/logisim/tools/AddTool.java
+++ b/src/main/java/com/cburch/logisim/tools/AddTool.java
@@ -554,8 +554,8 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
 
         for (var x = 0; x < matrix.getNrOfXCopies(); x++) {
           for (var y = 0; y < matrix.getNrOfYCopies(); y++) {
-            final var loc = Location.create(e.getX() + matrix.GetDeltaX() * x,
-                e.getY() + matrix.GetDeltaY() * y);
+            final var loc = Location.create(e.getX() + (matrix.GetDeltaX() * x),
+                e.getY() + (matrix.GetDeltaY() * y));
             final var attrsCopy = (AttributeSet) attrs.clone();
             if (matrix.GetLabel() != null) {
               if (MatrixPlace)

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntityAttributes.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntityAttributes.java
@@ -330,6 +330,6 @@ public class VhdlEntityAttributes extends AbstractAttributeSet {
 
   @Override
   public boolean isToSave(Attribute<?> attr) {
-    return attr != VhdlSimConstants.SIM_NAME_ATTR;
+    return attr.isToSave() && attr != VhdlSimConstants.SIM_NAME_ATTR;
   }
 }


### PR DESCRIPTION
In this bug fix following topics are addressed:
1) Placing an input pin on an output pin resulted in a null-pointer exception. This was originated in the sorting algorithm in the xml-writer. Fixed.
2) Hidden attributes that were only used internally were written as "dummy" attribute in the .circ file. This is fixed.
3) Custom appearance used the pin location to connect to the pin in the circuit. In case of an input pin directly placed on an output pin the data-structure would only contain one of the two pins and map the two appearance pin to exactly this pin. This caused when reading in the circuit that one would get multiple appearance pins referencing the same circuit pin. Each time the circuit was written out and read in again, the number of appearance pins would increase. This is fixed now. Side effect of this fix is that when reading in a circuit with custom appearance it might happen that logisim complains about pins that are not found in a circuit, and that the location of the pins are not exactly as they were before. This only happens once, writing back the circuit to a .circ file solves the problem. Unfortunately this cannot be solved in the source code as the .circ file does not provide enough information to do an automatic fix.
4) It is still possible to place equal components on top of each other. Whilst the xml-reader will put them slightly apart, this is not a nice thing. I added a check that prevents placing equal components on the same location. The exception to this rule are an input- and an output-pin.