### PR TITLE
Bumps checkstyle version used to address switch expresion related issue.

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -73,7 +73,7 @@ jobs:
       # We need bash here as java-wrappers.sh may not work with other shells.
       shell: bash
       run: |
-        VERSION="8.44"
+        VERSION="8.45.1"
         JAR="checkstyle-${VERSION}-all.jar"
         URL="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${VERSION}/${JAR}"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -583,7 +583,7 @@ tasks {
   // Checkstyles related tasks: "checkstylMain" and "checkstyleTest"
   checkstyle {
     // Checkstyle version to use
-    toolVersion = "8.43"
+    toolVersion = "8.45"
 
     // let's use google_checks.xml config provided with Checkstyle.
     // https://stackoverflow.com/a/67513272/1235698


### PR DESCRIPTION
[Checkstyle linter has a bug](https://github.com/checkstyle/checkstyle/issues/8929) that causes switch expression to always fail indentation check no matter what you do (you set it to 6, checkstyle reports it should be 8. You edit to make it 8, Checkstyle complains it should be 6 :) This affects our checkstyle action. This PR bumps used version to 8.45.1.