### PR TITLE
Bug fix for #1411

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
@@ -111,6 +111,7 @@ public class RegTabContent extends JScrollPane implements LocaleListener, Simula
         constraints.gridx++;
         final var selReg = registers.get(key);
         var mainCircState = proj.getCircuitState();
+        if (mainCircState == null) continue;
         while (mainCircState.getParentState() != null) { // Get the main circuit
           mainCircState = mainCircState.getParentState();
         }


### PR DESCRIPTION
As a vhdl "circuit" does not contain any state, the register tab triggered a NPE. This PR fixes this and addresses #1411