### PR TITLE
Stripped trailing spaces from copyright headers

### DIFF
--- a/src/main/java/com/cburch/draw/Strings.java
+++ b/src/main/java/com/cburch/draw/Strings.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/actions/ModelAction.java
+++ b/src/main/java/com/cburch/draw/actions/ModelAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/actions/ModelAddAction.java
+++ b/src/main/java/com/cburch/draw/actions/ModelAddAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/actions/ModelChangeAttributeAction.java
+++ b/src/main/java/com/cburch/draw/actions/ModelChangeAttributeAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/actions/ModelDeleteHandleAction.java
+++ b/src/main/java/com/cburch/draw/actions/ModelDeleteHandleAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/actions/ModelEditTextAction.java
+++ b/src/main/java/com/cburch/draw/actions/ModelEditTextAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/actions/ModelInsertHandleAction.java
+++ b/src/main/java/com/cburch/draw/actions/ModelInsertHandleAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/actions/ModelMoveHandleAction.java
+++ b/src/main/java/com/cburch/draw/actions/ModelMoveHandleAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/actions/ModelRemoveAction.java
+++ b/src/main/java/com/cburch/draw/actions/ModelRemoveAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/actions/ModelReorderAction.java
+++ b/src/main/java/com/cburch/draw/actions/ModelReorderAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/actions/ModelTranslateAction.java
+++ b/src/main/java/com/cburch/draw/actions/ModelTranslateAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/canvas/ActionDispatcher.java
+++ b/src/main/java/com/cburch/draw/canvas/ActionDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/canvas/Canvas.java
+++ b/src/main/java/com/cburch/draw/canvas/Canvas.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/canvas/CanvasListener.java
+++ b/src/main/java/com/cburch/draw/canvas/CanvasListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/canvas/CanvasTool.java
+++ b/src/main/java/com/cburch/draw/canvas/CanvasTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/canvas/Selection.java
+++ b/src/main/java/com/cburch/draw/canvas/Selection.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/canvas/SelectionEvent.java
+++ b/src/main/java/com/cburch/draw/canvas/SelectionEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/canvas/SelectionListener.java
+++ b/src/main/java/com/cburch/draw/canvas/SelectionListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/gui/AttrTableDrawManager.java
+++ b/src/main/java/com/cburch/draw/gui/AttrTableDrawManager.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/gui/AttrTableSelectionModel.java
+++ b/src/main/java/com/cburch/draw/gui/AttrTableSelectionModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/gui/AttrTableToolModel.java
+++ b/src/main/java/com/cburch/draw/gui/AttrTableToolModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/gui/SelectionAttributes.java
+++ b/src/main/java/com/cburch/draw/gui/SelectionAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/icons/DrawCurveIcon.java
+++ b/src/main/java/com/cburch/draw/icons/DrawCurveIcon.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/icons/DrawLineIcon.java
+++ b/src/main/java/com/cburch/draw/icons/DrawLineIcon.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/icons/DrawPolylineIcon.java
+++ b/src/main/java/com/cburch/draw/icons/DrawPolylineIcon.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/icons/DrawShapeIcon.java
+++ b/src/main/java/com/cburch/draw/icons/DrawShapeIcon.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/AbstractCanvasObject.java
+++ b/src/main/java/com/cburch/draw/model/AbstractCanvasObject.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/AttributeMapKey.java
+++ b/src/main/java/com/cburch/draw/model/AttributeMapKey.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/CanvasModel.java
+++ b/src/main/java/com/cburch/draw/model/CanvasModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/CanvasModelEvent.java
+++ b/src/main/java/com/cburch/draw/model/CanvasModelEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/CanvasModelListener.java
+++ b/src/main/java/com/cburch/draw/model/CanvasModelListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/CanvasObject.java
+++ b/src/main/java/com/cburch/draw/model/CanvasObject.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/Drawing.java
+++ b/src/main/java/com/cburch/draw/model/Drawing.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/DrawingOverlaps.java
+++ b/src/main/java/com/cburch/draw/model/DrawingOverlaps.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/Handle.java
+++ b/src/main/java/com/cburch/draw/model/Handle.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/HandleGesture.java
+++ b/src/main/java/com/cburch/draw/model/HandleGesture.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/model/ReorderRequest.java
+++ b/src/main/java/com/cburch/draw/model/ReorderRequest.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/Curve.java
+++ b/src/main/java/com/cburch/draw/shapes/Curve.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/CurveUtil.java
+++ b/src/main/java/com/cburch/draw/shapes/CurveUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/DrawAttr.java
+++ b/src/main/java/com/cburch/draw/shapes/DrawAttr.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/FillableCanvasObject.java
+++ b/src/main/java/com/cburch/draw/shapes/FillableCanvasObject.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/Line.java
+++ b/src/main/java/com/cburch/draw/shapes/Line.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/LineUtil.java
+++ b/src/main/java/com/cburch/draw/shapes/LineUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/Oval.java
+++ b/src/main/java/com/cburch/draw/shapes/Oval.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/Poly.java
+++ b/src/main/java/com/cburch/draw/shapes/Poly.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/PolyUtil.java
+++ b/src/main/java/com/cburch/draw/shapes/PolyUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/Rectangle.java
+++ b/src/main/java/com/cburch/draw/shapes/Rectangle.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/Rectangular.java
+++ b/src/main/java/com/cburch/draw/shapes/Rectangular.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/RoundRectangle.java
+++ b/src/main/java/com/cburch/draw/shapes/RoundRectangle.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/SvgCreator.java
+++ b/src/main/java/com/cburch/draw/shapes/SvgCreator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/SvgReader.java
+++ b/src/main/java/com/cburch/draw/shapes/SvgReader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/shapes/Text.java
+++ b/src/main/java/com/cburch/draw/shapes/Text.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/toolbar/AbstractToolbarModel.java
+++ b/src/main/java/com/cburch/draw/toolbar/AbstractToolbarModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/toolbar/Toolbar.java
+++ b/src/main/java/com/cburch/draw/toolbar/Toolbar.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/toolbar/ToolbarButton.java
+++ b/src/main/java/com/cburch/draw/toolbar/ToolbarButton.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/toolbar/ToolbarClickableItem.java
+++ b/src/main/java/com/cburch/draw/toolbar/ToolbarClickableItem.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/toolbar/ToolbarItem.java
+++ b/src/main/java/com/cburch/draw/toolbar/ToolbarItem.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/toolbar/ToolbarModel.java
+++ b/src/main/java/com/cburch/draw/toolbar/ToolbarModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/toolbar/ToolbarModelEvent.java
+++ b/src/main/java/com/cburch/draw/toolbar/ToolbarModelEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/toolbar/ToolbarModelListener.java
+++ b/src/main/java/com/cburch/draw/toolbar/ToolbarModelListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/toolbar/ToolbarSeparator.java
+++ b/src/main/java/com/cburch/draw/toolbar/ToolbarSeparator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/AbstractTool.java
+++ b/src/main/java/com/cburch/draw/tools/AbstractTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/CurveTool.java
+++ b/src/main/java/com/cburch/draw/tools/CurveTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/DrawingAttributeSet.java
+++ b/src/main/java/com/cburch/draw/tools/DrawingAttributeSet.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/LineTool.java
+++ b/src/main/java/com/cburch/draw/tools/LineTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/OvalTool.java
+++ b/src/main/java/com/cburch/draw/tools/OvalTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/PolyTool.java
+++ b/src/main/java/com/cburch/draw/tools/PolyTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/RectangleTool.java
+++ b/src/main/java/com/cburch/draw/tools/RectangleTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/RectangularTool.java
+++ b/src/main/java/com/cburch/draw/tools/RectangularTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/RoundRectangleTool.java
+++ b/src/main/java/com/cburch/draw/tools/RoundRectangleTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/SelectTool.java
+++ b/src/main/java/com/cburch/draw/tools/SelectTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/TextTool.java
+++ b/src/main/java/com/cburch/draw/tools/TextTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/tools/ToolbarToolItem.java
+++ b/src/main/java/com/cburch/draw/tools/ToolbarToolItem.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/undo/Action.java
+++ b/src/main/java/com/cburch/draw/undo/Action.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/util/EditableLabel.java
+++ b/src/main/java/com/cburch/draw/util/EditableLabel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/util/EditableLabelField.java
+++ b/src/main/java/com/cburch/draw/util/EditableLabelField.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/util/MatchingSet.java
+++ b/src/main/java/com/cburch/draw/util/MatchingSet.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/util/TextMetrics.java
+++ b/src/main/java/com/cburch/draw/util/TextMetrics.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/draw/util/ZOrder.java
+++ b/src/main/java/com/cburch/draw/util/ZOrder.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/gray/Components.java
+++ b/src/main/java/com/cburch/gray/Components.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/gray/CounterData.java
+++ b/src/main/java/com/cburch/gray/CounterData.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/gray/CounterPoker.java
+++ b/src/main/java/com/cburch/gray/CounterPoker.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/gray/GrayCounter.java
+++ b/src/main/java/com/cburch/gray/GrayCounter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/gray/GrayIncrementer.java
+++ b/src/main/java/com/cburch/gray/GrayIncrementer.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/gray/SimpleGrayCounter.java
+++ b/src/main/java/com/cburch/gray/SimpleGrayCounter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/hex/Caret.java
+++ b/src/main/java/com/cburch/hex/Caret.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/hex/HexEditor.java
+++ b/src/main/java/com/cburch/hex/HexEditor.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/hex/HexModel.java
+++ b/src/main/java/com/cburch/hex/HexModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/hex/HexModelListener.java
+++ b/src/main/java/com/cburch/hex/HexModelListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/hex/Highlighter.java
+++ b/src/main/java/com/cburch/hex/Highlighter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/hex/Measures.java
+++ b/src/main/java/com/cburch/hex/Measures.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/hex/Test.java
+++ b/src/main/java/com/cburch/hex/Test.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/Strings.java
+++ b/src/main/java/com/cburch/logisim/analyze/Strings.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/data/CsvInterpretor.java
+++ b/src/main/java/com/cburch/logisim/analyze/data/CsvInterpretor.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/data/CsvParameter.java
+++ b/src/main/java/com/cburch/logisim/analyze/data/CsvParameter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/data/ExpressionRenderData.java
+++ b/src/main/java/com/cburch/logisim/analyze/data/ExpressionRenderData.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/data/Range.java
+++ b/src/main/java/com/cburch/logisim/analyze/data/Range.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/file/TruthtableCsvFile.java
+++ b/src/main/java/com/cburch/logisim/analyze/file/TruthtableCsvFile.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/file/TruthtableFileFilter.java
+++ b/src/main/java/com/cburch/logisim/analyze/file/TruthtableFileFilter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/file/TruthtableTextFile.java
+++ b/src/main/java/com/cburch/logisim/analyze/file/TruthtableTextFile.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/Analyzer.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/Analyzer.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/AnalyzerManager.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/AnalyzerManager.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/AnalyzerMenuListener.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/AnalyzerMenuListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/AnalyzerTab.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/AnalyzerTab.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/BuildCircuitButton.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/BuildCircuitButton.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/CsvReadParameterDialog.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/CsvReadParameterDialog.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/ExportLatexButton.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/ExportLatexButton.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/ExportTableButton.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/ExportTableButton.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/ExpressionTab.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/ExpressionTab.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/ExpressionView.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/ExpressionView.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/ImportTableButton.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/ImportTableButton.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/KarnaughMapPanel.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/KarnaughMapPanel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/MinimizedTab.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/MinimizedTab.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/OutputSelector.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/OutputSelector.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/TabInterface.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/TabInterface.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/TableTab.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/TableTab.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/TableTabCaret.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/TableTabCaret.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/TableTabClip.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/TableTabClip.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/gui/VariableTab.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/VariableTab.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/AnalyzerModel.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/AnalyzerModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/Assignments.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Assignments.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/Entry.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Entry.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/Expression.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Expression.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/Expressions.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Expressions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/Implicant.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Implicant.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/OutputExpressions.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/OutputExpressions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/OutputExpressionsEvent.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/OutputExpressionsEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/OutputExpressionsListener.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/OutputExpressionsListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/Parser.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Parser.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/ParserException.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/ParserException.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/TruthTableEvent.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/TruthTableEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/TruthTableListener.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/TruthTableListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/Var.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Var.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/VariableList.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/VariableList.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/VariableListEvent.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/VariableListEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/analyze/model/VariableListListener.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/VariableListListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/Analyze.java
+++ b/src/main/java/com/cburch/logisim/circuit/Analyze.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/AnalyzeException.java
+++ b/src/main/java/com/cburch/logisim/circuit/AnalyzeException.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/Circuit.java
+++ b/src/main/java/com/cburch/logisim/circuit/Circuit.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitAction.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitChange.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitChange.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitEvent.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitException.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitException.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitListener.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitLocker.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitLocker.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitMapInfo.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitMapInfo.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitMutation.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitMutation.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitMutator.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitMutator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitMutatorImpl.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitMutatorImpl.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitPoints.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitPoints.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitState.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitState.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitTransaction.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitTransaction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitTransactionResult.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitTransactionResult.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/ComponentDataGuiProvider.java
+++ b/src/main/java/com/cburch/logisim/circuit/ComponentDataGuiProvider.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/ExpressionComputer.java
+++ b/src/main/java/com/cburch/logisim/circuit/ExpressionComputer.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/PropagationPoints.java
+++ b/src/main/java/com/cburch/logisim/circuit/PropagationPoints.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/Propagator.java
+++ b/src/main/java/com/cburch/logisim/circuit/Propagator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/RadixOption.java
+++ b/src/main/java/com/cburch/logisim/circuit/RadixOption.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/ReplacementMap.java
+++ b/src/main/java/com/cburch/logisim/circuit/ReplacementMap.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/Simulator.java
+++ b/src/main/java/com/cburch/logisim/circuit/Simulator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/Splitter.java
+++ b/src/main/java/com/cburch/logisim/circuit/Splitter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/SplitterAttributes.java
+++ b/src/main/java/com/cburch/logisim/circuit/SplitterAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/SplitterDistributeItem.java
+++ b/src/main/java/com/cburch/logisim/circuit/SplitterDistributeItem.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/SplitterFactory.java
+++ b/src/main/java/com/cburch/logisim/circuit/SplitterFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/SplitterPainter.java
+++ b/src/main/java/com/cburch/logisim/circuit/SplitterPainter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/SplitterParameters.java
+++ b/src/main/java/com/cburch/logisim/circuit/SplitterParameters.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/Strings.java
+++ b/src/main/java/com/cburch/logisim/circuit/Strings.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/SubcircuitFactory.java
+++ b/src/main/java/com/cburch/logisim/circuit/SubcircuitFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/SubcircuitPoker.java
+++ b/src/main/java/com/cburch/logisim/circuit/SubcircuitPoker.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/WidthIncompatibilityData.java
+++ b/src/main/java/com/cburch/logisim/circuit/WidthIncompatibilityData.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/Wire.java
+++ b/src/main/java/com/cburch/logisim/circuit/Wire.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/WireBundle.java
+++ b/src/main/java/com/cburch/logisim/circuit/WireBundle.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/WireFactory.java
+++ b/src/main/java/com/cburch/logisim/circuit/WireFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/WireIterator.java
+++ b/src/main/java/com/cburch/logisim/circuit/WireIterator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/WireRepair.java
+++ b/src/main/java/com/cburch/logisim/circuit/WireRepair.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/WireSet.java
+++ b/src/main/java/com/cburch/logisim/circuit/WireSet.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/WireThread.java
+++ b/src/main/java/com/cburch/logisim/circuit/WireThread.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/WireUtil.java
+++ b/src/main/java/com/cburch/logisim/circuit/WireUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceAnchor.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceAnchor.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceElement.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceElement.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearancePort.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearancePort.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearance.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearanceEvent.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearanceEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearanceListener.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearanceListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/CircuitPins.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/CircuitPins.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/DefaultAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DefaultAppearance.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/DefaultClassicAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DefaultClassicAppearance.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/DefaultEvolutionAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DefaultEvolutionAppearance.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/DefaultHolyCrossAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DefaultHolyCrossAppearance.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/DynamicElement.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DynamicElement.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/DynamicElementProvider.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DynamicElementProvider.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/DynamicElementWithPoker.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DynamicElementWithPoker.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/circuit/appear/PortManager.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/PortManager.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/AbstractComponent.java
+++ b/src/main/java/com/cburch/logisim/comp/AbstractComponent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/AbstractComponentFactory.java
+++ b/src/main/java/com/cburch/logisim/comp/AbstractComponentFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/Component.java
+++ b/src/main/java/com/cburch/logisim/comp/Component.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/ComponentDrawContext.java
+++ b/src/main/java/com/cburch/logisim/comp/ComponentDrawContext.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/ComponentEvent.java
+++ b/src/main/java/com/cburch/logisim/comp/ComponentEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/ComponentFactory.java
+++ b/src/main/java/com/cburch/logisim/comp/ComponentFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/ComponentListener.java
+++ b/src/main/java/com/cburch/logisim/comp/ComponentListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/ComponentState.java
+++ b/src/main/java/com/cburch/logisim/comp/ComponentState.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/ComponentUserEvent.java
+++ b/src/main/java/com/cburch/logisim/comp/ComponentUserEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/EndData.java
+++ b/src/main/java/com/cburch/logisim/comp/EndData.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/ManagedComponent.java
+++ b/src/main/java/com/cburch/logisim/comp/ManagedComponent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/TextField.java
+++ b/src/main/java/com/cburch/logisim/comp/TextField.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/TextFieldCaret.java
+++ b/src/main/java/com/cburch/logisim/comp/TextFieldCaret.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/TextFieldEvent.java
+++ b/src/main/java/com/cburch/logisim/comp/TextFieldEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/comp/TextFieldListener.java
+++ b/src/main/java/com/cburch/logisim/comp/TextFieldListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/AbstractAttributeSet.java
+++ b/src/main/java/com/cburch/logisim/data/AbstractAttributeSet.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/Attribute.java
+++ b/src/main/java/com/cburch/logisim/data/Attribute.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/AttributeDefaultProvider.java
+++ b/src/main/java/com/cburch/logisim/data/AttributeDefaultProvider.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/AttributeEvent.java
+++ b/src/main/java/com/cburch/logisim/data/AttributeEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/AttributeListener.java
+++ b/src/main/java/com/cburch/logisim/data/AttributeListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/AttributeOption.java
+++ b/src/main/java/com/cburch/logisim/data/AttributeOption.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/AttributeOptionInterface.java
+++ b/src/main/java/com/cburch/logisim/data/AttributeOptionInterface.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/AttributeSet.java
+++ b/src/main/java/com/cburch/logisim/data/AttributeSet.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/AttributeSets.java
+++ b/src/main/java/com/cburch/logisim/data/AttributeSets.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/Attributes.java
+++ b/src/main/java/com/cburch/logisim/data/Attributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/BitWidth.java
+++ b/src/main/java/com/cburch/logisim/data/BitWidth.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/Bounds.java
+++ b/src/main/java/com/cburch/logisim/data/Bounds.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/Direction.java
+++ b/src/main/java/com/cburch/logisim/data/Direction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/FailException.java
+++ b/src/main/java/com/cburch/logisim/data/FailException.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/Location.java
+++ b/src/main/java/com/cburch/logisim/data/Location.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/Strings.java
+++ b/src/main/java/com/cburch/logisim/data/Strings.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/TestException.java
+++ b/src/main/java/com/cburch/logisim/data/TestException.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/TestVector.java
+++ b/src/main/java/com/cburch/logisim/data/TestVector.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/data/Value.java
+++ b/src/main/java/com/cburch/logisim/data/Value.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/FileStatistics.java
+++ b/src/main/java/com/cburch/logisim/file/FileStatistics.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/LibraryEvent.java
+++ b/src/main/java/com/cburch/logisim/file/LibraryEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/LibraryEventSource.java
+++ b/src/main/java/com/cburch/logisim/file/LibraryEventSource.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/LibraryListener.java
+++ b/src/main/java/com/cburch/logisim/file/LibraryListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/LibraryLoader.java
+++ b/src/main/java/com/cburch/logisim/file/LibraryLoader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/LibraryManager.java
+++ b/src/main/java/com/cburch/logisim/file/LibraryManager.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/LoadFailedException.java
+++ b/src/main/java/com/cburch/logisim/file/LoadFailedException.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/LoadedLibrary.java
+++ b/src/main/java/com/cburch/logisim/file/LoadedLibrary.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/Loader.java
+++ b/src/main/java/com/cburch/logisim/file/Loader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/LoaderException.java
+++ b/src/main/java/com/cburch/logisim/file/LoaderException.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/LogisimFile.java
+++ b/src/main/java/com/cburch/logisim/file/LogisimFile.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/LogisimFileActions.java
+++ b/src/main/java/com/cburch/logisim/file/LogisimFileActions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/MouseMappings.java
+++ b/src/main/java/com/cburch/logisim/file/MouseMappings.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/Options.java
+++ b/src/main/java/com/cburch/logisim/file/Options.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/ProjectsDirty.java
+++ b/src/main/java/com/cburch/logisim/file/ProjectsDirty.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/ReaderInputStream.java
+++ b/src/main/java/com/cburch/logisim/file/ReaderInputStream.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/Strings.java
+++ b/src/main/java/com/cburch/logisim/file/Strings.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/ToolbarData.java
+++ b/src/main/java/com/cburch/logisim/file/ToolbarData.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/XmlIterator.java
+++ b/src/main/java/com/cburch/logisim/file/XmlIterator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/XmlReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlReader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/XmlReaderException.java
+++ b/src/main/java/com/cburch/logisim/file/XmlReaderException.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/Instance.java
+++ b/src/main/java/com/cburch/logisim/instance/Instance.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceComponent.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceComponent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceData.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceData.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceDataSingleton.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceDataSingleton.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceFactory.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceLogger.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceLogger.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceLoggerAdapter.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceLoggerAdapter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstancePainter.java
+++ b/src/main/java/com/cburch/logisim/instance/InstancePainter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstancePoker.java
+++ b/src/main/java/com/cburch/logisim/instance/InstancePoker.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstancePokerAdapter.java
+++ b/src/main/java/com/cburch/logisim/instance/InstancePokerAdapter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceState.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceState.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceStateImpl.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceStateImpl.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceTextField.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceTextField.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/Port.java
+++ b/src/main/java/com/cburch/logisim/instance/Port.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/instance/StdAttr.java
+++ b/src/main/java/com/cburch/logisim/instance/StdAttr.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/prefs/AbstractPrefMonitor.java
+++ b/src/main/java/com/cburch/logisim/prefs/AbstractPrefMonitor.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/prefs/ConvertEvent.java
+++ b/src/main/java/com/cburch/logisim/prefs/ConvertEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/prefs/RecentProjects.java
+++ b/src/main/java/com/cburch/logisim/prefs/RecentProjects.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/prefs/Template.java
+++ b/src/main/java/com/cburch/logisim/prefs/Template.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/proj/Action.java
+++ b/src/main/java/com/cburch/logisim/proj/Action.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/proj/Dependencies.java
+++ b/src/main/java/com/cburch/logisim/proj/Dependencies.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/proj/Project.java
+++ b/src/main/java/com/cburch/logisim/proj/Project.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/proj/ProjectActions.java
+++ b/src/main/java/com/cburch/logisim/proj/ProjectActions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/proj/ProjectListener.java
+++ b/src/main/java/com/cburch/logisim/proj/ProjectListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/proj/Projects.java
+++ b/src/main/java/com/cburch/logisim/proj/Projects.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/Soc.java
+++ b/src/main/java/com/cburch/logisim/soc/Soc.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/Strings.java
+++ b/src/main/java/com/cburch/logisim/soc/Strings.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/bus/SocBus.java
+++ b/src/main/java/com/cburch/logisim/soc/bus/SocBus.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/bus/SocBusAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/bus/SocBusAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/bus/SocBusMenuProvider.java
+++ b/src/main/java/com/cburch/logisim/soc/bus/SocBusMenuProvider.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/AssemblerHighlighter.java
+++ b/src/main/java/com/cburch/logisim/soc/data/AssemblerHighlighter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocBusInfo.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocBusInfo.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocBusMasterInterface.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocBusMasterInterface.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocBusSlaveInterface.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocBusSlaveInterface.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocBusSlaveListener.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocBusSlaveListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocBusSnifferInterface.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocBusSnifferInterface.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocBusStateInfo.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocBusStateInfo.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocBusTransaction.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocBusTransaction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocInstanceFactory.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocInstanceFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocMemMapModel.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocMemMapModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocProcessorInterface.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocProcessorInterface.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocSimulationManager.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocSimulationManager.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocSupport.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocSupport.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocUpMenuProvider.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocUpMenuProvider.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocUpSimulationState.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocUpSimulationState.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocUpSimulationStateListener.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocUpSimulationStateListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/SocUpStateInterface.java
+++ b/src/main/java/com/cburch/logisim/soc/data/SocUpStateInterface.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/data/TraceInfo.java
+++ b/src/main/java/com/cburch/logisim/soc/data/TraceInfo.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/file/ElfHeader.java
+++ b/src/main/java/com/cburch/logisim/soc/file/ElfHeader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/file/ElfProgramHeader.java
+++ b/src/main/java/com/cburch/logisim/soc/file/ElfProgramHeader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/file/ElfSectionHeader.java
+++ b/src/main/java/com/cburch/logisim/soc/file/ElfSectionHeader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/file/ProcessorReadElf.java
+++ b/src/main/java/com/cburch/logisim/soc/file/ProcessorReadElf.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/file/SectionHeader.java
+++ b/src/main/java/com/cburch/logisim/soc/file/SectionHeader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/file/SymbolTable.java
+++ b/src/main/java/com/cburch/logisim/soc/file/SymbolTable.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/gui/AssemblerPanel.java
+++ b/src/main/java/com/cburch/logisim/soc/gui/AssemblerPanel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/gui/BreakpointPanel.java
+++ b/src/main/java/com/cburch/logisim/soc/gui/BreakpointPanel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/gui/BusTransactionInsertionGui.java
+++ b/src/main/java/com/cburch/logisim/soc/gui/BusTransactionInsertionGui.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/gui/CpuDrawSupport.java
+++ b/src/main/java/com/cburch/logisim/soc/gui/CpuDrawSupport.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/gui/SocCPUShape.java
+++ b/src/main/java/com/cburch/logisim/soc/gui/SocCPUShape.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/gui/TraceWindowTableModel.java
+++ b/src/main/java/com/cburch/logisim/soc/gui/TraceWindowTableModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUart.java
+++ b/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUart.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUartAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUartAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUartState.java
+++ b/src/main/java/com/cburch/logisim/soc/jtaguart/JtagUartState.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/memory/SocMemory.java
+++ b/src/main/java/com/cburch/logisim/soc/memory/SocMemory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/memory/SocMemoryAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/memory/SocMemoryAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/memory/SocMemoryState.java
+++ b/src/main/java/com/cburch/logisim/soc/memory/SocMemoryState.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2ArithmeticAndLogicalInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2ArithmeticAndLogicalInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2Assembler.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2Assembler.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2Attributes.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2Attributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2ComparisonInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2ComparisonInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2CustomInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2CustomInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2DataTransferInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2DataTransferInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2OtherControlInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2OtherControlInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2ProgramControlInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2ProgramControlInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2ShiftAndRotateInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2ShiftAndRotateInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2State.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2State.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2Support.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2Support.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/nios2/Nios2SyntaxHighlighter.java
+++ b/src/main/java/com/cburch/logisim/soc/nios2/Nios2SyntaxHighlighter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/pio/PioAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/pio/PioAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/pio/PioMenu.java
+++ b/src/main/java/com/cburch/logisim/soc/pio/PioMenu.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/pio/PioState.java
+++ b/src/main/java/com/cburch/logisim/soc/pio/PioState.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/pio/SocPio.java
+++ b/src/main/java/com/cburch/logisim/soc/pio/SocPio.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imAssembler.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imAssembler.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imControlTransferInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imControlTransferInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imEnvironmentCallAndBreakpoints.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imEnvironmentCallAndBreakpoints.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imIntegerRegisterImmediateInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imIntegerRegisterImmediateInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imIntegerRegisterRegisterOperations.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imIntegerRegisterRegisterOperations.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imLoadAndStoreInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imLoadAndStoreInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imSupport.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imSupport.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imSyntaxHighlighter.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imSyntaxHighlighter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32im_M_ExtensionInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32im_M_ExtensionInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32im_state.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32im_state.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/Rv32imMemoryOrderingInstructions.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/Rv32imMemoryOrderingInstructions.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/rv32im/Rv32im_riscv.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/Rv32im_riscv.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/util/AbstractAssembler.java
+++ b/src/main/java/com/cburch/logisim/soc/util/AbstractAssembler.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/util/AbstractExecutionUnitWithLabelSupport.java
+++ b/src/main/java/com/cburch/logisim/soc/util/AbstractExecutionUnitWithLabelSupport.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/util/Assembler.java
+++ b/src/main/java/com/cburch/logisim/soc/util/Assembler.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/util/AssemblerAsmInstruction.java
+++ b/src/main/java/com/cburch/logisim/soc/util/AssemblerAsmInstruction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/util/AssemblerExecutionInterface.java
+++ b/src/main/java/com/cburch/logisim/soc/util/AssemblerExecutionInterface.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/util/AssemblerInfo.java
+++ b/src/main/java/com/cburch/logisim/soc/util/AssemblerInfo.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/util/AssemblerInterface.java
+++ b/src/main/java/com/cburch/logisim/soc/util/AssemblerInterface.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/util/AssemblerMacro.java
+++ b/src/main/java/com/cburch/logisim/soc/util/AssemblerMacro.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/util/AssemblerToken.java
+++ b/src/main/java/com/cburch/logisim/soc/util/AssemblerToken.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/vga/SocVga.java
+++ b/src/main/java/com/cburch/logisim/soc/vga/SocVga.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/vga/SocVgaShape.java
+++ b/src/main/java/com/cburch/logisim/soc/vga/SocVgaShape.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/vga/VgaAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/vga/VgaAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/vga/VgaMenu.java
+++ b/src/main/java/com/cburch/logisim/soc/vga/VgaMenu.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/soc/vga/VgaState.java
+++ b/src/main/java/com/cburch/logisim/soc/vga/VgaState.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/arith/FPAdder.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FPAdder.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/arith/FPMultiplier.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FPMultiplier.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/arith/Multiplier.java
+++ b/src/main/java/com/cburch/logisim/std/arith/Multiplier.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/arith/SubtractorHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/SubtractorHDLGeneratorFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/bfh/bin2bcd.java
+++ b/src/main/java/com/cburch/logisim/std/bfh/bin2bcd.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/gates/CircuitDetermination.java
+++ b/src/main/java/com/cburch/logisim/std/gates/CircuitDetermination.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/gates/XorGate.java
+++ b/src/main/java/com/cburch/logisim/std/gates/XorGate.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlContent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlContent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlContentEditor.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlContentEditor.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/io/Joystick.java
+++ b/src/main/java/com/cburch/logisim/std/io/Joystick.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/io/Led.java
+++ b/src/main/java/com/cburch/logisim/std/io/Led.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/io/PortHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/PortHDLGeneratorFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/io/PortIO.java
+++ b/src/main/java/com/cburch/logisim/std/io/PortIO.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/io/ReptarLocalBus.java
+++ b/src/main/java/com/cburch/logisim/std/io/ReptarLocalBus.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/io/ReptarLocalBusHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/ReptarLocalBusHDLGeneratorFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/io/Tty.java
+++ b/src/main/java/com/cburch/logisim/std/io/Tty.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/io/TtyShape.java
+++ b/src/main/java/com/cburch/logisim/std/io/TtyShape.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/io/extra/DigitalOscilloscope.java
+++ b/src/main/java/com/cburch/logisim/std/io/extra/DigitalOscilloscope.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/memory/ClockState.java
+++ b/src/main/java/com/cburch/logisim/std/memory/ClockState.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/memory/CounterAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/CounterAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/memory/CounterPoker.java
+++ b/src/main/java/com/cburch/logisim/std/memory/CounterPoker.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/memory/MemPoker.java
+++ b/src/main/java/com/cburch/logisim/std/memory/MemPoker.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/memory/Register.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Register.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/memory/RegisterData.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RegisterData.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/memory/RegisterPoker.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RegisterPoker.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/memory/Rom.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Rom.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/tcl/TclConsoleReds.java
+++ b/src/main/java/com/cburch/logisim/std/tcl/TclConsoleReds.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/tcl/TclGeneric.java
+++ b/src/main/java/com/cburch/logisim/std/tcl/TclGeneric.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/ttl/Drawgates.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Drawgates.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/ttl/ShiftRegisterData.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/ShiftRegisterData.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7404.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7404.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7418.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7418.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7421.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7421.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl74283HDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl74283HDLGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7430HDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7430HDLGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7454.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7454.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7458.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7458.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/wiring/ClockHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/ClockHDLGeneratorFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/wiring/DurationAttribute.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/DurationAttribute.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/wiring/PullResistor.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/PullResistor.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/wiring/Transistor.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Transistor.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/std/wiring/WiringLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/WiringLibrary.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/AbstractCaret.java
+++ b/src/main/java/com/cburch/logisim/tools/AbstractCaret.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/AddTool.java
+++ b/src/main/java/com/cburch/logisim/tools/AddTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/Caret.java
+++ b/src/main/java/com/cburch/logisim/tools/Caret.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/CaretEvent.java
+++ b/src/main/java/com/cburch/logisim/tools/CaretEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/CaretListener.java
+++ b/src/main/java/com/cburch/logisim/tools/CaretListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/CircuitStateHolder.java
+++ b/src/main/java/com/cburch/logisim/tools/CircuitStateHolder.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/CustomHandles.java
+++ b/src/main/java/com/cburch/logisim/tools/CustomHandles.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/EditTool.java
+++ b/src/main/java/com/cburch/logisim/tools/EditTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/FactoryAttributes.java
+++ b/src/main/java/com/cburch/logisim/tools/FactoryAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/FactoryDescription.java
+++ b/src/main/java/com/cburch/logisim/tools/FactoryDescription.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/Library.java
+++ b/src/main/java/com/cburch/logisim/tools/Library.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/LibraryTools.java
+++ b/src/main/java/com/cburch/logisim/tools/LibraryTools.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/MatrixPlacerDialog.java
+++ b/src/main/java/com/cburch/logisim/tools/MatrixPlacerDialog.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/MatrixPlacerInfo.java
+++ b/src/main/java/com/cburch/logisim/tools/MatrixPlacerInfo.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/MenuExtender.java
+++ b/src/main/java/com/cburch/logisim/tools/MenuExtender.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/MenuTool.java
+++ b/src/main/java/com/cburch/logisim/tools/MenuTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/MessageBox.java
+++ b/src/main/java/com/cburch/logisim/tools/MessageBox.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/Pokable.java
+++ b/src/main/java/com/cburch/logisim/tools/Pokable.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/PokeTool.java
+++ b/src/main/java/com/cburch/logisim/tools/PokeTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/SelectTool.java
+++ b/src/main/java/com/cburch/logisim/tools/SelectTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/SetAttributeAction.java
+++ b/src/main/java/com/cburch/logisim/tools/SetAttributeAction.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/Strings.java
+++ b/src/main/java/com/cburch/logisim/tools/Strings.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/TextEditable.java
+++ b/src/main/java/com/cburch/logisim/tools/TextEditable.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/TextTool.java
+++ b/src/main/java/com/cburch/logisim/tools/TextTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/Tool.java
+++ b/src/main/java/com/cburch/logisim/tools/Tool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/ToolTipMaker.java
+++ b/src/main/java/com/cburch/logisim/tools/ToolTipMaker.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/WireRepair.java
+++ b/src/main/java/com/cburch/logisim/tools/WireRepair.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/WireRepairData.java
+++ b/src/main/java/com/cburch/logisim/tools/WireRepairData.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/WiringTool.java
+++ b/src/main/java/com/cburch/logisim/tools/WiringTool.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/key/BitWidthConfigurator.java
+++ b/src/main/java/com/cburch/logisim/tools/key/BitWidthConfigurator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/key/DirectionConfigurator.java
+++ b/src/main/java/com/cburch/logisim/tools/key/DirectionConfigurator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/key/IntegerConfigurator.java
+++ b/src/main/java/com/cburch/logisim/tools/key/IntegerConfigurator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/key/JoinedConfigurator.java
+++ b/src/main/java/com/cburch/logisim/tools/key/JoinedConfigurator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/key/KeyConfigurationEvent.java
+++ b/src/main/java/com/cburch/logisim/tools/key/KeyConfigurationEvent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/key/KeyConfigurationResult.java
+++ b/src/main/java/com/cburch/logisim/tools/key/KeyConfigurationResult.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/key/KeyConfigurator.java
+++ b/src/main/java/com/cburch/logisim/tools/key/KeyConfigurator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/key/LongConfigurator.java
+++ b/src/main/java/com/cburch/logisim/tools/key/LongConfigurator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/key/NumericConfigurator.java
+++ b/src/main/java/com/cburch/logisim/tools/key/NumericConfigurator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/key/ParallelConfigurator.java
+++ b/src/main/java/com/cburch/logisim/tools/key/ParallelConfigurator.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/move/AvoidanceMap.java
+++ b/src/main/java/com/cburch/logisim/tools/move/AvoidanceMap.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/move/ConnectionData.java
+++ b/src/main/java/com/cburch/logisim/tools/move/ConnectionData.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/move/Connector.java
+++ b/src/main/java/com/cburch/logisim/tools/move/Connector.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/move/ConnectorThread.java
+++ b/src/main/java/com/cburch/logisim/tools/move/ConnectorThread.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/move/MoveGesture.java
+++ b/src/main/java/com/cburch/logisim/tools/move/MoveGesture.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/move/MoveRequest.java
+++ b/src/main/java/com/cburch/logisim/tools/move/MoveRequest.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/move/MoveRequestListener.java
+++ b/src/main/java/com/cburch/logisim/tools/move/MoveRequestListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/move/MoveResult.java
+++ b/src/main/java/com/cburch/logisim/tools/move/MoveResult.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/tools/move/SearchNode.java
+++ b/src/main/java/com/cburch/logisim/tools/move/SearchNode.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/ArgonXML.java
+++ b/src/main/java/com/cburch/logisim/util/ArgonXML.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/AutoLabel.java
+++ b/src/main/java/com/cburch/logisim/util/AutoLabel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/Cache.java
+++ b/src/main/java/com/cburch/logisim/util/Cache.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/CollectionUtil.java
+++ b/src/main/java/com/cburch/logisim/util/CollectionUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/Dag.java
+++ b/src/main/java/com/cburch/logisim/util/Dag.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/EventSourceWeakSupport.java
+++ b/src/main/java/com/cburch/logisim/util/EventSourceWeakSupport.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/FileUtil.java
+++ b/src/main/java/com/cburch/logisim/util/FileUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/FontUtil.java
+++ b/src/main/java/com/cburch/logisim/util/FontUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/GifEncoder.java
+++ b/src/main/java/com/cburch/logisim/util/GifEncoder.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/GraphicsUtil.java
+++ b/src/main/java/com/cburch/logisim/util/GraphicsUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/HorizontalSplitPane.java
+++ b/src/main/java/com/cburch/logisim/util/HorizontalSplitPane.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/Icons.java
+++ b/src/main/java/com/cburch/logisim/util/Icons.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/InputEventUtil.java
+++ b/src/main/java/com/cburch/logisim/util/InputEventUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/IteratorUtil.java
+++ b/src/main/java/com/cburch/logisim/util/IteratorUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/JDialogOk.java
+++ b/src/main/java/com/cburch/logisim/util/JDialogOk.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/JFileChoosers.java
+++ b/src/main/java/com/cburch/logisim/util/JFileChoosers.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/JInputComponent.java
+++ b/src/main/java/com/cburch/logisim/util/JInputComponent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/JInputDialog.java
+++ b/src/main/java/com/cburch/logisim/util/JInputDialog.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/LocaleListener.java
+++ b/src/main/java/com/cburch/logisim/util/LocaleListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/LocaleManager.java
+++ b/src/main/java/com/cburch/logisim/util/LocaleManager.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/LocaleSelector.java
+++ b/src/main/java/com/cburch/logisim/util/LocaleSelector.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/MacCompatibility.java
+++ b/src/main/java/com/cburch/logisim/util/MacCompatibility.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/OutputStreamBinarySanitizer.java
+++ b/src/main/java/com/cburch/logisim/util/OutputStreamBinarySanitizer.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/OutputStreamEscaper.java
+++ b/src/main/java/com/cburch/logisim/util/OutputStreamEscaper.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/PropertyChangeWeakSupport.java
+++ b/src/main/java/com/cburch/logisim/util/PropertyChangeWeakSupport.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/SmartScroller.java
+++ b/src/main/java/com/cburch/logisim/util/SmartScroller.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/SocketClient.java
+++ b/src/main/java/com/cburch/logisim/util/SocketClient.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/Softwares.java
+++ b/src/main/java/com/cburch/logisim/util/Softwares.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/StringGetter.java
+++ b/src/main/java/com/cburch/logisim/util/StringGetter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/StringUtil.java
+++ b/src/main/java/com/cburch/logisim/util/StringUtil.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/Strings.java
+++ b/src/main/java/com/cburch/logisim/util/Strings.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/SyntaxChecker.java
+++ b/src/main/java/com/cburch/logisim/util/SyntaxChecker.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/TableConstraints.java
+++ b/src/main/java/com/cburch/logisim/util/TableConstraints.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/TableLayout.java
+++ b/src/main/java/com/cburch/logisim/util/TableLayout.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/TableSorter.java
+++ b/src/main/java/com/cburch/logisim/util/TableSorter.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/TextLineNumber.java
+++ b/src/main/java/com/cburch/logisim/util/TextLineNumber.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/UniquelyNamedThread.java
+++ b/src/main/java/com/cburch/logisim/util/UniquelyNamedThread.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/UnmodifiableList.java
+++ b/src/main/java/com/cburch/logisim/util/UnmodifiableList.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/VerticalSplitPane.java
+++ b/src/main/java/com/cburch/logisim/util/VerticalSplitPane.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/WindowClosable.java
+++ b/src/main/java/com/cburch/logisim/util/WindowClosable.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/WindowMenu.java
+++ b/src/main/java/com/cburch/logisim/util/WindowMenu.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/WindowMenuItem.java
+++ b/src/main/java/com/cburch/logisim/util/WindowMenuItem.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/WindowMenuItemManager.java
+++ b/src/main/java/com/cburch/logisim/util/WindowMenuItemManager.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/WindowMenuManager.java
+++ b/src/main/java/com/cburch/logisim/util/WindowMenuManager.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/util/ZipClassLoader.java
+++ b/src/main/java/com/cburch/logisim/util/ZipClassLoader.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/Strings.java
+++ b/src/main/java/com/cburch/logisim/vhdl/Strings.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/base/HdlContent.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/HdlContent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/base/HdlModel.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/HdlModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/base/HdlModelListener.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/HdlModelListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlAppearance.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlAppearance.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlContent.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlContent.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntity.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntity.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntityAttributes.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntityAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlHDLGeneratorFactory.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlParser.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlParser.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlSimConstants.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlSimConstants.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/file/HdlFile.java
+++ b/src/main/java/com/cburch/logisim/vhdl/file/HdlFile.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/gui/HdlContentEditor.java
+++ b/src/main/java/com/cburch/logisim/vhdl/gui/HdlContentEditor.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/gui/HdlContentView.java
+++ b/src/main/java/com/cburch/logisim/vhdl/gui/HdlContentView.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/gui/HdlToolbarModel.java
+++ b/src/main/java/com/cburch/logisim/vhdl/gui/HdlToolbarModel.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/gui/VhdlSimState.java
+++ b/src/main/java/com/cburch/logisim/vhdl/gui/VhdlSimState.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/gui/VhdlSimulatorConsole.java
+++ b/src/main/java/com/cburch/logisim/vhdl/gui/VhdlSimulatorConsole.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorListener.java
+++ b/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorListener.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorTclBinder.java
+++ b/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorTclBinder.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorTclComp.java
+++ b/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorTclComp.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorTop.java
+++ b/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorTop.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorVhdlTop.java
+++ b/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorVhdlTop.java
@@ -1,9 +1,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 

--- a/src/main/java/com/cburch/logisim/vhdl/syntax/VhdlSyntax.java
+++ b/src/main/java/com/cburch/logisim/vhdl/syntax/VhdlSyntax.java
@@ -12,9 +12,9 @@
 /*
  * Logisim-evolution - digital logic design tool and simulator
  * Copyright by the Logisim-evolution developers
- * 
+ *
  * https://github.com/logisim-evolution/
- * 
+ *
  * This is free software released under GNU GPLv3 license
  */
 


### PR DESCRIPTION
I managed to plant trailing spaces to some of copyright headers and now, if your editor/IDE automatically trims such spaces, header lines will pollute your diff. This PR removes these trailing spaces.