### PR TITLE
Project "Dirty marker" improved

### DIFF
--- a/src/main/java/com/cburch/logisim/LogisimVersion.java
+++ b/src/main/java/com/cburch/logisim/LogisimVersion.java
@@ -33,11 +33,20 @@ public class LogisimVersion {
   private int major = 0;
   private int minor = 0;
   private int patch = 0;
+  private String suffix = "";
 
   public LogisimVersion(int major, int minor, int patch) {
+    this(major, minor, patch, "");
+  }
+
+  public LogisimVersion(int major, int minor, int patch, String suffix) {
     this.major = major;
     this.minor = minor;
     this.patch = patch;
+    if (suffix == null) {
+      suffix = "";
+    }
+    this.suffix = suffix.strip();
   }
 
   /**
@@ -45,26 +54,35 @@ public class LogisimVersion {
    * No exception is thrown if the version string contains non-integers, because literal values are
    * allowed.
    *
+   * <p>Supported version string formats are `X.Y.Z` or `X.Y.Z-SUFFIX`
+   *
    * @return LogisimVersion built from the string passed as parameter
    */
   public static LogisimVersion fromString(String versionString) {
-    final var parts = versionString.split("\\.");
     var major = 0;
     var minor = 0;
     var patch = 0;
+    var suffix = "";
 
-    if (versionString.isEmpty()) {
-      return new LogisimVersion(major, minor, patch);
+    // Let's see if we have suffix segment or not.
+    final var segments = versionString.split("-");
+
+    if (segments.length > 0) {
+      if (segments.length == 2) {
+        suffix = segments[1].strip();
+      }
+
+      final var parts = segments[0].split("\\.");
+      try {
+        if (parts.length >= 1) major = Integer.parseInt(parts[0]);
+        if (parts.length >= 2) minor = Integer.parseInt(parts[1]);
+        if (parts.length >= 3) patch = Integer.parseInt(parts[2]);
+      } catch (NumberFormatException ignored) {
+        // Just ignore. We will just fall back to `0`
+      }
     }
 
-    try {
-      if (parts.length >= 1) major = Integer.parseInt(parts[0]);
-      if (parts.length >= 2) minor = Integer.parseInt(parts[1]);
-      if (parts.length >= 3) patch = Integer.parseInt(parts[2]);
-    } catch (NumberFormatException ignored) {
-    }
-
-    return new LogisimVersion(major, minor, patch);
+    return new LogisimVersion(major, minor, patch, suffix);
   }
 
   /**
@@ -84,17 +102,43 @@ public class LogisimVersion {
       }
     }
 
+    // TODO: we do not understand what suffix means. The only rule here is that "no suffix"
+    // means stable version, while presence of suffix indicates unstable one, so in case
+    // all other values are equal, "no suffix" is considered newer.
+    if (result == 0) {
+      if (this.suffix.equals("") && !other.suffix.equals("")) {
+        result = 1; // this one is newer
+      } else if (!this.suffix.equals("") && other.suffix.equals("")) {
+        result = -1; // this one is older
+      }
+    }
+
     return result;
+  }
+
+  /**
+   * Returns TRUE if version is considered stable, false otherwise. Note the implementation is
+   * plaind dumb and relies on presence of version suffix (which, if not empty means non-stable
+   * release).
+   *
+   * @return
+   */
+  public boolean isStable() {
+    return suffix.equals("");
   }
 
   /** Build the hash code starting from the version number. */
   @Override
   public int hashCode() {
-    return (major * 31 + minor) * 31 + patch;
+    return (major * 31 + minor) * 31 + patch + suffix.hashCode();
   }
 
   @Override
   public String toString() {
-    return major + "." + minor + "." + patch;
+    String result = major + "." + minor + "." + patch;
+    if (!suffix.equals("")) {
+      result += "-" + suffix;
+    }
+    return result;
   }
 }

--- a/src/main/java/com/cburch/logisim/Main.java
+++ b/src/main/java/com/cburch/logisim/Main.java
@@ -89,6 +89,7 @@ public class Main {
 
   static final Logger logger = LoggerFactory.getLogger(Main.class);
 
+  // FIXME: this should not be here. We need separate class for all these consts!
   public static final String APP_NAME = "Logisim-evolution";
   public static final LogisimVersion VERSION = new LogisimVersion(3, 5, 0);
   public static final int COPYRIGHT_YEAR = 2021;
@@ -98,6 +99,10 @@ public class Main {
   public static boolean ANALYZE = true;
   public static boolean headless = false;
   public static final boolean MacOS = MacCompatibility.isRunningOnMac();
+
+  // FloppyDisk unicode character: https://charbase.com/1f4be-unicode-floppy-disk
+  public static final String DIRTY_MARKER = "\ud83d\udcbe";
+
 
   public static boolean hasGui() {
     return !headless;

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
@@ -29,6 +29,7 @@
 package com.cburch.logisim.gui.generic;
 
 import com.cburch.contracts.BaseMouseListenerContract;
+import com.cburch.logisim.Main;
 import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.SubcircuitFactory;
 import com.cburch.logisim.comp.ComponentDrawContext;
@@ -78,7 +79,7 @@ import javax.swing.tree.TreeSelectionModel;
 public class ProjectExplorer extends JTree implements LocaleListener {
   public static final Color MAGNIFYING_INTERIOR = new Color(200, 200, 255, 64);
   private static final long serialVersionUID = 1L;
-  private static final String DIRTY_MARKER = "*";
+
   private final Project proj;
   private final MyListener myListener = new MyListener();
   private final MyCellRenderer renderer = new MyCellRenderer();
@@ -208,12 +209,19 @@ public class ProjectExplorer extends JTree implements LocaleListener {
           label.setToolTipText(tool.getDescription());
         }
       } else if (value instanceof ProjectExplorerLibraryNode) {
-        ProjectExplorerLibraryNode libNode = (ProjectExplorerLibraryNode) value;
-        Library lib = libNode.getValue();
+        final var libNode = (ProjectExplorerLibraryNode) value;
+        final var lib = libNode.getValue();
 
         if (ret instanceof JLabel) {
-          String text = lib.getDisplayName();
-          if (lib.isDirty()) text += DIRTY_MARKER;
+          final var baseName = lib.getDisplayName();
+          var text = baseName;
+          if (lib.isDirty()) {
+            // TODO: Would be nice to use DIRTY_MARKER here instead of "*" but it does not render
+            // corectly in project tree, font seem to have the character as frame title is fine.
+            // Needs to figure out what is different (java fonts?). Keep "*" unless bug is resolved.
+            final var DIRTY_MARKER_LOCAL = "*"; // useless var for easy DIRTY_MARKER hunt in future.
+            text = DIRTY_MARKER_LOCAL + baseName;
+          }
 
           ((JLabel) ret).setText(text);
         }

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -358,13 +358,22 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
   private void computeTitle() {
     final var circuit = project.getCurrentCircuit();
     final var name = project.getLogisimFile().getName();
+
     final var title =
         (circuit != null)
             ? S.get("titleCircFileKnown", circuit.getName(), name)
             : S.get("titleFileKnown", name);
 
-    final var dirtyMarker = project.isFileDirty() ? "*" : "";
-    this.setTitle(StringUtil.format("%s %s · %s", dirtyMarker, title, Main.APP_DISPLAY_NAME).trim());
+    String dirtyMarkerState = "";
+    String dirtyMarker = "";
+
+    if (project.isFileDirty()) {
+      dirtyMarker = Main.DIRTY_MARKER + "\u0020"; // keep the space
+      // The icon alone may sometimes be missed so we add additional "[UNSAVED]" to the title too.
+      dirtyMarkerState = StringUtil.format("[%s]", S.get("titleUnsavedProjectState").toUpperCase());
+    }
+
+    this.setTitle(StringUtil.format("%s%s · %s %s", dirtyMarker, title, Main.APP_DISPLAY_NAME, dirtyMarkerState).trim());
     myProjectListener.enableSave();
   }
 

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -239,6 +239,7 @@ simulateTab = Simulate
 stateTab = State
 titleCircFileKnown = %s of %s
 titleFileKnown = %s
+titleUnsavedProjectState = Unsaved
 #
 # main/Print.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -239,6 +239,7 @@ saveOption = Speichern
 # ==> stateTab =
 titleCircFileKnown = %s von %s
 titleFileKnown = %s
+# ==> titleUnsavedProjectState =
 #
 # main/Print.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -239,6 +239,7 @@ saveOption = Αποθήκευση
 # ==> stateTab =
 titleCircFileKnown = %s από %s
 titleFileKnown = %s
+# ==> titleUnsavedProjectState =
 #
 # main/Print.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -239,6 +239,7 @@ saveOption = Guardar
 # ==> stateTab =
 titleCircFileKnown = %s de %s
 titleFileKnown = %s
+# ==> titleUnsavedProjectState =
 #
 # main/Print.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -239,6 +239,7 @@ simulateTab = Simulation
 stateTab = État
 titleCircFileKnown = %s de %s
 titleFileKnown = %s
+# ==> titleUnsavedProjectState =
 #
 # main/Print.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -239,6 +239,7 @@ saveOption = Salva
 # ==> stateTab =
 titleCircFileKnown = %s di %s
 titleFileKnown = %s
+# ==> titleUnsavedProjectState =
 #
 # main/Print.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -239,6 +239,7 @@ saveOption = 保存
 # ==> stateTab =
 titleCircFileKnown = %s の %s
 titleFileKnown = %s
+# ==> titleUnsavedProjectState =
 #
 # main/Print.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -239,6 +239,7 @@ simulateTab = Simuleren
 stateTab = Toestand
 titleCircFileKnown = %s van %s
 titleFileKnown = %s
+# ==> titleUnsavedProjectState =
 #
 # main/Print.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -284,6 +284,7 @@ simulateTab = Simulacja
 stateTab = Stan
 titleCircFileKnown = %s z %s
 titleFileKnown = %s
+titleUnsavedProjectState = Niezapisany
 #
 # main/Print.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -239,6 +239,7 @@ saveOption = Salvar
 # ==> stateTab =
 titleCircFileKnown = %s de %s
 titleFileKnown = %s
+# ==> titleUnsavedProjectState =
 #
 # main/Print.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -239,6 +239,7 @@ saveOption = Сохранить
 # ==> stateTab =
 titleCircFileKnown = %s из %s
 titleFileKnown = %s
+# ==> titleUnsavedProjectState =
 #
 # main/Print.java
 #

--- a/src/test/java/com/cburch/logisim/LogisimVersionTest.java
+++ b/src/test/java/com/cburch/logisim/LogisimVersionTest.java
@@ -34,59 +34,83 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Tests LogisimVersion class.
- */
+/** Tests LogisimVersion class. */
 public class LogisimVersionTest {
 
-    private LogisimVersion older;
-    private LogisimVersion newer;
-    private LogisimVersion newerToo;
+  private LogisimVersion older;
+  private LogisimVersion newer;
+  private LogisimVersion newerToo;
 
-    @Before
-    public void setUp() {
-        older = new LogisimVersion(1, 2, 3);
-        newer = new LogisimVersion(1, 2, 4);
-        newerToo = new LogisimVersion(1, 2, 4);
+  /** Test method for {@link com.cburch.logisim.LogisimVersion#fromString(java.lang.String)}. */
+  @Test
+  public void testFromString() {
+    String[] tests = {"1.2.3", "1.2.3-beta1"};
+    for (var test : tests) {
+      assertNotNull(LogisimVersion.fromString(test));
+      assertEquals(test, LogisimVersion.fromString(test).toString());
+      // Should return a new object
+      assertNotSame(LogisimVersion.fromString(test), LogisimVersion.fromString(test));
     }
+  }
 
-    /**
-     * Test method for
-     * {@link com.cburch.logisim.LogisimVersion#fromString(java.lang.String)}.
-     */
-    @Test
-    public void testFromString() {
-        assertNotNull(LogisimVersion.fromString("1.2.3"));
-        assertEquals("1.2.3", LogisimVersion.fromString("1.2.3").toString());
+  /**
+   * Test method for {@link
+   * com.cburch.logisim.LogisimVersion#compareTo(com.cburch.logisim.LogisimVersion)} .
+   */
+  @Test
+  public void testCompareTo() {
+    older = new LogisimVersion(1, 2, 3);
+    newer = new LogisimVersion(1, 2, 4);
+    newerToo = new LogisimVersion(1, 2, 4);
 
-		// Should return a new object
-		assertNotSame(LogisimVersion.fromString("1.2.3"), LogisimVersion.fromString("1.2.3"));
-	}
+    assertTrue(older.compareTo(newer) < 0);
+    assertEquals(0, newer.compareTo(newer));
+    assertEquals(0, newer.compareTo(newerToo));
+    assertTrue(newer.compareTo(older) > 0);
+  }
 
-	/**
-	 * Test method for
-	 * {@link com.cburch.logisim.LogisimVersion#compareTo(com.cburch.logisim.LogisimVersion)}
-	 * .
-	 */
-    @Test
-    public void testCompareTo() {
-        assertTrue(older.compareTo(newer) < 0);
-        assertEquals(0, newer.compareTo(newer));
-        assertEquals(0, newer.compareTo(newerToo));
-        assertTrue(newer.compareTo(older) > 0);
+  @Test
+  public void testCompareToWithSuffix() {
+    older = new LogisimVersion(1, 2, 3, "beta1");
+    newer = new LogisimVersion(1, 2, 3);
+
+    assertTrue(older.compareTo(newer) < 0);
+    assertEquals(0, newer.compareTo(newer));
+    assertTrue(newer.compareTo(older) > 0);
+  }
+
+  @Test
+  public void testCompareToObjectWithSuffix() {
+    older = new LogisimVersion(1, 2, 3, "beta1");
+    newer = new LogisimVersion(1, 2, 3, "RC1");
+    assertEquals(0, older.compareTo(newer));
+  }
+
+  /** Test method for {@link com.cburch.logisim.LogisimVersion#equals(java.lang.Object)}. */
+  @Test
+  public void testEqualsObject() {
+    older = new LogisimVersion(1, 2, 3);
+    newer = new LogisimVersion(1, 2, 4);
+    assertEquals(older, older);
+    assertNotEquals(older, newer);
+  }
+
+  @Test
+  public void testIsStable() {
+    final var tests =
+        new HashMap<String, Boolean>() {
+          {
+            put("1.2.3", true);
+            put("1.2.3-rc1", false);
+          }
+        };
+    for (final var test : tests.entrySet()) {
+      final var version = LogisimVersion.fromString(test.getKey());
+      assertEquals(test.getValue(), version.isStable());
     }
-
-    /**
-     * Test method for
-     * {@link com.cburch.logisim.LogisimVersion#equals(java.lang.Object)}.
-     */
-    @Test
-    public void testEqualsObject() {
-        assertEquals(older, older);
-        assertNotEquals(older, newer);
-    }
-
+  }
 }


### PR DESCRIPTION
This PR introduces new indicator of project dirty (unsaved) state. Before:

![before](https://user-images.githubusercontent.com/8041294/129882686-578a68c3-ccff-42dc-8d63-f04a4e5ae4be.png)

After

![after2](https://user-images.githubusercontent.com/8041294/129882737-a9c31af3-5065-4298-a254-c4812b6dfbaa.png)


One issue (to be fixed later) is that project tree is now showing new marker so it's still `*` used there unless this is fixed.

BLOCKED_BY #888