### PR TITLE
Swaps order of rotate left/right context menu items

### DIFF
--- a/src/main/java/com/cburch/logisim/tools/MenuTool.java
+++ b/src/main/java/com/cburch/logisim/tools/MenuTool.java
@@ -54,10 +54,10 @@ public class MenuTool extends Tool {
       boolean canChange = proj.getLogisimFile().contains(circ);
 
       if (comp.getAttributeSet().containsAttribute(StdAttr.FACING)) {
-        add(rotateRight);
-        rotateRight.addActionListener(this);
         add(rotateLeft);
         rotateLeft.addActionListener(this);
+        add(rotateRight);
+        rotateRight.addActionListener(this);
       }
 
       add(del);


### PR DESCRIPTION
Swaps order of rotate left/right context menu items as most people expect clock wise order (left first, right next).