### PR TITLE
Changed default addRemarkBlock() indentation

### DIFF
--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -340,7 +340,7 @@ public class LineBuffer implements RandomAccess {
    * @param remarkText Remark text.
    */
   public LineBuffer addRemarkBlock(String remarkText) {
-    return addRemarkBlock(remarkText, DEFAULT_INDENT);
+    return addRemarkBlock(remarkText, 0);
   }
 
   /**


### PR DESCRIPTION
Changed default addRemarkBlock() indentation from 3 to 0 as it is usually included into other blocks, so indentation should be added there.

Fixes #930.