### PR TITLE
Using TCK Tested JDK builds of OpenJDK. 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,11 @@ on:
 
 env:
   JDK_VERSION: 16
-
+  JDK_DISTRO: 'temurin'
 jobs:
   analyze_sources:
     name: "Do we need to build the application?"
     runs-on: ubuntu-latest
-
     outputs:
       # Export 'filter' step check result so next step can use it.
       run_build: ${{ steps.filter.outputs.src }}
@@ -57,7 +56,6 @@ jobs:
   build:
     name: "Gradle builder"
     runs-on: ubuntu-latest
-
     # Will run only if analyze_sources determined it is needed.
     needs: analyze_sources
     if: needs.analyze_sources.outputs.run_build == 'true'
@@ -65,12 +63,11 @@ jobs:
     steps:
     - name: "Checkout sources"
       uses: actions/checkout@v2
-
-    - name: "Set up JDK"
+    - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
       uses: actions/setup-java@v2
       with:
         java-version: ${{ env.JDK_VERSION }}
-        distribution: 'adopt'
+        distribution: ${{ env.JDK_DISTRO }}
 
     - name: "Build with Gradle"
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,12 +26,12 @@ on:
 
 env:
   JDK_VERSION: 16
+  JDK_DISTRO: 'temurin'
 
 jobs:
   git_check:
     name: "Any changes since last run?"
     runs-on: ubuntu-latest
-
     # HACK: Temporary workaround for `schedule` not working outside main
     # branch and lack of `type: merged` for `pull_request` trigger.
     # if: github.event.pull_request.merged == true
@@ -88,11 +88,9 @@ jobs:
   build_linux:
     name: 'Linux build'
     runs-on: ubuntu-latest
-
     # Will run only if git_check determined it is needed.
     needs: git_check
     if: needs.git_check.outputs.run_build == 'true'
-
     steps:
       # https://github.com/marketplace/actions/checkout
       - name: "Checkout sources"
@@ -100,12 +98,11 @@ jobs:
         with:
           # We want develop branch only.
           ref: 'develop'
-
-      - name: "Set up JDK"
+      - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_VERSION }}
-          distribution: 'adopt'
+          distribution: ${{ env.JDK_DISTRO }}
 
       # ###########################################################################################
 
@@ -185,11 +182,9 @@ jobs:
   build_macos:
     name: 'macOS build'
     runs-on: macos-latest
-
     # Will run only if git_check determined it is needed.
     needs: git_check
     if: needs.git_check.outputs.run_build == 'true'
-
 
     steps:
       # https://github.com/marketplace/actions/checkout
@@ -198,12 +193,11 @@ jobs:
         with:
           # We want develop branch only.
           ref: 'develop'
-
-      - name: "Set up JDK"
+      - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_VERSION }}
-          distribution: 'adopt'
+          distribution: ${{ env.JDK_DISTRO }}
 
       - name: "Build DMG"
         run: |
@@ -226,7 +220,6 @@ jobs:
   build_windows:
     name: 'Windows build'
     runs-on: windows-latest
-
     # Will run only if git_check determined it is needed.
     needs: git_check
     if: needs.git_check.outputs.run_build == 'true'
@@ -235,12 +228,11 @@ jobs:
       # https://github.com/marketplace/actions/checkout
       - name: "Checkout sources"
         uses: actions/checkout@v2
-
-      - name: "Set up JDK"
+      - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_VERSION }}
-          distribution: 'adopt'
+          distribution: ${{ env.JDK_DISTRO }}
 
       - name: "Build MSI"
         run: .\gradlew.bat createMsi -x checkstyleMain -x checkstyleTest


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.