### PR TITLE
Fix deprecated Runtime.exec() method for Java 18

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/hex/HexFile.java
+++ b/src/main/java/com/cburch/logisim/gui/hex/HexFile.java
@@ -503,11 +503,13 @@ public class HexFile {
         final var endian = desc.endsWith("big-endian") ? "big-endian" : "little-endian";
 
         final var other = new File(tmp + ".xxd");
-        Runtime.getRuntime().exec(String.format("xxd %s %s", tmp, other)).waitFor();
+        final String[] cmd1 = {"xxd", tmp.toString(), other.toString()};
+        Runtime.getRuntime().exec(cmd1).waitFor();
         compare(false, "v3.0 hex bytes addressed " + endian, other, addrSize, wordSize, vals);
 
         final var plain = new File(tmp + ".xxd-plain");
-        Runtime.getRuntime().exec(String.format("xxd -p %s %s", tmp, plain)).waitFor();
+        final String[] cmd2 = {"xxd", "-p", tmp.toString(), plain.toString()};
+        Runtime.getRuntime().exec(cmd2).waitFor();
         compare(false, "v3.0 hex bytes plain " + endian, plain, addrSize, wordSize, vals);
       }
 


### PR DESCRIPTION
In about a week, Java 18 will be released. I tried the release candidate with our code. Java 18 deprecates the use of Runtime.exec(String). This PR replaces the two places in our code that use this method. I did not see any other problems using Java 18 to compile our code.

I was unable to actually test this change. The only place this code is executed is during running the main method of the HexFile class. That method is intended to be a test of the code. However, it fails before even reaching the calls to exec. There are actually four main methods in our code that are likely intended as tests. These should be moved to junit tests or perhaps abandoned. I'll create an issue for this.