### PR TITLE
Fixed LibraryManager.toRelative regex split on backslash exception.

### DIFF
--- a/src/main/java/com/cburch/logisim/file/LibraryManager.java
+++ b/src/main/java/com/cburch/logisim/file/LibraryManager.java
@@ -17,7 +17,12 @@ import com.cburch.logisim.util.LineBuffer;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.regex.Pattern;
 
 public final class LibraryManager {
@@ -118,7 +123,7 @@ public final class LibraryManager {
     final var currentDirectory = loader.getCurrentDirectory();
     var fileName = file.toString();
     try {
-      fileName = file.getCanonicalPath(); 
+      fileName = file.getCanonicalPath();
     } catch (IOException e) {
       // Do nothing as we already have defined the default above
     }
@@ -128,7 +133,7 @@ public final class LibraryManager {
       final var nrOfNewParts = newParts.length;
       // note that the newParts includes the filename, whilst the old doesn't
       var nrOfPartsEqual = 0;
-      while ((nrOfPartsEqual < currentParts.length) && (nrOfPartsEqual < (nrOfNewParts - 1)) 
+      while ((nrOfPartsEqual < currentParts.length) && (nrOfPartsEqual < (nrOfNewParts - 1))
           && (currentParts[nrOfPartsEqual].equals(newParts[nrOfPartsEqual]))) {
         nrOfPartsEqual++;
       }
@@ -204,7 +209,7 @@ public final class LibraryManager {
       }
     }
   }
-  
+
   Collection<LogisimFile> getLogisimLibraries() {
     final var ret = new ArrayList<LogisimFile>();
     for (final var lib : invMap.keySet()) {
@@ -231,7 +236,7 @@ public final class LibraryManager {
     invMap.put(ret, jarDescriptor);
     return ret;
   }
-  
+
   public static Set<String> getBuildinNames(Loader loader) {
     final var buildinNames = new HashSet<String>();
     for (final var lib : loader.getBuiltin().getLibraries()) {
@@ -275,7 +280,7 @@ public final class LibraryManager {
         return null;
     }
   }
-  
+
   public static String getLibraryFilePath(Loader loader, String desc) {
     final var sep = desc.indexOf(DESC_SEP);
     if (sep < 0) {
@@ -286,7 +291,7 @@ public final class LibraryManager {
     final var name = desc.substring(sep + 1);
     return switch (type) {
       case "file" -> loader.getFileFor(name, Loader.LOGISIM_FILTER).getAbsolutePath();
-      case "jar" -> loader.getFileFor(name.substring(0, name.lastIndexOf(DESC_SEP)), Loader.JAR_FILTER).getAbsolutePath(); 
+      case "jar" -> loader.getFileFor(name.substring(0, name.lastIndexOf(DESC_SEP)), Loader.JAR_FILTER).getAbsolutePath();
       default -> null;
     };
   }
@@ -393,5 +398,5 @@ public final class LibraryManager {
         removeBaseLibraries(lib, baseLibs);
       }
     }
-  }  
+  }
 }

--- a/src/main/java/com/cburch/logisim/file/LibraryManager.java
+++ b/src/main/java/com/cburch/logisim/file/LibraryManager.java
@@ -17,12 +17,7 @@ import com.cburch.logisim.util.LineBuffer;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.WeakHashMap;
+import java.util.*;
 
 public final class LibraryManager {
 
@@ -118,6 +113,41 @@ public final class LibraryManager {
     ProjectsDirty.initialize();
   }
 
+  public static String[] split(String string, String separator)
+  {
+    List<String> strings = new ArrayList<>();
+
+    if (separator.length() > 1)
+    {
+      throw new RuntimeException(String.format("Separator [%s] must be exactly one character long.", separator));
+    }
+
+    char charSeparator = separator.charAt(0);
+
+    int index = 0;
+    for (int i = 0; i < string.length(); i++)
+    {
+      char c = string.charAt(i);
+      if (charSeparator == c)
+      {
+        strings.add(string.substring(index, i));
+        index = i + 1;
+      }
+    }
+
+    int length = string.length();
+    if (index > length)
+    {
+      strings.add("");
+    }
+    else
+    {
+      strings.add(string.substring(index, length));
+    }
+
+    return strings.toArray(new String[strings.size()]);
+  }
+
   private static String toRelative(Loader loader, File file) {
     final var currentDirectory = loader.getCurrentDirectory();
     var fileName = file.toString();
@@ -127,8 +157,8 @@ public final class LibraryManager {
       // Do nothing as we already have defined the default above
     }
     if (currentDirectory != null) {
-      final var currentParts = currentDirectory.toString().split(File.separator);
-      final var newParts = fileName.split(File.separator);
+      String[] currentParts = split(currentDirectory.toString(), File.separator);
+      String[] newParts = split(fileName, File.separator);
       final var nrOfNewParts = newParts.length;
       // note that the newParts includes the filename, whilst the old doesn't
       var nrOfPartsEqual = 0;

--- a/src/main/java/com/cburch/logisim/file/LibraryManager.java
+++ b/src/main/java/com/cburch/logisim/file/LibraryManager.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.*;
+import java.util.regex.Pattern;
 
 public final class LibraryManager {
 
@@ -113,41 +114,6 @@ public final class LibraryManager {
     ProjectsDirty.initialize();
   }
 
-  public static String[] split(String string, String separator)
-  {
-    List<String> strings = new ArrayList<>();
-
-    if (separator.length() > 1)
-    {
-      throw new RuntimeException(String.format("Separator [%s] must be exactly one character long.", separator));
-    }
-
-    char charSeparator = separator.charAt(0);
-
-    int index = 0;
-    for (int i = 0; i < string.length(); i++)
-    {
-      char c = string.charAt(i);
-      if (charSeparator == c)
-      {
-        strings.add(string.substring(index, i));
-        index = i + 1;
-      }
-    }
-
-    int length = string.length();
-    if (index > length)
-    {
-      strings.add("");
-    }
-    else
-    {
-      strings.add(string.substring(index, length));
-    }
-
-    return strings.toArray(new String[strings.size()]);
-  }
-
   private static String toRelative(Loader loader, File file) {
     final var currentDirectory = loader.getCurrentDirectory();
     var fileName = file.toString();
@@ -157,8 +123,8 @@ public final class LibraryManager {
       // Do nothing as we already have defined the default above
     }
     if (currentDirectory != null) {
-      String[] currentParts = split(currentDirectory.toString(), File.separator);
-      String[] newParts = split(fileName, File.separator);
+      final var currentParts = currentDirectory.toString().split(Pattern.quote(File.separator));
+      final var newParts = fileName.split(Pattern.quote(File.separator));
       final var nrOfNewParts = newParts.length;
       // note that the newParts includes the filename, whilst the old doesn't
       var nrOfPartsEqual = 0;

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.regex.Pattern;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
@@ -399,7 +400,7 @@ final class XmlWriter {
       if (lib instanceof LoadedLibrary) {
         final var origFile = LibraryManager.getLibraryFilePath(file.getLoader(), desc);
         if (origFile != null) {
-          final var names = origFile.split(File.separator);
+          final var names = origFile.split(Pattern.quote(File.separator));
           final var filename = names[names.length - 1];
           final var newFile = String.format("%s%s%s", librariesPath, File.separator, filename);
           try {

--- a/src/main/java/com/cburch/logisim/fpga/settings/BoardList.java
+++ b/src/main/java/com/cburch/logisim/fpga/settings/BoardList.java
@@ -93,7 +93,7 @@ public class BoardList {
 
   public BoardList() {
     final var classPath = System.getProperty("java.class.path", File.pathSeparator);
-    final var classPathElements = classPath.split(File.pathSeparator);
+    final var classPathElements = classPath.split(Pattern.quote(File.pathSeparator));
     final var pattern = Pattern.compile(".*.xml");
     for (final var element : classPathElements) {
       definedBoards.addAll(getBoards(pattern, boardResourcePath, element));


### PR DESCRIPTION
I get the exception below when saving in Windows.  It seems like it's an internal Java.String regex issue when a backslash is used as a split String.

I've written a separate 'split' command in the LibraryManager that allows me to save successfully.

Feel free to ignore this pull request if a fix has already been scheduled or my fix breaks Logisim-evolution under Linux.

Cheers,
Andrew

Signed-off-by: Andrew Paterson <andrew.ian.paterson@gmail.com>