### PR TITLE
Fixes Linebuffer.applyPairs() handling of special chars in replacement string

### DIFF
--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.RandomAccess;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -342,7 +343,11 @@ public class LineBuffer implements RandomAccess {
     if (pairs != null) {
       for (final var set : pairs.getContainer().entrySet()) {
         final var searchRegExp = String.format("\\{\\{\\s*%s\\s*\\}\\}", set.getKey());
-        format = format.replaceAll(searchRegExp, set.getValue().toString());
+        // Both backslashes (\) and dollar signs ($) in the replacement string may cause the
+        // results to be different than if it were being treated as a literal replacement string
+        // so as we do not need to support i.e. group references etc, we just need to escape it.
+        final var replacement = Matcher.quoteReplacement(set.getValue().toString());
+        format = format.replaceAll(searchRegExp, replacement);
       }
     }
     return format;

--- a/src/test/java/com/cburch/logisim/LineBufferTest.java
+++ b/src/test/java/com/cburch/logisim/LineBufferTest.java
@@ -209,6 +209,20 @@ public class LineBufferTest extends TestBase {
     assertEquals(exp, buffer.get(0));
   }
 
+  /**
+   * Ensures that we properly deal with special chars in replacement string as backslashes (\)
+   * and dollar signs ($) in the replacement string may cause the results to be different
+   * than if it were being treated as a literal replacement string.
+   */
+  @Test
+  public void testFormatWithSpecialCharsInReplacementString() {
+    final var tests = Map.of("$", "\\");
+    for (final var test : tests.entrySet()) {
+      final var result = LineBuffer.format("{{1}}", test.getValue());
+      assertEquals(test.getValue(), result);
+    }
+  }
+
   /* ********************************************************************************************* */
 
   /**


### PR DESCRIPTION
Fixed handling of special chars in replacement string in LineBuffer.applyPairs()

* #1097 