### PR TITLE
Fixed TTL 7442, 7443 and 7444 being non-placeable on the circuit canvas.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Fixed bug preventing TTL 7442, 7443 and 7444 from being placed on the circuit canvas.
 
 * v3.7.2 (2021-11-09)
   * Fixed Preferences/Window "Reset window layout to defaults" not doing much.

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7442.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7442.java
@@ -25,7 +25,7 @@ public class Ttl7442 extends AbstractTtlGate {
   private boolean isExec3 = false;
   private boolean isGray = false;
 
-  private static final byte pinCount = 14;
+  private static final byte pinCount = 16;
   private static final byte[] outPins = {1, 2, 3, 4, 5, 6, 7, 9, 10, 11};
   private static final String[] pinNames = {"O0", "O1", "O2", "O3", "O4", "O5", "O6", "O7", "O8", "O9", "D", "C", "B", "A"};
 

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7464.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7464.java
@@ -48,7 +48,7 @@ public class Ttl7464 extends AbstractTtlGate {
     int[] posX, posY;
     for (var i = 0; i < 4; i++) {
       if (!isIEC) {
-        int tmpOff = (i == 0) | (i == 3) ? 2 : 0;
+        int tmpOff = (i == 0) || (i == 3) ? 2 : 0;
         posX = new int[] {x + 105, x + 107 + tmpOff, x + 107 + tmpOff, x + 111};
         posY = new int[] {y + 20 + i * 10, y + 20 + i * 10, y + 32 + i * 2, y + 32 + i * 2};
         gfx.drawPolyline(posX, posY, 4);


### PR DESCRIPTION
Fixed bug preventing TTL 7442, 7443 and 7444 from being placed on the circuit canvas.
Closes #1342

* #1342