### PR TITLE
This PR addresses point B) in issue #873

### DIFF
--- a/src/main/java/com/cburch/logisim/std/gates/Buffer.java
+++ b/src/main/java/com/cburch/logisim/std/gates/Buffer.java
@@ -259,7 +259,7 @@ class Buffer extends InstanceFactory {
   public void propagate(InstanceState state) {
     var in = state.getPortValue(1);
     in = Buffer.repair(state, in);
-    state.setPort(0, in, GateAttributes.DELAY);
+    state.setPort(0, in.not().not(), GateAttributes.DELAY);
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/gates/ControlledBuffer.java
+++ b/src/main/java/com/cburch/logisim/std/gates/ControlledBuffer.java
@@ -265,15 +265,7 @@ class ControlledBuffer extends InstanceFactory {
     final var width = state.getAttributeValue(StdAttr.WIDTH);
     if (control == Value.TRUE) {
       final var in = state.getPortValue(1);
-      final var newState = Value.createKnown(in.getBitWidth(),0);
-      for (var bit = 0; bit < in.getWidth(); bit++) {
-        if (in.get(bit).isUnknown()) {
-          newState.set(bit, Value.ERROR);
-        } else {
-          newState.set(bit, isInverter ? in.get(bit).not() : in.get(bit));
-        }
-      }
-      state.setPort(0, newState, GateAttributes.DELAY);
+      state.setPort(0, isInverter ? in.not() : in.not().not(), GateAttributes.DELAY);
     } else if (control == Value.ERROR || control == Value.UNKNOWN) {
       state.setPort(0, Value.createError(width), GateAttributes.DELAY);
     } else {

--- a/src/main/java/com/cburch/logisim/std/gates/ControlledBuffer.java
+++ b/src/main/java/com/cburch/logisim/std/gates/ControlledBuffer.java
@@ -265,6 +265,9 @@ class ControlledBuffer extends InstanceFactory {
     final var width = state.getAttributeValue(StdAttr.WIDTH);
     if (control == Value.TRUE) {
       final var in = state.getPortValue(1);
+      /* in cannot passed directly, as the simulator would pass an u at the input to an u at the output. 
+       * Doing double inversion is the correct way to resolve this problem.
+       */
       state.setPort(0, isInverter ? in.not() : in.not().not(), GateAttributes.DELAY);
     } else if (control == Value.ERROR || control == Value.UNKNOWN) {
       state.setPort(0, Value.createError(width), GateAttributes.DELAY);

--- a/src/main/java/com/cburch/logisim/std/gates/ControlledBuffer.java
+++ b/src/main/java/com/cburch/logisim/std/gates/ControlledBuffer.java
@@ -265,7 +265,15 @@ class ControlledBuffer extends InstanceFactory {
     final var width = state.getAttributeValue(StdAttr.WIDTH);
     if (control == Value.TRUE) {
       final var in = state.getPortValue(1);
-      state.setPort(0, isInverter ? in.not() : in, GateAttributes.DELAY);
+      final var newState = Value.createKnown(in.getBitWidth(),0);
+      for (var bit = 0; bit < in.getWidth(); bit++) {
+        if (in.get(bit).isUnknown()) {
+          newState.set(bit, Value.ERROR);
+        } else {
+          newState.set(bit, isInverter ? in.get(bit).not() : in.get(bit));
+        }
+      }
+      state.setPort(0, newState, GateAttributes.DELAY);
     } else if (control == Value.ERROR || control == Value.UNKNOWN) {
       state.setPort(0, Value.createError(width), GateAttributes.DELAY);
     } else {


### PR DESCRIPTION
Although it looks bizar, .not().not() it is the correct way to go about this problem. In the original version the input value was passed directly to the output without any control.