### PR TITLE
Linebuffer runtime checks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,8 +84,8 @@ val TARGET_FILE_PATH_BASE = "targetFilePathBase"
 val UPPERCASE_PROJECT_NAME = "uppercaseProjectName"
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_14
-  targetCompatibility = JavaVersion.VERSION_14
+  sourceCompatibility = JavaVersion.VERSION_16
+  targetCompatibility = JavaVersion.VERSION_16
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,8 @@ dependencies {
   implementation("org.slf4j:slf4j-simple:1.7.30")
   implementation("com.formdev:flatlaf:1.2")
 
+  compileOnly("org.jetbrains:annotations:22.0.0")
+
   // NOTE: Be aware of reported issues with Eclipse and Batik
   // See: https://github.com/logisim-evolution/logisim-evolution/issues/709
   // implementation("org.apache.xmlgraphics:batik-swing:1.14")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,8 +86,8 @@ val TARGET_FILE_PATH_BASE = "targetFilePathBase"
 val UPPERCASE_PROJECT_NAME = "uppercaseProjectName"
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_16
-  targetCompatibility = JavaVersion.VERSION_16
+  sourceCompatibility = JavaVersion.VERSION_14
+  targetCompatibility = JavaVersion.VERSION_14
 }
 
 java {

--- a/src/main/java/com/cburch/logisim/fpga/download/AlteraDownload.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/AlteraDownload.java
@@ -204,9 +204,9 @@ public class AlteraDownload implements VendorDownload {
     final var fileType = HDLType.equals(HDLGeneratorFactory.VHDL) ? "VHDL_FILE" : "VERILOG_FILE";
     final var contents = new LineBuffer();
     contents
-        .addPair("topLevelName", ToplevelHDLGeneratorFactory.FPGAToplevelName)
-        .addPair("fileType", fileType)
-        .addPair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK);
+        .pair("topLevelName", ToplevelHDLGeneratorFactory.FPGAToplevelName)
+        .pair("fileType", fileType)
+        .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK);
 
     contents
         .addLines(
@@ -298,7 +298,7 @@ public class AlteraDownload implements VendorDownload {
     };
 
     return (new LineBuffer())
-        .addPair("assignName", "set_global_assignment -name")
+        .pair("assignName", "set_global_assignment -name")
         .add("{{assignName}} FAMILY \"{{1}}\"", currentBoard.fpga.getTechnology())
         .add("{{assignName}} DEVICE {{1}}", currentBoard.fpga.getPart())
         .add("{{assignName}} DEVICE_FILTER_PACKAGE {{1}}", pkg[0])

--- a/src/main/java/com/cburch/logisim/fpga/download/XilinxDownload.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/XilinxDownload.java
@@ -268,9 +268,9 @@ public class XilinxDownload implements VendorDownload {
     contents.clear();
     if (RootNetList.NumberOfClockTrees() > 0 || RootNetList.RequiresGlobalClockConnection()) {
       contents
-          .addPair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
-          .addPair("clockFreq", Download.GetClockFrequencyString(boardInfo))
-          .addPair("clockPin", GetXilinxClockPin(boardInfo))
+          .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
+          .pair("clockFreq", Download.GetClockFrequencyString(boardInfo))
+          .pair("clockPin", GetXilinxClockPin(boardInfo))
           .addLines(
             "NET \"{{clock}}\" {{clockPin}} ;",
             "NET \"{{clock}}\" TNM_NET = \"{{clock}}\" ;",

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/CircuitHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/CircuitHDLGeneratorFactory.java
@@ -260,7 +260,7 @@ public class CircuitHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   }
 
   public ArrayList<String> GetHDLWiring(Netlist TheNets) {
-    final var Contents = (new LineBuffer()).withHdlPairs();
+    final var Contents = (new LineBuffer()).addHdlPairs();
     final StringBuilder OneLine = new StringBuilder();
     /* we cycle through all nets with a forcedrootnet annotation */
     for (Net ThisNet : TheNets.GetAllNets()) {
@@ -371,7 +371,7 @@ public class CircuitHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist theNetlist, AttributeSet attrs) {
-    final var contents = (new LineBuffer()).withHdlPairs();
+    final var contents = (new LineBuffer()).addHdlPairs();
     var isFirstLine = true;
     final var temp = new StringBuilder();
     final var compIds = new HashMap<String, Long>();

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/CircuitHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/CircuitHDLGeneratorFactory.java
@@ -283,8 +283,8 @@ public class CircuitHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
               OneLine.append(" ");
             }
 
-            Contents.addUnique("   {{assign}} {{1}} {{=}} {{2}}{{3}}{{bracketOpen}}{{4}}{{bracketClose}};",
-                OneLine, BusName, TheNets.GetNetId(Source.GetParentNet()), Source.GetParentNetBitIndex());
+            Contents.addUnique(LineBuffer.format("   {{assign}} {{1}} {{=}} {{2}}{{3}}{{bracketOpen}}{{4}}{{bracketClose}};",
+                OneLine, BusName, TheNets.GetNetId(Source.GetParentNet()), Source.GetParentNetBitIndex()));
           }
           /* Next we perform all sink connections */
           for (ConnectionPoint Source : ThisNet.getSinkNets(bit)) {
@@ -305,7 +305,7 @@ public class CircuitHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
             } else {
               OneLine.append(NetName).append(TheNets.GetNetId(ThisNet));
             }
-            Contents.addUnique("   {{1}}{{2}};", HDL.assignPreamble(), OneLine);
+            Contents.addUnique(LineBuffer.format("   {{1}}{{2}};", HDL.assignPreamble(), OneLine));
           }
         }
       }

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/LedArrayColumnScanningHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/LedArrayColumnScanningHDLGeneratorFactory.java
@@ -64,22 +64,22 @@ public class LedArrayColumnScanningHDLGeneratorFactory extends AbstractHDLGenera
 
     final var contents =
         (new LineBuffer())
-            .addPair("nrOfLeds", nrOfLedsString)
-            .addPair("ledsCount", nrOfRows * nrOfColumns)
-            .addPair("maxNrLeds", maxNrLedsString)
-            .addPair("maxNrLedsCount", maxNrLeds)
-            .addPair("nrOfRows", nrOfRowsString)
-            .addPair("nrOfRowsCount", nrOfRows)
-            .addPair("nrOfColumns", nrOfColumnsString)
-            .addPair("nrOfColumnsCount", nrOfColumns)
-            .addPair("activeLow", activeLowString)
-            .addPair("activeLowValue", activeLow ? "1" : "0")
-            .addPair("nrColAddrBits", nrOfColumnAddressBitsString)
-            .addPair("nrColAddrBitsCount", nrColAddrBits)
-            .addPair("scanningCounterBits", scanningCounterBitsString)
-            .addPair("nrOfScanningBitsCount", nrOfScanningBitsCount)
-            .addPair("scanningCounter", scanningCounterValueString)
-            .addPair("scanningValue", (scanningReload - 1));
+            .pair("nrOfLeds", nrOfLedsString)
+            .pair("ledsCount", nrOfRows * nrOfColumns)
+            .pair("maxNrLeds", maxNrLedsString)
+            .pair("maxNrLedsCount", maxNrLeds)
+            .pair("nrOfRows", nrOfRowsString)
+            .pair("nrOfRowsCount", nrOfRows)
+            .pair("nrOfColumns", nrOfColumnsString)
+            .pair("nrOfColumnsCount", nrOfColumns)
+            .pair("activeLow", activeLowString)
+            .pair("activeLowValue", activeLow ? "1" : "0")
+            .pair("nrColAddrBits", nrOfColumnAddressBitsString)
+            .pair("nrColAddrBitsCount", nrColAddrBits)
+            .pair("scanningCounterBits", scanningCounterBitsString)
+            .pair("nrOfScanningBitsCount", nrOfScanningBitsCount)
+            .pair("scanningCounter", scanningCounterValueString)
+            .pair("scanningValue", (scanningReload - 1));
 
     if (HDL.isVHDL()) {
       contents.addLines(
@@ -108,11 +108,11 @@ public class LedArrayColumnScanningHDLGeneratorFactory extends AbstractHDLGenera
   public static ArrayList<String> getPortMap(int id) {
     final var contents =
         (new LineBuffer())
-            .addPair("columnAddress", LedArrayGenericHDLGeneratorFactory.LedArrayColumnAddress)
-            .addPair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayRowOutputs)
-            .addPair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
-            .addPair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
-            .addPair("id", id);
+            .pair("columnAddress", LedArrayGenericHDLGeneratorFactory.LedArrayColumnAddress)
+            .pair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayRowOutputs)
+            .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
+            .pair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
+            .pair("id", id);
 
     if (HDL.isVHDL()) {
       contents.addLines(
@@ -182,10 +182,10 @@ public class LedArrayColumnScanningHDLGeneratorFactory extends AbstractHDLGenera
   public ArrayList<String> getColumnCounterCode() {
     final var contents =
         (new LineBuffer())
-            .addPair("columnAddress", LedArrayGenericHDLGeneratorFactory.LedArrayColumnAddress)
-            .addPair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
-            .addPair("counterBits", scanningCounterBitsString)
-            .addPair("counterValue", scanningCounterValueString);
+            .pair("columnAddress", LedArrayGenericHDLGeneratorFactory.LedArrayColumnAddress)
+            .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
+            .pair("counterBits", scanningCounterBitsString)
+            .pair("counterValue", scanningCounterValueString);
 
     if (HDL.isVHDL()) {
       contents.addLines(
@@ -248,11 +248,11 @@ public class LedArrayColumnScanningHDLGeneratorFactory extends AbstractHDLGenera
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var contents =
         (new LineBuffer())
-            .addPair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
-            .addPair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayRowOutputs)
-            .addPair("nrOfLeds", nrOfLedsString)
-            .addPair("nrOfRows", nrOfRowsString)
-            .addPair("activeLow", activeLowString)
+            .pair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
+            .pair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayRowOutputs)
+            .pair("nrOfLeds", nrOfLedsString)
+            .pair("nrOfRows", nrOfRowsString)
+            .pair("activeLow", activeLowString)
             .add(getColumnCounterCode());
 
     if (HDL.isVHDL()) {

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/LedArrayGenericHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/LedArrayGenericHDLGeneratorFactory.java
@@ -260,10 +260,10 @@ public class LedArrayGenericHDLGeneratorFactory {
   }
 
   public static ArrayList<String> getLedArrayConnections(FPGAIOInformationContainer info, int id) {
-    final var connections = (new LineBuffer()).withHdlPairs();
-    connections.addPair("id", id).addPair("ins", LedArrayInputs);
+    final var connections = (new LineBuffer()).addHdlPairs();
+    connections.pair("id", id).pair("ins", LedArrayInputs);
     for (var pin = 0; pin < info.getNrOfPins(); pin++) {
-      connections.addPair("pin", pin);
+      connections.pair("pin", pin);
       if (!info.pinIsMapped(pin)) {
         connections.add("{{assign}} s_{{ins}}{{id}{{<}}{{pin}}{{>}} {{=}} {{0b}};");
       } else {
@@ -276,14 +276,14 @@ public class LedArrayGenericHDLGeneratorFactory {
   public static ArrayList<String> getRGBArrayConnections(FPGAIOInformationContainer array, int id) {
     final var connections =
         (new LineBuffer())
-            .withHdlPairs()
-            .addPair("id", id)
-            .addPair("insR", LedArrayRedInputs)
-            .addPair("insG", LedArrayGreenInputs)
-            .addPair("insB", LedArrayBlueInputs);
+            .addHdlPairs()
+            .pair("id", id)
+            .pair("insR", LedArrayRedInputs)
+            .pair("insG", LedArrayGreenInputs)
+            .pair("insB", LedArrayBlueInputs);
 
     for (var pin = 0; pin < array.getNrOfPins(); pin++) {
-      connections.addPair("pin", pin);
+      connections.pair("pin", pin);
       if (!array.pinIsMapped(pin)) {
         connections.addLines(
             "{{assign}} s_{{insR}}{{id}}{{<}}{{pin}}{{>}} {{=}} {{0b}};",
@@ -293,9 +293,9 @@ public class LedArrayGenericHDLGeneratorFactory {
         final var map = array.getPinMap(pin);
         if (map.getComponentFactory() instanceof RgbLed) {
           connections
-              .addPair("mapR", map.getHdlSignalName(RgbLed.RED))
-              .addPair("mapG", map.getHdlSignalName(RgbLed.GREEN))
-              .addPair("mapB", map.getHdlSignalName(RgbLed.BLUE))
+              .pair("mapR", map.getHdlSignalName(RgbLed.RED))
+              .pair("mapG", map.getHdlSignalName(RgbLed.GREEN))
+              .pair("mapB", map.getHdlSignalName(RgbLed.BLUE))
               .addLines(
                   "{{assign}} s_{{insR}}{{id}}{{<}}{{pin}}{{>}} {{=}} {{mapR}};",
                   "{{assign}} s_{{insG}}{{id}}{{<}}{{pin}}{{>}} {{=}} {{mapG}};",

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/LedArrayLedDefaultHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/LedArrayLedDefaultHDLGeneratorFactory.java
@@ -47,12 +47,12 @@ public class LedArrayLedDefaultHDLGeneratorFactory extends AbstractHDLGeneratorF
   public static ArrayList<String> getGenericMap(int nrOfRows, int nrOfColumns, long fpgaClockFrequency, boolean activeLow) {
     final var contents =
         (new LineBuffer())
-            .addPair("nrOfLeds", nrOfLedsString)
-            .addPair("ledsCount", nrOfRows * nrOfColumns)
-            .addPair("rows", nrOfRows)
-            .addPair("cols", nrOfColumns)
-            .addPair("activeLow", activeLow)
-            .addPair("activeLowVal", activeLow ? "1" : "0");
+            .pair("nrOfLeds", nrOfLedsString)
+            .pair("ledsCount", nrOfRows * nrOfColumns)
+            .pair("rows", nrOfRows)
+            .pair("cols", nrOfColumns)
+            .pair("activeLow", activeLow)
+            .pair("activeLowVal", activeLow ? "1" : "0");
 
     if (HDL.isVHDL()) {
       contents.addLines(
@@ -69,8 +69,8 @@ public class LedArrayLedDefaultHDLGeneratorFactory extends AbstractHDLGeneratorF
   public static ArrayList<String> getPortMap(int id) {
     final var map =
         (new LineBuffer())
-            .addPair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
-            .addPair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayOutputs);
+            .pair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
+            .pair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayOutputs);
     if (HDL.isVHDL()) {
       map.addLines(
           "PORT MAP ( {{outs}} => {{outs}}{{id}},",
@@ -109,8 +109,8 @@ public class LedArrayLedDefaultHDLGeneratorFactory extends AbstractHDLGeneratorF
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var contents =
         (new LineBuffer())
-            .addPair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
-            .addPair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayOutputs);
+            .pair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
+            .pair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayOutputs);
 
     if (HDL.isVHDL()) {
       contents.addLines(

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/LedArrayRowScanningHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/LedArrayRowScanningHDLGeneratorFactory.java
@@ -64,22 +64,22 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
 
     final var contents =
         (new LineBuffer())
-            .addPair("nrOfLeds", nrOfLedsString)
-            .addPair("nrOfLedsVal", nrOfRows * nrOfColumns)
-            .addPair("nrOfRows", nrOfRowsString)
-            .addPair("nrOfRowsVal", nrOfRows)
-            .addPair("nrOfColumns", nrOfColumnsString)
-            .addPair("nrOfColumnsVal", nrOfColumns)
-            .addPair("nrOfRowAddressBits", nrOfRowAddressBitsString)
-            .addPair("nrOfRowAddressBitsVal", nrRowAddrBits)
-            .addPair("scanningCounterBits", scanningCounterBitsString)
-            .addPair("scanningCounterBitsVal", nrOfScanningBits)
-            .addPair("scanningCounterValue", scanningCounterValueString)
-            .addPair("scanningCounterValueVal", scanningReload - 1)
-            .addPair("maxNrLeds", maxNrLedsString)
-            .addPair("maxNrLedsVal", maxNrLeds)
-            .addPair("activeLow", activeLowString)
-            .addPair("activeLowVal", activeLow ? "1" : "0");
+            .pair("nrOfLeds", nrOfLedsString)
+            .pair("nrOfLedsVal", nrOfRows * nrOfColumns)
+            .pair("nrOfRows", nrOfRowsString)
+            .pair("nrOfRowsVal", nrOfRows)
+            .pair("nrOfColumns", nrOfColumnsString)
+            .pair("nrOfColumnsVal", nrOfColumns)
+            .pair("nrOfRowAddressBits", nrOfRowAddressBitsString)
+            .pair("nrOfRowAddressBitsVal", nrRowAddrBits)
+            .pair("scanningCounterBits", scanningCounterBitsString)
+            .pair("scanningCounterBitsVal", nrOfScanningBits)
+            .pair("scanningCounterValue", scanningCounterValueString)
+            .pair("scanningCounterValueVal", scanningReload - 1)
+            .pair("maxNrLeds", maxNrLedsString)
+            .pair("maxNrLedsVal", maxNrLeds)
+            .pair("activeLow", activeLowString)
+            .pair("activeLowVal", activeLow ? "1" : "0");
 
     if (HDL.isVHDL()) {
       contents.addLines(
@@ -108,11 +108,11 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
   public static ArrayList<String> getPortMap(int id) {
     final var map =
         (new LineBuffer())
-            .addPair("rowAddr", LedArrayGenericHDLGeneratorFactory.LedArrayRowAddress)
-            .addPair("colOuts", LedArrayGenericHDLGeneratorFactory.LedArrayColumnOutputs)
-            .addPair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
-            .addPair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
-                .addPair("id", id);
+            .pair("rowAddr", LedArrayGenericHDLGeneratorFactory.LedArrayRowAddress)
+            .pair("colOuts", LedArrayGenericHDLGeneratorFactory.LedArrayColumnOutputs)
+            .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
+            .pair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
+                .pair("id", id);
     if (HDL.isVHDL()) {
       map.addLines(
           "PORT MAP ( {{rowAddr}} => {{rowAddr}}{{id}},",
@@ -181,10 +181,10 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
   public ArrayList<String> getRowCounterCode() {
     final var contents =
         (new LineBuffer())
-            .addPair("rowAddress", LedArrayGenericHDLGeneratorFactory.LedArrayRowAddress)
-            .addPair("bits", scanningCounterBitsString)
-            .addPair("value", scanningCounterValueString)
-            .addPair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK);
+            .pair("rowAddress", LedArrayGenericHDLGeneratorFactory.LedArrayRowAddress)
+            .pair("bits", scanningCounterBitsString)
+            .pair("value", scanningCounterValueString)
+            .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK);
     if (HDL.isVHDL()) {
       contents.addLines(
           "",
@@ -245,11 +245,11 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var contents =
         (new LineBuffer())
-            .addPair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
-            .addPair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayColumnOutputs)
-            .addPair("activeLow", activeLowString)
-            .addPair("nrOfLeds", nrOfLedsString)
-            .addPair("nrOfColumns", nrOfColumnsString)
+            .pair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
+            .pair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayColumnOutputs)
+            .pair("activeLow", activeLowString)
+            .pair("nrOfLeds", nrOfLedsString)
+            .pair("nrOfColumns", nrOfColumnsString)
             .add(getRowCounterCode());
 
     if (HDL.isVHDL()) {

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/RGBArrayColumnScanningHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/RGBArrayColumnScanningHDLGeneratorFactory.java
@@ -15,15 +15,15 @@ public class RGBArrayColumnScanningHDLGeneratorFactory extends LedArrayColumnSca
   public static ArrayList<String> getPortMap(int id) {
     final var contents =
         (new LineBuffer())
-            .addPair("addr", LedArrayGenericHDLGeneratorFactory.LedArrayColumnAddress)
-            .addPair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
-            .addPair("insR", LedArrayGenericHDLGeneratorFactory.LedArrayRedInputs)
-            .addPair("insG", LedArrayGenericHDLGeneratorFactory.LedArrayGreenInputs)
-            .addPair("insB", LedArrayGenericHDLGeneratorFactory.LedArrayBlueInputs)
-            .addPair("outsR", LedArrayGenericHDLGeneratorFactory.LedArrayRowRedOutputs)
-            .addPair("outsG", LedArrayGenericHDLGeneratorFactory.LedArrayRowGreenOutputs)
-            .addPair("outsB", LedArrayGenericHDLGeneratorFactory.LedArrayRowBlueOutputs)
-            .addPair("id", id);
+            .pair("addr", LedArrayGenericHDLGeneratorFactory.LedArrayColumnAddress)
+            .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
+            .pair("insR", LedArrayGenericHDLGeneratorFactory.LedArrayRedInputs)
+            .pair("insG", LedArrayGenericHDLGeneratorFactory.LedArrayGreenInputs)
+            .pair("insB", LedArrayGenericHDLGeneratorFactory.LedArrayBlueInputs)
+            .pair("outsR", LedArrayGenericHDLGeneratorFactory.LedArrayRowRedOutputs)
+            .pair("outsG", LedArrayGenericHDLGeneratorFactory.LedArrayRowGreenOutputs)
+            .pair("outsB", LedArrayGenericHDLGeneratorFactory.LedArrayRowBlueOutputs)
+            .pair("id", id);
 
     if (HDL.isVHDL()) {
       contents.addLines(
@@ -91,15 +91,15 @@ public class RGBArrayColumnScanningHDLGeneratorFactory extends LedArrayColumnSca
 
     final var contents =
         (new LineBuffer())
-            .addPair("nrOfLeds", nrOfLedsString)
-            .addPair("nrOfRows", nrOfRowsString)
-            .addPair("activeLow", activeLowString)
-            .addPair("insR", LedArrayGenericHDLGeneratorFactory.LedArrayRedInputs)
-            .addPair("insG", LedArrayGenericHDLGeneratorFactory.LedArrayGreenInputs)
-            .addPair("insB", LedArrayGenericHDLGeneratorFactory.LedArrayBlueInputs)
-            .addPair("outsR", LedArrayGenericHDLGeneratorFactory.LedArrayRedOutputs)
-            .addPair("outsG", LedArrayGenericHDLGeneratorFactory.LedArrayGreenOutputs)
-            .addPair("outsB", LedArrayGenericHDLGeneratorFactory.LedArrayBlueOutputs);
+            .pair("nrOfLeds", nrOfLedsString)
+            .pair("nrOfRows", nrOfRowsString)
+            .pair("activeLow", activeLowString)
+            .pair("insR", LedArrayGenericHDLGeneratorFactory.LedArrayRedInputs)
+            .pair("insG", LedArrayGenericHDLGeneratorFactory.LedArrayGreenInputs)
+            .pair("insB", LedArrayGenericHDLGeneratorFactory.LedArrayBlueInputs)
+            .pair("outsR", LedArrayGenericHDLGeneratorFactory.LedArrayRedOutputs)
+            .pair("outsG", LedArrayGenericHDLGeneratorFactory.LedArrayGreenOutputs)
+            .pair("outsB", LedArrayGenericHDLGeneratorFactory.LedArrayBlueOutputs);
 
     contents.add(getColumnCounterCode());
     if (HDL.isVHDL()) {

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/RGBArrayRowScanningHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/RGBArrayRowScanningHDLGeneratorFactory.java
@@ -51,9 +51,9 @@ public class RGBArrayRowScanningHDLGeneratorFactory extends LedArrayRowScanningH
   public static ArrayList<String> getPortMap(int id) {
     final var contents =
         (new LineBuffer(sharedPairs))
-            .addPair("address", LedArrayGenericHDLGeneratorFactory.LedArrayRowAddress)
-            .addPair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
-            .addPair("id", id);
+            .pair("address", LedArrayGenericHDLGeneratorFactory.LedArrayRowAddress)
+            .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
+            .pair("id", id);
 
     if (HDL.isVHDL()) {
       contents.addLines(
@@ -113,9 +113,9 @@ public class RGBArrayRowScanningHDLGeneratorFactory extends LedArrayRowScanningH
   public ArrayList<String> GetModuleFunctionality(Netlist theNetlist, AttributeSet attrs) {
     final var contents =
         (new LineBuffer(sharedPairs))
-            .addPair("activeLow", activeLowString)
-            .addPair("nrOfLeds", nrOfLedsString)
-            .addPair("nrOfColumns", nrOfColumnsString);
+            .pair("activeLow", activeLowString)
+            .pair("nrOfLeds", nrOfLedsString)
+            .pair("nrOfColumns", nrOfColumnsString);
 
     contents.add(getRowCounterCode());
     if (HDL.isVHDL()) {

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/TickComponentHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/TickComponentHDLGeneratorFactory.java
@@ -71,8 +71,8 @@ public class TickComponentHDLGeneratorFactory extends AbstractHDLGeneratorFactor
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var Contents =
         (new LineBuffer())
-            .withHdlPairs()
-            .addPair("nrOfCounterBits", NrOfCounterBitsStr)
+            .addHdlPairs()
+            .pair("nrOfCounterBits", NrOfCounterBitsStr)
             .add("")
             .addRemarkBlock("Here the Output is defined")
             .add(

--- a/src/main/java/com/cburch/logisim/std/arith/ComparatorHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/ComparatorHDLGeneratorFactory.java
@@ -63,7 +63,7 @@ public class ComparatorHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var Contents = new LineBuffer();
-    Contents.addPair("twosComplement", TwosComplementStr);
+    Contents.pair("twosComplement", TwosComplementStr);
 
     final var nrOfBits = attrs.getValue(StdAttr.WIDTH).getWidth();
     if (HDL.isVHDL()) {

--- a/src/main/java/com/cburch/logisim/std/arith/DividerHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/DividerHDLGeneratorFactory.java
@@ -64,9 +64,9 @@ public class DividerHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var Contents = (new LineBuffer())
-            .addPair("nrOfBits", NrOfBitsStr)
-            .addPair("unsigned", UnsignedStr)
-            .addPair("calcBits", CalcBitsStr);
+            .pair("nrOfBits", NrOfBitsStr)
+            .pair("unsigned", UnsignedStr)
+            .pair("calcBits", CalcBitsStr);
 
     if (HDL.isVHDL()) {
       Contents.addLines(

--- a/src/main/java/com/cburch/logisim/std/arith/MultiplierHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/MultiplierHDLGeneratorFactory.java
@@ -65,9 +65,9 @@ public class MultiplierHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var Contents =
         (new LineBuffer())
-            .addPair("nrOfBits", NrOfBitsStr)
-            .addPair("unsigned", UnsignedStr)
-            .addPair("calcBits", CalcBitsStr);
+            .pair("nrOfBits", NrOfBitsStr)
+            .pair("unsigned", UnsignedStr)
+            .pair("calcBits", CalcBitsStr);
 
     if (HDL.isVHDL()) {
       Contents.addLines(

--- a/src/main/java/com/cburch/logisim/std/arith/ShifterHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/ShifterHDLGeneratorFactory.java
@@ -60,7 +60,7 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var contents = (new LineBuffer())
-            .addPair("shiftMode", shiftModeStr);
+            .pair("shiftMode", shiftModeStr);
     final var nrOfBits = attrs.getValue(StdAttr.WIDTH).getWidth();
     if (HDL.isVHDL()) {
       contents
@@ -175,7 +175,7 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   private ArrayList<String> GetStageFunctionalityVerilog(int stageNumber, int nrOfBits) {
     final var contents = (new LineBuffer())
-            .addPair("shiftMode", shiftModeStr);
+            .pair("shiftMode", shiftModeStr);
     final var nrOfBitsToShift = (1 << stageNumber);
     contents
         .add("/***************************************************************************")
@@ -213,7 +213,7 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   }
 
   private ArrayList<String> GetStageFunctionalityVHDL(int stageNumber, int nrOfBits) {
-    final var contents = (new LineBuffer()).addPair("shiftMode", shiftModeStr);
+    final var contents = (new LineBuffer()).pair("shiftMode", shiftModeStr);
 
     final var nrOfBitsToShift = (1 << stageNumber);
     contents

--- a/src/main/java/com/cburch/logisim/std/bfh/bin2bcdHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/bfh/bin2bcdHDLGeneratorFactory.java
@@ -146,7 +146,7 @@ public class bin2bcdHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist netlist, AttributeSet attrs) {
     final var contents = (new LineBuffer())
-            .addPair("nrOfBits", NR_OF_BITS_STR);
+            .pair("nrOfBits", NR_OF_BITS_STR);
     final var nrOfBits = attrs.getValue(bin2bcd.ATTR_BinBits);
     final var nrOfPorts = (int) (Math.log10(1 << nrOfBits.getWidth()) + 1.0);
     if (HDL.isVHDL()) {
@@ -258,13 +258,13 @@ public class bin2bcdHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   private ArrayList<String> getAdd3Block(String srcName, int srcStartId, String destName, int destStartId, String processName) {
     return (new LineBuffer())
-        .addPair("srcName", srcName)
-        .addPair("srcStartId", srcStartId)
-        .addPair("srcDownTo", (srcStartId - 3))
-        .addPair("destName", destName)
-        .addPair("destStartId", destStartId)
-        .addPair("destDownTo", (destStartId - 3))
-        .addPair("proc", processName)
+        .pair("srcName", srcName)
+        .pair("srcStartId", srcStartId)
+        .pair("srcDownTo", (srcStartId - 3))
+        .pair("destName", destName)
+        .pair("destStartId", destStartId)
+        .pair("destDownTo", (destStartId - 3))
+        .pair("proc", processName)
         .addLines(
             "",
             "ADD3_{{proc}} : PROCESS({{srcName}})",

--- a/src/main/java/com/cburch/logisim/std/gates/NotGate.java
+++ b/src/main/java/com/cburch/logisim/std/gates/NotGate.java
@@ -70,7 +70,7 @@ class NotGate extends InstanceFactory {
     @Override
     public ArrayList<String> GetLogicFunction(int nrOfInputs, int bitwidth, boolean isOneHot) {
       return (new LineBuffer())
-          .withHdlPairs()
+          .addHdlPairs()
           .add("{{assign}} Result {{=}} {{not}}Input_1;")
           .add("")
           .getWithIndent();

--- a/src/main/java/com/cburch/logisim/std/io/HexDigitHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/HexDigitHDLGeneratorFactory.java
@@ -46,12 +46,12 @@ public class HexDigitHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
     final var bubbleBusName = HDLGeneratorFactory.LocalOutputBubbleBusname;
     final var contents =
         (new LineBuffer())
-            .addPair("busName", GetBusName(componentInfo, HexDigit.HEX, nets))
-            .addPair("bubbleBusName", bubbleBusName)
-            .addPair("startId", startId)
-            .addPair("regName", LineBuffer.format("s_{{1}}_reg", componentInfo.GetComponent().getAttributeSet().getValue(StdAttr.LABEL)))
-            .addPair("sigName", LineBuffer.format("{{1}}[{{2}}:{{3}}]", bubbleBusName, (startId + 6), startId))
-            .addPair("dpName", GetNetName(componentInfo, HexDigit.DP, true, nets));
+            .pair("busName", GetBusName(componentInfo, HexDigit.HEX, nets))
+            .pair("bubbleBusName", bubbleBusName)
+            .pair("startId", startId)
+            .pair("regName", LineBuffer.format("s_{{1}}_reg", componentInfo.GetComponent().getAttributeSet().getValue(StdAttr.LABEL)))
+            .pair("sigName", LineBuffer.format("{{1}}[{{2}}:{{3}}]", bubbleBusName, (startId + 6), startId))
+            .pair("dpName", GetNetName(componentInfo, HexDigit.DP, true, nets));
 
     if (HDL.isVHDL()) {
       contents.add("");

--- a/src/main/java/com/cburch/logisim/std/io/ReptarLocalBusHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/ReptarLocalBusHDLGeneratorFactory.java
@@ -46,7 +46,7 @@ public class ReptarLocalBusHDLGeneratorFactory extends AbstractHDLGeneratorFacto
     final var contents = new LineBuffer();
     if (HDL.isVHDL()) {
       contents
-          .addPair("compName", componentName)
+          .pair("compName", componentName)
           .add(FileWriter.getGenerateRemark(componentName, nets.projName()))
           .addLines(
               "",
@@ -112,7 +112,7 @@ public class ReptarLocalBusHDLGeneratorFactory extends AbstractHDLGeneratorFacto
   @Override
   public ArrayList<String> GetEntity(Netlist nets, AttributeSet attrs, String componentName) {
     return (new LineBuffer())
-        .addPair("compName", componentName)
+        .pair("compName", componentName)
         .add(FileWriter.getGenerateRemark(componentName, nets.projName()))
         .add(FileWriter.getExtendedLibrary())
         .addLines(

--- a/src/main/java/com/cburch/logisim/std/memory/AbstractFlipFlopHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/AbstractFlipFlopHDLGeneratorFactory.java
@@ -135,7 +135,7 @@ public class AbstractFlipFlopHDLGeneratorFactory extends AbstractHDLGeneratorFac
             "end");
       } else {
         contents
-            .addPair("activityLevel", ACTIVITY_LEVEL_STR)
+            .pair("activityLevel", ACTIVITY_LEVEL_STR)
             .addLines(
                 "always @(*)",
                 "begin",

--- a/src/main/java/com/cburch/logisim/std/memory/CounterHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/CounterHDLGeneratorFactory.java
@@ -72,7 +72,7 @@ public class CounterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    final var contents = (new LineBuffer()).addPair("activeEdge", activeEdgeStr);
+    final var contents = (new LineBuffer()).pair("activeEdge", activeEdgeStr);
     contents.addRemarkBlock(
         "Functionality of the counter:\\ __Load_Count_|_mode\\ ____0____0___|_halt\\ "
             + "____0____1___|_count_up_(default)\\ ____1____0___|load\\ ____1____1___|_count_down");

--- a/src/main/java/com/cburch/logisim/std/memory/RandomHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RandomHDLGeneratorFactory.java
@@ -67,8 +67,8 @@ public class RandomHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   public ArrayList<String> GetModuleFunctionality(Netlist nets, AttributeSet attrs) {
     final var contents =
         (new LineBuffer())
-            .addPair("seed", SEED_STR)
-            .addPair("nrOfBits", NR_OF_BITS_STR)
+            .pair("seed", SEED_STR)
+            .pair("nrOfBits", NR_OF_BITS_STR)
             .addRemarkBlock("This is a multicycle implementation of the Random Component")
             .empty();
 

--- a/src/main/java/com/cburch/logisim/std/memory/RegisterHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RegisterHDLGeneratorFactory.java
@@ -67,7 +67,7 @@ public class RegisterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist nets, AttributeSet attrs) {
     final var contents = (new LineBuffer())
-            .addPair("activeLevel", ACTIVE_LEVEL_STR);
+            .pair("activeLevel", ACTIVE_LEVEL_STR);
     if (HDL.isVHDL()) {
       contents.addLines(
           "Q <= s_state_reg;",

--- a/src/main/java/com/cburch/logisim/std/memory/SRFlipFlop.java
+++ b/src/main/java/com/cburch/logisim/std/memory/SRFlipFlop.java
@@ -74,7 +74,7 @@ public class SRFlipFlop extends AbstractFlipFlop {
     @Override
     public ArrayList<String> GetUpdateLogic() {
       return (new LineBuffer())
-          .withHdlPairs()
+          .addHdlPairs()
           .add("{{assign}} s_next_state {{=}} (s_current_state_reg {{or}} S) {{and}} {{not}}(R);")
           .getWithIndent();
     }

--- a/src/main/java/com/cburch/logisim/std/plexers/BitSelectorHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/BitSelectorHDLGeneratorFactory.java
@@ -66,9 +66,9 @@ public class BitSelectorHDLGeneratorFactory extends AbstractHDLGeneratorFactory 
   public ArrayList<String> GetModuleFunctionality(Netlist theNetlist, AttributeSet attrs) {
     final var contents =
         (new LineBuffer())
-            .addPair("extBits", EXTENDED_BITS_STR)
-            .addPair("inBits", INPUT_BITS_STR)
-            .addPair("outBits", OUTPUTS_BITS_STR);
+            .pair("extBits", EXTENDED_BITS_STR)
+            .pair("inBits", INPUT_BITS_STR)
+            .pair("outBits", OUTPUTS_BITS_STR);
     final var outputBits = attrs.getValue(BitSelector.GROUP_ATTR).getWidth();
     if (HDL.isVHDL()) {
       contents

--- a/src/main/java/com/cburch/logisim/std/plexers/DecoderHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/DecoderHDLGeneratorFactory.java
@@ -61,9 +61,9 @@ public class DecoderHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
     var space = " ";
     for (var i = 0; i < numOutputs; i++) {
       if (i == 7) space = "";
-      contents.addPair("bin", IntToBin(i, nrOfSelectBits))
-              .addPair("space", space)
-              .addPair("i", i);
+      contents.pair("bin", IntToBin(i, nrOfSelectBits))
+              .pair("space", space)
+              .pair("i", i);
       if (HDL.isVHDL()) {
         contents.addLines(
             "DecoderOut_{{i}}{{space}}<= '1' WHEN sel = {{bin}} AND",

--- a/src/main/java/com/cburch/logisim/std/plexers/PriorityEncoderHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/PriorityEncoderHDLGeneratorFactory.java
@@ -62,8 +62,8 @@ public class PriorityEncoderHDLGeneratorFactory extends AbstractHDLGeneratorFact
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist nets, AttributeSet attrs) {
     final var contents = (new LineBuffer())
-            .addPair("selBits", NR_OF_SELECT_BITS_STR)
-            .addPair("inBits", NR_OF_INPUT_BITS_STR);
+            .pair("selBits", NR_OF_SELECT_BITS_STR)
+            .pair("inBits", NR_OF_INPUT_BITS_STR);
     if (HDL.isVHDL()) {
       contents.addLines(
           "   -- Output Signals",

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7408.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7408.java
@@ -53,7 +53,7 @@ public class Ttl7408 extends AbstractTtlGate {
     @Override
     public ArrayList<String> GetLogicFunction(int index) {
       return (new LineBuffer())
-          .withHdlPairs()
+          .addHdlPairs()
           .add("{{assign}} gate_{{1}}_O {{=}} gate_{{1}}_A {{and}} gate_{{1}}_B;", index)
           .add("")
           .getWithIndent();

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7442HDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7442HDLGenerator.java
@@ -85,7 +85,7 @@ public class Ttl7442HDLGenerator extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist nets, AttributeSet attrs) {
-    final var contents = (new LineBuffer()).withHdlPairs();
+    final var contents = (new LineBuffer()).addHdlPairs();
 
     if (IsExes3) {
       contents.addLines(

--- a/src/main/java/com/cburch/logisim/std/wiring/AbstractConstantHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/AbstractConstantHDLGeneratorFactory.java
@@ -62,7 +62,7 @@ public class AbstractConstantHDLGeneratorFactory extends AbstractHDLGeneratorFac
       Long ComponentId,
       NetlistComponent ComponentInfo,
       String CircuitName) {
-    final var Contents = (new LineBuffer()).withHdlPairs();
+    final var Contents = (new LineBuffer()).addHdlPairs();
     int NrOfBits = ComponentInfo.GetComponent().getEnd(0).getWidth().getWidth();
     if (ComponentInfo.isEndConnected(0)) {
       long ConstantValue = GetConstant(ComponentInfo.GetComponent().getAttributeSet());

--- a/src/main/java/com/cburch/logisim/std/wiring/ClockHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/ClockHDLGeneratorFactory.java
@@ -83,10 +83,10 @@ public class ClockHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var Contents =
         (new LineBuffer())
-            .addPair("phase", PHASE_STR)
-            .addPair("nrOfBits", NR_OF_BITS_STR)
-            .addPair("lowTick", LOW_TICK_STR)
-            .addPair("highTick", HIGH_TICK_STR)
+            .pair("phase", PHASE_STR)
+            .pair("nrOfBits", NR_OF_BITS_STR)
+            .pair("lowTick", LOW_TICK_STR)
+            .pair("highTick", HIGH_TICK_STR)
             .addRemarkBlock("Here the output signals are defines; we synchronize them all on the main clock");
 
     if (HDL.isVHDL()) {

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -180,28 +180,48 @@ public class LineBuffer implements RandomAccess {
   /* ********************************************************************************************* */
 
   /**
-   * Adds line to the buffer only if line is not present already. Please note `addUnique()`
-   * does not do any string formatting. You musts pass final form of the string (pass thru
-   * `format()` if needed).
+   * Adds line to the buffer only if line is not present already, formatting it first.
+   *
+   * @param line Line to add if not present in buffer.
+   *
+   * @return Instance of self for easy chaining.
+   */
+  public LineBuffer addUnique(String fmt, Object... args) {
+    // Resolve positional arguments then apply paired ones.     WE need to do this first (instead of
+    // letting add() do that) otherwise `contains` would be looking for non-final version of the
+    // string.
+    final var line = applyPairs(format(fmt, args));
+    if (!contents.contains(line))
+      add(line, true);
+    return this;
+  }
+
+  /**
+   * Adds line to the buffer only if line is not present already. Please note this implementation
+   * of `addUnique()` does not resolve positional arguments. If you use them, you musts pass final
+   * form of the string (pass thru `format()` if needed) or use other implementations.
    *
    * @param line Line to add if not present in buffer.
    *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer addUnique(String line) {
-    if (!contents.contains(line)) {
+    // Resolve positional arguments then apply paired ones.     WE need to do this first (instead of
+    // letting add() do that) otherwise `contains` would be looking for non-final version of the
+    // string.
+    line = applyPairs(line);
+    if (!contents.contains(line))
       add(line, true);
-    }
     return this;
   }
 
   /* ********************************************************************************************* */
 
   /**
-   * Adds single line to the content buffer.
+   * Adds single line to the content buffer. Will resolve paried placeholders first (but not
+   * positionals).
    *
    * @param line String to be added to the content buffer.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String line) {
@@ -209,13 +229,12 @@ public class LineBuffer implements RandomAccess {
   }
 
   /**
-   * Adds single line to the content buffer. If applyMap is `true`, it will try to format line with
-   * known pairs (this is default behavior).
+   * Adds single line to the content buffer. Will resolve paried placeholders first, if applyMap is `true`,
+   * but won't resolve positionals).
    *
    * @param line line to be added
    * @param applyMap `true` if line shall be processed for placeholders (default), `false` if you
    *     want it to be added "raw".
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String line, boolean applyMap) {

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -208,8 +208,15 @@ public class LineBuffer implements RandomAccess {
     return this;
   }
 
-  public LineBuffer add(StringBuilder sb) {
-    return add(sb.toString());
+  /**
+   * Adds content of provided StringBuilder to the buffer.
+   *
+   * @param stringBuilder StringBuilder which contents is to be added.
+   *
+   * @return Instance of self for easy chaining.
+   */
+  public LineBuffer add(StringBuilder stringBuilder) {
+    return add(stringBuilder.toString());
   }
 
   /**
@@ -218,6 +225,7 @@ public class LineBuffer implements RandomAccess {
    *
    * @param fmt Formatting string as accepted by String.format()
    * @param args Optional arguments
+   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String fmt, Object... args) {
@@ -416,11 +424,13 @@ public class LineBuffer implements RandomAccess {
    */
   protected ArrayList<String> buildRemarkBlock(String remarkText, Integer nrOfIndentSpaces) {
     final var maxRemarkLength = MAX_LINE_LENGTH - 2 * HDL.remarkOverhead() - nrOfIndentSpaces;
-    var remarkWords = remarkText.split(" ");
-    var oneLine = new StringBuilder();
-    var contents = new ArrayList<String>();
+    final var remarkWords = remarkText.split(" ");
+    final var oneLine = new StringBuilder();
+    final var contents = new ArrayList<String>();
     var maxWordLength = 0;
-    for (var word : remarkWords) if (word.length() > maxWordLength) maxWordLength = word.length();
+    for (final var word : remarkWords) {
+      if (word.length() > maxWordLength) maxWordLength = word.length();
+    }
     if (maxRemarkLength < maxWordLength) return contents;
     /* we start with generating the first remark line */
     while (oneLine.length() < nrOfIndentSpaces) oneLine.append(" ");
@@ -430,12 +440,10 @@ public class LineBuffer implements RandomAccess {
     contents.add(oneLine.toString());
     oneLine.setLength(0);
     /* Next we put the remark text block in 1 or multiple lines */
-    for (var remarkWord : remarkWords) {
+    for (final var remarkWord : remarkWords) {
       if ((oneLine.length() + remarkWord.length() + HDL.remarkOverhead()) > (MAX_LINE_LENGTH - 1)) {
         /* Next word does not fit, we end this line and create a new one */
-        while (oneLine.length() < (MAX_LINE_LENGTH - HDL.remarkOverhead())) {
-          oneLine.append(" ");
-        }
+        while (oneLine.length() < (MAX_LINE_LENGTH - HDL.remarkOverhead())) oneLine.append(" ");
         oneLine
             .append(" ")
             .append(HDL.getRemakrChar(false, false))
@@ -444,12 +452,10 @@ public class LineBuffer implements RandomAccess {
         oneLine.setLength(0);
       }
       while (oneLine.length() < nrOfIndentSpaces) oneLine.append(" ");
-      if (oneLine.length() == nrOfIndentSpaces) {
-        /* we put the preamble */
-        oneLine.append(HDL.getRemarkStart());
-      }
+      if (oneLine.length() == nrOfIndentSpaces)
+        oneLine.append(HDL.getRemarkStart()); // we put the preamble
       if (remarkWord.endsWith("\\")) {
-        /* Forced new line */
+        // Forced new line
         oneLine.append(remarkWord, 0, remarkWord.length() - 1);
         while (oneLine.length() < (MAX_LINE_LENGTH - HDL.remarkOverhead())) oneLine.append(" ");
       } else {
@@ -457,7 +463,7 @@ public class LineBuffer implements RandomAccess {
       }
     }
     if (oneLine.length() > (nrOfIndentSpaces + HDL.remarkOverhead())) {
-      /* we have an unfinished remark line */
+      // We have an unfinished remark line
       while (oneLine.length() < (MAX_LINE_LENGTH - HDL.remarkOverhead())) oneLine.append(" ");
       oneLine
           .append(" ")
@@ -466,11 +472,12 @@ public class LineBuffer implements RandomAccess {
       contents.add(oneLine.toString());
       oneLine.setLength(0);
     }
-    /* we end with generating the last remark line */
+    // We end with generating the last remark line.
     while (oneLine.length() < nrOfIndentSpaces) oneLine.append(" ");
     for (var i = 0; i < MAX_LINE_LENGTH - nrOfIndentSpaces; i++)
       oneLine.append(HDL.getRemakrChar(i == MAX_LINE_LENGTH - nrOfIndentSpaces - 1, i == 0));
     contents.add(oneLine.toString());
+
     return contents;
   }
 

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -182,7 +182,7 @@ public class LineBuffer implements RandomAccess {
   /**
    * Adds line to the buffer only if line is not present already, formatting it first.
    *
-   * @param line Line to add if not present in buffer.
+   * @param fmt Line to add if not present in buffer.
    *
    * @return Instance of self for easy chaining.
    */

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -558,7 +558,7 @@ public class LineBuffer implements RandomAccess {
     if (errorCnt > 0) abort("Reference to non-existing positional arguments found.");
 
     // Warn if we have positional arguments given, but no positional placeholders used.
-    if (pairs.size() > 0 && positionalsCnt == 0) {
+    if ((pairs.size() > 0) && (positionalsCnt == 0)) {
         warn("#E004: No positional placeholders used but {{2}} positional arguments provided while processing '{{1}}'.",
             fmt, positionalsCnt);
     }
@@ -574,6 +574,13 @@ public class LineBuffer implements RandomAccess {
     if (errorCnt > 0) abort("Unmapped placeholders detected.");
   }
 
+  /**
+   * Extract names of valid placeholders found in provided string.
+   *
+   * @param fmt String to analyze.
+   *
+   * @return Returns list of found placeholders. If no placeholder is found, returnes empty list.
+   */
   public ArrayList<String> getUsedPlaceholders(String fmt) {
     final var keys = new ArrayList<String>();
 

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -180,14 +180,18 @@ public class LineBuffer implements RandomAccess {
   /* ********************************************************************************************* */
 
   /**
-   * Adds line to the buffer only if line is not present already.
+   * Adds line to the buffer only if line is not present already. Please note `addUnique()`
+   * does not do any string formatting. You musts pass final form of the string (pass thru
+   * `format()` if needed).
    *
-   * @param line Line to optionally add.
+   * @param line Line to add if not present in buffer.
    *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer addUnique(String line) {
-    add(line, true);
+    if (!contents.contains(line)) {
+      add(line, true);
+    }
     return this;
   }
 

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -61,6 +61,7 @@ public class LineBuffer implements RandomAccess {
 
   /**
    * Construct LineBuffer with line added to the container.
+   *
    * @param line text line to be added to buffer
    */
   public LineBuffer(String line) {
@@ -92,6 +93,7 @@ public class LineBuffer implements RandomAccess {
 
   /**
    * Returns number of unique pairs stored already.
+   *
    * @return number of pairs.
    */
   public int size() {
@@ -243,6 +245,7 @@ public class LineBuffer implements RandomAccess {
    *
    * @param format Formatting string. Wrap keys in `{{` and `}}`.
    * @param pairs Search-Replace map.
+   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String format, Pairs pairs) {
@@ -304,7 +307,8 @@ public class LineBuffer implements RandomAccess {
    *
    * @param count Number of times line should be added.
    * @param line String to be added to the buffer.
-   * @return
+   *
+   * @return Instance of self for easy chaining.
    */
   public LineBuffer repeat(int count, String line) {
     for (var i = 0; i < count; i++) add(line);
@@ -313,7 +317,11 @@ public class LineBuffer implements RandomAccess {
 
   /* ********************************************************************************************* */
 
-  /** Appends single empty line to the content buffer. */
+  /**
+   * Appends single empty line to the content buffer.
+   *
+   * @return Instance of self for easy chaining.
+   */
   public LineBuffer empty() {
     return repeat(1, "");
   }
@@ -322,6 +330,8 @@ public class LineBuffer implements RandomAccess {
    * Appends `count` number for empty lines to the content buffer.
    *
    * @param count number of empty lines to be addeed.
+   *
+   * @return Instance of self for easy chaining.
    */
   public LineBuffer empty(int count) {
     return repeat(count, "");
@@ -332,7 +342,7 @@ public class LineBuffer implements RandomAccess {
   /**
    * Returns specified line of the content buffer present at index position.
    *
-   * @return elment
+   * @return elment at given position or exception for invalid index.
    *
    * @throws IndexOutOfBoundsException
    */

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -48,55 +48,73 @@ public class LineBuffer implements RandomAccess {
 
   private ArrayList<String> contents = new java.util.ArrayList<String>();
 
-  public LineBuffer(String line) {
-    add(line);
-  }
+  /* ********************************************************************************************* */
 
-  public LineBuffer(String line, Pairs pairs) {
-    withPairs(pairs);
-    add(line);
-  }
-
+  /**
+   * Default constructor.
+   */
   public LineBuffer() {
     super();
   }
 
-  public LineBuffer(Pairs pairs) {
-    super();
-    withPairs(pairs);
+  /**
+   * Construct LineBuffer with line added to the container.
+   * @param line text line to be added to buffer
+   */
+  public LineBuffer(String line) {
+    add(line);
   }
 
+  /**
+   * Constructs LineBuffer instance, then sets placeholder pairs and adds given text line to the
+   * container. Note, that because placeholder pairs are set first, you can instantly use these
+   * placeholders in your line. Also note that
+   *
+   * @param line Text line to be added.
+   * @param pairs Placeholder pairs to be used.
+   */
+//  public LineBuffer(String line, Pairs pairs) {
+//    withPairs(pairs);
+//    add(line);
+//  }
+
+
+  /**
+   * Constructs LineBuffer instance, then adds provided placeholders pairs to be used with the instance.
+   *
+   * @param pairs Placeholder pairs to be used.
+   */
+  public LineBuffer(Pairs pairs) {
+    super();
+    addPairs(pairs);
+  }
+
+  /**
+   * Returns number of unique pairs stored already.
+   * @return number of pairs.
+   */
   public int size() {
     return contents.size();
   }
 
   protected Pairs pairs = new Pairs();
 
-  public LineBuffer withHdlPairs() {
-    return addPair("assign", HDL.assignPreamble())
-        .addPair("=", HDL.assignOperator())
-        .addPair("or", HDL.orOperator())
-        .addPair("and", HDL.andOperator())
-        .addPair("not", HDL.notOperator())
-        .addPair("bracketOpen", HDL.BracketOpen())
-        .addPair("bracketClose", HDL.BracketClose())
-        .addPair("<", HDL.BracketOpen())
-        .addPair(">", HDL.BracketClose())
-        .addPair("0b", HDL.zeroBit())
-        .addPair("1b", HDL.oneBit());
+  public LineBuffer addHdlPairs() {
+    return pair("assign", HDL.assignPreamble())
+        .pair("=", HDL.assignOperator())
+        .pair("or", HDL.orOperator())
+        .pair("and", HDL.andOperator())
+        .pair("not", HDL.notOperator())
+        .pair("bracketOpen", HDL.BracketOpen())
+        .pair("bracketClose", HDL.BracketClose())
+        .pair("<", HDL.BracketOpen())
+        .pair(">", HDL.BracketClose())
+        .pair("0b", HDL.zeroBit())
+        .pair("1b", HDL.oneBit());
   }
 
-  public Pairs withPairs() {
-    return pairs;
-  }
-
-  public LineBuffer withPairs(Pairs pairs) {
+  public LineBuffer addPairs(Pairs pairs) {
     this.pairs = pairs;
-    return this;
-  }
-
-  public LineBuffer withPair(String key, Object value) {
-    final var map = new Pairs(key, value);
     return this;
   }
 
@@ -176,6 +194,7 @@ public class LineBuffer implements RandomAccess {
    * Adds single line to the content buffer.
    *
    * @param line String to be added to the content buffer.
+   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String line) {
@@ -199,6 +218,7 @@ public class LineBuffer implements RandomAccess {
    *
    * @param fmt Formatting string as accepted by String.format()
    * @param args Optional arguments
+   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String fmt, Object... args) {
@@ -215,6 +235,7 @@ public class LineBuffer implements RandomAccess {
    *
    * @param format Formatting string. Wrap keys in `{{` and `}}`.
    * @param pairs Search-Replace map.
+   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String format, Pairs pairs) {
@@ -231,6 +252,18 @@ public class LineBuffer implements RandomAccess {
     return this;
   }
 
+  /**
+   *
+   * Adds each argument to be added as separate line to the buffer.
+   *
+   * Note: I had to use different name than add() for this particular method,
+   * as its signature takes over the `add(String fmt, Obj... args)` which in turn
+   * ends up placeholders keys being left unhandled.
+   *
+   * @param lines lines to be added to the buffer.
+   *
+   * @return Instance of self for easy chaining.
+   */
   public LineBuffer addLines(String... lines) {
     return add(Arrays.asList(lines));
   }
@@ -284,27 +317,44 @@ public class LineBuffer implements RandomAccess {
   }
 
 
+  /**
+   * Returns specified line of the content buffer present at index position.
+   *
+   * @return elment
+   *
+   * @throws IndexOutOfBoundsException
+   */
   public String get(int index) {
     return contents.get(index);
   }
 
   /**
-   * Returns content buffer as ArrayList()
+   * Returns whole content buffer as ArrayList(). Content is returned as-is, no additional
+   * processing happens.
    *
-   * @return
+   * @return unindented content of the buffer.
    */
   public ArrayList<String> get() {
     return contents;
   }
 
+  /**
+   * Returns content buffer as ArrayList(), with each line indented by `DEFAULT_INDENT` using
+   * `DEFAULT_INDENT_STR` as a indentation character.
+   *
+   * @return indented content of the buffer.
+   */
   public ArrayList<String> getWithIndent() {
     return getWithIndent(DEFAULT_INDENT, DEFAULT_INDENT_STR);
   }
 
   /**
-   * Returns content buffer as ArrayList() with every single entry prefixed by `howMany` spaces.
+   * Returns content buffer as ArrayList() with every single entry prefixed by `howMany` characters
+   * of `DEFAULT_INDENT_STR`.
    *
    * @param howMany Number of spaces to prefix each line with.
+   *
+   * @return indented content of the buffer.
    */
   public ArrayList<String> getWithIndent(int howMany) {
     return getWithIndent(howMany, DEFAULT_INDENT_STR);
@@ -317,7 +367,8 @@ public class LineBuffer implements RandomAccess {
    * @param howMany Number of times `indent` string should be repeated to form the final indent
    *     string.
    * @param indent Indent string.
-   * @return
+   *
+   * @return indented content of the buffer.
    */
   public ArrayList<String> getWithIndent(int howMany, String indent) {
     return getWithIndent(indent.repeat(howMany));
@@ -448,15 +499,7 @@ public class LineBuffer implements RandomAccess {
 
   /* ********************************************************************************************* */
 
-  public LineBuffer addPairs(Pairs pairs) {
-    for (final var pair : pairs.entrySet()) {
-      addPair(pair.getKey(), pair.getValue());
-    }
-
-    return this;
-  }
-
-  public LineBuffer addPair(String key, Object value) {
+  public LineBuffer pair(String key, Object value) {
     pairs.add(key, value);
     return this;
   }

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -173,19 +173,8 @@ public class LineBuffer implements RandomAccess {
    * @param line Line to optionally add.
    */
   public LineBuffer addUnique(String line) {
-    addUnique(line, true);
+    add(line, true);
     return this;
-  }
-
-  public LineBuffer addUnique(String line, boolean applyMap) {
-    if (!contains(line)) add(line, applyMap);
-    return this;
-  }
-
-  public LineBuffer addUnique(String fmt, Object... args) {
-    var line = String.format(fmt, args);
-    line = applyPairs(line, pairs);
-    return addUnique(line);
   }
 
   /* ********************************************************************************************* */
@@ -201,6 +190,16 @@ public class LineBuffer implements RandomAccess {
     return add(line, true);
   }
 
+  /**
+   * Adds single line to the content buffer. If applyMap is `true`, it will try to format line with
+   * known pairs (this is default behavior).
+   *
+   * @param line line to be added
+   * @param applyMap `true` if line shall be processed for placeholders (default), `false` if you
+   *     want it to be added "raw".
+   *
+   * @return Instance of self for easy chaining.
+   */
   public LineBuffer add(String line, boolean applyMap) {
     if (applyMap) {
       line = applyPairs(line, pairs);
@@ -214,11 +213,11 @@ public class LineBuffer implements RandomAccess {
   }
 
   /**
-   * Formats string using @String.format() and adds to the buffer.
+   * Formats string using @String.format() and adds to the buffer via standard pipeline (so
+   * placeholders will be handled too).
    *
    * @param fmt Formatting string as accepted by String.format()
    * @param args Optional arguments
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String fmt, Object... args) {
@@ -235,7 +234,6 @@ public class LineBuffer implements RandomAccess {
    *
    * @param format Formatting string. Wrap keys in `{{` and `}}`.
    * @param pairs Search-Replace map.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String format, Pairs pairs) {
@@ -243,7 +241,8 @@ public class LineBuffer implements RandomAccess {
   }
 
   /**
-   * Adds all lines from given collection to content buffer.
+   * Adds all lines from given collection to content buffer using defult pipeline, so placeholders
+   * are processed too.
    *
    * @param lines
    */
@@ -302,6 +301,8 @@ public class LineBuffer implements RandomAccess {
     return this;
   }
 
+  /* ********************************************************************************************* */
+
   /** Appends single empty line to the content buffer. */
   public LineBuffer empty() {
     return repeat(1, "");
@@ -316,6 +317,7 @@ public class LineBuffer implements RandomAccess {
     return repeat(count, "");
   }
 
+  /* ********************************************************************************************* */
 
   /**
    * Returns specified line of the content buffer present at index position.

--- a/src/test/java/com/cburch/logisim/LineBufferTest.java
+++ b/src/test/java/com/cburch/logisim/LineBufferTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.cburch.logisim.util.LineBuffer;
@@ -214,6 +215,28 @@ public class LineBufferTest extends TestBase {
       final var expected = new LineBuffer(test.getValue(), expPairs);
       assertEquals(expected, lb);
     }
+  }
+
+  /* ********************************************************************************************* */
+
+  /**
+   * Checks if providing less arguments than positional placeholders would be detected.
+   */
+  @Test
+  public void testAddTooLittlePosArgs() {
+    assertThrows(RuntimeException.class, () -> {
+      this.lb.add("This is {{1}} bar {{   2}} test", 666);
+    });
+  }
+
+  @Test
+  public void testGetUsedPlaceholders() {
+    assertThrows(RuntimeException.class, () -> {
+      this.lb.validateLine("""
+                This is {{foo}} bar {{   2}} test
+                line number {{2}} {{foo    }}
+                """);
+    });
   }
 
   /* ********************************************************************************************* */

--- a/src/test/java/com/cburch/logisim/LineBufferTest.java
+++ b/src/test/java/com/cburch/logisim/LineBufferTest.java
@@ -191,7 +191,7 @@ public class LineBufferTest extends TestBase {
             " {{   bar}} ", " BAR ",
             " {{bang}} ", " BANG ");
 
-    final var pairs =
+    final var globalPairs =
         new LineBuffer.Pairs() {
           {
             add("foo", "FOO");
@@ -200,7 +200,7 @@ public class LineBufferTest extends TestBase {
         };
 
     for (final var test : tests.entrySet()) {
-      final var lb = new LineBuffer(pairs);
+      final var lb = new LineBuffer(globalPairs);
       lb.add(test.getKey(), new LineBuffer.Pairs("bang", "BANG"));
 
       final var expPairs =
@@ -232,7 +232,7 @@ public class LineBufferTest extends TestBase {
   @Test
   public void testGetUsedPlaceholders() {
     assertThrows(RuntimeException.class, () -> {
-      this.lb.validateLine("""
+      this.lb.validateLineNoPositionals("""
                 This is {{foo}} bar {{   2}} test
                 line number {{2}} {{foo    }}
                 """);

--- a/src/test/java/com/cburch/logisim/LineBufferTest.java
+++ b/src/test/java/com/cburch/logisim/LineBufferTest.java
@@ -116,7 +116,7 @@ public class LineBufferTest extends TestBase {
     final var bar = getRandomInt(0, 100);
 
     final var lb = (new LineBuffer())
-            .addPair("pair", pair)
+            .pair("pair", pair)
             .add("{{pair}}-{{1}}-{{2}}", foo, bar);
     System.out.println(lb.toString());
     assertEquals(1, lb.size());
@@ -173,7 +173,7 @@ public class LineBufferTest extends TestBase {
     for (final var test : tests.entrySet()) {
       final var lb = new LineBuffer(pairs);
       lb.add(test.getKey());
-      final var expected = new LineBuffer(test.getValue(), pairs);
+      final var expected = (new LineBuffer()).add(test.getValue(), pairs);
       assertEquals(expected, lb);
     }
   }

--- a/src/test/java/com/cburch/logisim/LineBufferTest.java
+++ b/src/test/java/com/cburch/logisim/LineBufferTest.java
@@ -232,10 +232,7 @@ public class LineBufferTest extends TestBase {
   @Test
   public void testGetUsedPlaceholders() {
     assertThrows(RuntimeException.class, () -> {
-      this.lb.validateLineNoPositionals("""
-                This is {{foo}} bar {{   2}} test
-                line number {{2}} {{foo    }}
-                """);
+      this.lb.validateLineNoPositionals("This is {{foo}} bar {{   2}} test");
     });
   }
 

--- a/src/test/java/com/cburch/logisim/LineBufferTest.java
+++ b/src/test/java/com/cburch/logisim/LineBufferTest.java
@@ -76,21 +76,12 @@ public class LineBufferTest extends TestBase {
   /** Tests is plain add(String) works as expected. */
   @Test
   public void testAdd() {
-    final var tests =
-        new ArrayList<String>() {
-          {
-            add(getRandomString());
-            add(" {{placeholders}} should not be processed");
-          }
-        };
+    final var lb = new LineBuffer();
+    final var test = getRandomString();
+    lb.add(test);
 
-    for (final var test : tests) {
-      final var lb = new LineBuffer();
-      lb.add(test);
-
-      assertEquals(1, lb.size());
-      assertEquals(test, lb.get(0));
-    }
+    assertEquals(1, lb.size());
+    assertEquals(test, lb.get(0));
   }
 
   /** Tests is add(String, Object...) works as expected. */


### PR DESCRIPTION
This PR add extra sanity checks to LineBuffer implementation that are expected to find possible issues like unmapped placeholder or less positional arguments provided than positional placeholders exists, i.e.:

```java
.add("This {{1}} is {{2}}", name)
```
should be caught. It shall also trap using of undefined (at the moment of `add()` call) paired placeholders,

```java
.add("This {{foo}}")
```

For now each trap ends up with Runtime exception with details about the reason. 