### PR TITLE
fix: PlaRom in subcircuit stops clock from working

### DIFF
--- a/src/main/java/com/cburch/logisim/instance/InstanceLoggerAdapter.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceLoggerAdapter.java
@@ -28,7 +28,7 @@ class InstanceLoggerAdapter implements LoggableContract {
     try {
       this.comp = comp;
       this.logger = loggerClass.getDeclaredConstructor().newInstance();
-      this.state = new InstanceStateImpl(null, comp);
+      this.state = new InstanceStateImpl(comp.getInstanceStateImpl().getCircuitState(), comp);
     } catch (Exception t) {
       final var className = loggerClass.getName();
       loggerS.error("Error while instantiating logger {}: {}", className, t.getClass().getName());


### PR DESCRIPTION
PLA ROM (in section `Input / Output Extra`) placed in a sub-circuit can stop the clock from working.

Clicking on the clock throws the following error in console:

```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: Cannot invoke "com.cburch.logisim.circuit.CircuitState.getData(com.cburch.logisim.comp.Component)" because "this.circuitState" is null
	at com.cburch.logisim.instance.InstanceStateImpl.getData(InstanceStateImpl.java:56)
	at com.cburch.logisim.std.io.extra.PlaRom.getPlaRomData(PlaRom.java:227)
	at com.cburch.logisim.std.io.extra.PlaRom$Logger.getBitWidth(PlaRom.java:140)
	at com.cburch.logisim.instance.InstanceLoggerAdapter.getBitWidth(InstanceLoggerAdapter.java:48)
	at com.cburch.logisim.gui.log.ComponentSelector$CircuitNode.computeChildren(ComponentSelector.java:236)
	at com.cburch.logisim.gui.log.ComponentSelector$CircuitNode.<init>(ComponentSelector.java:192)
	at com.cburch.logisim.gui.log.ComponentSelector$CircuitNode.computeChildren(ComponentSelector.java:264)
	at com.cburch.logisim.gui.log.ComponentSelector$CircuitNode.<init>(ComponentSelector.java:192)
	at com.cburch.logisim.gui.log.ComponentSelector.setRootCircuit(ComponentSelector.java:463)
	at com.cburch.logisim.gui.log.ComponentSelector.<init>(ComponentSelector.java:389)
	at com.cburch.logisim.gui.log.ComponentSelector.findClocks(ComponentSelector.java:512)
	at com.cburch.logisim.circuit.Simulator.ensureClocks(Simulator.java:583)
	at com.cburch.logisim.circuit.Simulator.setAutoTicking(Simulator.java:540)
	at com.cburch.logisim.gui.menu.MenuSimulate$MyListener.actionPerformed(MenuSimulate.java:379)
	at com.cburch.logisim.gui.menu.MenuItemHelper.actionPerformed(MenuItemHelper.java:45)
	at com.cburch.logisim.gui.menu.MenuItemCheckImpl.actionPerformed(MenuItemCheckImpl.java:29)
	at com.cburch.logisim.gui.menu.LogisimMenuBar.doAction(LogisimMenuBar.java:138)
	at com.cburch.logisim.gui.menu.MenuListener.doAction(MenuListener.java:45)
	at com.cburch.logisim.gui.main.LogisimToolbarItem.doAction(LogisimToolbarItem.java:50)
	at com.cburch.logisim.gui.main.SimulationToolbarModel.itemSelected(SimulationToolbarModel.java:90)
	at com.cburch.draw.toolbar.ToolbarButton.mouseReleased(ToolbarButton.java:85)
	at java.desktop/java.awt.AWTEventMulticaster.mouseReleased(Unknown Source)
	at java.desktop/java.awt.Component.processMouseEvent(Unknown Source)
	at java.desktop/javax.swing.JComponent.processMouseEvent(Unknown Source)
	at java.desktop/java.awt.Component.processEvent(Unknown Source)
	at java.desktop/java.awt.Container.processEvent(Unknown Source)
	at java.desktop/java.awt.Component.dispatchEventImpl(Unknown Source)
	at java.desktop/java.awt.Container.dispatchEventImpl(Unknown Source)
	at java.desktop/java.awt.Component.dispatchEvent(Unknown Source)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Unknown Source)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Unknown Source)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Unknown Source)
	at java.desktop/java.awt.Container.dispatchEventImpl(Unknown Source)
	at java.desktop/java.awt.Window.dispatchEventImpl(Unknown Source)
	at java.desktop/java.awt.Component.dispatchEvent(Unknown Source)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(Unknown Source)
	at java.desktop/java.awt.EventQueue$4.run(Unknown Source)
	at java.desktop/java.awt.EventQueue$4.run(Unknown Source)
	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.desktop/java.awt.EventQueue$5.run(Unknown Source)
	at java.desktop/java.awt.EventQueue$5.run(Unknown Source)
	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.desktop/java.awt.EventQueue.dispatchEvent(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.run(Unknown Source)
```

This PR should fix that.

Reproducible with circuit:
[pla_in_subcirc.circ.zip](https://github.com/logisim-evolution/logisim-evolution/files/7367427/pla_in_subcirc.circ.zip)
