### PR TITLE
ChronoPanel NPE fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Fixed Simulate -> Timing Diagram not opening when using "Nimbus" look and feel.
 
 * v3.7.2 (2021-11-09)
   * Fixed Preferences/Window "Reset window layout to defaults" not doing much.

--- a/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
+++ b/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
@@ -305,11 +305,11 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
   public Color[] rowColors(SignalInfo item, boolean isSelected) {
     if (isSelected) return selectColors;
     final var spotlight = model.getSpotlight();
-    if (spotlight != null && spotlight.info == item) return SPOT;
-    return PLAIN;
+    return (spotlight != null && spotlight.info == item) ? SPOT : PLAIN;
   }
 
   private static Color darker(Color c) {
+    if (c == null) return null;
     final var hsb = Color.RGBtoHSB(c.getRed(), c.getGreen(), c.getBlue(), null);
     final var s = 0.8f;
     return (hsb[1] == 0.0)


### PR DESCRIPTION
Adds handling of `null` arguments, fixing #1336 type of NPEs

* #1336