### PR TITLE
Removed unnecessary base language check

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -51,8 +51,8 @@ jobs:
           # Read currently supported languages from settings.properties
           declare -r "langs_list=$(cat src/main/resources/resources/logisim/settings.properties | cut -d  ' ' -f3-)"
 
-          # Turn list into comma separated one
-          declare -r langs="${langs_list// /,}"
+          # Remove base language from list and turn it into a comma separated one
+          declare -r langs="${${langs_list//en /}// /,}"
 
           # Validate.
           failed=


### PR DESCRIPTION
Currently, the base language (en) is parsed as an argument to `trans-tool`.
Because of that, the following happens for each localization group.
> EN: src/main/resources/resources/logisim/strings/std/std_en.properties
    E: File not found: src/main/resources/resources/logisim/strings/std/std_en.properties
    
This PR simply solves this by removing `en` from the list.