### PR TITLE
Fixes for issue #1339 (wire starting position error) and #1277 (UI scale auto button)

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -272,6 +272,7 @@ class WindowOptions extends OptionsPanel {
       } else if (e.getActionCommand().equals(cmdSetAutoScaleFactor)) {
         final var tmp = AppPreferences.getAutoScaleFactor();
         AppPreferences.SCALE_FACTOR.set(tmp);
+        AppPreferences.getPrefs().remove(AppPreferences.SCALE_FACTOR.getIdentifier());
         zoomValue.setValue((int) (tmp * 100));
       }
     }

--- a/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -272,7 +272,7 @@ class WindowOptions extends OptionsPanel {
       } else if (e.getActionCommand().equals(cmdSetAutoScaleFactor)) {
         var tmp = AppPreferences.getAutoScaleFactor();
         AppPreferences.SCALE_FACTOR.set(tmp);
-        zoomValue.setValue( (int)(tmp*100) );
+        zoomValue.setValue((int) (tmp * 100));
       }
     }
   }

--- a/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -270,7 +270,7 @@ class WindowOptions extends OptionsPanel {
           proj.getFrame().repaint();
         }
       } else if (e.getActionCommand().equals(cmdSetAutoScaleFactor)) {
-        var tmp = AppPreferences.getAutoScaleFactor();
+        final var tmp = AppPreferences.getAutoScaleFactor();
         AppPreferences.SCALE_FACTOR.set(tmp);
         zoomValue.setValue((int) (tmp * 100));
       }

--- a/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -39,6 +39,7 @@ class WindowOptions extends OptionsPanel {
   private final PrefOptionList toolbarPlacement;
   private final PrefOptionList canvasPlacement;
   private final ZoomSlider zoomValue;
+  private final JButton zoomAutoButton;
   private final JLabel lookfeelLabel;
   private final JLabel zoomLabel;
   private final JLabel importantA;
@@ -60,6 +61,7 @@ class WindowOptions extends OptionsPanel {
 
   protected final String cmdResetWindowLayout = "reset-window-layout";
   protected final String cmdResetGridColors = "reset-grid-colors";
+  protected final String cmdSetAutoScaleFactor = "set-auto-scale-factor";
 
   public WindowOptions(PreferencesFrame window) {
     super(window);
@@ -136,9 +138,14 @@ class WindowOptions extends OptionsPanel {
 
     zoomLabel = new JLabel(S.get("windowToolbarZoomfactor"));
     zoomValue = new ZoomSlider(JSlider.HORIZONTAL, 100, 300, (int) (AppPreferences.SCALE_FACTOR.get() * 100));
-
+    zoomAutoButton = new JButton();
+    zoomAutoButton.addActionListener(listener);
+    zoomAutoButton.setActionCommand(cmdSetAutoScaleFactor);
+    zoomAutoButton.setText(S.get("windowSetAutoScaleFactor"));
     panel.add(zoomLabel);
     panel.add(zoomValue);
+    panel.add(new JLabel(" "));
+    panel.add(zoomAutoButton);
     zoomValue.addChangeListener(listener);
 
     panel.add(new JLabel(" "));
@@ -262,6 +269,10 @@ class WindowOptions extends OptionsPanel {
         for (final var proj : nowOpen) {
           proj.getFrame().repaint();
         }
+      } else if (e.getActionCommand().equals(cmdSetAutoScaleFactor)) {
+        var tmp = AppPreferences.getAutoScaleFactor();
+        AppPreferences.SCALE_FACTOR.set(tmp);
+        zoomValue.setValue( (int)(tmp*100) );
       }
     }
   }

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -575,17 +575,21 @@ public class AppPreferences {
 
   public static final PrefMonitor<Boolean> NEW_INPUT_OUTPUT_SHAPES =
       create(new PrefMonitorBooleanConvert("oldIO", true));
+
+  public static double getAutoScaleFactor() {
+    return (((!GraphicsEnvironment.isHeadless())
+                  ? Toolkit.getDefaultToolkit().getScreenSize().getHeight()
+                  : 0)
+              / 1000);
+  }
+
   public static final PrefMonitor<Double> SCALE_FACTOR =
       create(
           new PrefMonitorDouble(
               "Scale",
               Math.max(
-                  (((!GraphicsEnvironment.isHeadless())
-                          ? Toolkit.getDefaultToolkit().getScreenSize().getHeight()
-                          : 0)
-                      / 1000),
+                  getAutoScaleFactor(),
                   1.0)));
-
   public static final PrefMonitor<String> ADD_AFTER =
       create(
           new PrefMonitorStringOpts(

--- a/src/main/java/com/cburch/logisim/tools/WiringTool.java
+++ b/src/main/java/com/cburch/logisim/tools/WiringTool.java
@@ -49,6 +49,7 @@ public class WiringTool extends Tool {
   private static final int VERTICAL = 2;
 
   private boolean exists = false;
+  private boolean dragFinished = false;
   private boolean inCanvas = false;
   private Location start = Location.create(0, 0);
   private Location cur = Location.create(0, 0);
@@ -274,22 +275,17 @@ public class WiringTool extends Tool {
       canvas.setErrorMessage(S.getter("cannotModifyError"));
       return;
     }
+    Canvas.snapToGrid(e);
+    start = Location.create(e.getX(), e.getY());
+    cur = start;
+    exists = true;
+    hasDragged = false;
 
-    if (exists) {
-      mouseDragged(canvas, g, e);
-    } else {
-      Canvas.snapToGrid(e);
-      start = Location.create(e.getX(), e.getY());
-      cur = start;
-      exists = true;
-      hasDragged = false;
+    startShortening = !canvas.getCircuit().getWires(start).isEmpty();
+    shortening = null;
 
-      startShortening = !canvas.getCircuit().getWires(start).isEmpty();
-      shortening = null;
-
-      super.mousePressed(canvas, g, e);
-      canvas.getProject().repaintCanvas();
-    }
+    super.mousePressed(canvas, g, e);
+    canvas.getProject().repaintCanvas();
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/tools/WiringTool.java
+++ b/src/main/java/com/cburch/logisim/tools/WiringTool.java
@@ -49,7 +49,6 @@ public class WiringTool extends Tool {
   private static final int VERTICAL = 2;
 
   private boolean exists = false;
-  private boolean dragFinished = false;
   private boolean inCanvas = false;
   private Location start = Location.create(0, 0);
   private Location cur = Location.create(0, 0);

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -618,6 +618,7 @@ windowGridBgColor = Grid Background Color:
 windowGridDotColor = Grid Dot Color:
 windowGridZoomedDotColor = Grid Zoomed Dot Color:
 windowGridColorsReset = Reset grid colors to Logisim's defaults
+windowSetAutoScaleFactor = Set zoom factor to Logisim's default
 windowCanvasLocation = Main canvas location:
 #
 # start/AboutCredits.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_cn.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_cn.properties
@@ -618,6 +618,7 @@ windowGridBgColor =网格背景颜色：
 windowGridDotColor =栅格点颜色：
 windowGridZoomedDotColor =栅格缩放点颜色：
 windowGridColorsReset =将网格颜色重置为Logisim的默认值
+# ==> windowSetAutoScaleFactor =
 #
 # start/AboutCredits.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -618,6 +618,7 @@ windowGridBgColor = Grid Hintergrundfarbe:
 windowGridDotColor = Grid Punkt Farbe:
 windowGridZoomedDotColor = Grid Zoom Punkt Farbe:
 windowGridColorsReset = Grid Farbe auf den Logisim standart zurücksetzen
+# ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
 # start/AboutCredits.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -618,6 +618,7 @@ windowToolbarLocation = Θέση Εργαλειοθήκης
 # ==> windowGridDotColor =
 # ==> windowGridZoomedDotColor =
 # ==> windowGridColorsReset =
+# ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
 # start/AboutCredits.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -618,6 +618,7 @@ windowToolbarZoomfactor = Factor de zoom
 # ==> windowGridDotColor =
 # ==> windowGridZoomedDotColor =
 # ==> windowGridColorsReset =
+# ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
 # start/AboutCredits.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -618,6 +618,7 @@ windowGridBgColor = Couleur de fond si grille :
 windowGridDotColor = Couleur des points d'unitée :
 windowGridZoomedDotColor = Couleur des points de sous unitée :
 windowGridColorsReset = Réinitialiser les couleurs de la grille aux valeurs par défaut de Logisim
+# ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
 # start/AboutCredits.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -618,6 +618,7 @@ windowToolbarZoomfactor = Fattore di zoom
 # ==> windowGridDotColor =
 # ==> windowGridZoomedDotColor =
 # ==> windowGridColorsReset =
+# ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
 # start/AboutCredits.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -618,6 +618,7 @@ windowToolbarZoomfactor = ズームファクタ
 # ==> windowGridDotColor =
 # ==> windowGridZoomedDotColor =
 # ==> windowGridColorsReset =
+# ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
 # start/AboutCredits.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -618,6 +618,7 @@ windowGridBgColor = Grid achtergrond kleur
 windowGridDotColor = Grid punt kleur
 windowGridZoomedDotColor = Uitvergrote grid punt kleur
 windowGridColorsReset = Herstel logisims standard grid kleuren
+# ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
 # start/AboutCredits.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -679,6 +679,7 @@ windowGridBgColor = Tło siatki:
 windowGridDotColor = Punkty siatki:
 windowGridZoomedDotColor = Większe punkty siatki:
 windowGridColorsReset = Przywróć kolory domyślne
+# ==> windowSetAutoScaleFactor =
 windowCanvasLocation = Położenie płótna edytora:
 #
 # start/AboutCredits.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -619,6 +619,7 @@ windowGridBgColor = Cor do fundo da grade
 windowGridDotColor = Cor dos pontos da grade
 windowGridZoomedDotColor = Cor dos pontos da grade no zoom
 windowGridColorsReset = Resetar as cores da grade para o padrão do Logisim
+# ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
 # start/AboutCredits.java

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -619,6 +619,7 @@ windowToolbarZoomfactor = коэффициент масштабирования
 # ==> windowGridDotColor =
 # ==> windowGridZoomedDotColor =
 # ==> windowGridColorsReset =
+# ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
 # start/AboutCredits.java


### PR DESCRIPTION
### #1339 - wire starting position error on RMB click
Weirdly enough, when you cancel a left mouse button press-and-drag with a right-click, **no `mouseReleased` event is fired** - not for either mouse button release. This is likely related to Swing.

If you cancel the LMB press with RMB, the `WiringTool` state is as follows:
 - `mousePressed` is fired once
 - `exists` is true
 - `hasDragged` is true if a `mouseMove` was fired before RMB was clicked
 - `start` contains the position where LMB was first pressed

As far as the `WiringTool` is concerned, the LMB is still pressed. Then, a second LMB press does the following:
- `mousePressed` tests `exists` (which is true) and calls `mouseDragged` with the position of the second LMB press
- `mouseDragged` sets `hasDragged`, if the mouse cursor position has changed

Thus, the drag continues from the original starting point, as though it were dragging the whole time. Once `mouseReleased` is fired, the drag operation finishes and the wire is created.

Removing the `exists` test causes the `WiringTool` to treat each `mousePressed` event like it's the first one, resetting state and fixing the issue. 

### #1277 - UI scale auto button
Added a button to reset the UI scale to its calculated default. I moved the calculation to `getAutoScaleFactor()` and call it with an event listener attached to the button.
![image](https://user-images.githubusercontent.com/47301809/150237162-6fbfa7a4-2176-4cfe-bc4f-0d3ca0af38f2.png)
