### PR TITLE
Fix problem with reading "v3.0 hex byte addressed" memory

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/hex/HexFile.java
+++ b/src/main/java/com/cburch/logisim/gui/hex/HexFile.java
@@ -1526,7 +1526,7 @@ public class HexFile {
           for (; j < m; j++) {
             int d;
             try {
-              d = hex2int(word.charAt(i));
+              d = hex2int(word.charAt(j));
             } catch (NumberFormatException e) {
               warn("Character '%s' is not a hex digit.", OutputStreamEscaper.escape(word.charAt(i)));
               continue;


### PR DESCRIPTION
This fixes the problem that caused the "main" test to fail in HexFile as reported in #1414. The problem was introduced about a year ago when cleaning up error handling.

With this change, the test now succeeds. I will now look at moving this test to junit as noted in #1415.
