### PR TITLE
Fix Locale constructor deprecations

### DIFF
--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -65,7 +65,7 @@ public class AppPreferences {
 
       String localeStr = this.get();
       if (!("".equals(localeStr))) {
-        LocaleManager.setLocale(new Locale(localeStr));
+        LocaleManager.setLocale(Locale.forLanguageTag(localeStr));
       }
       LocaleManager.addLocaleListener(myListener);
       myListener.localeChanged();

--- a/src/main/java/com/cburch/logisim/util/LocaleManager.java
+++ b/src/main/java/com/cburch/logisim/util/LocaleManager.java
@@ -207,7 +207,7 @@ public class LocaleManager {
         }
       }
       if (select == null) {
-        select = Objects.requireNonNullElseGet(backup, () -> new Locale("en"));
+        select = Objects.requireNonNullElseGet(backup, () -> Locale.ENGLISH);
       }
 
       curLocale = select;
@@ -224,7 +224,7 @@ public class LocaleManager {
     var locales = getLocaleOptions();
     if (locales == null || locales.length == 0) {
       var cur = getLocale();
-      if (cur == null) cur = new Locale("en");
+      if (cur == null) cur = Locale.ENGLISH;
       locales = new Locale[] {cur};
     }
     return new JScrollPane(new LocaleSelector(locales));
@@ -277,7 +277,7 @@ public class LocaleManager {
         country = null;
       }
       if (language != null) {
-        final var loc = country == null ? new Locale(language) : new Locale(language, country);
+        final var loc = new Locale.Builder().setLanguage(language).setRegion(country).build();
         retl.add(loc);
       }
     }


### PR DESCRIPTION
Java 19 will be released in September. I downloaded the release candidate and used it to build LE. It works well, except for deprecation of some constructors for Locale. This PR fixes the deprecated items so LE will compile cleanly in Java 19.