### PR TITLE
Using TCK Tested JDK builds of OpenJDK  in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.jdk }}
-        distribution: 'adopt'
+        distribution: 'zulu'
 
     - name: "Build with Gradle"
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 14
-          distribution: 'adopt'
+          distribution: 'zulu'
 
       # ###########################################################################################
 
@@ -201,7 +201,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 14
-          distribution: 'adopt'
+          distribution: 'zulu'
 
       - name: "Build DMG"
         run: |
@@ -239,7 +239,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 14
-          distribution: 'adopt'
+          distribution: 'zulu'
 
       - name: "Build MSI"
         run: .\gradlew.bat createMsi -x checkstyleMain -x checkstyleTest


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.