### PR TITLE
Add a manual way to run the nightly workflow.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,7 @@ on:
   schedule:
     # every day at midnight
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 env:
   JDK_VERSION: 16


### PR DESCRIPTION
Today, despite the README.md file pointing to nightly.yml to download a nightly, there are none there.
The workflow is not run because "schedule" is not triggered on branches.

As a workaround, we can add a button to manually run the workflow whenever we want to run this workflow.