### PR TITLE
Add Clear pixel dot feature on RGB Video Component

### DIFF
--- a/src/main/java/com/cburch/logisim/std/io/Video.java
+++ b/src/main/java/com/cburch/logisim/std/io/Video.java
@@ -159,6 +159,7 @@ class Video extends ManagedComponent implements ToolTipMaker, AttributeListener 
   static final int P_X = 3;
   static final int P_Y = 4;
   static final int P_DATA = 5;
+  static final int P_CLR = 6;
 
   private Video(Location loc, AttributeSet attrs) {
     super(loc, attrs, 6);
@@ -211,14 +212,20 @@ class Video extends ManagedComponent implements ToolTipMaker, AttributeListener 
       g.setColor(new Color(cm.getRGB(color)));
       g.fillRect(x, y, 1, 1);
       if (RESET_SYNC.equals(resetOption) && val(circuitState, P_RST) == Value.TRUE) {
-        g.setColor(Color.BLACK);
+        g.setColor(Color.YELLOW);
         g.fillRect(0, 0, w, h);
       }
     }
 
+    if (val(circuitState, P_CLR) == Value.TRUE) {
+      final var g = state.img.getGraphics();
+      g.setColor(Color.YELLOW);
+      g.fillRect(x, y, 1, 1);
+    }
+
     if (!RESET_SYNC.equals(resetOption) && val(circuitState, P_RST) == Value.TRUE) {
       final var g = state.img.getGraphics();
-      g.setColor(Color.BLACK);
+      g.setColor(Color.YELLOW);
       g.fillRect(0, 0, w, h);
     }
   }
@@ -381,7 +388,7 @@ class Video extends ManagedComponent implements ToolTipMaker, AttributeListener 
     y += (-bh);
 
     g.drawRoundRect(x, y, bw, bh, 6, 6);
-    for (var i = 0; i < 6; i++) {
+    for (var i = 0; i < 7; i++) {
       if (i != P_CLK) context.drawPin(this, i);
     }
     context.drawClock(this, P_CLK, Direction.NORTH);
@@ -472,6 +479,8 @@ class Video extends ManagedComponent implements ToolTipMaker, AttributeListener 
         return S.get("rgbVideoData", attrs.getValue(COLOR_OPTION));
       case P_RST:
         return S.get("rgbVideoRST");
+      case P_CLR:
+        return S.get("rgbVideoCLR");
       default:
         return null;
     }
@@ -493,6 +502,7 @@ class Video extends ManagedComponent implements ToolTipMaker, AttributeListener 
     setEnd(P_X, getLocation().translate(40, 0), BitWidth.create(xs), EndData.INPUT_ONLY);
     setEnd(P_Y, getLocation().translate(50, 0), BitWidth.create(ys), EndData.INPUT_ONLY);
     setEnd(P_DATA, getLocation().translate(60, 0), BitWidth.create(bpp), EndData.INPUT_ONLY);
+    setEnd(P_CLR, getLocation().translate(30, 0), BitWidth.ONE, EndData.INPUT_ONLY);
     recomputeBounds();
     fireComponentInvalidated(new ComponentEvent(this));
   }

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -473,6 +473,7 @@ rgbVideoWE = Write Enable
 rgbVideoWidth = Width
 rgbVideoX = X Coordinate
 rgbVideoY = Y Coordinate
+rgbVideoCLR = Clear Pixel
 #
 # bfh/bcd2sevenseg.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_cn.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_cn.properties
@@ -473,6 +473,7 @@ rgbVideoWE =写入启用
 rgbVideoWidth =宽度
 rgbVideoX =X坐标
 rgbVideoY =Y坐标
+rgbVideoCLR = 清除像素
 #
 # bfh/bcd2sevenseg.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -467,6 +467,7 @@ rgbVideoWE = Habilitar escritura
 rgbVideoWidth = Ancho
 rgbVideoX = X Coordenada
 rgbVideoY = Coordenada Y
+rgbVideoCLR = Borrar Píxel
 #
 # bfh/bcd2sevenseg.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -473,6 +473,7 @@ rgbVideoWE = Écriture autorisée
 rgbVideoWidth = Largeur
 rgbVideoX = Coordonnée X
 rgbVideoY = Coordonnée Y
+rgbVideoCLR = Effacer Pixel
 #
 # bfh/bcd2sevenseg.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -473,6 +473,7 @@ rgbVideoWE = Abilitazione in scrittura
 rgbVideoWidth = Larghezza
 rgbVideoX = X Coordinata
 rgbVideoY = Coordinata Y
+rgbVideoCLR = Cancella Pixel
 #
 # bfh/bcd2sevenseg.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -473,6 +473,7 @@ rgbVideoWE = 書き込み可能
 rgbVideoWidth = 幅
 rgbVideoX = X 座標
 rgbVideoY = Y 座標
+rgbVideoCLR = ピクセルをクリア
 #
 # bfh/bcd2sevenseg.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -473,6 +473,7 @@ rgbVideoWE = Schrijf inschakelen
 rgbVideoWidth = Breedte
 rgbVideoX = X Coördineren
 rgbVideoY = Y Coördinaat
+rgbVideoCLR = Pixel Wissen
 #
 # bfh/bcd2sevenseg.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -536,6 +536,7 @@ rgbVideoWE = Write Enable
 rgbVideoWidth = Szerokość
 rgbVideoX = Współrzędna X
 rgbVideoY = Współrzędna Y
+rgbVideoCLR = Wyczyść Piksel
 #
 # bfh/bcd2sevenseg.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -473,6 +473,7 @@ rgbVideoWE = Escrever Habilitar
 rgbVideoWidth = Largura
 rgbVideoX = X Coordenadas
 rgbVideoY = Y Coordenada
+rgbVideoCLR = Limpar Pixel
 #
 # bfh/bcd2sevenseg.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -473,6 +473,7 @@ rgbVideoWE = Включить запись
 rgbVideoWidth = Ширина
 rgbVideoX = X Координата
 rgbVideoY = Y Координата
+rgbVideoCLR = Очистить пиксель
 #
 # bfh/bcd2sevenseg.java
 #


### PR DESCRIPTION
New ```IO Pin``` added called ```CLR``` for clear that clears a pixel dot that has been previously written using ```WE``` and a color.

The ```CLR``` is ``` 1-bit wide 0 or 1```, asynchronous, it does react, whether the clock is ticking or not.
Can ```clear``` a pixel dot at a specific ```(x, y)```coordinate.

To clear all the pixels, use the previous ```RST``` pin. Instead of darkening the entire display, it turns it into the original state ```Yellow``` color. Original when you first place the component or when you hit ```Ctrl+R```.