### PR TITLE
Fixed compile errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,19 +144,22 @@ extra.apply {
       "--main-class", "com.cburch.logisim.Main",
       "--main-jar", "${project.name}-${project.version}-all.jar",
       "--app-version", project.version as String,
-      "--copyright", "Copyright © 2001–" + year + " Carl Burch, BFH, HEIG-VD, HEPIA, Holy Cross, et al.",
+      "--copyright", "Copyright © 2001–${SimpleDateFormat("yyyy").format(Date())} Carl Burch, BFH, HEIG-VD, HEPIA, Holy Cross, et al.",
       "--dest", "${buildDir}/dist",
       "--description", "Digital logic design tool and simulator",
       "--vendor", "${project.name} developers",
-  ))
-  val linuxParameters = ArrayList<String>(Arrays.asList(
-      "--name", project.name,
-      "--file-associations", "${supportPath}/file.jpackage",
-      "--icon", "${supportPath}/logisim-icon-128.png",
-      "--install-dir", "/opt",
-      "--linux-shortcut"
   )
-  set("linuxParameters", linuxParams)
+  val linuxParameters = ArrayList<String>()
+  linuxParameters.add("--name")
+  linuxParameters.add(project.name)
+  linuxParameters.add("--file-associations")
+  linuxParameters.add("${supportDir}/file.jpackage")
+  linuxParameters.add("--icon")
+  linuxParameters.add("${supportDir}/logisim-icon-128.png")
+  linuxParameters.add("--install-dir")
+  linuxParameters.add("/opt")
+  linuxParameters.add("--linux-shortcut")
+  set("linuxParameters", linuxParameters)
 
   // All the macOS specific stuff.
   val uppercaseProjectName = project.name.capitalize().trim()


### PR DESCRIPTION
With the current head of development on linux logisim cannot be build, output:
```
> Configure project :
e: /home/theo/git/logisim-evolution/build.gradle.kts:151:4: Unexpected tokens (use ';' to separate expressions on the same line)
e: /home/theo/git/logisim-evolution/build.gradle.kts:159:24: Expecting ')'
e: /home/theo/git/logisim-evolution/build.gradle.kts:147:44: Unresolved reference: year
e: /home/theo/git/logisim-evolution/build.gradle.kts:152:43: Unresolved reference: Arrays
e: /home/theo/git/logisim-evolution/build.gradle.kts:154:33: Unresolved reference: supportPath
e: /home/theo/git/logisim-evolution/build.gradle.kts:155:20: Unresolved reference: supportPath
e: /home/theo/git/logisim-evolution/build.gradle.kts:159:26: Too many arguments for public final fun <E> <init>(): kotlin.collections.ArrayList<E> /* = java.util.ArrayList<E> */ defined in kotlin.collections.ArrayList
e: /home/theo/git/logisim-evolution/build.gradle.kts:159:26: Unresolved reference: linuxParams

FAILURE: Build failed with an exception.

* Where:
Build file '/home/theo/git/logisim-evolution/build.gradle.kts' line: 151

* What went wrong:
Script compilation errors:

  Line 151:   ))
               ^ Unexpected tokens (use ';' to separate expressions on the same line)

  Line 159:   set("linuxParameters", linuxParams)
                                   ^ Expecting ')'

  Line 147:       "--copyright", "Copyright © 2001–" + year + " Carl Burch, BFH, HEIG-VD, HEPIA, Holy Cross, et al.",
                                                       ^ Unresolved reference: year

  Line 152:   val linuxParameters = ArrayList<String>(Arrays.asList(
                                                      ^ Unresolved reference: Arrays

  Line 154:       "--file-associations", "${supportPath}/file.jpackage",
                                            ^ Unresolved reference: supportPath

  Line 155:       "--icon", "${supportPath}/logisim-icon-128.png",
                               ^ Unresolved reference: supportPath

  Line 159:   set("linuxParameters", linuxParams)
                                     ^ Too many arguments for public final fun <E> <init>(): kotlin.collections.ArrayList<E> /* = java.util.ArrayList<E> */ defined in kotlin.collections.ArrayList

  Line 159:   set("linuxParameters", linuxParams)
                                     ^ Unresolved reference: linuxParams

8 errors

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
```
I tried to solve the problem, am not sure if all is as it was intended.
Especially the problem ```Arrays.asList()``` where Arrays is not defined, is not really cleanly solved.