### PR TITLE
Fix macOS signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,17 @@ The Java JAR [`logisim-evolution-<version>-all.jar`](https://github.com/logisim-
 is also available and can be run on any system with a supported Java runtime installed.
 
 **Note for macOS users**:
-The Logisim-evolution.app is not code-signed.
+The Logisim-evolution.app is not signed with an Apple approved certificate.
 
 When launching the application for the first time, you will have to start it via the "Open" entry in the
 application icon's context menu in the macOS Finder. This is either done by clicking the application
 icon with the right mouse button or holding down <kbd>CTRL</kbd> while clicking the icon with the
 left mouse button. This will open a panel asking you to verify that you wish to launch the application.
+On more recent versions of macOS, the panel will only give you a choice of moving the app to the trash or Cancel.
+On those systems, click Cancel, open `System Preferences`, and select `Security & Privacy`.
+There you may need to click the lock to make changes and authenticate with an administrative acccount.
+It should show an option to open the app.
+See [Safely open apps on your Mac](https://support.apple.com/en-us/HT202491) for more information.
 
 Depending on your security settings, you may also get a panel asking if you wish to allow it to accept
 network connections. You can click "Deny" as we do not need network access currently nor we do request any.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -403,30 +403,30 @@ tasks.register("createApp") {
 
     var params = ext.get(SHARED_PARAMS) as List<String>
     params += listOf(
-      "--name", ext.get(UPPERCASE_PROJECT_NAME) as String,
-      "--file-associations", "${supportDir}/macos/file.jpackage",
-      "--icon", "${supportDir}/macos/Logisim-evolution.icns",
-      // app versioning is strictly checked for macOS. No suffix allowed for `app-image` type.
-      "--app-version", ext.get(APP_VERSION_SHORT) as String,
-      "--type", "app-image",
+        "--name", ext.get(UPPERCASE_PROJECT_NAME) as String,
+        "--file-associations", "${supportDir}/macos/file.jpackage",
+        "--icon", "${supportDir}/macos/Logisim-evolution.icns",
+        // app versioning is strictly checked for macOS. No suffix allowed for `app-image` type.
+        "--app-version", ext.get(APP_VERSION_SHORT) as String,
+        "--type", "app-image",
     )
     runCommand(params, "Error while creating the .app directory.")
 
     val targetDir = ext.get(TARGET_DIR) as String
     val pListFilename = "${appDirName}/Contents/Info.plist"
     runCommand(listOf(
-      "awk",
-      "/Unknown/{sub(/Unknown/,\"public.app-category.education\")};"
-              + "{print >\"${targetDir}/Info.plist\"};"
-              + "/NSHighResolutionCapable/{"
-              + "print \"  <string>true</string>\" >\"${targetDir}/Info.plist\";"
-              + "print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"${targetDir}/Info.plist\""
-              + "}",
-      pListFilename,
+        "awk",
+        "/Unknown/{sub(/Unknown/,\"public.app-category.education\")};"
+            + "{print >\"${targetDir}/Info.plist\"};"
+            + "/NSHighResolutionCapable/{"
+            + "print \"  <string>true</string>\" >\"${targetDir}/Info.plist\";"
+            + "print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"${targetDir}/Info.plist\""
+            + "}",
+        pListFilename,
     ), "Error while patching Info.plist file.")
 
     runCommand(listOf(
-      "mv", "${targetDir}/Info.plist", pListFilename
+        "mv", "${targetDir}/Info.plist", pListFilename
     ), "Error while moving Info.plist into the .app directory.")
 
     runCommand(listOf(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -417,6 +417,7 @@ tasks.register("createApp") {
     runCommand(listOf(
         "awk",
         "/Unknown/{sub(/Unknown/,\"public.app-category.education\")};"
+            + "/utilities/{sub(/public.app-category.utilities/,\"public.app-category.education\")};"
             + "{print >\"${targetDir}/Info.plist\"};"
             + "/NSHighResolutionCapable/{"
             + "print \"  <string>true</string>\" >\"${targetDir}/Info.plist\";"
@@ -430,8 +431,8 @@ tasks.register("createApp") {
     ), "Error while moving Info.plist into the .app directory.")
 
     runCommand(listOf(
-        "codesign", "--remove-signature", appDirName
-    ), "Error while executing: codesign --remove-signature")
+        "codesign", "--force", "--sign", "-", appDirName
+    ), "Error while executing: codesign")
   }
 }
 


### PR DESCRIPTION
This PR addresses issue #1267. Rather than unsign the Mac app, this now signs it with a generic signature. 

The README is also updated with more detailed instructions for launching the app the first time.

I also note that the app-category generated from jpackage in Java 16 is `Unknown`. In Java 17 it is `public.app-category.utilities`. We now switch it to `public.app-category.education` in all cases.