### PR TITLE
Fixes ArrayOutOfBounds bug introduced in #1060

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/HDL.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/HDL.java
@@ -153,9 +153,7 @@ public abstract class HDL {
           // The net is connected, we have to find out if the connection
           // is to a bus or to a normal net.
           netName = (solderPoint.getParentNet().getBitWidth() == 1)
-                  // The connection is to a Net
                   ? LineBuffer.formatHdl("{{1}}{{2}}", NET_NAME, myNetlist.getNetId(solderPoint.getParentNet()))
-                  // The connection is to an entry of a bus
                   : LineBuffer.formatHdl("{{1}}{{2}}{{<}}{{3}}{{>}}", BUS_NAME,
                       myNetlist.getNetId(solderPoint.getParentNet()), solderPoint.getParentNetBitIndex());
         }
@@ -165,26 +163,28 @@ public abstract class HDL {
   }
 
   public static String getBusEntryName(NetlistComponent comp, int endIndex, boolean floatingNetTiedToGround, int bitindex, Netlist theNets) {
-    var netName = "";
+    var busName = "";
     if ((endIndex >= 0) && (endIndex < comp.nrOfEnds())) {
       final var thisEnd = comp.getEnd(endIndex);
       final var isOutput = thisEnd.isOutputEnd();
       final var nrOfBits = thisEnd.getNrOfBits();
       if ((nrOfBits > 1) && (bitindex >= 0) && (bitindex < nrOfBits)) {
         if (thisEnd.get((byte) bitindex).getParentNet() == null) {
-          /* The net is not connected */
-          netName = LineBuffer.formatHdl(isOutput ? unconnected(false) : GetZeroVector(1, floatingNetTiedToGround));
+          // The net is not connected
+          busName = LineBuffer.formatHdl(isOutput ? unconnected(false) : GetZeroVector(1, floatingNetTiedToGround));
         } else {
           final var connectedNet = thisEnd.get((byte) bitindex).getParentNet();
           final var connectedNetBitIndex = thisEnd.get((byte) bitindex).getParentNetBitIndex();
-          netName =
+          // The net is connected, we have to find out if the connection
+          // is to a bus or to a normal net.
+          busName =
               !connectedNet.isBus()
                   ? LineBuffer.formatHdl("{{1}}{{2}}", NET_NAME, theNets.getNetId(connectedNet))
                   : LineBuffer.formatHdl("{{1}}{{2}}{{<}}{{3}}{{>}}", BUS_NAME, theNets.getNetId(connectedNet), connectedNetBitIndex);
         }
       }
     }
-    return netName;
+    return busName;
   }
 
   public static String getBusNameContinues(NetlistComponent comp, int endIndex, Netlist theNets) {

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/HDL.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/HDL.java
@@ -123,7 +123,7 @@ public abstract class HDL {
   public static String getConstantVector(long value, int nrOfBits) {
     final var bitString = new StringBuffer();
     var mask = 1L << (nrOfBits - 1);
-    if (HDL.isVHDL()) 
+    if (HDL.isVHDL())
       bitString.append('"');
     else
       bitString.append(LineBuffer.format("{{1}}'b", nrOfBits));
@@ -137,41 +137,35 @@ public abstract class HDL {
     return bitString.toString();
   }
 
-  public static String getNetName(NetlistComponent comp, int endIndex, boolean floatingNetTiedToGround,
-      Netlist myNetlist) {
-    final var floatingValue = floatingNetTiedToGround ? zeroBit() : oneBit();
-    final var contents = (new LineBuffer()).addHdlPairs();
+  public static String getNetName(NetlistComponent comp, int endIndex, boolean floatingNetTiedToGround, Netlist myNetlist) {
+    var netName = "";
     if ((endIndex >= 0) && (endIndex < comp.nrOfEnds())) {
+      final var floatingValue = floatingNetTiedToGround ? zeroBit() : oneBit();
       final var thisEnd = comp.getEnd(endIndex);
       final var isOutput = thisEnd.isOutputEnd();
+
       if (thisEnd.getNrOfBits() == 1) {
         final var solderPoint = thisEnd.get((byte) 0);
         if (solderPoint.getParentNet() == null) {
-          /* The net is not connected */
-          contents.add(isOutput ? unconnected(true) : floatingValue);
+          // The net is not connected
+          netName = LineBuffer.formatHdl(isOutput ? unconnected(true) : floatingValue);
         } else {
-          /*
-           * The net is connected, we have to find out if the
-           * connection is to a bus or to a normal net
-           */
-          if (solderPoint.getParentNet().getBitWidth() == 1) {
-            /* The connection is to a Net */
-            contents.add("{{1}}{{2}}", NET_NAME, myNetlist.getNetId(solderPoint.getParentNet()));
-          } else {
-            /* The connection is to an entry of a bus */
-            contents.add("{{1}}{{2}}{{<}}{{3}}{{>}}", BUS_NAME, myNetlist.getNetId(solderPoint.getParentNet()),
-                solderPoint.getParentNetBitIndex());
-          }
+          // The net is connected, we have to find out if the connection
+          // is to a bus or to a normal net.
+          netName = (solderPoint.getParentNet().getBitWidth() == 1)
+                  // The connection is to a Net
+                  ? LineBuffer.formatHdl("{{1}}{{2}}", NET_NAME, myNetlist.getNetId(solderPoint.getParentNet()))
+                  // The connection is to an entry of a bus
+                  : LineBuffer.formatHdl("{{1}}{{2}}{{<}}{{3}}{{>}}", BUS_NAME,
+                      myNetlist.getNetId(solderPoint.getParentNet()), solderPoint.getParentNetBitIndex());
         }
       }
     }
-    return contents.get(0);
+    return netName;
   }
 
-  public static String getBusEntryName(NetlistComponent comp, int endIndex, boolean floatingNetTiedToGround,
-      int bitindex, Netlist theNets) {
-
-    final var contents = (new LineBuffer()).addHdlPairs();
+  public static String getBusEntryName(NetlistComponent comp, int endIndex, boolean floatingNetTiedToGround, int bitindex, Netlist theNets) {
+    var netName = "";
     if ((endIndex >= 0) && (endIndex < comp.nrOfEnds())) {
       final var thisEnd = comp.getEnd(endIndex);
       final var isOutput = thisEnd.isOutputEnd();
@@ -179,19 +173,18 @@ public abstract class HDL {
       if ((nrOfBits > 1) && (bitindex >= 0) && (bitindex < nrOfBits)) {
         if (thisEnd.get((byte) bitindex).getParentNet() == null) {
           /* The net is not connected */
-          contents.add(isOutput ? unconnected(false) : GetZeroVector(1, floatingNetTiedToGround));
+          netName = LineBuffer.formatHdl(isOutput ? unconnected(false) : GetZeroVector(1, floatingNetTiedToGround));
         } else {
           final var connectedNet = thisEnd.get((byte) bitindex).getParentNet();
           final var connectedNetBitIndex = thisEnd.get((byte) bitindex).getParentNetBitIndex();
-          if (!connectedNet.isBus()) {
-            contents.add("{{1}}{{2}}", NET_NAME, theNets.getNetId(connectedNet));
-          } else {
-            contents.add("{{1}}{{2}}{{<}}{{3}}{{>}}", BUS_NAME, theNets.getNetId(connectedNet), connectedNetBitIndex);
-          }
+          netName =
+              !connectedNet.isBus()
+                  ? LineBuffer.formatHdl("{{1}}{{2}}", NET_NAME, theNets.getNetId(connectedNet))
+                  : LineBuffer.formatHdl("{{1}}{{2}}{{<}}{{3}}{{>}}", BUS_NAME, theNets.getNetId(connectedNet), connectedNetBitIndex);
         }
       }
     }
-    return contents.get(0);
+    return netName;
   }
 
   public static String getBusNameContinues(NetlistComponent comp, int endIndex, Netlist theNets) {
@@ -201,7 +194,7 @@ public abstract class HDL {
     if (nrOfBits == 1) return getNetName(comp, endIndex, true, theNets);
     if (!theNets.isContinuesBus(comp, endIndex)) return null;
     final var connectedNet = connectionInformation.get((byte) 0).getParentNet();
-    return LineBuffer.format("{{1}}{{2}}{{<}}{{3}}{{4}}{{5}}{{>}}", 
+    return LineBuffer.format("{{1}}{{2}}{{<}}{{3}}{{4}}{{5}}{{>}}",
         BUS_NAME,
         theNets.getNetId(connectedNet),
         connectionInformation.get((byte) (connectionInformation.getNrOfBits() - 1)).getParentNetBitIndex(),

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/WithSelectHDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/WithSelectHDLGenerator.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import com.cburch.logisim.util.LineBuffer;
 
 public class WithSelectHDLGenerator {
-  
+
   private final Map<Long, Long> myCases;
   private final String regName;
   private final String sourceSignal;
@@ -23,8 +23,8 @@ public class WithSelectHDLGenerator {
   private final String destinationSignal;
   private final int nrOfDestinationBits;
   private Long defaultValue = 0L;
-  
-  public WithSelectHDLGenerator(String componentName, String sourceSignal, int nrOfSourceBits, 
+
+  public WithSelectHDLGenerator(String componentName, String sourceSignal, int nrOfSourceBits,
       String destinationSignal, int nrOfDestinationBits) {
     myCases = new HashMap<>();
     regName = LineBuffer.format("s_{{1}}_reg", componentName);
@@ -33,7 +33,7 @@ public class WithSelectHDLGenerator {
     this.destinationSignal = destinationSignal;
     this.nrOfDestinationBits = nrOfDestinationBits;
   }
-  
+
   private Long binairyStringToInt(String binairyValue) {
     var result = 0L;
     for (var charIndex = 0; charIndex < binairyValue.length(); charIndex++) {
@@ -44,39 +44,39 @@ public class WithSelectHDLGenerator {
     }
     return result;
   }
-  
+
   public WithSelectHDLGenerator add(Long selectValue, Long assignValue) {
     myCases.put(selectValue, assignValue);
     return this;
   }
-  
+
   public WithSelectHDLGenerator add(Long selectValue, String binairyAssignValue) {
     myCases.put(selectValue, binairyStringToInt(binairyAssignValue));
     return this;
   }
-  
+
   public WithSelectHDLGenerator add(String binairySelectValue, String binairyAssignValue) {
     myCases.put(binairyStringToInt(binairySelectValue), binairyStringToInt(binairyAssignValue));
     return this;
   }
-  
+
   public WithSelectHDLGenerator add(String binairySelectValue, Long assignValue) {
     myCases.put(binairyStringToInt(binairySelectValue), assignValue);
     return this;
   }
-  
+
   public WithSelectHDLGenerator setDefault(Long assignValue) {
     defaultValue = assignValue;
     return this;
   }
-  
+
   public WithSelectHDLGenerator setDefault(String binairyAssignValue) {
     defaultValue = binairyStringToInt(binairyAssignValue);
     return this;
   }
-  
+
   public ArrayList<String> getHdlCode() {
-    final var contents = (new LineBuffer()).withHdlPairs()
+    final var contents = (new LineBuffer()).addHdlPairs()
         .pair("sourceName", sourceSignal)
         .pair("destName", destinationSignal)
         .pair("regName", regName)
@@ -105,11 +105,11 @@ public class WithSelectHDLGenerator {
     } else {
       contents.add("      default : {{regName}} = {{1}};", HDL.getConstantVector(defaultValue, nrOfDestinationBits));
     }
-    if (HDL.isVerilog()) 
+    if (HDL.isVerilog())
       contents.add("""
              endcase
           end
-          
+
           assign {{destName}} = {{regName}};
           """);
     return contents.get();

--- a/src/main/java/com/cburch/logisim/std/io/HexDigitHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/HexDigitHDLGeneratorFactory.java
@@ -25,11 +25,11 @@ public class HexDigitHDLGeneratorFactory extends InlinedHdlGeneratorFactory {
   public ArrayList<String> GetInlinedCode(Netlist nets, Long componentId, NetlistComponent componentInfo, String circuitName) {
     final var startId = componentInfo.getLocalBubbleOutputStartId();
     final var bubbleBusName = HDLGeneratorFactory.LocalOutputBubbleBusname;
-    final var signalName = LineBuffer.format("{{1}}{{<}}{{2}}{{3}}{{4}}{{>}}", bubbleBusName, (startId + 6), HDL.vectorLoopId(), startId); 
+    final var signalName = LineBuffer.format("{{1}}{{<}}{{2}}{{3}}{{4}}{{>}}", bubbleBusName, (startId + 6), HDL.vectorLoopId(), startId);
     final var contents =
-        (new LineBuffer()).withHdlPairs()
+        (new LineBuffer()).addHdlPairs()
             .pair("bubbleBusName", bubbleBusName)
-            .pair("sigName", signalName) 
+            .pair("sigName", signalName)
             .pair("dpName", HDL.getNetName(componentInfo, HexDigit.DP, true, nets));
     contents.add("");
     if (componentInfo.isEndConnected(HexDigit.HEX)) {

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -14,7 +14,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.RandomAccess;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -25,13 +27,15 @@ import java.util.regex.Pattern;
  */
 public class LineBuffer implements RandomAccess {
   public static final int MAX_LINE_LENGTH = 80;
+  // Default indentation string
+  public static final String DEFAULT_INDENT_STR = "   "; // three spaces
   public static final int DEFAULT_INDENT = 1;
-  public static final String DEFAULT_INDENT_STR = "   ";
 
+  // Internal buffer holding separate lines.
   private ArrayList<String> contents = new java.util.ArrayList<String>();
 
-  // Paired placeholders
-  protected Pairs pairs = new Pairs();
+  // Paired placeholders.
+  protected Pairs lineBufferPairs = new Pairs();
 
   /* ********************************************************************************************* */
 
@@ -63,18 +67,19 @@ public class LineBuffer implements RandomAccess {
    */
   public LineBuffer(String line, Pairs pairs) {
     this();
-    addPairs(pairs);
+    lineBufferPairs.addPairs(pairs);
     add(line);
   }
 
   /**
-   * Constructs LineBuffer instance, then adds provided placeholders pairs to be used with the instance.
+   * Constructs LineBuffer instance, then adds provided placeholders pairs to be used with the
+   * instance.
    *
    * @param pairs Placeholder pairs to be used.
    */
   public LineBuffer(Pairs pairs) {
     this();
-    addPairs(pairs);
+    lineBufferPairs.addPairs(pairs);
   }
   /* ********************************************************************************************* */
 
@@ -98,31 +103,36 @@ public class LineBuffer implements RandomAccess {
     return contents.size();
   }
 
-  public LineBuffer addDefaultPairs() {
+  /**
+   * Checks if given entry exists in content buffer
+   * @param line Line to look for.
+   */
+  public boolean contains(String line) {
+    return contents.contains(line);
+  }
+
+  /**
+   * Copies pairs from provided container to internal pair buffer.
+   *
+   * @param pairs Pairs to copy.
+   */
+  public LineBuffer addPairs(Pairs pairs) {
+    lineBufferPairs.addPairs(pairs);
+    return this;
+  }
+
+  /* ********************************************************************************************* */
+
+  /**
+   * Adds pairs that are always available.
+   *
+   * @return Instance of self for easy chaining.
+   */
+  protected LineBuffer addDefaultPairs() {
     return pair("1u", getDefaultIndent())
         .pair("2u", getIndent(2))
         .pair("3u", getIndent(3));
   }
-
-  public LineBuffer withHdlPairs() {
-    return pair("assign", HDL.assignPreamble())
-        .pair("=", HDL.assignOperator())
-        .pair("or", HDL.orOperator())
-        .pair("and", HDL.andOperator())
-        .pair("not", HDL.notOperator())
-        .pair("bracketOpen", HDL.BracketOpen())
-        .pair("bracketClose", HDL.BracketClose())
-        .pair("<", HDL.BracketOpen())
-        .pair(">", HDL.BracketClose())
-        .pair("0b", HDL.zeroBit())
-        .pair("1b", HDL.oneBit());
-  }
-
-  public boolean contains(Object obj) {
-    return contents.contains(obj);
-  }
-
-  /* ********************************************************************************************* */
 
   /**
    * Injects commonly used HDL pairs making them enabled for placeholders.
@@ -144,19 +154,6 @@ public class LineBuffer implements RandomAccess {
   }
 
   /**
-   * Adds paired placeholders to internal map.
-   *
-   * @param pairs
-   *
-   * @return Instance of self for easy chaining.
-   */
-  public LineBuffer addPairs(Pairs pairs) {
-    // FIXME we appedn placeholders, not replace existing map! Also shall detect positionals
-    this.pairs = pairs;
-    return this;
-  }
-
-  /**
    * Clears content buffer and pairs.
    *
    * @return Instance of self for easy chaining.
@@ -173,7 +170,7 @@ public class LineBuffer implements RandomAccess {
    * @return Instance of self for easy chaining.
    */
   public LineBuffer clearPairs() {
-    pairs.clear();
+    lineBufferPairs.clear();
     return this;
   }
 
@@ -193,7 +190,6 @@ public class LineBuffer implements RandomAccess {
    * Adds line to the buffer only if line is not present already, formatting it first.
    *
    * @param fmt Line to add if not present in buffer.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer addUnique(String fmt, Object... args) {
@@ -201,18 +197,16 @@ public class LineBuffer implements RandomAccess {
     // letting add() do that) otherwise `contains` would be looking for non-final version of the
     // string.
     final var line = applyPairs(format(fmt, args));
-    if (!contents.contains(line))
-      add(line, true);
+    if (!contents.contains(line)) add(line, true);
     return this;
   }
 
   /**
-   * Adds line to the buffer only if line is not present already. Please note this implementation
-   * of `addUnique()` does not resolve positional arguments. If you use them, you musts pass final
-   * form of the string (pass thru `format()` if needed) or use other implementations.
+   * Adds line to the buffer only if line is not present already. Please note this implementation of
+   * `addUnique()` does not resolve positional arguments. If you use them, you musts pass final form
+   * of the string (pass thru `format()` if needed) or use other implementations.
    *
    * @param line Line to add if not present in buffer.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer addUnique(String line) {
@@ -220,8 +214,7 @@ public class LineBuffer implements RandomAccess {
     // letting add() do that) otherwise `contains` would be looking for non-final version of the
     // string.
     line = applyPairs(line);
-    if (!contents.contains(line))
-      add(line, true);
+    if (!contents.contains(line)) add(line, true);
     return this;
   }
 
@@ -239,8 +232,8 @@ public class LineBuffer implements RandomAccess {
   }
 
   /**
-   * Adds single line to the content buffer. Will resolve paried placeholders first, if applyMap is `true`,
-   * but won't resolve positionals).
+   * Adds single line to the content buffer. Will resolve paried placeholders first, if applyMap is
+   * `true`, but won't resolve positionals).
    *
    * @param line line to be added
    * @param applyMap `true` if line shall be processed for placeholders (default), `false` if you
@@ -249,7 +242,7 @@ public class LineBuffer implements RandomAccess {
    */
   public LineBuffer add(String line, boolean applyMap) {
     if (applyMap) {
-      line = applyPairs(line, pairs);
+      line = applyPairs(line, lineBufferPairs);
     }
 
     // Ensure no placeholders left unprocessed.
@@ -263,7 +256,6 @@ public class LineBuffer implements RandomAccess {
    * Adds content of provided StringBuilder to the buffer.
    *
    * @param stringBuilder StringBuilder which contents is to be added.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(StringBuilder stringBuilder) {
@@ -276,7 +268,6 @@ public class LineBuffer implements RandomAccess {
    *
    * @param fmt Formatting string as accepted by String.format()
    * @param args Optional values for positional placeholders.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String fmt, Object... args) {
@@ -293,7 +284,6 @@ public class LineBuffer implements RandomAccess {
    *
    * @param fmt Formatting string. Wrap keys in `{{` and `}}`.
    * @param pairs Search-Replace map.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer add(String fmt, Pairs pairs) {
@@ -324,7 +314,6 @@ public class LineBuffer implements RandomAccess {
    * left unhandled.
    *
    * @param lines lines to be added to the buffer.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer addLines(String... lines) {
@@ -337,11 +326,10 @@ public class LineBuffer implements RandomAccess {
    * Formats provided fmt string using global pairs.
    *
    * @param fnt Formatting string.
-   *
    * @return Instance of self for easy chaining.
    */
   public String applyPairs(String fnt) {
-    return applyPairs(fnt, pairs);
+    return applyPairs(fnt, lineBufferPairs);
   }
 
   /**
@@ -349,12 +337,11 @@ public class LineBuffer implements RandomAccess {
    *
    * @param format String to format, with (optional) `{{placeholders}}`.
    * @param pairs Instance of `Pairs` holdinhg replacements for placeholders.
-   *
    * @return Formatted string.
    */
   public static String applyPairs(String format, Pairs pairs) {
     if (pairs != null) {
-      for (final var set : pairs.entrySet()) {
+      for (final var set : pairs.getContainer().entrySet()) {
         final var searchRegExp = String.format("\\{\\{\\s*%s\\s*\\}\\}", set.getKey());
         format = format.replaceAll(searchRegExp, set.getValue().toString());
       }
@@ -367,7 +354,6 @@ public class LineBuffer implements RandomAccess {
    *
    * @param count Number of times line should be added.
    * @param line String to be added to the buffer.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer repeat(int count, String line) {
@@ -390,7 +376,6 @@ public class LineBuffer implements RandomAccess {
    * Appends `count` number for empty lines to the content buffer.
    *
    * @param count number of empty lines to be addeed.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer empty(int count) {
@@ -403,7 +388,6 @@ public class LineBuffer implements RandomAccess {
    * Returns specified line of the content buffer present at index position.
    *
    * @return elment at given position or exception for invalid index.
-   *
    * @throws IndexOutOfBoundsException
    */
   public String get(int index) {
@@ -435,7 +419,6 @@ public class LineBuffer implements RandomAccess {
    * of `DEFAULT_INDENT_STR`.
    *
    * @param howMany Number of spaces to prefix each line with.
-   *
    * @return indented content of the buffer.
    */
   public ArrayList<String> getWithIndent(int howMany) {
@@ -446,9 +429,9 @@ public class LineBuffer implements RandomAccess {
    * Returns content buffer as ArrayList() with every single entry prefixed by `indent` string
    * `howMany` times.
    *
-   * @param howMany Number of times `indent` string should be repeated to form the final indent string.
+   * @param howMany Number of times `indent` string should be repeated to form the final indent
+   *     string.
    * @param indent Indent string.
-   *
    * @return indented content of the buffer.
    */
   public ArrayList<String> getWithIndent(int howMany, String indent) {
@@ -459,7 +442,6 @@ public class LineBuffer implements RandomAccess {
    * Returns content buffer as ArrayList() with every single entry prefixed by `indent` string.
    *
    * @param indent Indent string.
-   *
    * @return indented content of the buffer.
    */
   public ArrayList<String> getWithIndent(String indent) {
@@ -471,16 +453,35 @@ public class LineBuffer implements RandomAccess {
     return result;
   }
 
+
+  public Pairs getPairCopy() {
+    final var clone = (Pairs) lineBufferPairs.clone();
+    return clone;
+  }
+
   /* ********************************************************************************************* */
 
+  /**
+   * Returns default unit of indentation string.
+   */
   public static String getDefaultIndent() {
     return getIndent(DEFAULT_INDENT, DEFAULT_INDENT_STR);
   }
 
+  /**
+   * Returns 2 units of default indentation string.
+   * @param indentUnits Number of indentation units to return.
+   */
   public static String getIndent(int indentUnits) {
     return getIndent(indentUnits, DEFAULT_INDENT_STR);
   }
 
+  /**
+   * Returns 3 units of default indentation string.
+   *
+   * @param indentUnits Number of indentation units to return.
+   * @param indentString Indentation string.
+   */
   public static String getIndent(int indentUnits, String indentString) {
     return indentString.repeat(indentUnits);
   }
@@ -491,7 +492,6 @@ public class LineBuffer implements RandomAccess {
    * Builds and adds remark block to the contents buffer.
    *
    * @param remarkText Remark text.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer addRemarkBlock(String remarkText) {
@@ -503,7 +503,6 @@ public class LineBuffer implements RandomAccess {
    *
    * @param remarkText Remark text.
    * @param nrOfIndentSpaces Number of extra indentation spaces.
-   *
    * @return Instance of self for easy chaining.
    */
   public LineBuffer addRemarkBlock(String remarkText, Integer nrOfIndentSpaces) {
@@ -516,7 +515,6 @@ public class LineBuffer implements RandomAccess {
    *
    * @param remarkText Remark text.
    * @param nrOfIndentSpaces Number of extra indentation spaces.
-   *
    * @return Constructed lines of remark block.
    */
   protected ArrayList<String> buildRemarkBlock(String remarkText, Integer nrOfIndentSpaces) {
@@ -585,11 +583,22 @@ public class LineBuffer implements RandomAccess {
    *
    * @param fmt Formattting string.
    * @param args Positional placeholders.
-   *
    * @return Formatted string.
    */
   public static String format(String fmt, Object... args) {
     return applyPairs(fmt, Pairs.fromArgs(args));
+  }
+
+  /**
+   * Formats provided fmt string using given arguments for positional placeholders but also includes
+   * HDL placeholders.
+   *
+   * @param fmt Formattting string.
+   * @param args Positional placeholders.
+   * @return Formatted string.
+   */
+  public static String formatHdl(String fmt, Object... args) {
+    return getHdlBuffer().add(fmt, args).get(0);
   }
 
   /* ********************************************************************************************* */
@@ -599,7 +608,6 @@ public class LineBuffer implements RandomAccess {
    *
    * @param fmt Formatting string.
    * @param args Positional arguments.
-   *
    * @return Instance of self for easy chaining.
    */
   private LineBuffer warn(String fmt, Object... args) {
@@ -637,11 +645,10 @@ public class LineBuffer implements RandomAccess {
   // for paired check mapping vs global map and one-time pairs
 
   /**
-   * Parses formatting string looking for positional placeholders and then
-   * nitializes internal validator data.
+   * Parses formatting string looking for positional placeholders and then nitializes internal
+   * validator data.
    *
    * @param fmt Formatting string to analize.
-   *
    * @return Instance of self for easy chaining.
    */
   protected LineBuffer initValidator(String fmt) {
@@ -673,24 +680,32 @@ public class LineBuffer implements RandomAccess {
     if (positionalPlaceholders.isEmpty()) {
       // Warn if we have no positional placeholders used, but still receive positional arguments.
       if (args.length > 0)
-        warn("#E004: Useless positional arguments. Expected nothing, but received {{2}} for '{{1}}'.", fmt, posArgsCnt);
+        warn(
+            "#E004: Useless positional arguments. Expected nothing, but received {{2}} for '{{1}}'.",
+            fmt, posArgsCnt);
     } else {
       if (posArgsCnt < args.length)
         // We had too many positional args given compared to positional placeholders. But that
         // difference can be OK, so just warn.
-        abort("#E001: Too many positional arguments, Expected {{2}}, but received {{3}} for '{{1}}'.",
-                fmt, posArgsCnt, args.length);
+        abort(
+            "#E001: Too many positional arguments, Expected {{2}}, but received {{3}} for '{{1}}'.",
+            fmt, posArgsCnt, args.length);
 
       if (posArgsCnt > args.length)
-        // Too little arguments provided vs. awaiting placeholders. That's life threatening condition.
-        abort("#E002: Insufficient positional arguments. Expected {{2}}, but received {{3}} for '{{1}}'.", fmt, posArgsCnt, args.length);
+        // Too little arguments provided vs. awaiting placeholders. That's life threatening
+        // condition.
+        abort(
+            "#E002: Insufficient positional arguments. Expected {{2}}, but received {{3}} for '{{1}}'.",
+            fmt, posArgsCnt, args.length);
 
       // count matches, let's see if contents too.
       for (final var posKey : positionalPlaceholders) {
         if (Integer.valueOf(posKey) > posArgsCnt) {
           // Reference to non-existing position found. Warn about all detected issues. We fail
           // later.
-          warn("#E003: Invalid positional argument. '{{1}}' used, but max value is {{2}} for '{{3}}'.", posKey, posArgsCnt, fmt);
+          warn(
+              "#E003: Invalid positional argument. '{{1}}' used, but max value is {{2}} for '{{3}}'.",
+              posKey, posArgsCnt, fmt);
         }
       }
     }
@@ -714,12 +729,14 @@ public class LineBuffer implements RandomAccess {
       validateLineWithPositionalArgs(fmt, argPairs);
     } else {
       if (positionalPlaceholders.size() > 0)
-        abort("#E004: No positional arguments, but expected {{2}} for '{{1}}'.", fmt, positionalPlaceholders.size());
+        abort(
+            "#E004: No positional arguments, but expected {{2}} for '{{1}}'.",
+            fmt, positionalPlaceholders.size());
     }
 
     // Check if paired placeholders used in formatting string are known at this point.
     for (final var key : pairedPlaceholders) {
-      if (!(pairs.containsKey(key) || (argPairs != null && argPairs.containsKey(key)))) {
+      if (!(lineBufferPairs.getContainer().containsKey(key) || (argPairs != null && argPairs.getContainer().containsKey(key)))) {
         abort("#E006: No mapping for '{{1}}' placeholder in '{{2}}'.", key, fmt);
       }
     }
@@ -731,7 +748,6 @@ public class LineBuffer implements RandomAccess {
    * Extract names of valid placeholders found in provided string.
    *
    * @param fmt String to analyze.
-   *
    * @return Returns list of found placeholders. If no placeholder is found, returnes empty list.
    */
   public ArrayList<String> extractPlaceholders(String fmt) {
@@ -780,21 +796,49 @@ public class LineBuffer implements RandomAccess {
 
   /* ********************************************************************************************* */
 
+  /**
+   * Create new pair and adds it to internal pair contaier.
+   *
+   * @param key Pair's key.
+   * @param value Pair's value.
+   *
+   * @return Instance of self for easy chaining.
+   */
   public LineBuffer pair(String key, Object value) {
-    pairs.pair(key, value);
+    lineBufferPairs.pair(key, value);
     return this;
   }
 
   /* ********************************************************************************************* */
 
-  public static class Pairs extends HashMap<String, Object> {
+  /**
+   * Container holding all the key-value pairs used by LineBuffer.
+   */
+  public static class Pairs implements Cloneable {
+    /**
+     * Internal pair container.
+     */
+    private HashMap<String, Object> pairContainer = new HashMap<String, Object>();
+
+    /**
+     * Default constructor.
+     */
     public Pairs() {
-      // empty
+      // default constructor does nothing special.
     }
 
     /**
-     * Constructs Pairs map from positional arguments auto-assigning numerical
-     * placeholders `{{x}}` where `x` is integer starting from `1`.
+     * Creates pairs container and adds new pair to it.
+     * @param key Pair's key.
+     * @param value Pair's value.
+     */
+    public Pairs(String key, Object value) {
+      pair(key, value);
+    }
+
+    /**
+     * Constructs Pairs map from positional arguments auto-assigning numerical placeholders `{{x}}`
+     * where `x` is integer starting from `1`.
      *
      * @param args Arguments to use to build the map.
      */
@@ -802,22 +846,107 @@ public class LineBuffer implements RandomAccess {
       final var map = new Pairs();
       var idx = 1;
       for (final var arg : args) {
-        map.pair(String.valueOf(idx++), "" + arg);
+        map.addPositionalPair(String.valueOf(idx++), arg.toString());
       }
       return map;
     }
 
-
-    public Pairs(String key, Object value) {
-      pair(key, value);
+    @Override
+    public String toString() {
+      return pairContainer.toString();
     }
 
     public Pairs pair(String key, Object value) {
-      put(key, value);
+      return addNonPositionalPair(key, value);
+    }
+
+    /**
+     * Adds new, non-positional pair to the container.
+     *
+     * @param key Pair's key.
+     * @param value Pair's value.
+     *
+     * @return Returns instance of container for easy chaining.
+     *
+     * @throws RuntimeException for invalid keys.
+     */
+    public Pairs addNonPositionalPair(String key, Object value) {
+      // Numeric only keys are not allowed because these are reserved for positional placeholders.
+      if (key.matches("^\\d+$")) {
+        throw new RuntimeException(
+                format("Invalid pair key '{{1}}'. You cannot add positional arguments as pairs.", key));
+      }
+      pairContainer.put(key, value);
       return this;
     }
-  }
 
-  /* ********************************************************************************************* */
+    /**
+     * Adds pairs form another container.
+     *
+     * @param pairs Pair container to copy pairs from.
+     *
+     * @return Returns instance of container for easy chaining.
+     */
+    public Pairs addPairs(Pairs pairs) {
+      for (final var pair : pairs.entrySet()) {
+        addNonPositionalPair(pair.getKey(), pair.getValue());
+      }
+      return this;
+    }
+
+    /**
+     * Adds given pair, ensuring it's for postional placeholders only.
+     *
+     * @param key Pair's key.
+     * @param value Pair's value.
+     *
+     * @return Returns instance of container for easy chaining.
+     */
+    public Pairs addPositionalPair(String key, Object value) {
+      if (!key.matches("^\\d+$")) {
+        throw new RuntimeException(
+            format("Invalid pair key '{{1}}'. Positional arguments' keys must be numeric.", key));
+      }
+      pairContainer.put(key, value);
+      return this;
+    }
+
+    /**
+     * Clears pair container.
+     *
+     * @return Returns instance of container for easy chaining.
+     */
+    public Pairs clear() {
+      pairContainer.clear();
+      return this;
+    }
+
+    /**
+     * Returns instance of internal HashMap holding all the pairs.
+     */
+    protected HashMap<String, Object> getContainer() {
+      return pairContainer;
+    }
+
+    /**
+     * Returns entrySet for internal pair container for easier iteration over it.
+     */
+    public Set<Map.Entry<String, Object>> entrySet() {
+      return pairContainer.entrySet();
+    }
+
+    /**
+     * Clones current instance of Pairs.
+     */
+    @Override
+    protected Pairs clone() {
+      final var clone = new Pairs();
+      for (final var pair : pairContainer.entrySet()) {
+        clone.pair(pair.getKey(), pair.getValue());
+      }
+      return clone;
+    }
+
+  } // end of Pairs
 
 } // end of LineBuffer

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -104,7 +104,8 @@ public class LineBuffer implements RandomAccess {
   }
 
   /**
-   * Checks if given entry exists in content buffer
+   * Checks if given entry exists in content buffer.
+   *
    * @param line Line to look for.
    */
   public boolean contains(String line) {
@@ -470,6 +471,7 @@ public class LineBuffer implements RandomAccess {
 
   /**
    * Returns 2 units of default indentation string.
+   *
    * @param indentUnits Number of indentation units to return.
    */
   public static String getIndent(int indentUnits) {
@@ -829,6 +831,7 @@ public class LineBuffer implements RandomAccess {
 
     /**
      * Creates pairs container and adds new pair to it.
+     *
      * @param key Pair's key.
      * @param value Pair's value.
      */


### PR DESCRIPTION
Fixes ArrayOutOfBounds bug introduced in #1061 as this is what gets thrown when you try to `get(x)` from empty LineBuffer.

DEPENDS_ON #1080

* #1061
* #1080