### PR TITLE
fix mistake made in #934

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -49,10 +49,10 @@ jobs:
           declare -r base_files=$(find src/main/resources/resources/logisim/* -name "*.properties" | grep -E '*/[a-zA-Z]+.properties$' | grep -v settings.properties)
 
           # Read currently supported languages from settings.properties
-          declare -r langs_list="$(cat src/main/resources/resources/logisim/settings.properties | cut -d  ' ' -f3-)"
+          declare -r langs_list="$(cat src/main/resources/resources/logisim/settings.properties | cut -d  ' ' -f3-) "
 
           # Remove base language from list
-          declare -r langs="${langs_list//en&/}"
+          declare -r langs="${langs_list//en /}"
 
           # Validate.
           failed=

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -49,10 +49,13 @@ jobs:
           declare -r base_files=$(find src/main/resources/resources/logisim/* -name "*.properties" | grep -E '*/[a-zA-Z]+.properties$' | grep -v settings.properties)
 
           # Read currently supported languages from settings.properties
-          declare -r "langs_list=$(cat src/main/resources/resources/logisim/settings.properties | cut -d  ' ' -f3-)"
+          declare -r langs_list="$(cat src/main/resources/resources/logisim/settings.properties | cut -d  ' ' -f3-)"
 
-          # Remove base language from list and turn it into a comma separated one
-          declare -r langs="${${langs_list//en /}// /,}"
+          # Remove base language from list
+          declare -r langs_list_without_base="${langs_list//en /}"
+
+          # Turn list into comma separated one
+          declare -r langs="${langs_list_without_base// /,}"
 
           # Validate.
           failed=

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -52,10 +52,7 @@ jobs:
           declare -r langs_list="$(cat src/main/resources/resources/logisim/settings.properties | cut -d  ' ' -f3-)"
 
           # Remove base language from list
-          declare -r langs_list_without_base="${langs_list//en /}"
-
-          # Turn list into comma separated one
-          declare -r langs="${langs_list_without_base// /,}"
+          declare -r langs="${langs_list//en&/}"
 
           # Validate.
           failed=


### PR DESCRIPTION
#934 used nested substitution, which is not supported by all bash implementations/shells.

limitations:
`en` must not be the last language (right most in `settings.properties`).