### PR TITLE
Fixes Flatpak namespace related issue

### DIFF
--- a/support/Flatpak/com.github.reds.LogisimEvolution.xml
+++ b/support/Flatpak/com.github.reds.LogisimEvolution.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mime-info xmlns="https://www.freedesktop.org/standards/shared-mime-info">
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="application/x-logisim-circuit">
     <comment>Logisim Circuit</comment>
     <glob pattern="*.circ"/>


### PR DESCRIPTION
Whenever I update applications, I get the following error:

```
Wrong namespace on document element in '/var/home/TheEvilSkeleton/.local/share/flatpak/exports/share/mime/packages/com.github.reds.LogisimEvolution.xml' (should be http://www.freedesktop.org/standards/shared-mime-info)
```

This warning was caused by https://github.com/logisim-evolution/logisim-evolution/commit/5f2a9d2e18a5177c10ce48934876f2b0647f2ca4#diff-9d30aa366f803208d2f221bfa3d703ac8791f95367ba0fcfd68f1ac5fef79b86R2, which switched from http to https. I reverted that change due to the warning I was getting.

Fixes: https://github.com/flathub/com.github.reds.LogisimEvolution/issues/21