### PR TITLE
(#1379) Fixed unintended shallow copy in CircuitAppearance.java

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearance.java
@@ -468,8 +468,14 @@ public class CircuitAppearance extends Drawing implements AttributeListener {
   public void setObjectsForce(List<? extends CanvasObject> shapesBase, boolean isDefault) {
     // This shouldn't ever be an issue, but just to make doubly sure, we'll
     // check that the anchor and all ports are in their proper places.
-    final var shapes = new ArrayList<CanvasObject>(shapesBase);
-    final var n = shapes.size();
+    
+    // Must manually deep-copy arrays in Java...
+    // final var shapes = new ArrayList<CanvasObject>(shapesBase);
+    final var n = shapesBase.size();
+    final var shapes = new ArrayList<CanvasObject>(n);
+    for (var i = 0; i < n; i++) {
+      shapes.add(shapesBase.get(i).clone());
+    }
     var ports = 0;
     for (var i = n - 1; i >= 0; i--) { // count ports, move anchor to end
       final var obj = shapes.get(i);


### PR DESCRIPTION
### #1379 

In `XmlReader.java`, line 274, there was a test to determine whether a particular circuit had a custom appearance or the default. This function (`hasCustomAppearance()`) is implemented in `CircuitAppearance.java`, line 79.

The algorithm used for `hasCustomAppearance()` ignored pin count and position, among other things. If `hasCustomAppearance()` returned false for a circuit, then the `XmlReader` didn't write an `<appear>` block in the XML - which causes the next file load to erroneously reset the custom appearance of that circuit.

Instead of troubleshooting the algorithm, I opted to remove the test on line 274, since it doesn't seem to be very expensive to have an `<appear>` block for every circuit. 