### PR TITLE
Added -dev suffix to version string (in develop branch)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ name = logisim-evolution
 #  x.y.z-suffix (i.e. "3.6.9-beta1")
 # Suffix is optional and can be any string indicating **non-stable** releases
 # (i.e. "beta1" or "rc1"). Keep suffix EMPTY string for every stable release!
-version = 3.7.0
+version = 3.7.0-dev


### PR DESCRIPTION
Rationale version from gradle.properties is then used in the app, so even if nightly builder renames artifacts so filename contains no version string, the version string is still visible, so it must clarly indicate it's non-stable build.