### PR TITLE
Fix for Eclipse

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,7 @@ java {
 
 java {
   sourceSets["main"].java {
-    srcDir("${buildDir}/generated/logisim/")
+    srcDir("${buildDir}/generated/logisim/java")
     srcDir("${buildDir}/generated/sources/srcgen")
   }
 }
@@ -468,8 +468,10 @@ tasks.register("createDmg") {
 fun genBuildInfo(buildInfoFilePath: String) {
   val now = Date()
   val nowIso = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(now)
-  val branchName = runCommand(listOf("git","rev-parse", "--abbrev-ref", "HEAD"), "Failed getting branch name.")
-  val branchLastCommitHash = runCommand(listOf("git","rev-parse", "--short=8", "HEAD"), "Failed getting last commit has.")
+  val branchName = runCommand(listOf("git", "-C", "$projectDir", "rev-parse", "--abbrev-ref", "HEAD"),
+      "Failed getting branch name.")
+  val branchLastCommitHash = runCommand(listOf("git", "-C", "$projectDir", "rev-parse", "--short=8", "HEAD"),
+      "Failed getting last commit has.")
   val currentMillis = Date().time
   val buildYear = SimpleDateFormat("yyyy").format(now)
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -45,6 +45,7 @@ You can do this by running task `genBuildInfo` before importing the project.
 See [Building from sources](#building-from-sources) for how to run Gradle.
 
 To run the task within Eclipse after importing the logisim-evolution project:
+
 * Bring up the `Gradle Tasks` view, if it is not already showing, by selecting the Menu `Window/Show View/Other...`
   and selecting `Gradle Tasks` under Gradle.
 * In the `Gradle Tasks` view, double-click on `logisim-evolution/build/genBuildInfo`.

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -38,6 +38,20 @@ How to import a Gradle project:
 * [How to import Gradle project into IntelliJ IDEA](https://www.jetbrains.com/help/idea/gradle.html) (section "Importing a project
   from a Gradle model").
 
+**Note for Eclipse Users:**
+
+Eclipse needs to have Gradle build the generated source files before it can build the project.
+You can do this by running task `genBuildInfo` before importing the project.
+See [Building from sources](#building-from-sources) for how to run Gradle.
+
+To run the task within Eclipse after importing the logisim-evolution project:
+* Bring up the `Gradle Tasks` view, if it is not already showing, by selecting the Menu `Window/Show View/Other...`
+  and selecting `Gradle Tasks` under Gradle.
+* In the `Gradle Tasks` view, double-click on `logisim-evolution/build/genBuildInfo`.
+  Check the `Console View` to see when it finishes.
+* Right click on the logisim-evolution project in the Project Explorer and select `Gradle/Refresh Gradle Project`.
+* You may then need to Right click on the logisim-evolution project and select `Refresh`
+
 ## Building from sources ##
 
 To build and run the `Logisim-evolution` application, invoke the `Gradle` build system and pass a task name as an argument.


### PR DESCRIPTION
This PR closes #925.

The srcDir change addresses @BFH-ktt1's specific problem in importing the project.

The change to git parameters in genBuildInfo addresses an issue that Eclipse doesn't have the correct current directory for the git command to work when Eclipse invokes the Gradle task.

This PR also adds a note for Eclipse users explaining what they need to do in order to successfully import and build the project.

Could @MarcinOrlowski and @BFH-ktt1 please review this.