### PR TITLE
Enforce `plain` attribute on font change (should solve #1217)

### DIFF
--- a/src/main/java/com/cburch/logisim/data/Attributes.java
+++ b/src/main/java/com/cburch/logisim/data/Attributes.java
@@ -204,7 +204,7 @@ public class Attributes {
     }
 
     public Object getValue() {
-      return getSelectedFont();
+      return getSelectedFont().deriveFont(Font.PLAIN);
     }
 
     public void setValue(Object value) {


### PR DESCRIPTION
In logisim we cannot modify the bold and italic attribute. Make surethat the attribute is plain. This should solve the backward
compatibility problem in case the labelfont is changed.