### PR TITLE
Fixed off-grid components causing logisim to get an out of memory error. Fixes #1516

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
-  * fixed off grid components bug
+  * Fixed off grid components bug that could lead to OutOfMemory error.
   * Fixed bug preventing TTL 7442, 7443 and 7444 from being placed on the circuit canvas.
   * Sub-circuit can now be deleted with `DELETE` key, along with `BACKSPACE` used so far.
   * Fixed `Simulate` -> `Timing Diagram` not opening when using "Nimbus" look and feel.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * fixed off grid components bug
   * Fixed bug preventing TTL 7442, 7443 and 7444 from being placed on the circuit canvas.
   * Sub-circuit can now be deleted with `DELETE` key, along with `BACKSPACE` used so far.
   * Fixed `Simulate` -> `Timing Diagram` not opening when using "Nimbus" look and feel.

--- a/src/main/java/com/cburch/draw/canvas/CanvasListener.java
+++ b/src/main/java/com/cburch/draw/canvas/CanvasListener.java
@@ -56,7 +56,7 @@ class CanvasListener
   }
 
   private void handlePopupTrigger(MouseEvent e) {
-    final var loc = Location.create(e.getX(), e.getY());
+    final var loc = Location.create(e.getX(), e.getY(), false);
     final var objects = canvas.getModel().getObjectsFromTop();
     CanvasObject clicked = null;
     for (final var o : objects) {
@@ -77,7 +77,7 @@ class CanvasListener
   }
 
   private void handlePorts(MouseEvent e) {
-    final var loc = Location.create(e.getX(), e.getY());
+    final var loc = Location.create(e.getX(), e.getY(), true);
     final var objects = canvas.getModel().getObjectsFromTop();
     final var ports = new ArrayList<CanvasObject>();
     CanvasObject newSelectedPort = null;

--- a/src/main/java/com/cburch/draw/canvas/Selection.java
+++ b/src/main/java/com/cburch/draw/canvas/Selection.java
@@ -90,7 +90,7 @@ public class Selection {
   }
 
   public Location getMovingDelta() {
-    return Location.create(moveDx, moveDy);
+    return Location.create(moveDx, moveDy, false);
   }
 
   public Set<CanvasObject> getSelected() {

--- a/src/main/java/com/cburch/draw/model/AbstractCanvasObject.java
+++ b/src/main/java/com/cburch/draw/model/AbstractCanvasObject.java
@@ -112,7 +112,7 @@ public abstract class AbstractCanvasObject implements AttributeSet, CanvasObject
     final var w = bds.getWidth();
     final var h = bds.getHeight();
     for (var i = 0; i < GENERATE_RANDOM_TRIES; i++) {
-      final var loc = Location.create(x + rand.nextInt(w), y + rand.nextInt(h));
+      final var loc = Location.create(x + rand.nextInt(w), y + rand.nextInt(h), false);
       if (contains(loc, false)) return loc;
     }
     return null;

--- a/src/main/java/com/cburch/draw/model/Handle.java
+++ b/src/main/java/com/cburch/draw/model/Handle.java
@@ -34,7 +34,7 @@ public class Handle {
   }
 
   public Location getLocation() {
-    return Location.create(x, y);
+    return Location.create(x, y, false);
   }
 
   public CanvasObject getObject() {

--- a/src/main/java/com/cburch/draw/shapes/Line.java
+++ b/src/main/java/com/cburch/draw/shapes/Line.java
@@ -77,11 +77,11 @@ public class Line extends AbstractCanvasObject {
   }
 
   public Location getEnd0() {
-    return Location.create(x0, y0);
+    return Location.create(x0, y0, false);
   }
 
   public Location getEnd1() {
-    return Location.create(x1, y1);
+    return Location.create(x1, y1, false);
   }
 
   public List<Handle> getHandles() {
@@ -98,8 +98,8 @@ public class Line extends AbstractCanvasObject {
       final var dx = gesture.getDeltaX();
       final var dy = gesture.getDeltaY();
       final var ret = new Handle[2];
-      ret[0] = new Handle(this, h.isAt(x0, y0) ? Location.create(x0 + dx, y0 + dy) : Location.create(x0, y0));
-      ret[1] = new Handle(this, h.isAt(x1, y1) ? Location.create(x1 + dx, y1 + dy) : Location.create(x1, y1));
+      ret[0] = new Handle(this, h.isAt(x0, y0) ? Location.create(x0 + dx, y0 + dy, false) : Location.create(x0, y0, false));
+      ret[1] = new Handle(this, h.isAt(x1, y1) ? Location.create(x1 + dx, y1 + dy, false) : Location.create(x1, y1, false));
       return UnmodifiableList.create(ret);
     }
   }
@@ -114,7 +114,7 @@ public class Line extends AbstractCanvasObject {
       x += (rand.nextInt(w) - w / 2);
       y += (rand.nextInt(w) - w / 2);
     }
-    return Location.create(x, y);
+    return Location.create(x, y, false);
   }
 
   @Override

--- a/src/main/java/com/cburch/draw/shapes/LineUtil.java
+++ b/src/main/java/com/cburch/draw/shapes/LineUtil.java
@@ -88,22 +88,22 @@ public final class LineUtil {
         case 0:
         case 8: // going west
         case 4: // going east
-          return Location.create(mx, py);
+          return Location.create(mx, py, false);
         case 2: // going north
         case 6: // going south
-          return Location.create(px, my);
+          return Location.create(px, my, false);
         case 1: // going northwest
-          return Location.create(px - d45, py - d45);
+          return Location.create(px - d45, py - d45, false);
         case 3: // going northeast
-          return Location.create(px + d45, py - d45);
+          return Location.create(px + d45, py - d45, false);
         case 5: // going southeast
-          return Location.create(px + d45, py + d45);
+          return Location.create(px + d45, py + d45, false);
         case 7: // going southwest
-          return Location.create(px - d45, py + d45);
+          return Location.create(px - d45, py + d45, false);
         default:
           break;
       }
     }
-    return Location.create(mx, my); // should never happen
+    return Location.create(mx, my, false); // should never happen
   }
 }

--- a/src/main/java/com/cburch/draw/shapes/Oval.java
+++ b/src/main/java/com/cburch/draw/shapes/Oval.java
@@ -68,7 +68,7 @@ public class Oval extends Rectangular {
       x += rand.nextInt(d) - d / 2;
       y += rand.nextInt(d) - d / 2;
     }
-    return Location.create(x, y);
+    return Location.create(x, y, false);
   }
 
   @Override

--- a/src/main/java/com/cburch/draw/shapes/Poly.java
+++ b/src/main/java/com/cburch/draw/shapes/Poly.java
@@ -190,7 +190,7 @@ public class Poly extends FillableCanvasObject {
           } else if (next == null) {
             r = LineUtil.snapTo8Cardinals(prev, x, y);
           } else {
-            final var to = Location.create(x, y);
+            final var to = Location.create(x, y, false);
             final var a = LineUtil.snapTo8Cardinals(prev, x, y);
             final var b = LineUtil.snapTo8Cardinals(next, x, y);
             final var ad = a.manhattanDistanceTo(to);
@@ -198,7 +198,7 @@ public class Poly extends FillableCanvasObject {
             r = ad < bd ? a : b;
           }
         } else {
-          r = Location.create(x, y);
+          r = Location.create(x, y, false);
         }
         ret[i] = new Handle(this, r);
       } else {
@@ -250,7 +250,7 @@ public class Poly extends FillableCanvasObject {
         final var u = Math.random();
         final var x = (int) Math.round(p.getX() + u * (q.getX() - p.getX()));
         final var y = (int) Math.round(p.getY() + u * (q.getY() - p.getY()));
-        return Location.create(x, y);
+        return Location.create(x, y, false);
       }
     }
   }

--- a/src/main/java/com/cburch/draw/shapes/PolyUtil.java
+++ b/src/main/java/com/cburch/draw/shapes/PolyUtil.java
@@ -49,7 +49,7 @@ public final class PolyUtil {
       final var h1 = ret.nextHandle;
       final var p =
           LineUtil.nearestPointSegment(xq, yq, h0.getX(), h0.getY(), h1.getX(), h1.getY());
-      ret.loc = Location.create((int) Math.round(p[0]), (int) Math.round(p[1]));
+      ret.loc = Location.create((int) Math.round(p[0]), (int) Math.round(p[1]), false);
       return ret;
     }
   }

--- a/src/main/java/com/cburch/draw/shapes/Rectangle.java
+++ b/src/main/java/com/cburch/draw/shapes/Rectangle.java
@@ -74,7 +74,7 @@ public class Rectangle extends Rectangular {
       x += rand.nextInt(d) - d / 2;
       y += rand.nextInt(d) - d / 2;
     }
-    return Location.create(x, y);
+    return Location.create(x, y, false);
   }
 
   @Override

--- a/src/main/java/com/cburch/draw/shapes/RoundRectangle.java
+++ b/src/main/java/com/cburch/draw/shapes/RoundRectangle.java
@@ -119,7 +119,7 @@ public class RoundRectangle extends Rectangular {
       x += rand.nextInt(d) - d / 2;
       y += rand.nextInt(d) - d / 2;
     }
-    return Location.create(x, y);
+    return Location.create(x, y, false);
   }
 
   @Override

--- a/src/main/java/com/cburch/draw/shapes/SvgReader.java
+++ b/src/main/java/com/cburch/draw/shapes/SvgReader.java
@@ -91,9 +91,9 @@ public final class SvgReader {
           x2 += x0;
           y2 += y0;
         }
-        final var e0 = Location.create(x0, y0);
-        final var e1 = Location.create(x2, y2);
-        final var ct = Location.create(x1, y1);
+        final var e0 = Location.create(x0, y0, false);
+        final var e1 = Location.create(x2, y2, false);
+        final var ct = Location.create(x1, y1, false);
         return new Curve(e0, e1, ct);
       } else {
         throw new NumberFormatException("Unexpected format for curve");
@@ -300,7 +300,7 @@ public final class SvgReader {
     for (var i = 0; i < ret.length; i++) {
       final var x = Integer.parseInt(toks[2 * i]);
       final var y = Integer.parseInt(toks[2 * i + 1]);
-      ret[i] = Location.create(x, y);
+      ret[i] = Location.create(x, y, false);
     }
     return UnmodifiableList.create(ret);
   }

--- a/src/main/java/com/cburch/draw/shapes/Text.java
+++ b/src/main/java/com/cburch/draw/shapes/Text.java
@@ -94,7 +94,7 @@ public class Text extends AbstractCanvasObject {
   }
 
   public Location getLocation() {
-    return Location.create(label.getX(), label.getY());
+    return Location.create(label.getX(), label.getY(), false);
   }
 
   public String getText() {

--- a/src/main/java/com/cburch/draw/tools/CurveTool.java
+++ b/src/main/java/com/cburch/draw/tools/CurveTool.java
@@ -120,12 +120,12 @@ public class CurveTool extends AbstractTool {
 
     switch (state) {
       case BEFORE_CREATION, CONTROL_DRAG -> {
-        end0 = Location.create(mx, my);
+        end0 = Location.create(mx, my, false);
         end1 = end0;
         state = ENDPOINT_DRAG;
       }
       case ENDPOINT_DRAG -> {
-        curCurve = new Curve(end0, end1, Location.create(mx, my));
+        curCurve = new Curve(end0, end1, Location.create(mx, my, false));
         state = CONTROL_DRAG;
       }
       default -> {
@@ -180,7 +180,7 @@ public class CurveTool extends AbstractTool {
             mx = canvas.snapX(mx);
             my = canvas.snapY(my);
           }
-          end1 = Location.create(mx, my);
+          end1 = Location.create(mx, my, false);
         }
         break;
       case CONTROL_DRAG:
@@ -212,7 +212,7 @@ public class CurveTool extends AbstractTool {
             cx = (int) Math.round(ct[0]);
             cy = (int) Math.round(ct[1]);
           }
-          ret = new Curve(end0, end1, Location.create(cx, cy));
+          ret = new Curve(end0, end1, Location.create(cx, cy, false));
           curCurve = ret;
         }
         break;

--- a/src/main/java/com/cburch/draw/tools/LineTool.java
+++ b/src/main/java/com/cburch/draw/tools/LineTool.java
@@ -46,10 +46,10 @@ public class LineTool extends AbstractTool {
     final var py = from.getY();
     if (mx != px && my != py) {
       return (Math.abs(my - py) < Math.abs(mx - px))
-          ? Location.create(mx, py)
-          : Location.create(px, my);
+          ? Location.create(mx, py, false)
+          : Location.create(px, my, false);
     }
-    return Location.create(mx, my); // should never happen
+    return Location.create(mx, my, false); // should never happen
   }
 
   @Override
@@ -104,7 +104,7 @@ public class LineTool extends AbstractTool {
       x = canvas.snapX(x);
       y = canvas.snapY(y);
     }
-    final var loc = Location.create(x, y);
+    final var loc = Location.create(x, y, false);
     mouseStart = loc;
     mouseEnd = loc;
     lastMouseX = loc.getX();
@@ -148,14 +148,14 @@ public class LineTool extends AbstractTool {
     if (active) {
       final var shift = (mods & MouseEvent.SHIFT_DOWN_MASK) != 0;
       var newEnd =
-          (shift) ? LineUtil.snapTo8Cardinals(mouseStart, mx, my) : Location.create(mx, my);
+          (shift) ? LineUtil.snapTo8Cardinals(mouseStart, mx, my) : Location.create(mx, my, false);
 
       if ((mods & InputEvent.CTRL_DOWN_MASK) != 0) {
         var x = newEnd.getX();
         var y = newEnd.getY();
         x = canvas.snapX(x);
         y = canvas.snapY(y);
-        newEnd = Location.create(x, y);
+        newEnd = Location.create(x, y, false);
       }
 
       if (!newEnd.equals(mouseEnd)) {

--- a/src/main/java/com/cburch/draw/tools/PolyTool.java
+++ b/src/main/java/com/cburch/draw/tools/PolyTool.java
@@ -150,7 +150,7 @@ public class PolyTool extends AbstractTool {
       return;
     }
 
-    final var loc = Location.create(mx, my);
+    final var loc = Location.create(mx, my, false);
     final var locs = locations;
     if (!active) {
       locs.clear();
@@ -203,14 +203,14 @@ public class PolyTool extends AbstractTool {
         final var nextLast = locations.get(index - 1);
         newLast = LineUtil.snapTo8Cardinals(nextLast, mx, my);
       } else {
-        newLast = Location.create(mx, my);
+        newLast = Location.create(mx, my, false);
       }
       if ((mods & MouseEvent.CTRL_DOWN_MASK) != 0) {
         var lastX = newLast.getX();
         var lastY = newLast.getY();
         lastX = canvas.snapX(lastX);
         lastY = canvas.snapY(lastY);
-        newLast = Location.create(lastX, lastY);
+        newLast = Location.create(lastX, lastY, false);
       }
 
       if (!newLast.equals(last)) {

--- a/src/main/java/com/cburch/draw/tools/RectangularTool.java
+++ b/src/main/java/com/cburch/draw/tools/RectangularTool.java
@@ -132,7 +132,7 @@ abstract class RectangularTool extends AbstractTool {
 
   @Override
   public void mousePressed(Canvas canvas, MouseEvent e) {
-    final var loc = Location.create(e.getX(), e.getY());
+    final var loc = Location.create(e.getX(), e.getY(), false);
     final var bds = Bounds.create(loc);
     dragStart = loc;
     lastMouseX = loc.getX();

--- a/src/main/java/com/cburch/draw/tools/SelectTool.java
+++ b/src/main/java/com/cburch/draw/tools/SelectTool.java
@@ -56,13 +56,13 @@ public class SelectTool extends AbstractTool {
 
   public SelectTool() {
     curAction = IDLE;
-    dragStart = Location.create(0, 0);
+    dragStart = Location.create(0, 0, false);
     dragEnd = dragStart;
     dragEffective = false;
   }
 
   private static CanvasObject getObjectAt(CanvasModel model, int x, int y, boolean assumeFilled) {
-    final var loc = Location.create(x, y);
+    final var loc = Location.create(x, y, false);
     for (final var o : model.getObjectsFromTop()) {
       if (o.contains(loc, assumeFilled)) return o;
     }
@@ -272,7 +272,7 @@ public class SelectTool extends AbstractTool {
     beforePressHandle = canvas.getSelection().getSelectedHandle();
     final var mx = e.getX();
     final var my = e.getY();
-    dragStart = Location.create(mx, my);
+    dragStart = Location.create(mx, my, false);
     dragEffective = false;
     dragEnd = dragStart;
     lastMouseX = mx;
@@ -378,7 +378,7 @@ public class SelectTool extends AbstractTool {
     switch (action) {
       case MOVE_ALL:
         final var moveDelta = selection.getMovingDelta();
-        if (dragEffective && !moveDelta.equals(Location.create(0, 0))) {
+        if (dragEffective && !moveDelta.equals(Location.create(0, 0, false))) {
           canvas.doAction(
               new ModelTranslateAction(model, selected, moveDelta.getX(), moveDelta.getY()));
         }
@@ -430,7 +430,7 @@ public class SelectTool extends AbstractTool {
   private void setMouse(Canvas canvas, int mx, int my, int mods) {
     lastMouseX = mx;
     lastMouseY = my;
-    final var newEnd = Location.create(mx, my);
+    final var newEnd = Location.create(mx, my, false);
     dragEnd = newEnd;
 
     final var start = dragStart;

--- a/src/main/java/com/cburch/draw/tools/TextTool.java
+++ b/src/main/java/com/cburch/draw/tools/TextTool.java
@@ -121,7 +121,7 @@ public class TextTool extends AbstractTool {
     var found = false;
     final var mx = e.getX();
     final var my = e.getY();
-    final var mloc = Location.create(mx, my);
+    final var mloc = Location.create(mx, my, false);
     for (final var o : canvas.getModel().getObjectsFromTop()) {
       if (o instanceof Text && o.contains(mloc, true)) {
         clicked = (Text) o;

--- a/src/main/java/com/cburch/logisim/circuit/Splitter.java
+++ b/src/main/java/com/cburch/logisim/circuit/Splitter.java
@@ -31,7 +31,6 @@ import com.cburch.logisim.tools.ToolTipMaker;
 import com.cburch.logisim.tools.WireRepair;
 import com.cburch.logisim.tools.WireRepairData;
 import com.cburch.logisim.util.GraphicsUtil;
-import com.cburch.logisim.util.StringUtil;
 import javax.swing.JPopupMenu;
 
 public class Splitter extends ManagedComponent
@@ -117,7 +116,7 @@ public class Splitter extends ManagedComponent
     final var ends = new EndData[fanout + 1];
     ends[0] = new EndData(origin, BitWidth.create(bitEnd.length), EndData.INPUT_OUTPUT);
     for (var i = 0; i < fanout; i++) {
-      ends[i + 1] = new EndData(Location.create(x, y), BitWidth.create(endWidth[i + 1]), EndData.INPUT_OUTPUT);
+      ends[i + 1] = new EndData(Location.create(x, y, true), BitWidth.create(endWidth[i + 1]), EndData.INPUT_OUTPUT);
       x += dx;
       y += dy;
     }

--- a/src/main/java/com/cburch/logisim/circuit/SplitterFactory.java
+++ b/src/main/java/com/cburch/logisim/circuit/SplitterFactory.java
@@ -56,7 +56,7 @@ public class SplitterFactory extends AbstractComponentFactory {
   public void drawGhost(ComponentDrawContext context, Color color, int x, int y, AttributeSet attrsBase) {
     final var attrs = (SplitterAttributes) attrsBase;
     context.getGraphics().setColor(color);
-    final var loc = Location.create(x, y);
+    final var loc = Location.create(x, y, true);
     if (attrs.appear == SplitterAttributes.APPEAR_LEGACY) {
       SplitterPainter.drawLegacy(context, attrs, loc);
     } else {

--- a/src/main/java/com/cburch/logisim/circuit/SplitterPainter.java
+++ b/src/main/java/com/cburch/logisim/circuit/SplitterPainter.java
@@ -104,7 +104,7 @@ class SplitterPainter {
       var yi = y1;
       for (int i = 1; i <= fanout; i++) {
         if (context.getShowState()) {
-          g.setColor(state.getValue(Location.create(xi, yi)).getColor());
+          g.setColor(state.getValue(Location.create(xi, yi, true)).getColor());
         }
         final var xSpine = xi + (xi == x0 ? 0 : (xi < x0 ? 10 : -10));
         g.drawLine(xi, yi, xSpine, ySpine);
@@ -128,7 +128,7 @@ class SplitterPainter {
       var yi = y1;
       for (int i = 1; i <= fanout; i++) {
         if (context.getShowState()) {
-          g.setColor(state.getValue(Location.create(xi, yi)).getColor());
+          g.setColor(state.getValue(Location.create(xi, yi, true)).getColor());
         }
         final var ySpine = yi + (yi == y0 ? 0 : (yi < y0 ? 10 : -10));
         g.drawLine(xi, yi, xSpine, ySpine);
@@ -168,7 +168,7 @@ class SplitterPainter {
     GraphicsUtil.switchToWidth(g, Wire.WIDTH);
     for (int i = 0, n = attrs.fanout; i < n; i++) {
       if (showState) {
-        final var val = state.getValue(Location.create(x, y));
+        final var val = state.getValue(Location.create(x, y, true));
         g.setColor(val.getColor());
       }
       g.drawLine(x, y, x + dxEndSpine, y + dyEndSpine);

--- a/src/main/java/com/cburch/logisim/circuit/WireFactory.java
+++ b/src/main/java/com/cburch/logisim/circuit/WireFactory.java
@@ -28,7 +28,7 @@ class WireFactory extends AbstractComponentFactory {
 
   @Override
   public AttributeSet createAttributeSet() {
-    return Wire.create(Location.create(0, 0), Location.create(100, 0));
+    return Wire.create(Location.create(0, 0, true), Location.create(100, 0, true));
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/circuit/WireIterator.java
+++ b/src/main/java/com/cburch/logisim/circuit/WireIterator.java
@@ -51,7 +51,7 @@ class WireIterator implements Iterator<Location> {
 
   @Override
   public Location next() {
-    final var ret = Location.create(curX, curY);
+    final var ret = Location.create(curX, curY, true);
     destReturned |= curX == destX && curY == destY;
     curX += deltaX;
     curY += deltaY;

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceAnchor.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceAnchor.java
@@ -120,8 +120,8 @@ public class AppearanceAnchor extends AppearanceElement {
   public Element toSvgElement(Document doc) {
     final var loc = getLocation();
     final var ret = doc.createElement("circ-anchor");
-    ret.setAttribute("x", "" + loc.getX());
-    ret.setAttribute("y", "" + loc.getY());
+    ret.setAttribute("x", Integer.toString(loc.getX()));
+    ret.setAttribute("y", Integer.toString(loc.getY()));
     ret.setAttribute("facing", factingDirection.toString());
     return ret;
   }

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceAnchor.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceAnchor.java
@@ -120,10 +120,8 @@ public class AppearanceAnchor extends AppearanceElement {
   public Element toSvgElement(Document doc) {
     final var loc = getLocation();
     final var ret = doc.createElement("circ-anchor");
-    ret.setAttribute("x", "" + (loc.getX() - RADIUS));
-    ret.setAttribute("y", "" + (loc.getY() - RADIUS));
-    ret.setAttribute("width", "" + 2 * RADIUS);
-    ret.setAttribute("height", "" + 2 * RADIUS);
+    ret.setAttribute("x", "" + loc.getX());
+    ret.setAttribute("y", "" + loc.getY());
     ret.setAttribute("facing", factingDirection.toString());
     return ret;
   }

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearancePort.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearancePort.java
@@ -128,12 +128,10 @@ public class AppearancePort extends AppearanceElement {
     final var loc = getLocation();
     final var pinLoc = pin.getLocation();
     final var ret = doc.createElement("circ-port");
-    final var r = isInput() ? INPUT_RADIUS : OUTPUT_RADIUS;
-    ret.setAttribute("x", "" + (loc.getX() - r));
-    ret.setAttribute("y", "" + (loc.getY() - r));
-    ret.setAttribute("width", "" + 2 * r);
-    ret.setAttribute("height", "" + 2 * r);
-    ret.setAttribute("pin", "" + pinLoc.getX() + "," + pinLoc.getY());
+    ret.setAttribute("x", Integer.toString(loc.getX()));
+    ret.setAttribute("y", Integer.toString(loc.getY()));
+    ret.setAttribute("dir", isInput() ? "in" : "out");
+    ret.setAttribute("pin", String.format("%d,%d", pinLoc.getX(), pinLoc.getY()));
     return ret;
   }
 }

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
@@ -136,12 +136,11 @@ public class AppearanceSvgReader {
     if (elt.hasAttribute("dir")) {
       final var direction = elt.getAttribute("dir");
       return direction.equals("in");
-    } else {
-      // for backward compatability
-      final var width = Double.parseDouble(elt.getAttribute("width"));
-      final var radius = (int) Math.round(width / 2.0);
-      return AppearancePort.isInputAppearance(radius);
     }
+    // for backward compatability
+    final var width = Double.parseDouble(elt.getAttribute("width"));
+    final var radius = (int) Math.round(width / 2.0);
+    return AppearancePort.isInputAppearance(radius);
   }
 
   private static Location getLocation(Element elt, boolean hasToSnap) {

--- a/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/AppearanceSvgReader.java
@@ -64,7 +64,7 @@ public class AppearanceSvgReader {
   public static AbstractCanvasObject createShape(Element elt, List<PinInfo> pins, Circuit circuit) {
     final var name = elt.getTagName();
     if (name.equals("circ-anchor") || name.equals("circ-origin")) {
-      final var loc = getLocation(elt);
+      final var loc = getLocation(elt, true);
       final var ret = new AppearanceAnchor(loc);
       if (elt.hasAttribute("facing")) {
         final var facing = Direction.parse(elt.getAttribute("facing"));
@@ -74,9 +74,9 @@ public class AppearanceSvgReader {
     }
 
     if (name.equals("circ-port")) {
-      final var loc = getLocation(elt);
+      final var loc = getLocation(elt, true);
       final var pinStr = elt.getAttribute("pin").split(",");
-      final var pinLoc = Location.create(Integer.parseInt(pinStr[0].trim()), Integer.parseInt(pinStr[1].trim()));
+      final var pinLoc = Location.create(Integer.parseInt(pinStr[0].trim()), Integer.parseInt(pinStr[1].trim()), true);
       for (final var pin : pins) {
         if (pin.pinIsAlreadyUsed()) continue;
         if (pin.getPinLocation().equals(pinLoc)) {
@@ -132,18 +132,33 @@ public class AppearanceSvgReader {
   }
 
   private static Boolean isInputPinReference(Element elt) {
-    final var width = Double.parseDouble(elt.getAttribute("width"));
-    final var radius = (int) Math.round(width / 2.0);
-    return AppearancePort.isInputAppearance(radius);
+    
+    if (elt.hasAttribute("dir")) {
+      final var direction = elt.getAttribute("dir");
+      return direction.equals("in");
+    } else {
+      // for backward compatability
+      final var width = Double.parseDouble(elt.getAttribute("width"));
+      final var radius = (int) Math.round(width / 2.0);
+      return AppearancePort.isInputAppearance(radius);
+    }
   }
 
-  private static Location getLocation(Element elt) {
-    final var x = Double.parseDouble(elt.getAttribute("x"));
-    final var y = Double.parseDouble(elt.getAttribute("y"));
-    final var w = Double.parseDouble(elt.getAttribute("width"));
-    final var h = Double.parseDouble(elt.getAttribute("height"));
-    final var px = (int) Math.round(x + w / 2);
-    final var py = (int) Math.round(y + h / 2);
-    return Location.create(px, py);
+  private static Location getLocation(Element elt, boolean hasToSnap) {
+    // for backward compatability
+    var px = 0;
+    var py = 0;
+    if (elt.hasAttribute("width") && elt.hasAttribute("height")) {
+      final var x = Double.parseDouble(elt.getAttribute("x"));
+      final var y = Double.parseDouble(elt.getAttribute("y"));
+      final var w = Double.parseDouble(elt.getAttribute("width"));
+      final var h = Double.parseDouble(elt.getAttribute("height"));
+      px = (int) Math.round(x + w / 2);
+      py = (int) Math.round(y + h / 2);
+    } else {
+      px = Integer.parseInt(elt.getAttribute("x"));
+      py = Integer.parseInt(elt.getAttribute("y"));
+    }
+    return Location.create(px, py, hasToSnap);
   }
 }

--- a/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearance.java
@@ -193,7 +193,7 @@ public class CircuitAppearance extends Drawing implements AttributeListener {
 
   private Location findAnchorLocation() {
     final var anchor = findAnchor();
-    return (anchor == null) ? Location.create(100, 100) : anchor.getLocation();
+    return (anchor == null) ? Location.create(100, 100, true) : anchor.getLocation();
   }
 
   void fireCircuitAppearanceChanged(int affected) {

--- a/src/main/java/com/cburch/logisim/circuit/appear/DefaultClassicAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DefaultClassicAppearance.java
@@ -80,12 +80,12 @@ public class DefaultClassicAppearance {
     }
 
     // place rectangle so anchor is on the grid
-    final var rX = OFFS + (9 - (ax + 9) % 10);
-    final var rY = OFFS + (9 - (ay + 9) % 10);
+    final var rX = Math.round((OFFS + ax) / 10) * 10;
+    final var rY = Math.round((OFFS + ay) / 10) * 10;
 
-    final var e0 = Location.create(rX + (width - 8) / 2, rY + 1);
-    final var e1 = Location.create(rX + (width + 8) / 2, rY + 1);
-    final var ct = Location.create(rX + width / 2, rY + 11);
+    final var e0 = Location.create(rX + (width - 8) / 2, rY + 1, false);
+    final var e1 = Location.create(rX + (width + 8) / 2, rY + 1, false);
+    final var ct = Location.create(rX + width / 2, rY + 11, false);
     final var notch = new Curve(e0, e1, ct);
     notch.setValue(DrawAttr.STROKE_WIDTH, 2);
     notch.setValue(DrawAttr.STROKE_COLOR, Color.GRAY);
@@ -99,7 +99,7 @@ public class DefaultClassicAppearance {
     placePins(ret, edge.get(Direction.EAST), rX + width, rY + offsEast, 0, 10);
     placePins(ret, edge.get(Direction.NORTH), rX + offsNorth, rY, 10, 0);
     placePins(ret, edge.get(Direction.SOUTH), rX + offsSouth, rY + height, 10, 0);
-    ret.add(new AppearanceAnchor(Location.create(rX + ax, rY + ay)));
+    ret.add(new AppearanceAnchor(Location.create(rX + ax, rY + ay, true)));
     return ret;
   }
 
@@ -125,7 +125,7 @@ public class DefaultClassicAppearance {
 
   private static void placePins(List<CanvasObject> dest, List<Instance> pins, int x, int y, int dx, int dy) {
     for (final var pin : pins) {
-      dest.add(new AppearancePort(Location.create(x, y), pin));
+      dest.add(new AppearancePort(Location.create(x, y, true), pin));
       x += dx;
       y += dy;
     }

--- a/src/main/java/com/cburch/logisim/circuit/appear/DefaultCustomAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DefaultCustomAppearance.java
@@ -85,14 +85,14 @@ public class DefaultCustomAppearance {
     final var rect = new Rectangle(rx, ry, width, height);
     rect.setValue(DrawAttr.STROKE_WIDTH, 1);
     ret.add(rect);
-    ret.add(new AppearanceAnchor(Location.create(rx + ax, ry + ay)));
+    ret.add(new AppearanceAnchor(Location.create(rx + ax, ry + ay, true)));
     return ret;
   }
 
   private static void placePins(
       List<CanvasObject> dest, List<Instance> pins, int x, int y, int dX, int dY) {
     for (final var pin : pins) {
-      dest.add(new AppearancePort(Location.create(x, y), pin));
+      dest.add(new AppearancePort(Location.create(x, y, true), pin));
       x += dX;
       y += dY;
     }

--- a/src/main/java/com/cburch/logisim/circuit/appear/DefaultEvolutionAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DefaultEvolutionAppearance.java
@@ -118,7 +118,7 @@ public class DefaultEvolutionAppearance {
     textLabel.getLabel().setColor(Color.WHITE);
     textLabel.getLabel().setFont(DrawAttr.DEFAULT_NAME_FONT);
     ret.add(textLabel);
-    ret.add(new AppearanceAnchor(Location.create(rx + ax, ry + ay)));
+    ret.add(new AppearanceAnchor(Location.create(rx + ax, ry + ay, true)));
     return ret;
   }
 
@@ -156,7 +156,7 @@ public class DefaultEvolutionAppearance {
       rect.setValue(DrawAttr.PAINT_TYPE, DrawAttr.PAINT_FILL);
       rect.setValue(DrawAttr.FILL_COLOR, Color.BLACK);
       dest.add(rect);
-      dest.add(new AppearancePort(Location.create(x, y), pin));
+      dest.add(new AppearancePort(Location.create(x, y, true), pin));
       if (pin.getAttributeSet().containsAttribute(StdAttr.LABEL)) {
         var label = pin.getAttributeValue(StdAttr.LABEL);
         final var maxLength = 12;

--- a/src/main/java/com/cburch/logisim/circuit/appear/DefaultHolyCrossAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DefaultHolyCrossAppearance.java
@@ -21,7 +21,6 @@ import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.std.wiring.Pin;
 import java.awt.Canvas;
 import java.awt.Color;
-import java.awt.Font;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -188,7 +187,7 @@ public class DefaultHolyCrossAppearance {
       ret.add(label);
     }
 
-    ret.add(new AppearanceAnchor(Location.create(rx + aX, ry + aY)));
+    ret.add(new AppearanceAnchor(Location.create(rx + aX, ry + aY, true)));
     return ret;
   }
 
@@ -208,7 +207,7 @@ public class DefaultHolyCrossAppearance {
     final var color = Color.DARK_GRAY; // maybe GRAY instead?
     int ldx;
     for (final var pin : pins) {
-      dest.add(new AppearancePort(Location.create(x, y), pin));
+      dest.add(new AppearancePort(Location.create(x, y, true), pin));
       if (isLeftSide) {
         ldx = LABEL_OUTSIDE;
         hAlign = EditableLabel.LEFT;

--- a/src/main/java/com/cburch/logisim/circuit/appear/DynamicElement.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DynamicElement.java
@@ -106,7 +106,7 @@ public abstract class DynamicElement extends AbstractCanvasObject {
           throw new IllegalArgumentException("Bad path element: " + ss);
         final var x = Integer.parseInt(ss.substring(p + 1, c).trim());
         final var y = Integer.parseInt(ss.substring(c + 1, e).trim());
-        final var loc = Location.create(x, y);
+        final var loc = Location.create(x, y, false);
         final var name = unescape(ss.substring(0, p));
         var circ = circuit;
         if (i > 0) circ = ((SubcircuitFactory) elt[i - 1].getFactory()).getSubcircuit();
@@ -174,7 +174,7 @@ public abstract class DynamicElement extends AbstractCanvasObject {
   }
 
   public Location getLocation() {
-    return Location.create(bounds.getX(), bounds.getY());
+    return Location.create(bounds.getX(), bounds.getY(), false);
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/circuit/appear/PortManager.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/PortManager.java
@@ -100,7 +100,7 @@ class PortManager {
     }
     x = (x + 9) / 10 * 10; // round coordinates up to ensure they're on grid
     y = (y + 9) / 10 * 10;
-    var loc = Location.create(x, y);
+    var loc = Location.create(x, y, true);
     while (usedLocs.contains(loc)) {
       loc = loc.translate(dX, dY);
     }
@@ -140,7 +140,7 @@ class PortManager {
         }
       }
       if (anchor == null) {
-        anchor = new AppearanceAnchor(Location.create(100, 100));
+        anchor = new AppearanceAnchor(Location.create(100, 100, true));
       }
       final var dest = appearance.getCustomObjectsFromBottom().size();
       appearance.addObjects(dest, Collections.singleton(anchor));

--- a/src/main/java/com/cburch/logisim/data/Location.java
+++ b/src/main/java/com/cburch/logisim/data/Location.java
@@ -20,8 +20,8 @@ import java.util.List;
 public class Location implements Comparable<Location> {
   public static Location create(int x, int y, boolean hasToSnap) {
     // we round to half-grid base
-    final var xrounded = hasToSnap ? Math.round(x/5)*5 : x;
-    final var yrounded = hasToSnap ? Math.round(y/5)*5 : y;
+    final var xrounded = hasToSnap ? Math.round(x / 5) * 5 : x;
+    final var yrounded = hasToSnap ? Math.round(y / 5) * 5 : y;
     int hashCode = 31 * xrounded + yrounded;
     Object ret = cache.get(hashCode);
     if (ret != null) {

--- a/src/main/java/com/cburch/logisim/data/Location.java
+++ b/src/main/java/com/cburch/logisim/data/Location.java
@@ -18,14 +18,17 @@ import java.util.List;
  * </code> class, except that objects of this type are immutable.
  */
 public class Location implements Comparable<Location> {
-  public static Location create(int x, int y) {
-    int hashCode = 31 * x + y;
+  public static Location create(int x, int y, boolean hasToSnap) {
+    // we round to half-grid base
+    final var xrounded = hasToSnap ? Math.round(x/5)*5 : x;
+    final var yrounded = hasToSnap ? Math.round(y/5)*5 : y;
+    int hashCode = 31 * xrounded + yrounded;
     Object ret = cache.get(hashCode);
     if (ret != null) {
       final var loc = (Location) ret;
-      if (loc.x == x && loc.y == y) return loc;
+      if (loc.x == xrounded && loc.y == yrounded) return loc;
     }
-    Location loc = new Location(hashCode, x, y);
+    Location loc = new Location(hashCode, xrounded, yrounded, hasToSnap);
     cache.put(hashCode, loc);
     return loc;
   }
@@ -51,18 +54,18 @@ public class Location implements Comparable<Location> {
     }
     final var x = Integer.parseInt(value.substring(0, comma).trim());
     final var y = Integer.parseInt(value.substring(comma + 1).trim());
-    return Location.create(x, y);
+    return Location.create(x, y, true);
   }
 
   private static final Cache cache = new Cache();
   private final int hashCode;
-
   private final int x;
-
   private final int y;
+  private final boolean hasToSnap;
 
-  private Location(int hashCode, int x, int y) {
+  private Location(int hashCode, int x, int y, boolean hasToSnap) {
     this.hashCode = hashCode;
+    this.hasToSnap = hasToSnap;
     this.x = x;
     this.y = y;
   }
@@ -110,11 +113,11 @@ public class Location implements Comparable<Location> {
     final var dx = x - xc;
     final var dy = y - yc;
     if (degrees == 90) {
-      return create(xc + dy, yc - dx);
+      return create(xc + dy, yc - dx, hasToSnap);
     } else if (degrees == 180) {
-      return create(xc - dx, yc - dy);
+      return create(xc - dx, yc - dy, hasToSnap);
     } else if (degrees == 270) {
-      return create(xc - dy, yc + dx);
+      return create(xc - dy, yc + dx, hasToSnap);
     } else {
       return this;
     }
@@ -131,16 +134,16 @@ public class Location implements Comparable<Location> {
 
   public Location translate(Direction dir, int dist, int right) {
     if (dist == 0 && right == 0) return this;
-    if (dir == Direction.EAST) return Location.create(x + dist, y + right);
-    if (dir == Direction.WEST) return Location.create(x - dist, y - right);
-    if (dir == Direction.SOUTH) return Location.create(x - right, y + dist);
-    if (dir == Direction.NORTH) return Location.create(x + right, y - dist);
-    return Location.create(x + dist, y + right);
+    if (dir == Direction.EAST) return Location.create(x + dist, y + right, hasToSnap);
+    if (dir == Direction.WEST) return Location.create(x - dist, y - right, hasToSnap);
+    if (dir == Direction.SOUTH) return Location.create(x - right, y + dist, hasToSnap);
+    if (dir == Direction.NORTH) return Location.create(x + right, y - dist, hasToSnap);
+    return Location.create(x + dist, y + right, hasToSnap);
   }
 
   public Location translate(int dx, int dy) {
     if (dx == 0 && dy == 0) return this;
-    return Location.create(x + dx, y + dy);
+    return Location.create(x + dx, y + dy, hasToSnap);
   }
 
   public interface At {

--- a/src/main/java/com/cburch/logisim/data/Location.java
+++ b/src/main/java/com/cburch/logisim/data/Location.java
@@ -20,15 +20,15 @@ import java.util.List;
 public class Location implements Comparable<Location> {
   public static Location create(int x, int y, boolean hasToSnap) {
     // we round to half-grid base
-    final var xrounded = hasToSnap ? Math.round(x / 5) * 5 : x;
-    final var yrounded = hasToSnap ? Math.round(y / 5) * 5 : y;
-    int hashCode = 31 * xrounded + yrounded;
-    Object ret = cache.get(hashCode);
+    final var xRounded = hasToSnap ? Math.round(x / 5) * 5 : x;
+    final var yRounded = hasToSnap ? Math.round(y / 5) * 5 : y;
+    final var hashCode = 31 * xRounded + yRounded;
+    final var ret = cache.get(hashCode);
     if (ret != null) {
       final var loc = (Location) ret;
-      if (loc.x == xrounded && loc.y == yrounded) return loc;
+      if (loc.x == xRounded && loc.y == yRounded) return loc;
     }
-    Location loc = new Location(hashCode, xrounded, yrounded, hasToSnap);
+    final var loc = new Location(hashCode, xRounded, yRounded, hasToSnap);
     cache.put(hashCode, loc);
     return loc;
   }

--- a/src/main/java/com/cburch/logisim/gui/appear/LayoutPopupManager.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/LayoutPopupManager.java
@@ -109,7 +109,7 @@ class LayoutPopupManager implements SelectionListener, BaseMouseListenerContract
   public void mousePressed(MouseEvent e) {
     final var sincePopup = System.currentTimeMillis() - curPopupTime;
     if (sincePopup > 50) hideCurrentPopup();
-    dragStart = Location.create(e.getX(), e.getY());
+    dragStart = Location.create(e.getX(), e.getY(), false);
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/appear/ShowStateDialog.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/ShowStateDialog.java
@@ -155,7 +155,7 @@ public class ShowStateDialog extends JDialog implements ActionListener {
     for (final var shape : model.getObjectsFromBottom()) {
       boundingBox = boundingBox.add(shape.getBounds());
     }
-    var loc = Location.create(((boundingBox.getX() + 9) / 10 * 10), ((boundingBox.getY() + 9) / 10 * 10));
+    var loc = Location.create(boundingBox.getX(), boundingBox.getY(), true);
 
     // TreePath[] roots = tree.getCheckingRoots();
     final var checked = tree.getCheckingPaths();

--- a/src/main/java/com/cburch/logisim/gui/main/Canvas.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Canvas.java
@@ -442,7 +442,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
     boolean showTips = AppPreferences.COMPONENT_TIPS.getBoolean();
     if (showTips) {
       Canvas.snapToGrid(event);
-      Location loc = Location.create(event.getX(), event.getY());
+      Location loc = Location.create(event.getX(), event.getY(), false);
       ComponentUserEvent e = null;
       for (Component comp : getCircuit().getAllContaining(loc)) {
         Object makerObj = comp.getFeature(ToolTipMaker.class);

--- a/src/main/java/com/cburch/logisim/gui/main/Canvas.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Canvas.java
@@ -442,7 +442,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
     boolean showTips = AppPreferences.COMPONENT_TIPS.getBoolean();
     if (showTips) {
       Canvas.snapToGrid(event);
-      Location loc = Location.create(event.getX(), event.getY(), false);
+      final var loc = Location.create(event.getX(), event.getY(), false);
       ComponentUserEvent e = null;
       for (Component comp : getCircuit().getAllContaining(loc)) {
         Object makerObj = comp.getFeature(ToolTipMaker.class);

--- a/src/main/java/com/cburch/logisim/gui/main/SelectionBase.java
+++ b/src/main/java/com/cburch/logisim/gui/main/SelectionBase.java
@@ -194,7 +194,7 @@ class SelectionBase {
         newX = Canvas.snapXToGrid(newX);
         newY = Canvas.snapYToGrid(newY);
       }
-      Location newLoc = Location.create(newX, newY);
+      Location newLoc = Location.create(newX, newY, false);
       Component copy = comp.getFactory().createComponent(newLoc, attrs);
       ret.put(comp, copy);
     }

--- a/src/main/java/com/cburch/logisim/gui/main/SelectionBase.java
+++ b/src/main/java/com/cburch/logisim/gui/main/SelectionBase.java
@@ -194,7 +194,7 @@ class SelectionBase {
         newX = Canvas.snapXToGrid(newX);
         newY = Canvas.snapYToGrid(newY);
       }
-      Location newLoc = Location.create(newX, newY, false);
+      final var newLoc = Location.create(newX, newY, false);
       Component copy = comp.getFactory().createComponent(newLoc, attrs);
       ret.put(comp, copy);
     }

--- a/src/main/java/com/cburch/logisim/instance/InstancePainter.java
+++ b/src/main/java/com/cburch/logisim/instance/InstancePainter.java
@@ -166,7 +166,7 @@ public class InstancePainter implements InstanceState {
   }
 
   public Location getLocation() {
-    return comp == null ? Location.create(0, 0) : comp.getLocation();
+    return comp == null ? Location.create(0, 0, false) : comp.getLocation();
   }
 
   public Bounds getOffsetBounds() {

--- a/src/main/java/com/cburch/logisim/std/gates/AbstractGate.java
+++ b/src/main/java/com/cburch/logisim/std/gates/AbstractGate.java
@@ -260,13 +260,13 @@ abstract class AbstractGate extends InstanceFactory {
     }
 
     if (facing == Direction.NORTH) {
-      return Location.create(dy, dx);
+      return Location.create(dy, dx, true);
     } else if (facing == Direction.SOUTH) {
-      return Location.create(dy, -dx);
+      return Location.create(dy, -dx, true);
     } else if (facing == Direction.WEST) {
-      return Location.create(dx, dy);
+      return Location.create(dx, dy, true);
     } else {
-      return Location.create(-dx, dy);
+      return Location.create(-dx, dy, true);
     }
   }
 

--- a/src/main/java/com/cburch/logisim/std/gates/Buffer.java
+++ b/src/main/java/com/cburch/logisim/std/gates/Buffer.java
@@ -107,7 +107,7 @@ class Buffer extends InstanceFactory {
 
     final var ports = new Port[2];
     ports[0] = new Port(0, 0, Port.OUTPUT, StdAttr.WIDTH);
-    final var out = Location.create(0, 0).translate(facing, -20);
+    final var out = Location.create(0, 0, true).translate(facing, -20);
     ports[1] = new Port(out.getX(), out.getY(), Port.INPUT, StdAttr.WIDTH);
     instance.setPorts(ports);
   }

--- a/src/main/java/com/cburch/logisim/std/gates/CircuitBuilder.java
+++ b/src/main/java/com/cburch/logisim/std/gates/CircuitBuilder.java
@@ -232,7 +232,7 @@ public class CircuitBuilder {
         int dy = 0;
         if (layout.outputY < 20) dy = 20 - layout.outputY;
         height = Math.max(dy + layout.height, 40);
-        output = Location.create(outputX, y + dy + layout.outputY);
+        output = Location.create(outputX, y + dy + layout.outputY, true);
         outputData.addInput(outputName, new SingleInput(outputX, y + dy + layout.outputY));
         placeComponents(result, layouts[i], x, y + dy, inputData, output);
       }
@@ -436,13 +436,13 @@ public class CircuitBuilder {
       CircuitMutation result, Layout layout, int x, int y, InputData inputData, Location output) {
     if (layout.inputName != null) {
       final var inputX = inputData.getSpineX(layout.inputName, layout.inverted);
-      final var input = Location.create(inputX, output.getY());
+      final var input = Location.create(inputX, output.getY(), true);
       inputData.registerConnection(layout.inputName, input, layout.inverted);
       result.add(Wire.create(input, output));
       return;
     }
 
-    final var compOutput = Location.create(x + layout.width, output.getY());
+    final var compOutput = Location.create(x + layout.width, output.getY(), true);
     final var parent = layout.factory.createComponent(compOutput, layout.attrs);
     result.add(parent);
     if (!compOutput.equals(output)) {
@@ -459,9 +459,9 @@ public class CircuitBuilder {
       final var input1 = parent.getEnd(2).getLocation();
 
       int midX = input0.getX() - 20;
-      final var subOutput = Location.create(midX, output.getY());
-      final var midInput0 = Location.create(midX, input0.getY());
-      final var midInput1 = Location.create(midX, input1.getY());
+      final var subOutput = Location.create(midX, output.getY(), true);
+      final var midInput0 = Location.create(midX, input0.getY(), true);
+      final var midInput1 = Location.create(midX, input1.getY(), true);
       result.add(Wire.create(subOutput, midInput0));
       result.add(Wire.create(midInput0, input0));
       result.add(Wire.create(subOutput, midInput1));
@@ -520,8 +520,8 @@ public class CircuitBuilder {
           }
         }
         int subOutputX = subDest.getX() - 20 - 10 * back;
-        subOutput = Location.create(subOutputX, subOutputY);
-        final var mid = Location.create(subOutputX, subDest.getY());
+        subOutput = Location.create(subOutputX, subOutputY, true);
+        final var mid = Location.create(subOutputX, subDest.getY(), true);
         result.add(Wire.create(subOutput, mid));
         result.add(Wire.create(mid, subDest));
       }
@@ -541,29 +541,29 @@ public class CircuitBuilder {
           final var fact = NandGate.FACTORY;
           final var attrs = fact.createAttributeSet();
           attrs.setValue(GateAttributes.ATTR_SIZE, GateAttributes.SIZE_NARROW);
-          var ipLoc1 = Location.create(inputData.getSpineX("1", false), invPosY - 10);
+          var ipLoc1 = Location.create(inputData.getSpineX("1", false), invPosY - 10, true);
           inputData.registerConnection("1", ipLoc1, false);
-          final var Ploc = Location.create(inputData.getInverterXLoc(), invPosY);
+          final var Ploc = Location.create(inputData.getInverterXLoc(), invPosY, true);
           result.add(fact.createComponent(Ploc, attrs));
-          var ipLoc2 = Location.create(inputData.getInverterXLoc() - NAND_WIDTH, invPosY - 10);
+          var ipLoc2 = Location.create(inputData.getInverterXLoc() - NAND_WIDTH, invPosY - 10, true);
           result.add(Wire.create(ipLoc1, ipLoc2));
-          ipLoc1 = Location.create(inputData.getSpineX(inputName, false), invPosY + 10);
-          ipLoc2 = Location.create(inputData.getInverterXLoc() - NAND_WIDTH, invPosY + 10);
+          ipLoc1 = Location.create(inputData.getSpineX(inputName, false), invPosY + 10, true);
+          ipLoc2 = Location.create(inputData.getInverterXLoc() - NAND_WIDTH, invPosY + 10, true);
           result.add(Wire.create(ipLoc1, ipLoc2));
           inputData.registerConnection(inputName, ipLoc1, false);
-          final var IPloc3 = Location.create(inputData.getSpineX(inputName, true), invPosY);
+          final var IPloc3 = Location.create(inputData.getSpineX(inputName, true), invPosY, true);
           result.add(Wire.create(Ploc, IPloc3));
           inputData.registerConnection(inputName, IPloc3, true);
         } else {
           final var fact = NotGate.FACTORY;
           final var attrs = fact.createAttributeSet();
-          final var Ploc = Location.create(inputData.getInverterXLoc(), invPosY);
+          final var Ploc = Location.create(inputData.getInverterXLoc(), invPosY, true);
           result.add(fact.createComponent(Ploc, attrs));
-          final var IPloc1 = Location.create(inputData.getSpineX(inputName, false), invPosY);
-          final var IPloc2 = Location.create(inputData.getInverterXLoc() - INVERTER_WIDTH, invPosY);
+          final var IPloc1 = Location.create(inputData.getSpineX(inputName, false), invPosY, true);
+          final var IPloc2 = Location.create(inputData.getInverterXLoc() - INVERTER_WIDTH, invPosY, true);
           result.add(Wire.create(IPloc1, IPloc2));
           inputData.registerConnection(inputName, IPloc1, false);
-          final var IPloc3 = Location.create(inputData.getSpineX(inputName, true), invPosY);
+          final var IPloc3 = Location.create(inputData.getSpineX(inputName, true), invPosY, true);
           result.add(Wire.create(Ploc, IPloc3));
           inputData.registerConnection(inputName, IPloc3, true);
         }
@@ -580,7 +580,7 @@ public class CircuitBuilder {
       final var attrs = fact.createAttributeSet();
       attrs.setValue(StdAttr.FACING, Direction.SOUTH);
       attrs.setValue(Constant.ATTR_VALUE, 0L);
-      final var loc = Location.create(inputData.getSpineX("0", false), inputData.startY - 10);
+      final var loc = Location.create(inputData.getSpineX("0", false), inputData.startY - 10, true);
       result.add(fact.createComponent(loc, attrs));
       inputData.registerConnection("0", loc, false);
       createSpine(result, inputData.getInputLocs("0", false).ys, new CompareYs());
@@ -589,7 +589,7 @@ public class CircuitBuilder {
       final var attrs = fact.createAttributeSet();
       attrs.setValue(StdAttr.FACING, Direction.SOUTH);
       attrs.setValue(Constant.ATTR_VALUE, 1L);
-      final var loc = Location.create(inputData.getSpineX("1", false), inputData.startY - 10);
+      final var loc = Location.create(inputData.getSpineX("1", false), inputData.startY - 10, true);
       result.add(fact.createComponent(loc, attrs));
       inputData.registerConnection("1", loc, false);
       createSpine(result, inputData.getInputLocs("1", false).ys, new CompareYs());
@@ -622,7 +622,7 @@ public class CircuitBuilder {
 
         // determine point where we can intersect with spine
         int spineX = singleInput.spineX;
-        var spineLoc = Location.create(spineX, curY);
+        var spineLoc = Location.create(spineX, curY, true);
         if (!singleInput.ys.isEmpty()) {
           // search for a Y that won't intersect with others
           // (we needn't bother if the pin doesn't connect
@@ -630,11 +630,11 @@ public class CircuitBuilder {
           forbiddenYs.sort(compareYs);
           while (Collections.binarySearch(forbiddenYs, spineLoc, compareYs) >= 0) {
             curY += 10;
-            spineLoc = Location.create(spineX, curY);
+            spineLoc = Location.create(spineX, curY, true);
           }
           singleInput.ys.add(spineLoc);
         }
-        Location loc = Location.create(curX, curY);
+        Location loc = Location.create(curX, curY, true);
 
         // now create the pin
         placeInput(result, loc, name, 1);
@@ -653,18 +653,18 @@ public class CircuitBuilder {
       } else {
         /* first place the input and the splitter */
         final var name = inp.name;
-        final var ploc = Location.create(curX, curY);
+        final var ploc = Location.create(curX, curY, true);
         /* create the pin */
         placeInput(result, ploc, name, inp.width);
         /* determine the position of the splitter */
         var msbName = inputData.getInputName(idx);
         var singleInput = inputData.getInputLocs(msbName, false);
         int spineX = singleInput.spineX;
-        final var sloc = Location.create(spineX - 10, busY - SPLITTER_HEIGHT);
+        final var sloc = Location.create(spineX - 10, busY - SPLITTER_HEIGHT, true);
         placeSplitter(result, sloc, inp.width, true);
         /* place the bus connection */
-        final var BI1 = Location.create(ploc.getX() + 10 + busNr * SPINE_DISTANCE, ploc.getY());
-        final var BI2 = Location.create(BI1.getX(), sloc.getY());
+        final var BI1 = Location.create(ploc.getX() + 10 + busNr * SPINE_DISTANCE, ploc.getY(), true);
+        final var BI2 = Location.create(BI1.getX(), sloc.getY(), true);
         result.add(Wire.create(ploc, BI1));
         result.add(Wire.create(BI1, BI2));
         result.add(Wire.create(BI2, sloc));
@@ -677,7 +677,7 @@ public class CircuitBuilder {
           final var spine = singleInput.ys;
           if (!spine.isEmpty()) {
             /* add a location for the bus entry */
-            final var bloc = Location.create(spineX, busY);
+            final var bloc = Location.create(spineX, busY, true);
             spine.add(bloc);
             forbiddenYs.sort(compareYs);
             // create spine
@@ -756,47 +756,48 @@ public class CircuitBuilder {
       final var outp = outputs.vars.get(idx);
       final var name = outputData.getInputName(cnt);
       if (outp.width == 1) {
-        final var pointP = Location.create(pinX, pinY);
+        final var pointP = Location.create(pinX, pinY, true);
         placeOutput(result, pointP, outp.name, 1);
         final var singleOutput = outputData.getInputLocs(name, false);
         if (singleOutput != null) {
-          final var pointC = Location.create(singleOutput.spineX, singleOutput.spineY);
+          final var pointC = Location.create(singleOutput.spineX, singleOutput.spineY, true);
           int xOffset = startX + cnt * SPINE_DISTANCE;
-          final var pointI1 = Location.create(xOffset, pointC.getY());
-          final var pointI2 = Location.create(xOffset, pointP.getY());
+          final var pointI1 = Location.create(xOffset, pointC.getY(), true);
+          final var pointI2 = Location.create(xOffset, pointP.getY(), true);
           if (pointC.getX() != pointI1.getX()) result.add(Wire.create(pointC, pointI1));
           if (pointI1.getY() != pointI2.getY()) result.add(Wire.create(pointI1, pointI2));
           if (pointI2.getX() != pointP.getX()) result.add(Wire.create(pointI2, pointP));
         }
         cnt++;
       } else {
-        final var pointP = Location.create(pinX, pinY);
+        final var pointP = Location.create(pinX, pinY, true);
         placeOutput(result, pointP, outp.name, outp.width);
         /* process the splitter */
         int sStartX = startX + cnt * SPINE_DISTANCE;
         final var pointS =
             Location.create(
                 sStartX + (outp.width - 1) * SPINE_DISTANCE + 10,
-                TOP_BORDER + busID * SPLITTER_HEIGHT);
+                TOP_BORDER + busID * SPLITTER_HEIGHT,
+                true);
         placeSplitter(result, pointS, outp.width, false);
         // process the bus connection
-        final var pointI1 = Location.create(busX - busID * SPINE_DISTANCE, pointS.getY());
-        final var pointI2 = Location.create(pointI1.getX(), pointP.getY());
+        final var pointI1 = Location.create(busX - busID * SPINE_DISTANCE, pointS.getY(), true);
+        final var pointI2 = Location.create(pointI1.getX(), pointP.getY(), true);
         busID++;
         if (pointS.getX() != pointI1.getX()) result.add(Wire.create(pointS, pointI1));
         if (pointI1.getY() != pointI2.getY()) result.add(Wire.create(pointI1, pointI2));
         if (pointI2.getX() != pointP.getX()) result.add(Wire.create(pointI2, pointP));
         // process the connections
         for (int bit = 0; bit < outp.width; bit++) {
-          final var pointSe = Location.create(sStartX + bit * SPINE_DISTANCE, pointS.getY() + 20);
+          final var pointSe = Location.create(sStartX + bit * SPINE_DISTANCE, pointS.getY() + 20, true);
           final var tName = outputData.getInputName(cnt + bit);
           final var singleOutput = outputData.getInputLocs(tName, false);
           if (singleOutput != null) {
-            final var pointC = Location.create(singleOutput.spineX, singleOutput.spineY);
+            final var pointC = Location.create(singleOutput.spineX, singleOutput.spineY, true);
             if (pointSe.getX() == pointC.getX()) {
               result.add(Wire.create(pointSe, pointC));
             } else {
-              final var pointI = Location.create(pointSe.getX(), pointC.getY());
+              final var pointI = Location.create(pointSe.getX(), pointC.getY(), true);
               result.add(Wire.create(pointC, pointI));
               result.add(Wire.create(pointSe, pointI));
             }

--- a/src/main/java/com/cburch/logisim/std/gates/ControlledBuffer.java
+++ b/src/main/java/com/cburch/logisim/std/gates/ControlledBuffer.java
@@ -111,7 +111,7 @@ class ControlledBuffer extends InstanceFactory {
     final var facing = instance.getAttributeValue(StdAttr.FACING);
     final var bds = getOffsetBounds(instance.getAttributeSet());
     int d = Math.max(bds.getWidth(), bds.getHeight()) - 20;
-    final var loc0 = Location.create(0, 0);
+    final var loc0 = Location.create(0, 0, true);
     final var loc1 = loc0.translate(facing.reverse(), 20 + d);
     Location loc2;
     if (instance.getAttributeValue(ATTR_CONTROL) == LEFT_HANDED) {

--- a/src/main/java/com/cburch/logisim/std/gates/NotGate.java
+++ b/src/main/java/com/cburch/logisim/std/gates/NotGate.java
@@ -124,7 +124,7 @@ class NotGate extends InstanceFactory {
 
     final var ports = new Port[2];
     ports[0] = new Port(0, 0, Port.OUTPUT, StdAttr.WIDTH);
-    Location out = Location.create(0, 0).translate(facing, dx);
+    Location out = Location.create(0, 0, true).translate(facing, dx);
     ports[1] = new Port(out.getX(), out.getY(), Port.INPUT, StdAttr.WIDTH);
     instance.setPorts(ports);
   }

--- a/src/main/java/com/cburch/logisim/std/plexers/BitSelector.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/BitSelector.java
@@ -164,21 +164,21 @@ public class BitSelector extends InstanceFactory {
     Location inPt;
     Location selPt;
     if (facing == Direction.WEST) {
-      inPt = Location.create(30, 0);
-      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) selPt = Location.create(10, -10);
-      else selPt = Location.create(10, 10);
+      inPt = Location.create(30, 0, true);
+      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) selPt = Location.create(10, -10, true);
+      else selPt = Location.create(10, 10, true);
     } else if (facing == Direction.NORTH) {
-      inPt = Location.create(0, 30);
-      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) selPt = Location.create(-10, 10);
-      else selPt = Location.create(10, 10);
+      inPt = Location.create(0, 30, true);
+      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) selPt = Location.create(-10, 10, true);
+      else selPt = Location.create(10, 10, true);
     } else if (facing == Direction.SOUTH) {
-      inPt = Location.create(0, -30);
-      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) selPt = Location.create(-10, -10);
-      else selPt = Location.create(10, -10);
+      inPt = Location.create(0, -30, true);
+      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) selPt = Location.create(-10, -10, true);
+      else selPt = Location.create(10, -10, true);
     } else {
-      inPt = Location.create(-30, 0);
-      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) selPt = Location.create(-10, 10);
-      else selPt = Location.create(-10, -10);
+      inPt = Location.create(-30, 0, true);
+      if (selectLoc == StdAttr.SELECT_BOTTOM_LEFT) selPt = Location.create(-10, 10, true);
+      else selPt = Location.create(-10, -10, true);
     }
 
     final var ps = new Port[3];

--- a/src/main/java/com/cburch/logisim/std/plexers/Decoder.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Decoder.java
@@ -301,20 +301,20 @@ public class Decoder extends InstanceFactory {
       if (facing == Direction.NORTH || facing == Direction.SOUTH) {
         int y = facing == Direction.NORTH ? -10 : 10;
         if (selectLoc == StdAttr.SELECT_TOP_RIGHT) {
-          end0 = Location.create(-30, y);
-          end1 = Location.create(-10, y);
+          end0 = Location.create(-30, y, true);
+          end1 = Location.create(-10, y, true);
         } else {
-          end0 = Location.create(10, y);
-          end1 = Location.create(30, y);
+          end0 = Location.create(10, y, true);
+          end1 = Location.create(30, y, true);
         }
       } else {
         int x = facing == Direction.WEST ? -10 : 10;
         if (selectLoc == StdAttr.SELECT_TOP_RIGHT) {
-          end0 = Location.create(x, 10);
-          end1 = Location.create(x, 30);
+          end0 = Location.create(x, 10, true);
+          end1 = Location.create(x, 30, true);
         } else {
-          end0 = Location.create(x, -30);
-          end1 = Location.create(x, -10);
+          end0 = Location.create(x, -30, true);
+          end1 = Location.create(x, -10, true);
         }
       }
       ps[0] = new Port(end0.getX(), end0.getY(), Port.OUTPUT, 1);
@@ -341,7 +341,7 @@ public class Decoder extends InstanceFactory {
         dy += ddy;
       }
     }
-    final var en = Location.create(0, 0).translate(facing, -10);
+    final var en = Location.create(0, 0, true).translate(facing, -10);
     ps[outputs] = new Port(0, 0, Port.INPUT, select.getWidth());
     if (enable) {
       ps[outputs + 1] = new Port(en.getX(), en.getY(), Port.INPUT, BitWidth.ONE);

--- a/src/main/java/com/cburch/logisim/std/plexers/Demultiplexer.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Demultiplexer.java
@@ -301,21 +301,21 @@ public class Demultiplexer extends InstanceFactory {
       Location end0;
       Location end1;
       if (facing == Direction.WEST) {
-        end0 = Location.create(-30, -10);
-        end1 = Location.create(-30, 10);
-        sel = Location.create(-20, selMult * 20);
+        end0 = Location.create(-30, -10, true);
+        end1 = Location.create(-30, 10, true);
+        sel = Location.create(-20, selMult * 20, true);
       } else if (facing == Direction.NORTH) {
-        end0 = Location.create(-10, -30);
-        end1 = Location.create(10, -30);
-        sel = Location.create(selMult * -20, -20);
+        end0 = Location.create(-10, -30, true);
+        end1 = Location.create(10, -30, true);
+        sel = Location.create(selMult * -20, -20, true);
       } else if (facing == Direction.SOUTH) {
-        end0 = Location.create(-10, 30);
-        end1 = Location.create(10, 30);
-        sel = Location.create(selMult * -20, 20);
+        end0 = Location.create(-10, 30, true);
+        end1 = Location.create(10, 30, true);
+        sel = Location.create(selMult * -20, 20, true);
       } else {
-        end0 = Location.create(30, -10);
-        end1 = Location.create(30, 10);
-        sel = Location.create(20, selMult * 20);
+        end0 = Location.create(30, -10, true);
+        end1 = Location.create(30, 10, true);
+        sel = Location.create(20, selMult * 20, true);
       }
       ps[0] = new Port(end0.getX(), end0.getY(), Port.OUTPUT, data.getWidth());
       ps[1] = new Port(end1.getX(), end1.getY(), Port.OUTPUT, data.getWidth());
@@ -327,19 +327,19 @@ public class Demultiplexer extends InstanceFactory {
       if (facing == Direction.WEST) {
         dx = -40;
         ddx = 0;
-        sel = Location.create(-20, selMult * (dy + 10 * outputs));
+        sel = Location.create(-20, selMult * (dy + 10 * outputs), true);
       } else if (facing == Direction.NORTH) {
         dy = -40;
         ddy = 0;
-        sel = Location.create(selMult * dx, -20);
+        sel = Location.create(selMult * dx, -20, true);
       } else if (facing == Direction.SOUTH) {
         dy = 40;
         ddy = 0;
-        sel = Location.create(selMult * dx, 20);
+        sel = Location.create(selMult * dx, 20, true);
       } else {
         dx = 40;
         ddx = 0;
-        sel = Location.create(20, selMult * (dy + 10 * outputs));
+        sel = Location.create(20, selMult * (dy + 10 * outputs), true);
       }
       for (var i = 0; i < outputs; i++) {
         ps[i] = new Port(dx, dy, Port.OUTPUT, data.getWidth());

--- a/src/main/java/com/cburch/logisim/std/plexers/Multiplexer.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Multiplexer.java
@@ -308,21 +308,21 @@ public class Multiplexer extends InstanceFactory {
       Location end0;
       Location end1;
       if (dir == Direction.WEST) {
-        end0 = Location.create(w, -10);
-        end1 = Location.create(w, 10);
-        sel = Location.create(s, selMult * 20);
+        end0 = Location.create(w, -10, true);
+        end1 = Location.create(w, 10, true);
+        sel = Location.create(s, selMult * 20, true);
       } else if (dir == Direction.NORTH) {
-        end0 = Location.create(-10, w);
-        end1 = Location.create(10, w);
-        sel = Location.create(selMult * -20, s);
+        end0 = Location.create(-10, w, true);
+        end1 = Location.create(10, w, true);
+        sel = Location.create(selMult * -20, s, true);
       } else if (dir == Direction.SOUTH) {
-        end0 = Location.create(-10, -w);
-        end1 = Location.create(10, -w);
-        sel = Location.create(selMult * -20, -s);
+        end0 = Location.create(-10, -w, true);
+        end1 = Location.create(10, -w, true);
+        sel = Location.create(selMult * -20, -s, true);
       } else {
-        end0 = Location.create(-w, -10);
-        end1 = Location.create(-w, 10);
-        sel = Location.create(-s, selMult * 20);
+        end0 = Location.create(-w, -10, true);
+        end1 = Location.create(-w, 10, true);
+        sel = Location.create(-s, selMult * 20, true);
       }
       ps[0] = new Port(end0.getX(), end0.getY(), Port.INPUT, data.getWidth());
       ps[1] = new Port(end1.getX(), end1.getY(), Port.INPUT, data.getWidth());
@@ -336,19 +336,19 @@ public class Multiplexer extends InstanceFactory {
       if (dir == Direction.WEST) {
         dx = w;
         ddx = 0;
-        sel = Location.create(s, selMult * (dy + 10 * inputs));
+        sel = Location.create(s, selMult * (dy + 10 * inputs), true);
       } else if (dir == Direction.NORTH) {
         dy = w;
         ddy = 0;
-        sel = Location.create(selMult * dx, s);
+        sel = Location.create(selMult * dx, s, true);
       } else if (dir == Direction.SOUTH) {
         dy = -w;
         ddy = 0;
-        sel = Location.create(selMult * dx, -s);
+        sel = Location.create(selMult * dx, -s, true);
       } else {
         dx = -w;
         ddx = 0;
-        sel = Location.create(-s, selMult * (dy + 10 * inputs));
+        sel = Location.create(-s, selMult * (dy + 10 * inputs), true);
       }
       for (var i = 0; i < inputs; i++) {
         ps[i] = new Port(dx, dy, Port.INPUT, data.getWidth());

--- a/src/main/java/com/cburch/logisim/std/wiring/Transistor.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Transistor.java
@@ -109,7 +109,7 @@ public class Transistor extends InstanceFactory {
   public boolean contains(Location loc, AttributeSet attrs) {
     if (super.contains(loc, attrs)) {
       Direction facing = attrs.getValue(StdAttr.FACING);
-      Location center = Location.create(0, 0).translate(facing, -20);
+      Location center = Location.create(0, 0, true).translate(facing, -20);
       return center.manhattanDistanceTo(loc) < 24;
     } else {
       return false;

--- a/src/main/java/com/cburch/logisim/std/wiring/TransmissionGate.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/TransmissionGate.java
@@ -92,7 +92,7 @@ public class TransmissionGate extends InstanceFactory {
   public boolean contains(Location loc, AttributeSet attrs) {
     if (super.contains(loc, attrs)) {
       Direction facing = attrs.getValue(StdAttr.FACING);
-      Location center = Location.create(0, 0).translate(facing, -20);
+      Location center = Location.create(0, 0, true).translate(facing, -20);
       return center.manhattanDistanceTo(loc) < 24;
     } else {
       return false;

--- a/src/main/java/com/cburch/logisim/tools/AddTool.java
+++ b/src/main/java/com/cburch/logisim/tools/AddTool.java
@@ -532,7 +532,7 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
         for (var x = 0; x < matrix.getCopiesCountX(); x++) {
           for (var y = 0; y < matrix.getCopiesCountY(); y++) {
             final var loc = Location.create(event.getX() + (matrix.getDeltaX() * x),
-                event.getY() + (matrix.getDeltaY() * y));
+                event.getY() + (matrix.getDeltaY() * y), true);
             final var attrsCopy = (AttributeSet) attrs.clone();
             if (matrix.getLabel() != null) {
               if (matrixPlace)

--- a/src/main/java/com/cburch/logisim/tools/EditTool.java
+++ b/src/main/java/com/cburch/logisim/tools/EditTool.java
@@ -71,7 +71,7 @@ public class EditTool extends Tool {
   private static final int CACHE_MAX_SIZE = 32;
 
   private static final Location NULL_LOCATION =
-      Location.create(Integer.MIN_VALUE, Integer.MIN_VALUE);
+      Location.create(Integer.MIN_VALUE, Integer.MIN_VALUE, false);
 
   private final Listener listener;
   private final SelectTool select;
@@ -444,7 +444,7 @@ public class EditTool extends Tool {
     if (lastX == snapx && lastY == snapy && modsSame) { // already computed
       return wireLoc != NULL_LOCATION;
     } else {
-      final var snap = Location.create(snapx, snapy);
+      final var snap = Location.create(snapx, snapy, false);
       if (modsSame) {
         Object o = cache.get(snap);
         if (o != null) {

--- a/src/main/java/com/cburch/logisim/tools/MenuTool.java
+++ b/src/main/java/com/cburch/logisim/tools/MenuTool.java
@@ -161,7 +161,7 @@ public class MenuTool extends Tool {
   public void mousePressed(Canvas canvas, Graphics g, MouseEvent e) {
     int x = e.getX();
     int y = e.getY();
-    final var pt = Location.create(x, y);
+    final var pt = Location.create(x, y, false);
 
     JPopupMenu menu;
     final var proj = canvas.getProject();

--- a/src/main/java/com/cburch/logisim/tools/PokeTool.java
+++ b/src/main/java/com/cburch/logisim/tools/PokeTool.java
@@ -224,7 +224,7 @@ public class PokeTool extends Tool {
   public void mousePressed(Canvas canvas, Graphics g, MouseEvent e) {
     int x = e.getX();
     int y = e.getY();
-    final var loc = Location.create(x, y);
+    final var loc = Location.create(x, y, false);
     var dirty = false;
     canvas.setHighlightedWires(WireSet.EMPTY);
     if (pokeCaret != null && !pokeCaret.getBounds(g).contains(loc)) {

--- a/src/main/java/com/cburch/logisim/tools/SelectTool.java
+++ b/src/main/java/com/cburch/logisim/tools/SelectTool.java
@@ -414,7 +414,7 @@ public class SelectTool extends Tool {
     canvas.requestFocusInWindow();
     final var proj = canvas.getProject();
     final var sel = proj.getSelection();
-    start = Location.create(e.getX(), e.getY());
+    start = Location.create(e.getX(), e.getY(), false);
     curDx = 0;
     curDy = 0;
     moveGesture = null;

--- a/src/main/java/com/cburch/logisim/tools/TextTool.java
+++ b/src/main/java/com/cburch/logisim/tools/TextTool.java
@@ -260,7 +260,7 @@ public class TextTool extends Tool {
     // Otherwise search for a new caret.
     int x = e.getX();
     int y = e.getY();
-    final var loc = Location.create(x, y);
+    final var loc = Location.create(x, y, false);
     final var event = new ComponentUserEvent(canvas, x, y);
 
     // First search in selection.

--- a/src/main/java/com/cburch/logisim/tools/WiringTool.java
+++ b/src/main/java/com/cburch/logisim/tools/WiringTool.java
@@ -50,8 +50,8 @@ public class WiringTool extends Tool {
 
   private boolean exists = false;
   private boolean inCanvas = false;
-  private Location start = Location.create(0, 0);
-  private Location cur = Location.create(0, 0);
+  private Location start = Location.create(0, 0, true);
+  private Location cur = Location.create(0, 0, true);
   private boolean hasDragged = false;
   private boolean startShortening = false;
   private Wire shortening = null;
@@ -70,9 +70,9 @@ public class WiringTool extends Tool {
     int delta = (end.equals(w.getEnd0()) ? 10 : -10);
     Location cand;
     if (w.isVertical()) {
-      cand = Location.create(end.getX(), end.getY() + delta);
+      cand = Location.create(end.getX(), end.getY() + delta, true);
     } else {
-      cand = Location.create(end.getX() + delta, end.getY());
+      cand = Location.create(end.getX() + delta, end.getY(), true);
     }
 
     for (final var comp : canvas.getCircuit().getNonWires(cand)) {
@@ -213,7 +213,7 @@ public class WiringTool extends Tool {
       rect.add(curX, curY);
       rect.grow(3, 3);
 
-      cur = Location.create(curX, curY);
+      cur = Location.create(curX, curY, true);
       super.mouseDragged(canvas, g, e);
 
       Wire shorten = null;
@@ -261,7 +261,7 @@ public class WiringTool extends Tool {
       final var curX = e.getX();
       final var curY = e.getY();
       if (cur.getX() != curX || cur.getY() != curY) {
-        cur = Location.create(curX, curY);
+        cur = Location.create(curX, curY, true);
       }
       canvas.getProject().repaintCanvas();
     }
@@ -275,7 +275,7 @@ public class WiringTool extends Tool {
       return;
     }
     Canvas.snapToGrid(e);
-    start = Location.create(e.getX(), e.getY());
+    start = Location.create(e.getX(), e.getY(), true);
     cur = start;
     exists = true;
     hasDragged = false;
@@ -295,7 +295,7 @@ public class WiringTool extends Tool {
     final var curX = e.getX();
     final var curY = e.getY();
     if (computeMove(curX, curY)) {
-      cur = Location.create(curX, curY);
+      cur = Location.create(curX, curY, true);
     }
     if (hasDragged) {
       exists = false;
@@ -311,9 +311,9 @@ public class WiringTool extends Tool {
       } else {
         Location m;
         if (direction == HORIZONTAL) {
-          m = Location.create(cur.getX(), start.getY());
+          m = Location.create(cur.getX(), start.getY(), true);
         } else {
-          m = Location.create(start.getX(), cur.getY());
+          m = Location.create(start.getX(), cur.getY(), true);
         }
         var wire0 = Wire.create(start, m);
         var wire1 = Wire.create(m, cur);
@@ -375,8 +375,8 @@ public class WiringTool extends Tool {
   private void reset() {
     exists = false;
     inCanvas = false;
-    start = Location.create(0, 0);
-    cur = Location.create(0, 0);
+    start = Location.create(0, 0, true);
+    cur = Location.create(0, 0, true);
     startShortening = false;
     shortening = null;
     direction = 0;

--- a/src/main/java/com/cburch/logisim/tools/move/AvoidanceMap.java
+++ b/src/main/java/com/cburch/logisim/tools/move/AvoidanceMap.java
@@ -65,7 +65,7 @@ public final class AvoidanceMap {
     y0 += 9 - (y0 + 9) % 10;
     for (var x = x0; x <= x1; x += 10) {
       for (var y = y0; y <= y1; y += 10) {
-        final var loc = Location.create(x, y);
+        final var loc = Location.create(x, y, false);
         // loc is most likely in the component, so go ahead and
         // put it into the map as if it is - and in the rare event
         // that loc isn't in the component, we can remove it.

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntity.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntity.java
@@ -295,7 +295,7 @@ public class VhdlEntity extends InstanceFactory implements HdlModelListener {
       attr.setValue(Pin.ATTR_TYPE, !port.getType().equals(Port.INPUT));
       attr.setValue(StdAttr.FACING, !port.getType().equals(Port.INPUT) ? Direction.WEST : Direction.EAST);
       attr.setValue(StdAttr.WIDTH, port.getWidth());
-      final var component = (InstanceComponent) Pin.FACTORY.createComponent(Location.create(100, yPos), attr);
+      final var component = (InstanceComponent) Pin.FACTORY.createComponent(Location.create(100, yPos, true), attr);
       pins.add(component.getInstance());
       yPos += 10;
     }


### PR DESCRIPTION
This was really a nasty one. For some reason the location of wires were off-grid in the .circ file. Causing the wire-repair to continue up to the moment the no memory was left. By introducing a "snap" functionality in the Location class this has been resolved. All is backward compatible to earlier logisim versions