### PR TITLE
Default XOR (XNOR) multiple input behaviour changed to odd

### DIFF
--- a/src/main/java/com/cburch/logisim/std/gates/GateAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/gates/GateAttributes.java
@@ -66,7 +66,7 @@ public class GateAttributes extends AbstractAttributeSet {
   Font labelFont = StdAttr.DEFAULT_LABEL_FONT;
 
   GateAttributes(boolean isXor) {
-    xorBehave = isXor ? XOR_ONE : null;
+    xorBehave = isXor ? XOR_ODD : null;
   }
 
   @Override


### PR DESCRIPTION
I believe that the default behaviour of multiple-inputs xor (or xnor) should be odd behaviour rather than one.

This pull request changes this to the odd behaviour by default.

Addresses 'issue' #1321 