### PR TITLE
LineBuffer API change (broken)

### DIFF
--- a/src/main/java/com/cburch/logisim/Main.java
+++ b/src/main/java/com/cburch/logisim/Main.java
@@ -67,7 +67,6 @@ public class Main {
     }
   }
 
-  // @deprecated use BuildInfo instead
   public static final String APP_NAME = BuildInfo.name;
   // @deprecated use BuildInfo instead
   public static final LogisimVersion VERSION = BuildInfo.version;

--- a/src/main/java/com/cburch/logisim/fpga/download/AlteraDownload.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/AlteraDownload.java
@@ -183,7 +183,7 @@ public class AlteraDownload implements VendorDownload {
       return scriptFile.exists();
     }
     final var fileType = HDLType.equals(HDLGeneratorFactory.VHDL) ? "VHDL_FILE" : "VERILOG_FILE";
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     contents
         .pair("topLevelName", ToplevelHDLGeneratorFactory.FPGA_TOP_LEVEL_NAME)
         .pair("fileType", fileType)
@@ -193,10 +193,10 @@ public class AlteraDownload implements VendorDownload {
         .add("""
             # Load Quartus II Tcl Project package
             package require ::quartus::project
-            
+
             set need_to_close_project 0
             set make_assignments 1
-            
+
             # Check that the right project is open
             if {[is_project_open]} {
                 if {[string compare $quartus(project) "{{topLevelName}}"]} {
@@ -237,7 +237,7 @@ public class AlteraDownload implements VendorDownload {
         .add("""
                 # Commit assignments
                 export_assignments
-            
+
                 # Close project
                 if {$need_to_close_project} {
                     project_close
@@ -248,7 +248,7 @@ public class AlteraDownload implements VendorDownload {
   }
 
   private ArrayList<String> getPinLocStrings() {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
 
     for (final var key : mapInfo.getMappableResources().keySet()) {
       final var map = mapInfo.getMappableResources().get(key);
@@ -281,7 +281,7 @@ public class AlteraDownload implements VendorDownload {
       default -> throw new IllegalStateException("Unexpected value: " + currentBehavior);
     };
 
-    return (new LineBuffer())
+    return LineBuffer.getBuffer()
         .pair("assignName", "set_global_assignment -name")
         .add("{{assignName}} FAMILY \"{{1}}\"", currentBoard.fpga.getTechnology())
         .add("{{assignName}} DEVICE {{1}}", currentBoard.fpga.getPart())
@@ -365,7 +365,7 @@ public class AlteraDownload implements VendorDownload {
       Reporter.Report.AddError(S.get("AlteraFlashError", jicFile));
       return false;
     }
-    final var command = new LineBuffer();
+    final var command = LineBuffer.getBuffer();
     command
         .add(alteraVendor.getBinaryPath(1))
         .add("-c")
@@ -409,7 +409,7 @@ public class AlteraDownload implements VendorDownload {
       Reporter.Report.AddError(S.get("AlteraProgSofError", ProgrammerSofFile));
       return false;
     }
-    final var command = new LineBuffer();
+    final var command = LineBuffer.getBuffer();
     command.add(alteraVendor.getBinaryPath(1))
             .add("-c")
             .add(cablename)

--- a/src/main/java/com/cburch/logisim/fpga/download/VivadoDownload.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/VivadoDownload.java
@@ -226,7 +226,7 @@ public class VivadoDownload implements VendorDownload {
   }
 
   private ArrayList<String> getPinLocStrings() {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     for (final var key : MapInfo.getMappableResources().keySet()) {
       final var map = MapInfo.getMappableResources().get(key);
       for (var i = 0; i < map.getNrOfPins(); i++) {

--- a/src/main/java/com/cburch/logisim/fpga/download/XilinxDownload.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/XilinxDownload.java
@@ -195,7 +195,7 @@ public class XilinxDownload implements VendorDownload {
           && UcfFile.exists()
           && DownloadFile.exists();
     }
-    final var contents = (new LineBuffer())
+    final var contents = LineBuffer.getBuffer()
             .pair("JTAGPos", JTAGPos)
             .pair("fileExt", bitfileExt)
             .pair("fileBaseName", ToplevelHDLGeneratorFactory.FPGA_TOP_LEVEL_NAME)
@@ -324,7 +324,7 @@ public class XilinxDownload implements VendorDownload {
   }
 
   private ProcessBuilder Stage0Synth() {
-    final var command = new LineBuffer();
+    final var command = LineBuffer.getBuffer();
     command
         .add(xilinxVendor.getBinaryPath(0))
         .add("-ifn")
@@ -337,7 +337,7 @@ public class XilinxDownload implements VendorDownload {
   }
 
   private ProcessBuilder Stage1Constraints() {
-    final var command = new LineBuffer();
+    final var command = LineBuffer.getBuffer();
     command
         .add(xilinxVendor.getBinaryPath(1))
         .add("-intstyle")
@@ -353,7 +353,7 @@ public class XilinxDownload implements VendorDownload {
 
   private ProcessBuilder Stage2Map() {
     if (IsCPLD) return null; /* mapping is skipped for the CPLD target*/
-    final var command = new LineBuffer();
+    final var command = LineBuffer.getBuffer();
     command
         .add(xilinxVendor.getBinaryPath(2))
         .add("-intstyle")
@@ -367,7 +367,7 @@ public class XilinxDownload implements VendorDownload {
   }
 
   private ProcessBuilder Stage3PAR() {
-    final var command = new LineBuffer();
+    final var command = LineBuffer.getBuffer();
     if (!IsCPLD) {
       command
           .add(xilinxVendor.getBinaryPath(3))
@@ -407,7 +407,7 @@ public class XilinxDownload implements VendorDownload {
   }
 
   private ProcessBuilder Stage4Bit() {
-    var command = new LineBuffer();
+    var command = LineBuffer.getBuffer();
     if (!IsCPLD) {
       command.add(xilinxVendor.getBinaryPath(4)).add("-w");
       if (boardInfo.fpga.getUnusedPinsBehavior() == PullBehaviors.PULL_UP) command.add("-g").add("UnusedPin:PULLUP");

--- a/src/main/java/com/cburch/logisim/fpga/file/FileWriter.java
+++ b/src/main/java/com/cburch/logisim/fpga/file/FileWriter.java
@@ -25,24 +25,24 @@ public class FileWriter {
   public static final String ARCHITECTURE_EXTENSION = "_behavior";
 
   public static ArrayList<String> getExtendedLibrary() {
-    final var lines = new LineBuffer();
+    final var lines = LineBuffer.getBuffer();
     lines.add("""
-           
+
                LIBRARY ieee;
                USE ieee.std_logic_1164.all;
                USE ieee.numeric_std.all;
-               
+
                """);
     return lines.get();
   }
 
   public static ArrayList<String> getStandardLibrary() {
-    final var lines = new LineBuffer();
+    final var lines = LineBuffer.getBuffer();
     lines.add("""
-      
+
               LIBRARY ieee;
               USE ieee.std_logic_1164.all;
-              
+
               """);
     return lines.get();
   }
@@ -51,7 +51,7 @@ public class FileWriter {
       String targetDirectory,
       String componentName,
       boolean isEntity) {
-    final var fileName = new StringBuffer(); 
+    final var fileName = new StringBuffer();
     try {
       final var outDir = new File(targetDirectory);
       if (!outDir.exists()) {

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHDLGeneratorFactory.java
@@ -35,7 +35,7 @@ public class AbstractHDLGeneratorFactory implements HDLGeneratorFactory {
   private final String subDirectoryName;
 
   public AbstractHDLGeneratorFactory() {
-    final var className = getClass().toString().replace('.', ':').replace(' ', ':'); 
+    final var className = getClass().toString().replace('.', ':').replace(' ', ':');
     final var parts = className.split(":");
     if (parts.length < 2) throw new ExceptionInInitializerError("Cannot read class path!");
     subDirectoryName = parts[parts.length - 2];
@@ -56,7 +56,7 @@ public class AbstractHDLGeneratorFactory implements HDLGeneratorFactory {
 
   @Override
   public ArrayList<String> getArchitecture(Netlist theNetlist, AttributeSet attrs, String componentName) {
-    final var Contents = new LineBuffer();
+    final var Contents = LineBuffer.getBuffer();
     final var inputs = GetInputList(theNetlist, attrs);
     final var inOuts = GetInOutList(theNetlist, attrs);
     final var outputs = GetOutputList(theNetlist, attrs);
@@ -361,7 +361,7 @@ public class AbstractHDLGeneratorFactory implements HDLGeneratorFactory {
 
   @Override
   public ArrayList<String> getComponentInstantiation(Netlist theNetlist, AttributeSet attrs, String componentName) {
-    var Contents = new LineBuffer();
+    var Contents = LineBuffer.getBuffer();
     if (HDL.isVHDL()) Contents.add(GetVHDLBlackBox(theNetlist, attrs, componentName, false));
     return Contents.get();
   }
@@ -373,11 +373,11 @@ public class AbstractHDLGeneratorFactory implements HDLGeneratorFactory {
       Object componentInfo,
       String name) {
     final var Contents = new ArrayList<String>();
-    final var ParameterMap = (componentInfo == null) | componentInfo instanceof NetlistComponent 
+    final var ParameterMap = (componentInfo == null) | componentInfo instanceof NetlistComponent
         ? GetParameterMap(nets, (NetlistComponent) componentInfo) : null;
     final var PortMap = GetPortMap(nets, componentInfo);
-    final var componentHDLName = componentInfo instanceof NetlistComponent 
-        ? ((NetlistComponent) componentInfo).getComponent().getFactory().getHDLName(((NetlistComponent) componentInfo).getComponent().getAttributeSet()) : 
+    final var componentHDLName = componentInfo instanceof NetlistComponent
+        ? ((NetlistComponent) componentInfo).getComponent().getFactory().getHDLName(((NetlistComponent) componentInfo).getComponent().getAttributeSet()) :
           name;
     final var CompName = (name != null && !name.isEmpty()) ? name : componentHDLName;
     final var ThisInstanceIdentifier = getInstanceIdentifier(componentInfo, componentId);
@@ -513,7 +513,7 @@ public class AbstractHDLGeneratorFactory implements HDLGeneratorFactory {
       Netlist theNetlist,
       AttributeSet attrs,
       String componentName) {
-    var Contents = new LineBuffer();
+    var Contents = LineBuffer.getBuffer();
     if (HDL.isVHDL()) {
       Contents.add(FileWriter.getGenerateRemark(componentName, theNetlist.projName()))
           .add(FileWriter.getExtendedLibrary())

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/ToplevelHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/ToplevelHDLGeneratorFactory.java
@@ -158,7 +158,7 @@ public class ToplevelHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist theNetlist, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     final var nrOfClockTrees = theNetlist.numberOfClockTrees();
     /* First we process all components */
     contents.addRemarkBlock("Here all signal adaptations are performed");

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/WithSelectHDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/WithSelectHDLGenerator.java
@@ -76,7 +76,7 @@ public class WithSelectHDLGenerator {
   }
 
   public ArrayList<String> getHdlCode() {
-    final var contents = (new LineBuffer()).addHdlPairs()
+    final var contents = LineBuffer.getBuffer().addHdlPairs()
         .pair("sourceName", sourceSignal)
         .pair("destName", destinationSignal)
         .pair("regName", regName)

--- a/src/main/java/com/cburch/logisim/std/arith/AdderHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/AdderHDLGeneratorFactory.java
@@ -39,7 +39,7 @@ public class AdderHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    final var Contents = new LineBuffer();
+    final var Contents = LineBuffer.getBuffer();
     int nrOfBits = attrs.getValue(StdAttr.WIDTH).getWidth();
     if (HDL.isVHDL()) {
       Contents.add("""
@@ -48,7 +48,7 @@ public class AdderHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
           s_sum_result     <= std_logic_vector(unsigned(s_extended_dataA) +
                                                unsigned(s_extended_dataB) +
                                                (""&CarryIn));
-          
+
           """);
       if (nrOfBits == 1) {
         Contents.add("Result <= s_sum_result(0);");

--- a/src/main/java/com/cburch/logisim/std/arith/ComparatorHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/ComparatorHDLGeneratorFactory.java
@@ -38,7 +38,7 @@ public class ComparatorHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    final var Contents = new LineBuffer();
+    final var Contents = LineBuffer.getBuffer();
     Contents.pair("twosComplement", TwosComplementStr);
 
     final var nrOfBits = attrs.getValue(StdAttr.WIDTH).getWidth();
@@ -66,7 +66,7 @@ public class ComparatorHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
         Contents.add("""
             assign A_EQ_B = (DataA == DataB);
             assign A_LT_B = (DataA < DataB);
-            assign A_GT_B = (DataA > DataB); 
+            assign A_GT_B = (DataA > DataB);
             """);
       } else {
         Contents.add("""
@@ -74,7 +74,7 @@ public class ComparatorHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
             assign s_unsigned_less = (DataA < DataB);
             assign s_signed_greater = ($signed(DataA) > $signed(DataB));
             assign s_unsigned_greater = (DataA > DataB);
-            
+
             assign A_EQ_B = (DataA == DataB);
             assign A_GT_B = ({{twosComplement}}==1) ? s_signed_greater : s_unsigned_greater;
             assign A_LT_B = ({{twosComplement}}==1) ? s_signed_less : s_unsigned_less;

--- a/src/main/java/com/cburch/logisim/std/arith/DividerHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/DividerHDLGeneratorFactory.java
@@ -39,7 +39,7 @@ public class DividerHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    final var Contents = (new LineBuffer())
+    final var Contents = LineBuffer.getBuffer()
             .pair("nrOfBits", NrOfBitsStr)
             .pair("unsigned", UnsignedStr)
             .pair("calcBits", CalcBitsStr);

--- a/src/main/java/com/cburch/logisim/std/arith/MultiplierHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/MultiplierHDLGeneratorFactory.java
@@ -40,7 +40,7 @@ public class MultiplierHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var Contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("nrOfBits", NrOfBitsStr)
             .pair("unsigned", UnsignedStr)
             .pair("calcBits", CalcBitsStr);
@@ -83,7 +83,7 @@ public class MultiplierHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                    s_interm_result = $signed(s_mult_signed) + $signed(s_Cin);
                  end
           end
-          
+
           assign Mult_hi = s_interm_result[{{calcBits}}-1:{{nrOfBits}}];
           assign Mult_lo = s_interm_result[{{nrOfBits}}-1:0];
           """);

--- a/src/main/java/com/cburch/logisim/std/arith/NegatorHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/NegatorHDLGeneratorFactory.java
@@ -35,7 +35,7 @@ public class NegatorHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    final var Contents = new LineBuffer();
+    final var Contents = LineBuffer.getBuffer();
     if (HDL.isVHDL()) {
       int nrOfBits = attrs.getValue(StdAttr.WIDTH).getWidth();
       Contents.add(

--- a/src/main/java/com/cburch/logisim/std/arith/ShifterHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/ShifterHDLGeneratorFactory.java
@@ -35,7 +35,7 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    final var contents = (new LineBuffer())
+    final var contents = LineBuffer.getBuffer()
             .pair("shiftMode", shiftModeStr);
     final var nrOfBits = attrs.getValue(StdAttr.WIDTH).getWidth();
     if (HDL.isVHDL()) {
@@ -80,8 +80,8 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
              ** 3 : Arithmetic Shift Right                                            **
              ** 4 : Rotate Right                                                      **
              ***************************************************************************/
-             
-             
+
+
             """);
 
       if (nrOfBits == 1) {
@@ -98,9 +98,9 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
             /***************************************************************************
              ** Here we assign the result                                             **
              ***************************************************************************/
-             
+
             assign Result = s_stage_{{1}}_result;
-            
+
             """, getNrofShiftBits(attrs) - 1);
       }
     }
@@ -153,7 +153,7 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   }
 
   private ArrayList<String> GetStageFunctionalityVerilog(int stageNumber, int nrOfBits) {
-    final var contents = (new LineBuffer())
+    final var contents = LineBuffer.getBuffer()
             .pair("shiftMode", shiftModeStr)
             .pair("stageNumber", stageNumber)
             .pair("nrOfBits1", nrOfBits - 1)
@@ -163,19 +163,19 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
           "/***************************************************************************
           ** Here stage {{stageNumber}} of the binary shift tree is defined
           ***************************************************************************/
-          
+
           """);
     if (stageNumber == 0) {
       contents.add("""
           assign s_stage_0_shiftin = (({{shiftMode}} == 1) || ({{shiftMode}} == 3))
                ? DataA[{{shiftMode}}] : ({{nrOfBits1}} == 4) ? DataA[0] : 0;
-          
+
           assign s_stage_0_result  = (ShiftAmount == 0)
                ? DataA
                : (({{shiftMode}} == 0) || ({{shiftMode}} == 1))
                   ? {DataA[{{nrOfBits2}}:0],s_stage_0_shiftin}
                   : {s_stage_0_shiftin,DataA[{{nrOfBits1}}:1]};
-          
+
           """);
     } else {
       final var pairs =
@@ -198,7 +198,7 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                                      (({{shiftMode}} == 0)||({{shiftMode}} == 1)) ?
                                      {s_stage_{{stageNumber1}}_result[{{bitsShiftDiff1}}:0],s_stage_{{stageNumber}}_shiftin} :
                                      {s_stage_{{stageNumber}}_shiftin,s_stage_{{stageNumber1}}_result[{{nrOfBits1}}:{{nrOfBitsToShift}}]};
-          
+
           """, pairs);
     }
     return contents.getWithIndent();
@@ -207,7 +207,7 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   private ArrayList<String> GetStageFunctionalityVHDL(int stageNumber, int nrOfBits) {
     final var nrOfBitsToShift = (1 << stageNumber);
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
           .pair("shiftMode", shiftModeStr)
           .pair("stageNumber", stageNumber)
           .pair("stageNumber1", stageNumber - 1)
@@ -222,7 +222,7 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
         -----------------------------------------------------------------------------
         --- Here stage {{stageNumber}} of the binary shift tree is defined
         -----------------------------------------------------------------------------
-          
+
         """);
 
     if (stageNumber == 0) {
@@ -230,7 +230,7 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
           .add("""
             s_stage_0_shiftin <= DataA({{nrOfBits1}}) WHEN {{shiftMode}} = 1 OR {{shiftMode}} = 3 ELSE
                                  DataA(0) WHEN {{shiftMode}} = 4 ELSE '0';
- 
+
             s_stage_0_result  <= DataA
             """)
           .add(
@@ -249,7 +249,7 @@ public class ShifterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                                  (OTHERS => s_stage_{{stageNumber1}}_result({{stageNumber1}})) WHEN {{shiftMode}} = 3 ELSE
                                  s_stage_{{stageNumber1}}_result( {{nrOfBitsToShift1}} DOWNTO 0 ) WHEN {{shiftMode}} = 4 ELSE
                                  (OTHERS => '0');
-            
+
             s_stage_{{stageNumber}}_result  <= s_stage_{{stageNumber1}}_result
                                     WHEN ShiftAmount({{stageNumber}}) = '0' ELSE
                                  s_stage_{{stageNumber1}}_result( {{bitsShiftDiff1}} DOWNTO 0 )&s_stage_{{stageNumber}}_shiftin

--- a/src/main/java/com/cburch/logisim/std/arith/SubtractorHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/SubtractorHDLGeneratorFactory.java
@@ -39,7 +39,7 @@ public class SubtractorHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    final var Contents = new LineBuffer();
+    final var Contents = LineBuffer.getBuffer();
     int nrOfBits = attrs.getValue(StdAttr.WIDTH).getWidth();
     if (HDL.isVHDL()) {
       Contents.add("""
@@ -50,7 +50,7 @@ public class SubtractorHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
           s_sum_result     <= std_logic_vector(unsigned(s_extended_dataA)+
                               unsigned(s_extended_dataB)+
                               (""&s_carry));
-          
+
           """);
       Contents.add(
           (nrOfBits == 1)

--- a/src/main/java/com/cburch/logisim/std/bfh/bcd2sevensegHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/bfh/bcd2sevensegHDLGeneratorFactory.java
@@ -50,7 +50,7 @@ public class bcd2sevensegHDLGeneratorFactory extends AbstractHDLGeneratorFactory
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    return (new LineBuffer())
+    return LineBuffer.getBuffer()
         .add("""
             Segment_a <= s_output_value(0);
             Segment_b <= s_output_value(1);
@@ -59,7 +59,7 @@ public class bcd2sevensegHDLGeneratorFactory extends AbstractHDLGeneratorFactory
             Segment_e <= s_output_value(4);
             Segment_f <= s_output_value(5);
             Segment_g <= s_output_value(6);
-            
+
             MakeSegs : PROCESS( BCDin )
             BEGIN
                CASE (BCDin) IS

--- a/src/main/java/com/cburch/logisim/std/bfh/bin2bcdHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/bfh/bin2bcdHDLGeneratorFactory.java
@@ -116,7 +116,7 @@ public class bin2bcdHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist netlist, AttributeSet attrs) {
-    final var contents = (new LineBuffer())
+    final var contents = LineBuffer.getBuffer()
             .pair("nrOfBits", NR_OF_BITS_STR);
     final var nrOfBits = attrs.getValue(bin2bcd.ATTR_BinBits);
     final var nrOfPorts = (int) (Math.log10(1 << nrOfBits.getWidth()) + 1.0);
@@ -132,7 +132,7 @@ public class bin2bcdHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                   s_level_2(6)          <= s_level_1(6);
                   s_level_3(6 DOWNTO 5) <= s_level_2(6 DOWNTO 5);
                   s_level_3(0)          <= s_level_2(0);
-                  
+
                   BCD1  <= s_level_3( 3 DOWNTO 0);
                   BCD10 <= \"0\"&s_level_3(6 DOWNTO 4);
                   """)
@@ -156,7 +156,7 @@ public class bin2bcdHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                   s_level_5( 1 DOWNTO 0) <= s_level_4( 1 DOWNTO 0);
                   s_level_6(10 DOWNTO 9) <= s_level_5(10 DOWNTO 9);
                   s_level_6(0)           <= s_level_5(0);
-                  
+
                   BCD1   <= s_level_6( 3 DOWNTO 0 );
                   BCD10  <= s_level_6( 7 DOWNTO 4 );
                   BCD100 <= "0"&s_level_6(10 DOWNTO 8);
@@ -195,7 +195,7 @@ public class bin2bcdHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                   s_level_9( 1 DOWNTO  0)  <= s_level_8( 1 DOWNTO  0);
                   s_level_10(15 DOWNTO 13) <= s_level_9(15 DOWNTO 13);
                   s_level_10(0)            <= s_level_9(0);
-                  
+
                   BCD1    <= s_level_10( 3 DOWNTO  0);
                   BCD10   <= s_level_10( 7 DOWNTO  4);
                   BCD100  <= s_level_10(11 DOWNTO  8);
@@ -231,7 +231,7 @@ public class bin2bcdHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   }
 
   private ArrayList<String> getAdd3Block(String srcName, int srcStartId, String destName, int destStartId, String processName) {
-    return (new LineBuffer())
+    return LineBuffer.getBuffer()
         .pair("srcName", srcName)
         .pair("srcStartId", srcStartId)
         .pair("srcDownTo", (srcStartId - 3))
@@ -240,7 +240,7 @@ public class bin2bcdHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
         .pair("destDownTo", (destStartId - 3))
         .pair("proc", processName)
         .add("""
-            
+
             ADD3_{{proc}} : PROCESS({{srcName}})
             BEGIN
                CASE ( {{srcName}}( {{srcStartId}} DOWNTO {{srcDownTo}}) ) IS

--- a/src/main/java/com/cburch/logisim/std/gates/AbstractGateHDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/gates/AbstractGateHDLGenerator.java
@@ -26,7 +26,7 @@ public class AbstractGateHDLGenerator extends AbstractHDLGeneratorFactory {
   private static final String BIT_WIDTH_STRING = "NrOfBits";
   private static final int BUBBLES_GENERIC = -2;
   private static final String BUBBLES_MASK = "BubblesMask";
-  
+
   public boolean GetFloatingValue(boolean isInverted) {
     return !isInverted;
   }
@@ -51,7 +51,7 @@ public class AbstractGateHDLGenerator extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist nets, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     final var bitWidth = attrs.getValue(StdAttr.WIDTH).getWidth();
     final var nrOfInputs =
         attrs.containsAttribute(GateAttributes.ATTR_INPUTS)

--- a/src/main/java/com/cburch/logisim/std/gates/Buffer.java
+++ b/src/main/java/com/cburch/logisim/std/gates/Buffer.java
@@ -48,7 +48,7 @@ class Buffer extends InstanceFactory {
   private static class BufferGateHDLGeneratorFactory extends AbstractGateHDLGenerator {
     @Override
     public ArrayList<String> GetLogicFunction(int nrOfInputs, int bitwidth, boolean isOneHot) {
-      return (new LineBuffer())
+      return LineBuffer.getBuffer()
           .add(HDL.isVHDL() ? "Result <= Input_1;" : "assign Result = Input_1;")
           .empty()
           .getWithIndent();

--- a/src/main/java/com/cburch/logisim/std/gates/ControlledBufferHDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/gates/ControlledBufferHDLGenerator.java
@@ -21,7 +21,7 @@ public class ControlledBufferHDLGenerator extends InlinedHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> getInlinedCode(Netlist nets, Long componentId, NetlistComponent componentInfo, String circuitName) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     final var triName = HDL.getNetName(componentInfo, 2, true, nets);
     var inpName = "";
     var outpName = "";

--- a/src/main/java/com/cburch/logisim/std/gates/EvenParityGate.java
+++ b/src/main/java/com/cburch/logisim/std/gates/EvenParityGate.java
@@ -24,7 +24,7 @@ class EvenParityGate extends AbstractGate {
   private static class XNorGateHDLGeneratorFactory extends AbstractGateHDLGenerator {
     @Override
     public ArrayList<String> GetLogicFunction(int nrOfInputs, int bitwidth, boolean isOneHot) {
-      return (new LineBuffer()).add(GetParity(true, nrOfInputs, bitwidth > 1)).empty().get();
+      return LineBuffer.getBuffer().add(GetParity(true, nrOfInputs, bitwidth > 1)).empty().get();
     }
   }
 

--- a/src/main/java/com/cburch/logisim/std/gates/OddParityGate.java
+++ b/src/main/java/com/cburch/logisim/std/gates/OddParityGate.java
@@ -24,7 +24,7 @@ class OddParityGate extends AbstractGate {
   private static class XorGateHDLGeneratorFactory extends AbstractGateHDLGenerator {
     @Override
     public ArrayList<String> GetLogicFunction(int nrOfInputs, int bitwidth, boolean isOneHot) {
-      final var contents = new LineBuffer();
+      final var contents = LineBuffer.getBuffer();
       contents.add(GetParity(false, nrOfInputs, bitwidth > 1)).empty();
       return contents.get();
     }

--- a/src/main/java/com/cburch/logisim/std/gates/PLAHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/gates/PLAHDLGeneratorFactory.java
@@ -44,7 +44,7 @@ public class PLAHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist nets, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     final var tt = attrs.getValue(PLA.ATTR_TABLE);
     final var outSz = attrs.getValue(PLA.ATTR_OUT_WIDTH).getWidth();
     if (HDL.isVHDL()) {

--- a/src/main/java/com/cburch/logisim/std/gates/XnorGate.java
+++ b/src/main/java/com/cburch/logisim/std/gates/XnorGate.java
@@ -27,7 +27,7 @@ class XnorGate extends AbstractGate {
   private static class XNorGateHDLGeneratorFactory extends AbstractGateHDLGenerator {
     @Override
     public ArrayList<String> GetLogicFunction(int nrOfInputs, int bitwidth, boolean isOneHot) {
-      return (new LineBuffer())
+      return LineBuffer.getBuffer()
           .add(
               isOneHot
                   ? GetOneHot(true, nrOfInputs, bitwidth > 1)

--- a/src/main/java/com/cburch/logisim/std/gates/XorGate.java
+++ b/src/main/java/com/cburch/logisim/std/gates/XorGate.java
@@ -29,7 +29,7 @@ class XorGate extends AbstractGate {
   private static class XorGateHDLGeneratorFactory extends AbstractGateHDLGenerator {
     @Override
     public ArrayList<String> GetLogicFunction(int nrOfInputs, int bitwidth, boolean isOneHot) {
-      return (new LineBuffer())
+      return LineBuffer.getBuffer()
           .add(
               isOneHot
                   ? GetOneHot(false, nrOfInputs, bitwidth > 1)

--- a/src/main/java/com/cburch/logisim/std/io/AbstractSimpleIOHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/AbstractSimpleIOHDLGeneratorFactory.java
@@ -18,16 +18,16 @@ import com.cburch.logisim.fpga.hdlgenerator.InlinedHDLGeneratorFactory;
 import com.cburch.logisim.util.LineBuffer;
 
 public class AbstractSimpleIOHDLGeneratorFactory extends InlinedHDLGeneratorFactory {
-  
+
   private final boolean isInputComponent;
-  
+
   public AbstractSimpleIOHDLGeneratorFactory(boolean isInputComponent) {
     this.isInputComponent = isInputComponent;
   }
 
   @Override
   public ArrayList<String> getInlinedCode(Netlist nets, Long componentId, NetlistComponent componentInfo, String circuitName) {
-    final var contents = (new LineBuffer()).addHdlPairs();
+    final var contents = LineBuffer.getBuffer().addHdlPairs();
     for (int i = 0; i < componentInfo.nrOfEnds(); i++) {
       if (componentInfo.isEndConnected(i) && isInputComponent) {
         final var pressPassive = componentInfo.getComponent().getAttributeSet().getValue(Button.ATTR_PRESS) ==  Button.BUTTON_PRESS_PASSIVE;

--- a/src/main/java/com/cburch/logisim/std/io/DotMatrixHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/DotMatrixHDLGeneratorFactory.java
@@ -31,7 +31,7 @@ public class DotMatrixHDLGeneratorFactory extends InlinedHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> getInlinedCode(Netlist netlist, Long componentId, NetlistComponent componentInfo, String circuitName) {
-    final var contents = (new LineBuffer()).addHdlPairs();
+    final var contents = LineBuffer.getBuffer().addHdlPairs();
     final var colBased = componentInfo.getComponent().getAttributeSet().getValue(DotMatrixBase.ATTR_INPUT_TYPE) == DotMatrixBase.INPUT_COLUMN;
     final var rowBased = componentInfo.getComponent().getAttributeSet().getValue(DotMatrixBase.ATTR_INPUT_TYPE) == DotMatrixBase.INPUT_ROW;
     final var rows = componentInfo.getComponent().getAttributeSet().getValue(getAttributeRows()).getWidth();

--- a/src/main/java/com/cburch/logisim/std/io/HexDigitHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/HexDigitHDLGeneratorFactory.java
@@ -26,7 +26,7 @@ public class HexDigitHDLGeneratorFactory extends InlinedHDLGeneratorFactory {
     final var bubbleBusName = LOCAL_OUTPUT_BUBBLE_BUS_NAME;
     final var signalName = LineBuffer.format("{{1}}{{<}}{{2}}{{3}}{{4}}{{>}}", bubbleBusName, (startId + 6), HDL.vectorLoopId(), startId);
     final var contents =
-        (new LineBuffer()).addHdlPairs()
+        LineBuffer.getBuffer().addHdlPairs()
             .pair("bubbleBusName", bubbleBusName)
             .pair("sigName", signalName)
             .pair("dpName", HDL.getNetName(componentInfo, HexDigit.DP, true, nets));

--- a/src/main/java/com/cburch/logisim/std/io/LedArrayColumnScanningHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/LedArrayColumnScanningHDLGeneratorFactory.java
@@ -47,7 +47,7 @@ public class LedArrayColumnScanningHDLGeneratorFactory extends AbstractHDLGenera
     final var maxNrLeds = ((int) Math.pow(2.0, (double) nrColAddrBits)) * nrOfRows;
 
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("nrOfLeds", nrOfLedsString)
             .pair("ledsCount", nrOfRows * nrOfColumns)
             .pair("maxNrLeds", maxNrLedsString)
@@ -93,7 +93,7 @@ public class LedArrayColumnScanningHDLGeneratorFactory extends AbstractHDLGenera
 
   public static ArrayList<String> getPortMap(int id) {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("columnAddress", LedArrayGenericHDLGeneratorFactory.LedArrayColumnAddress)
             .pair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayRowOutputs)
             .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
@@ -169,7 +169,7 @@ public class LedArrayColumnScanningHDLGeneratorFactory extends AbstractHDLGenera
 
   public ArrayList<String> getColumnCounterCode() {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("columnAddress", LedArrayGenericHDLGeneratorFactory.LedArrayColumnAddress)
             .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
             .pair("counterBits", scanningCounterBitsString)
@@ -237,7 +237,7 @@ public class LedArrayColumnScanningHDLGeneratorFactory extends AbstractHDLGenera
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
             .pair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayRowOutputs)
             .pair("nrOfLeds", nrOfLedsString)

--- a/src/main/java/com/cburch/logisim/std/io/LedArrayGenericHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/LedArrayGenericHDLGeneratorFactory.java
@@ -195,7 +195,7 @@ public class LedArrayGenericHDLGeneratorFactory {
   }
 
   public static ArrayList<String> GetComponentMap(char typeId, int nrOfRows, int nrOfColumns, int identifier, long FpgaClockFrequency, boolean isActiveLow) {
-    final var componentMap = (new LineBuffer())
+    final var componentMap = LineBuffer.getBuffer()
             .add(HDL.isVHDL()
                 ? "   array" + identifier + " : " + getSpecificHDLName(typeId)
                 : "   " + getSpecificHDLName(typeId));

--- a/src/main/java/com/cburch/logisim/std/io/LedArrayLedDefaultHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/LedArrayLedDefaultHDLGeneratorFactory.java
@@ -29,7 +29,7 @@ public class LedArrayLedDefaultHDLGeneratorFactory extends AbstractHDLGeneratorF
 
   public static ArrayList<String> getGenericMap(int nrOfRows, int nrOfColumns, long fpgaClockFrequency, boolean activeLow) {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("nrOfLeds", nrOfLedsString)
             .pair("ledsCount", nrOfRows * nrOfColumns)
             .pair("rows", nrOfRows)
@@ -53,7 +53,7 @@ public class LedArrayLedDefaultHDLGeneratorFactory extends AbstractHDLGeneratorF
 
   public static ArrayList<String> getPortMap(int id) {
     final var map =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("id", id)
             .pair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
             .pair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayOutputs);
@@ -96,7 +96,7 @@ public class LedArrayLedDefaultHDLGeneratorFactory extends AbstractHDLGeneratorF
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
             .pair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayOutputs);
 

--- a/src/main/java/com/cburch/logisim/std/io/LedArrayRowScanningHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/LedArrayRowScanningHDLGeneratorFactory.java
@@ -47,7 +47,7 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
     final var maxNrLeds = ((int) Math.pow(2.0, (double) nrRowAddrBits)) * nrOfRows;
 
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("nrOfLeds", nrOfLedsString)
             .pair("nrOfLedsVal", nrOfRows * nrOfColumns)
             .pair("nrOfRows", nrOfRowsString)
@@ -93,7 +93,7 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
 
   public static ArrayList<String> getPortMap(int id) {
     final var map =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("rowAddr", LedArrayGenericHDLGeneratorFactory.LedArrayRowAddress)
             .pair("colOuts", LedArrayGenericHDLGeneratorFactory.LedArrayColumnOutputs)
             .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
@@ -168,28 +168,28 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
 
   public ArrayList<String> getRowCounterCode() {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("rowAddress", LedArrayGenericHDLGeneratorFactory.LedArrayRowAddress)
             .pair("bits", scanningCounterBitsString)
             .pair("value", scanningCounterValueString)
             .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK);
     if (HDL.isVHDL()) {
       contents.add("""
-          
+
           {{rowAddress}} <= s_rowCounterReg;
-          
+
           s_tickNext <= '1' WHEN s_scanningCounterReg = std_logic_vector(to_unsigned(0, {{bits}})) ELSE '0';
-          
+
           s_scanningCounterNext <= (OTHERS => '0') WHEN s_tickReg /= '0' AND s_tickReg /= '1' ELSE -- for simulation
-                                   std_logic_vector(to_unsigned({{value}}-1, {{bits}})) WHEN s_scanningCounterReg = std_logic_vector(to_unsigned(0, {{bits}})) ELSE 
+                                   std_logic_vector(to_unsigned({{value}}-1, {{bits}})) WHEN s_scanningCounterReg = std_logic_vector(to_unsigned(0, {{bits}})) ELSE
                                    std_logic_vector(unsigned(s_scanningCounterReg)-1);
-          
+
           s_rowCounterNext <= (OTHERS => '0') WHEN s_tickReg /= '0' AND s_tickReg /= '1' ELSE -- for simulation
                               s_rowCounterReg WHEN s_tickReg = '0' ELSE
                               std_logic_vector(to_unsigned(nrOfRows-1,nrOfRowAddressBits))
                                  WHEN s_rowCounterReg = std_logic_vector(to_unsigned(0,nrOfRowAddressBits)) ELSE
                               std_logic_vector(unsigned(s_rowCounterReg)-1);
-          
+
           makeFlops : PROCESS ({{clock}}) IS
           BEGIN
              IF (rising_edge({{clock}})) THEN
@@ -201,12 +201,12 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
           """);
     } else {
       contents.add("""
-          
+
           assign rowAddress = s_rowCounterReg;
-          
+
           assign s_tickNext = (s_scanningCounterReg == 0) ? 1'b1 : 1'b0;
           assign s_scanningCounterNext = (s_scanningCounterReg == 0) ? {{value}} : s_scanningCounterReg - 1;
-          assign s_rowCounterNext = (s_tickReg == 1'b0) ? s_rowCounterReg : 
+          assign s_rowCounterNext = (s_tickReg == 1'b0) ? s_rowCounterReg :
                                     (s_rowCounterReg == 0) ? nrOfRows-1 : s_rowCounterReg-1;
           """)
           .addRemarkBlock("Here the simulation only initial is defined")
@@ -217,7 +217,7 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
                   s_scanningCounterReg = 0;
                   s_tickReg            = 1'b0;
                end
-     
+
                always @(posedge {{clock}})
                begin
                    s_rowCounterReg      = s_rowCounterNext;
@@ -232,7 +232,7 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("ins", LedArrayGenericHDLGeneratorFactory.LedArrayInputs)
             .pair("outs", LedArrayGenericHDLGeneratorFactory.LedArrayColumnOutputs)
             .pair("activeLow", activeLowString)
@@ -251,14 +251,14 @@ public class LedArrayRowScanningHDLGeneratorFactory extends AbstractHDLGenerator
                 s_maxLedInputs({{nrOfLeds}}-1 DOWNTO 0) <= {{ins}};
              END IF;
           END PROCESS makeVirtualInputs;
-          
+
           GenOutputs : FOR n IN {{nrOfColumns}}-1 DOWNTO 0 GENERATE
              {{outs}}(n) <= s_maxLedInputs({{nrOfColumns}} * to_integer(unsigned(s_rowCounterReg)) + n);
           END GENERATE GenOutputs;
           """);
     } else {
       contents.add("""
-          
+
           genvar i;
           generate
              for (i = 0; i < {{nrOfColumns}}; i = i + 1)

--- a/src/main/java/com/cburch/logisim/std/io/LedBarHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/LedBarHDLGeneratorFactory.java
@@ -28,7 +28,7 @@ public class LedBarHDLGeneratorFactory extends InlinedHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> getInlinedCode(Netlist netlist, Long componentId, NetlistComponent componentInfo, String circuitName) {
-    final var contents = (new LineBuffer()).addHdlPairs();
+    final var contents = LineBuffer.getBuffer().addHdlPairs();
     final var isSingleBus = componentInfo.getComponent().getAttributeSet().getValue(LedBar.ATTR_INPUT_TYPE).equals(LedBar.INPUT_ONE_WIRE);
     final var nrOfSegments = componentInfo.getComponent().getAttributeSet().getValue(getAttributeColumns()).getWidth();
     for (var pin = 0; pin < nrOfSegments; pin++) {

--- a/src/main/java/com/cburch/logisim/std/io/RGBArrayColumnScanningHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/RGBArrayColumnScanningHDLGeneratorFactory.java
@@ -25,7 +25,7 @@ public class RGBArrayColumnScanningHDLGeneratorFactory extends LedArrayColumnSca
 
   public static ArrayList<String> getPortMap(int id) {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("addr", LedArrayGenericHDLGeneratorFactory.LedArrayColumnAddress)
             .pair("clock", TickComponentHDLGeneratorFactory.FPGA_CLOCK)
             .pair("insR", LedArrayGenericHDLGeneratorFactory.LedArrayRedInputs)
@@ -95,7 +95,7 @@ public class RGBArrayColumnScanningHDLGeneratorFactory extends LedArrayColumnSca
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist netlist, AttributeSet attrs) {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("nrOfLeds", nrOfLedsString)
             .pair("nrOfRows", nrOfRowsString)
             .pair("activeLow", activeLowString)
@@ -124,7 +124,7 @@ public class RGBArrayColumnScanningHDLGeneratorFactory extends LedArrayColumnSca
                 s_maxBlueLedInputs({{nrOfLeds}}-1 DOWNTO 0)  <= {{insB}};
              END IF;
           END PROCESS makeVirtualInputs;
-          
+
           GenOutputs : FOR n IN {{nrOfRows}}-1 DOWNTO 0 GENERATE
              {{outsR}}(n) <= s_maxRedLedInputs(to_integer(unsigned(s_columnCounterReg)) + n*nrOfColumns);
              {{outsG}}(n) <= s_maxGreenLedInputs(to_integer(unsigned(s_columnCounterReg)) + n*nrOfColumns);

--- a/src/main/java/com/cburch/logisim/std/io/ReptarLocalBusHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/ReptarLocalBusHDLGeneratorFactory.java
@@ -24,17 +24,17 @@ public class ReptarLocalBusHDLGeneratorFactory extends AbstractHDLGeneratorFacto
 
   @Override
   public ArrayList<String> getArchitecture(Netlist nets, AttributeSet attrs, String componentName) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     if (HDL.isVHDL()) {
       contents
           .pair("compName", componentName)
           .add(FileWriter.getGenerateRemark(componentName, nets.projName()))
           .add("""
-              
-              ARCHITECTURE PlatformIndependent OF {{compName}} IS 
-              
+
+              ARCHITECTURE PlatformIndependent OF {{compName}} IS
+
               BEGIN
-              
+
               FPGA_out(0) <= NOT SP6_LB_WAIT3_i;
               FPGA_out(1) <= NOT IRQ_i;
               SP6_LB_nCS3_o       <= FPGA_in(0);
@@ -42,7 +42,7 @@ public class ReptarLocalBusHDLGeneratorFactory extends AbstractHDLGeneratorFacto
               SP6_LB_RE_nOE_o     <= FPGA_in(2);
               SP6_LB_nWE_o        <= FPGA_in(3);
               Addr_LB_o           <= FPGA_in(11 DOWNTO 4);
-              
+
               IOBUF_Addresses_Datas : for i in 0 to Addr_Data_LB_io'length-1 generate
                 IOBUF_Addresse_Data : IOBUF
                 generic map (
@@ -57,7 +57,7 @@ public class ReptarLocalBusHDLGeneratorFactory extends AbstractHDLGeneratorFacto
                   T => Addr_Data_LB_tris_i -- 3-state enable input, high=input, low=output
                 );
               end generate;
-              
+
               END PlatformIndependent;
               """);
     }
@@ -66,7 +66,7 @@ public class ReptarLocalBusHDLGeneratorFactory extends AbstractHDLGeneratorFacto
 
   @Override
   public ArrayList<String> getComponentInstantiation(Netlist theNetlist, AttributeSet attrs, String componentName) {
-    return (new LineBuffer())
+    return LineBuffer.getBuffer()
         .add("""
             COMPONENT LocalBus
                PORT ( SP6_LB_WAIT3_i     : IN  std_logic;
@@ -89,14 +89,14 @@ public class ReptarLocalBusHDLGeneratorFactory extends AbstractHDLGeneratorFacto
 
   @Override
   public ArrayList<String> getEntity(Netlist nets, AttributeSet attrs, String componentName) {
-    return (new LineBuffer())
+    return LineBuffer.getBuffer()
         .pair("compName", componentName)
         .add(FileWriter.getGenerateRemark(componentName, nets.projName()))
         .add(FileWriter.getExtendedLibrary())
         .add("""
             Library UNISIM;
             use UNISIM.vcomponents.all;
-            
+
             ENTITY {{compName}} IS
                PORT ( Addr_Data_LB_io     : INOUT std_logic_vector(15 downto 0);
                       SP6_LB_nCS3_o       : OUT std_logic;

--- a/src/main/java/com/cburch/logisim/std/memory/RamHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamHDLGeneratorFactory.java
@@ -84,7 +84,7 @@ public class RamHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist theNetlist, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     final var be = attrs.getValue(RamAttributes.ATTR_ByteEnables);
     final var byteEnables = be != null && be.equals(RamAttributes.BUS_WITH_BYTEENABLES);
     if (HDL.isVHDL()) {
@@ -208,7 +208,7 @@ public class RamHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                       END IF;
                    END IF;
                 END PROCESS Res;
-                
+
                 """);
       }
     }

--- a/src/main/java/com/cburch/logisim/std/memory/RandomHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RandomHDLGeneratorFactory.java
@@ -42,7 +42,7 @@ public class RandomHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist nets, AttributeSet attrs) {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("seed", SEED_STR)
             .pair("nrOfBits", NR_OF_BITS_STR)
             .addRemarkBlock("This is a multicycle implementation of the Random Component")
@@ -68,23 +68,23 @@ public class RandomHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                                s_current_seed WHEN s_start_reg = '1' ELSE
                                s_seed_shift_reg(46 DOWNTO 0)&'0';
           s_mult_busy       <= '0' WHEN s_mult_shift_reg = X"000000000" ELSE '1';
-          
+
           s_mac_lo_in_1     <= (OTHERS => '0') WHEN s_start_reg = '1' OR
                                                     s_reset = '1' ELSE
                                '0'&s_mac_lo_reg(23 DOWNTO 0);
           s_mac_lo_in_2     <= '0'&X"00000B"
                                   WHEN s_start_reg = '1' ELSE
-                               '0'&s_seed_shift_reg(23 DOWNTO 0) 
+                               '0'&s_seed_shift_reg(23 DOWNTO 0)
                                   WHEN s_mult_shift_reg(0) = '1' ELSE
                                (OTHERS => '0');
           s_mac_hi_in_2     <= (OTHERS => '0') WHEN s_start_reg = '1' ELSE
                                s_mac_hi_reg;
-          s_mac_hi_1_next   <= s_seed_shift_reg(47 DOWNTO 24) 
+          s_mac_hi_1_next   <= s_seed_shift_reg(47 DOWNTO 24)
                                   WHEN s_mult_shift_reg(0) = '1' ELSE
                                (OTHERS => '0');
           s_busy_pipe_next  <= "00" WHEN s_reset = '1' ELSE
                                s_busy_pipe_reg(0)&s_mult_busy;
-          
+
           make_current_seed : PROCESS( GlobalClock , s_busy_pipe_reg , s_reset )
           BEGIN
              IF (GlobalClock'event AND (GlobalClock = '1')) THEN
@@ -94,7 +94,7 @@ public class RandomHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                 END IF;
              END IF;
           END PROCESS make_current_seed;
-          
+
           make_shift_regs : PROCESS(GlobalClock,s_mult_shift_next,s_seed_shift_next,
                                     s_mac_lo_in_1,s_mac_lo_in_2)
           BEGIN
@@ -108,21 +108,21 @@ public class RandomHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                 s_busy_pipe_reg  <= s_busy_pipe_next;
              END IF;
           END PROCESS make_shift_regs;
-          
+
           make_start_reg : PROCESS(GlobalClock,s_start)
           BEGIN
              IF (GlobalClock'event AND (GlobalClock = '1')) THEN
                 s_start_reg <= s_start;
              END IF;
           END PROCESS make_start_reg;
-          
+
           make_reset_reg : PROCESS(GlobalClock,s_reset_next)
           BEGIN
              IF (GlobalClock'event AND (GlobalClock = '1')) THEN
                 s_reset_reg <= s_reset_next;
              END IF;
           END PROCESS make_reset_reg;
-          
+
           make_output : PROCESS( GlobalClock , s_reset , s_InitSeed )
           BEGIN
              IF (GlobalClock'event AND (GlobalClock = '1')) THEN
@@ -139,10 +139,10 @@ public class RandomHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
           assign s_InitSeed = ({{seed}}) ? {{seed}} : 48'h5DEECE66D;
           assign s_reset = (s_reset_reg==3'b010) ? 1'b1 : 1'b0;
           assign s_reset_next = (( (s_reset_reg == 3'b101) | (s_reset_reg == 3'b010)) & clear)
-                                ? 3'b010 
+                                ? 3'b010
                                 : (s_reset_reg==3'b001) ? 3'b101 : 3'b001;
           assign s_start = ((ClockEnable&enable)|((s_reset_reg == 3'b101)&clear)) ? 1'b1 : 1'b0;
-          assign s_mult_shift_next = (s_reset) 
+          assign s_mult_shift_next = (s_reset)
                                      ? 36'd0
                                      : (s_start_reg) ? 36'h5DEECE66D : {1'b0,s_mult_shift_reg[35:1]};
           assign s_seed_shift_next = (s_reset)
@@ -156,13 +156,13 @@ public class RandomHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
           assign s_mac_hi_in_2 = (s_start_reg) ? 0 : s_mac_hi_reg;
           assign s_mac_hi_1_next = (s_mult_shift_reg[0]) ? s_seed_shift_reg[47:24] : 0;
           assign s_busy_pipe_next = (s_reset) ? 2'd0 : {s_busy_pipe_reg[0],s_mult_busy};
-          
+
           always @(posedge GlobalClock)
           begin
              if (s_reset) s_current_seed <= s_InitSeed;
              else if (s_busy_pipe_reg == 2'b10) s_current_seed <= {s_mac_hi_reg,s_mac_lo_reg[23:0]};
           end
-          
+
           always @(posedge GlobalClock)
           begin
                 s_mult_shift_reg <= s_mult_shift_next;
@@ -174,7 +174,7 @@ public class RandomHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                 s_start_reg      <= s_start;
                 s_reset_reg      <= s_reset_next;
           end
-          
+
           always @(posedge GlobalClock)
           begin
              if (s_reset) s_output_reg <= s_InitSeed[({{nrOfBits}}-1):0];

--- a/src/main/java/com/cburch/logisim/std/memory/RegisterHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RegisterHDLGeneratorFactory.java
@@ -42,12 +42,12 @@ public class RegisterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist nets, AttributeSet attrs) {
-    final var contents = (new LineBuffer())
+    final var contents = LineBuffer.getBuffer()
             .pair("activeLevel", ACTIVE_LEVEL_STR);
     if (HDL.isVHDL()) {
       contents.add("""
           Q <= s_state_reg;
-          
+
           make_memory : PROCESS( clock , Reset , ClockEnable , Tick , D )
           BEGIN
              IF (Reset = '1') THEN s_state_reg <= (OTHERS => '0');
@@ -91,7 +91,7 @@ public class RegisterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
       if (!Netlist.isFlipFlop(attrs)) {
         contents.add("""
             assign Q = s_state_reg;
-            
+
             always @(*)
             begin
                if (Reset) s_state_reg <= 0;
@@ -101,13 +101,13 @@ public class RegisterHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
       } else {
         contents.add("""
             assign Q = ({{activeLevel}}) ? s_state_reg : s_state_reg_neg_edge;
-            
+
             always @(posedge Clock or posedge Reset)
             begin
                if (Reset) s_state_reg <= 0;
                else if (ClockEnable&Tick) s_state_reg <= D;
             end
-            
+
             always @(negedge Clock or posedge Reset)
             begin
                if (Reset) s_state_reg_neg_edge <= 0;

--- a/src/main/java/com/cburch/logisim/std/memory/RomHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RomHDLGeneratorFactory.java
@@ -29,16 +29,16 @@ public class RomHDLGeneratorFactory extends InlinedHDLGeneratorFactory {
     final var dataWidth = attrs.getValue(Mem.DATA_ATTR).getWidth();
     final var romContents = attrs.getValue(Rom.CONTENTS_ATTR);
     final var generator = (new WithSelectHDLGenerator(componentInfo.getComponent().getAttributeSet().getValue(StdAttr.LABEL),
-        HDL.getBusName(componentInfo, RamAppearance.getAddrIndex(0, attrs), nets), addressWidth, 
+        HDL.getBusName(componentInfo, RamAppearance.getAddrIndex(0, attrs), nets), addressWidth,
         HDL.getBusName(componentInfo, RamAppearance.getDataOutIndex(0, attrs), nets), dataWidth))
         .setDefault(0L);
     for (var addr = 0L; addr < (1L << addressWidth); addr++) {
-      final var romValue = romContents.get(addr); 
+      final var romValue = romContents.get(addr);
       if (romValue != 0L) generator.add(addr, romValue);
     }
-    return (new LineBuffer()).add(generator.getHdlCode()).getWithIndent(3);
+    return LineBuffer.getBuffer().add(generator.getHdlCode()).getWithIndent(3);
   }
-  
+
   @Override
   public boolean isHDLSupportedTarget(AttributeSet attrs) {
     if (attrs == null) return false;

--- a/src/main/java/com/cburch/logisim/std/memory/TFlipFlop.java
+++ b/src/main/java/com/cburch/logisim/std/memory/TFlipFlop.java
@@ -52,7 +52,7 @@ public class TFlipFlop extends AbstractFlipFlop {
 
     @Override
     public ArrayList<String> GetUpdateLogic() {
-      return (new LineBuffer())
+      return LineBuffer.getBuffer()
           .add("{{1}} s_next_state {{2}} s_current_state_reg {{3}} T;", HDL.assignPreamble(), HDL.assignOperator(), HDL.xorOperator())
           .getWithIndent();
     }

--- a/src/main/java/com/cburch/logisim/std/plexers/BitSelectorHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/BitSelectorHDLGeneratorFactory.java
@@ -41,7 +41,7 @@ public class BitSelectorHDLGeneratorFactory extends AbstractHDLGeneratorFactory 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist theNetlist, AttributeSet attrs) {
     final var contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("extBits", EXTENDED_BITS_STR)
             .pair("inBits", INPUT_BITS_STR)
             .pair("outBits", OUTPUTS_BITS_STR);
@@ -68,7 +68,7 @@ public class BitSelectorHDLGeneratorFactory extends AbstractHDLGeneratorFactory 
             assign s_select_vector[513:{{extBits}}] = 0;
             assign s_select_vector[{{extBits}}-1:0] = s_extended_vector;
             assign DataOut = s_selected_slice;
-            
+
             always @(*)
             begin
                case (Sel)

--- a/src/main/java/com/cburch/logisim/std/plexers/DecoderHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/DecoderHDLGeneratorFactory.java
@@ -31,7 +31,7 @@ public class DecoderHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist theNetList, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     final var nrOfSelectBits = attrs.getValue(PlexersLibrary.ATTR_SELECT).getWidth();
     final var numOutputs = (1 << nrOfSelectBits);
     var space = " ";

--- a/src/main/java/com/cburch/logisim/std/plexers/DemultiplexerHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/DemultiplexerHDLGeneratorFactory.java
@@ -38,7 +38,7 @@ public class DemultiplexerHDLGeneratorFactory extends AbstractHDLGeneratorFactor
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist theNetList, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     var space = "  ";
     final var nrOfSelectBits = attrs.getValue(PlexersLibrary.ATTR_SELECT).getWidth();
     var numOutputs = (1 << nrOfSelectBits);

--- a/src/main/java/com/cburch/logisim/std/plexers/MultiplexerHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/MultiplexerHDLGeneratorFactory.java
@@ -39,7 +39,7 @@ public class MultiplexerHDLGeneratorFactory extends AbstractHDLGeneratorFactory 
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist theNetList, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     int nrOfSelectBits = attrs.getValue(PlexersLibrary.ATTR_SELECT).getWidth();
     if (HDL.isVHDL()) {
       contents.add("make_mux : PROCESS( Enable,");
@@ -61,14 +61,14 @@ public class MultiplexerHDLGeneratorFactory extends AbstractHDLGeneratorFactory 
         contents.add("         WHEN {{1}} => MuxOut <= MuxIn_{{2}};", HDL.getConstantVector(i, nrOfSelectBits), i);
       contents.add("         WHEN OTHERS  => MuxOut <= MuxIn_{{1}};", (1 << nrOfSelectBits) - 1)
               .add("""
-                         END CASE; 
+                         END CASE;
                       END IF;
                    END PROCESS make_mux;
                    """);
     } else {
       contents.add("""
           assign MuxOut = s_selected_vector;
-          
+
           always @(*)
           begin
              if (~Enable) s_selected_vector <= 0;

--- a/src/main/java/com/cburch/logisim/std/plexers/PriorityEncoderHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/PriorityEncoderHDLGeneratorFactory.java
@@ -37,7 +37,7 @@ public class PriorityEncoderHDLGeneratorFactory extends AbstractHDLGeneratorFact
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist nets, AttributeSet attrs) {
-    final var contents = (new LineBuffer())
+    final var contents = LineBuffer.getBuffer()
             .pair("selBits", NR_OF_SELECT_BITS_STR)
             .pair("inBits", NR_OF_INPUT_BITS_STR);
     if (HDL.isVHDL()) {
@@ -47,10 +47,10 @@ public class PriorityEncoderHDLGeneratorFactory extends AbstractHDLGeneratorFact
           EnableOut   <= s_in_is_zero AND enable;
           Address     <= (OTHERS => '0') WHEN enable = '0' ELSE
                          s_address({{selBits}}-1 DOWNTO 0);
-       
-          -- Control Signals 
+
+          -- Control Signals
           s_in_is_zero  <= '1' WHEN input_vector = std_logic_vector(to_unsigned(0,{{inBits}})) ELSE '0';
-       
+
           -- Processes
           make_addr : PROCESS( input_vector , v_select_1_vector , v_select_2_vector , v_select_3_vector , v_select_4_vector )
           BEGIN
@@ -84,7 +84,7 @@ public class PriorityEncoderHDLGeneratorFactory extends AbstractHDLGeneratorFact
           assign EnableOut = s_in_is_zero&enable;
           assign Address = (~enable) ? 0 : s_address[{{selBits}}-1:0];
           assign s_in_is_zero = (input_vector == 0) ? 1'b1 : 1'b0;
-          
+
           assign v_select_1_vector[32:{{selBits}}] = 0;
           assign v_select_1_vector[{{selBits}}-1:0] = input_vector;
           assign s_address[4] = (v_select_1_vector[31:16] == 0) ? 1'b0 : 1'b1;

--- a/src/main/java/com/cburch/logisim/std/ttl/AbstractGateHDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/AbstractGateHDLGenerator.java
@@ -51,7 +51,7 @@ public class AbstractGateHDLGenerator extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     final var nrOfGates = (IsInverter()) ? 6 : 4;
     for (var i = 0; i < nrOfGates; i++) {
       contents.addRemarkBlock("Here gate %d is described", i).add(GetLogicFunction(i));

--- a/src/main/java/com/cburch/logisim/std/ttl/AbstractOctalFlopsHDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/AbstractOctalFlopsHDLGenerator.java
@@ -67,7 +67,7 @@ public class AbstractOctalFlopsHDLGenerator extends AbstractHDLGeneratorFactory 
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist theNetlist, AttributeSet attrs) {
-    return (new LineBuffer())
+    return LineBuffer.getBuffer()
         .add("""
             enable <= tick and NOT(nCLKen);
             nexts  <= D7&D6&D5&D4&D3&D2&D1&D0 WHEN enable = '1' ELSE state;
@@ -79,13 +79,13 @@ public class AbstractOctalFlopsHDLGenerator extends AbstractHDLGeneratorFactory 
             Q5     <= state(5);
             Q6     <= state(6);
             Q7     <= state(7);
-            
+
             dffs : PROCESS( CLK , nCLR ) IS
                BEGIN
                   IF (nCLR = '1') THEN state <= (OTHERS => '0');
                   ELSIF (rising_edge(CLK)) THEN state <= nexts;
                   END IF;
-               END PROCESS dffs; 
+               END PROCESS dffs;
             """)
         .getWithIndent();
   }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl74165HDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl74165HDLGenerator.java
@@ -62,18 +62,18 @@ public class Ttl74165HDLGenerator extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    return (new LineBuffer())
+    return LineBuffer.getBuffer()
         .add("""
             Q7  <= CurState(0);
             Q7n <= NOT(CurState(0));
-            
+
             Enable  <= NOT(CKIh) AND Tick;
             ParData <= P7&P6&P5&P4&P3&P2&P1&P0;
-            
+
             NextState <= CurState WHEN Enable = '0' ELSE
                          ParData WHEN SHnLD = '0' ELSE
                          SER&CurState(7 DOWNTO 1);
-            
+
             dffs : PROCESS( CK ) IS
                BEGIN
                   IF (rising_edge(CK)) THEN CurState <= NextState;

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl74175HDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl74175HDLGenerator.java
@@ -60,11 +60,11 @@ public class Ttl74175HDLGenerator extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    return (new LineBuffer())
+    return LineBuffer.getBuffer()
         .add("""
             NextState <= CurState WHEN tick = '0' ELSE
                          D4&D3&D2&D1;
-            
+
             dffs : PROCESS( CLK , nCLR ) IS
                BEGIN
                   IF (nCLR = '0') THEN CurState <= "0000";
@@ -72,7 +72,7 @@ public class Ttl74175HDLGenerator extends AbstractHDLGeneratorFactory {
                      CurState <= NextState;
                   END IF;
                END PROCESS dffs;
-            
+
             nQ1 <= NOT(CurState(0));
             Q1  <= CurState(0);
             nQ2 <= NOT(CurState(1));

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl74283HDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl74283HDLGenerator.java
@@ -59,7 +59,7 @@ public class Ttl74283HDLGenerator extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    return (new LineBuffer())
+    return LineBuffer.getBuffer()
         .add("""
             oppA   <= "0"&A4&A3&A2&A1;
             oppB   <= "0"&B4&B3&B2&B1;

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7447HDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7447HDLGenerator.java
@@ -57,7 +57,7 @@ public class Ttl7447HDLGenerator extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     return contents
         .add("""
             Sega  <= segments(0,
@@ -67,9 +67,9 @@ public class Ttl7447HDLGenerator extends AbstractHDLGeneratorFactory {
             Sege  <= segments(4,
             Segf  <= segments(5,
             Segg  <= segments(6,
-            
+
             bcd   <= BCD3&BCD2&BCD1&BCD0;
-            
+
             Decode : PROCESS ( bcd , LT , BI , RBI ) IS
                BEGIN
                   CASE bcd IS

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7474HDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7474HDLGenerator.java
@@ -61,17 +61,17 @@ public class Ttl7474HDLGenerator extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist theNetlist, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     return contents
         .add("""
             Q1  <= state1;
             nQ1 <= NOT(state1,
             Q2  <= state1;
             nQ2 <= NOT(state1,
-            
+
             next1 <= D1 WHEN tick1='1' ELSE state1;
             next2 <= D2 WHEN tick2='1' ELSE state2;
-            
+
             ff1 : PROCESS ( CLK1 , nCLR1 , nPRE1 ) IS
                BEGIN
                   IF (nCLR1 = '0') THEN state1 <= '0';
@@ -79,7 +79,7 @@ public class Ttl7474HDLGenerator extends AbstractHDLGeneratorFactory {
                   ELSIF (rising_edge(CLK1)) THEN state1 <= next1;
                   END IF;
                END PROCESS ff1;
-            
+
             ff2 : PROCESS ( CLK2 , nCLR2 , nPRE2 ) IS
                BEGIN
                   IF (nCLR2 = '0') THEN state2 <= '0';

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7485HDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7485HDLGenerator.java
@@ -62,7 +62,7 @@ public class Ttl7485HDLGenerator extends AbstractHDLGeneratorFactory {
 
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist netlist, AttributeSet attrs) {
-    final var contents = new LineBuffer();
+    final var contents = LineBuffer.getBuffer();
     return contents
         .add("""
             oppA   <= A3&A2&A1&A0;
@@ -70,15 +70,15 @@ public class Ttl7485HDLGenerator extends AbstractHDLGeneratorFactory {
             gt     <= '1' WHEN unsigned(oppA) > unsigned(oppB) ELSE '0';
             eq     <= '1' WHEN unsigned(oppA) = unsigned(oppB) ELSE '0';
             lt     <= '1' WHEN unsigned(oppA) < unsigned(oppB) ELSE '0';
-            
+
             CompIn <= AgtBin&AltBin&AeqBin;
-            WITH (CompIn) SELECT CompOut <= 
+            WITH (CompIn) SELECT CompOut <=
                "100" WHEN "100",
                "010" WHEN "010",
                "000" WHEN "110",
                "110" WHEN "000",
                "001" WHEN OTHERS;
-            
+
             AgtBout <= '1' WHEN gt = '1' ELSE '0' WHEN lt = '1' ELSE CompOut(2);
             AltBout <= '0' WHEN gt = '1' ELSE '1' WHEN lt = '1' ELSE CompOut(1);
             AeqBout <= '0' WHEN (gt = '1') OR (lt = '1') ELSE CompOut(0);

--- a/src/main/java/com/cburch/logisim/std/wiring/BitExtenderHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/BitExtenderHDLGeneratorFactory.java
@@ -25,7 +25,7 @@ public class BitExtenderHDLGeneratorFactory extends InlinedHDLGeneratorFactory {
       Long componentId,
       NetlistComponent componentInfo,
       String circuitName) {
-    final var Contents = new LineBuffer();
+    final var Contents = LineBuffer.getBuffer();
     int NrOfPins = componentInfo.nrOfEnds();
     for (int i = 1; i < NrOfPins; i++) {
       if (!componentInfo.isEndConnected(i)) {

--- a/src/main/java/com/cburch/logisim/std/wiring/ClockHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/ClockHDLGeneratorFactory.java
@@ -38,7 +38,7 @@ public class ClockHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   private static final int PHASE_ID = -3;
   private static final String NR_OF_BITS_STR = "NrOfBits";
   private static final int NR_OF_BITS_ID = -4;
-  
+
   public ClockHDLGeneratorFactory() {
     super("base");
   }
@@ -63,7 +63,7 @@ public class ClockHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
   @Override
   public ArrayList<String> GetModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var Contents =
-        (new LineBuffer())
+        LineBuffer.getBuffer()
             .pair("phase", PHASE_STR)
             .pair("nrOfBits", NR_OF_BITS_STR)
             .pair("lowTick", LOW_TICK_STR)
@@ -117,7 +117,7 @@ public class ClockHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                                          : (s_derived_clock_reg[0] == 1'b1)
                                             ? {{lowTick}} - 1
                                             : {{highTick}} - 1;
-              
+
               """)
           .addRemarkBlock("Here the initial values are defined (for simulation only)")
           .add("""
@@ -146,7 +146,7 @@ public class ClockHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                 END IF;
              END IF;
           END PROCESS makeDerivedClock;
-          
+
           makeCounter : PROCESS( GlobalClock , ClockTick , s_counter_next ,
                                  s_derived_clock_reg )
           BEGIN
@@ -172,7 +172,7 @@ public class ClockHDLGeneratorFactory extends AbstractHDLGeneratorFactory {
                 end
              end
           end
-          
+
           always @(posedge GlobalClock)
           begin
              if (ClockTick)

--- a/src/main/java/com/cburch/logisim/util/LineBuffer.java
+++ b/src/main/java/com/cburch/logisim/util/LineBuffer.java
@@ -43,7 +43,7 @@ public class LineBuffer implements RandomAccess {
   /**
    * Default constructor.
    */
-  public LineBuffer() {
+  protected LineBuffer() {
     super();
     addDefaultPairs();
   }
@@ -85,12 +85,21 @@ public class LineBuffer implements RandomAccess {
   /* ********************************************************************************************* */
 
   /**
+   * Returns instance of LineBuffer with default settings.
+   *
+   * @return instance of LineBuffer
+   */
+  public static LineBuffer getBuffer() {
+    return new LineBuffer();
+  }
+
+  /**
    * Returns instance of LineBuffer preconfigured with HdlPairs.
    *
    * @return instance of LineBuffer
    */
   public static LineBuffer getHdlBuffer() {
-    return (new LineBuffer()).addHdlPairs();
+    return getBuffer().addHdlPairs();
   }
 
   /* ********************************************************************************************* */

--- a/src/test/java/com/cburch/logisim/LineBufferTest.java
+++ b/src/test/java/com/cburch/logisim/LineBufferTest.java
@@ -286,8 +286,8 @@ public class LineBufferTest extends TestBase {
   /* ********************************************************************************************* */
 
   /**
-   * This tests ensures default constructor exists but is made protected to enforce users to
-   * call getBuffer() and getHdlBuffer().
+   * This tests ensures default constructor exists but is not public to enforce use of
+   * getBuffer() and getHdlBuffer() calls.
    */
   @Test
   public void testDefaultConstructorIsNotPublic()  {
@@ -302,10 +302,7 @@ public class LineBufferTest extends TestBase {
       if (!ctor.getDeclaringClass().equals(LineBuffer.class)) continue;
       if(ctor.getParameterCount() != 0) continue;
       assertEquals(0, ctor.getParameterCount());
-
-      final var modifiers = ctor.getModifiers();
-      assertFalse(Modifier.isPrivate(modifiers));
-      assertTrue(Modifier.isProtected(modifiers));
+      assertFalse(Modifier.isPublic(ctor.getModifiers()));
       found = true;
       break;
     }


### PR DESCRIPTION
This PR removes access to `LineBuffer`'s default constructor, enforcing use of `getBuffer()` and `getHdlBuffer()` static calls.

* DEPENDS_ON #1115
* DEPENDS_ON #1118