### PR TITLE
Sub-circuit can now be deleted with `DELETE` key, along with `BACKSPACE`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * @dev (????-??-??)
   * Fixed bug preventing TTL 7442, 7443 and 7444 from being placed on the circuit canvas.
+  * Sub-circuit can now be deleted with `DELETE` key, along with `BACKSPACE` used so far.
 
 * v3.7.2 (2021-11-09)
   * Fixed Preferences/Window "Reset window layout to defaults" not doing much.

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
@@ -83,6 +83,7 @@ public class ProjectExplorer extends JTree implements LocaleListener {
 
     InputMap imap = getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
     imap.put(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0), deleteAction);
+    imap.put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), deleteAction);
     ActionMap amap = getActionMap();
     amap.put(deleteAction, deleteAction);
 


### PR DESCRIPTION
Sub-circuit can now be deleted with `DELETE` key, along with `BACKSPACE` supported so far

DEPENDS_ON #1343