### PR TITLE
Add list of Package Managers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,13 @@ network connections. You can click "Deny" as we do not need network access curre
 ### Package Manager ###
 
 `Logisim-evolution` is available from a bunch of package managers.  
-Note that these (except of Snap) exare not maintained by the core developers.
+Note that these (except of Snap) exare not maintained by the core developers.  
 If you should observe a bug in Logisim-evolution while using one of these packages,
-first make sure that it can be reproduced with the most recent official packages [provided through this repository](https://github.com/logisim-evolution/logisim-evolution/releases)
-and ideally the HEAD of our [develop branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop) before [creating an issue](https://github.com/logisim-evolution/logisim-evolution/issues) on the official [Logisim-evolution repository](https://github.com/logisim-evolution/logisim-evolution).
+first make sure that it can be reproduced with the most recent official packages
+[provided through this repository](https://github.com/logisim-evolution/logisim-evolution/releases)
+and ideally the HEAD of our [develop branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop) 
+before [creating an issue](https://github.com/logisim-evolution/logisim-evolution/issues) on
+the official [Logisim-evolution repository](https://github.com/logisim-evolution/logisim-evolution).  
 Otherwise, report the issue to the package maintainer!
 
 * [Snap](https://snapcraft.io/logisim-evolution) (`snap install logisim-evolution`)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Branch [develop](https://github.com/logisim-evolution/logisim-evolution/tree/dev
   * [Features](#features)
   * [Requirements](#requirements)
   * **[Downloads](#download)**
+    * [Package Manager](#package-manager)
     * [Nightly builds (unstable)](#nightly-builds)
   * [Pictures of Logisim-evolution](docs/pics.md)
   * [More Information](docs/docs.md)
@@ -66,9 +67,7 @@ include the Java runtime and do not require it to be installed separately:
 * `logisim-evolution_<version>-1_amd64.deb`: Debian package (also suitable for Ubuntu and derivatives),
 * `logisim-evolution-<version>-1.x86_64.rpm`: Package for Fedora/Redhat/CentOS/SuSE Linux distributions,
 * `logisim-evolution-<version>.msi`: Installer package for Microsoft Windows,
-* `logisim-evolution-<version>.dmg`: macOS package. Note that `Logisim-evolution` may also be installed
-  using [MacPorts](https://www.macports.org/) (by typing `sudo port install logisim-evolution`)
-  or via [Homebrew](https://brew.sh/) (by typing `brew install --cask logisim-evolution`).
+* `logisim-evolution-<version>.dmg`: macOS package.
 
 The Java JAR [`logisim-evolution-<version>-all.jar`](https://github.com/logisim-evolution/logisim-evolution/releases)
 is also available and can be run on any system with a supported Java runtime installed.
@@ -88,6 +87,17 @@ See [Safely open apps on your Mac](https://support.apple.com/en-us/HT202491) for
 
 Depending on your security settings, you may also get a panel asking if you wish to allow it to accept
 network connections. You can click "Deny" as we do not need network access currently nor we do request any.
+
+### Package Manager ###
+`Logisim-evolution` is available from a bunch of package managers.  
+Note that these are not mentained by the core developers.
+- [Flathub](https://flathub.org/apps/details/com.github.reds.LogisimEvolution) (`flatpak install flathub com.github.reds.LogisimEvolution`)
+- [Snap](https://snapcraft.io/logisim-evolution-snapcraft) (`snap install logisim-evolution-snapcraft`)
+- [Homebrew](https://formulae.brew.sh/cask/logisim-evolution) (`brew install --cask logisim-evolution`)
+- [MacPorts](https://ports.macports.org/port/logisim-evolution/details/) (`port install logisim-evolution`)
+- [Chocolatey](https://community.chocolatey.org/packages/logisim-evolution) (`choco install logisim-evolution`)
+- [winget](https://wingetgui.com/apps?id=Logisim-evolution.Logisim-evolution) (`winget install --id=Logisim-evolution.Logisim-evolution  -e`)
+- [Arch User Repository](https://aur.archlinux.org/packages/logisim-evolution)
 
 ### Nightly builds ###
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Note that these (except of Snap) exare not maintained by the core developers.
 If you should observe a bug in Logisim-evolution while using one of these packages,
 first make sure that it can be reproduced with the most recent official packages
 [provided through this repository](https://github.com/logisim-evolution/logisim-evolution/releases)
-and ideally the HEAD of our [develop branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop) 
+and ideally the HEAD of our [develop branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop)
 before [creating an issue](https://github.com/logisim-evolution/logisim-evolution/issues) on
 the official [Logisim-evolution repository](https://github.com/logisim-evolution/logisim-evolution).  
 Otherwise, report the issue to the package maintainer!

--- a/README.md
+++ b/README.md
@@ -89,15 +89,17 @@ Depending on your security settings, you may also get a panel asking if you wish
 network connections. You can click "Deny" as we do not need network access currently nor we do request any.
 
 ### Package Manager ###
+
 `Logisim-evolution` is available from a bunch of package managers.  
 Note that these are not mentained by the core developers.
-- [Flathub](https://flathub.org/apps/details/com.github.reds.LogisimEvolution) (`flatpak install flathub com.github.reds.LogisimEvolution`)
-- [Snap](https://snapcraft.io/logisim-evolution-snapcraft) (`snap install logisim-evolution-snapcraft`)
-- [Homebrew](https://formulae.brew.sh/cask/logisim-evolution) (`brew install --cask logisim-evolution`)
-- [MacPorts](https://ports.macports.org/port/logisim-evolution/details/) (`port install logisim-evolution`)
-- [Chocolatey](https://community.chocolatey.org/packages/logisim-evolution) (`choco install logisim-evolution`)
-- [winget](https://wingetgui.com/apps?id=Logisim-evolution.Logisim-evolution) (`winget install --id=Logisim-evolution.Logisim-evolution  -e`)
-- [Arch User Repository](https://aur.archlinux.org/packages/logisim-evolution)
+
+* [Flathub](https://flathub.org/apps/details/com.github.reds.LogisimEvolution) (`flatpak install flathub com.github.reds.LogisimEvolution`)
+* [Snap](https://snapcraft.io/logisim-evolution-snapcraft) (`snap install logisim-evolution-snapcraft`)
+* [Homebrew](https://formulae.brew.sh/cask/logisim-evolution) (`brew install --cask logisim-evolution`)
+* [MacPorts](https://ports.macports.org/port/logisim-evolution/details/) (`port install logisim-evolution`)
+* [Chocolatey](https://community.chocolatey.org/packages/logisim-evolution) (`choco install logisim-evolution`)
+* [winget](https://wingetgui.com/apps?id=Logisim-evolution.Logisim-evolution) (`winget install --id=Logisim-evolution.Logisim-evolution  -e`)
+* [Arch User Repository](https://aur.archlinux.org/packages/logisim-evolution)
 
 ### Nightly builds ###
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Note that these are not mentained by the core developers.
 * [Homebrew](https://formulae.brew.sh/cask/logisim-evolution) (`brew install --cask logisim-evolution`)
 * [MacPorts](https://ports.macports.org/port/logisim-evolution/details/) (`port install logisim-evolution`)
 * [Chocolatey](https://community.chocolatey.org/packages/logisim-evolution) (`choco install logisim-evolution`)
-* [winget](https://wingetgui.com/apps?id=Logisim-evolution.Logisim-evolution) (`winget install --id=Logisim-evolution.Logisim-evolution  -e`)
+* [winget](https://wingetgui.com/apps?id=Logisim-evolution.Logisim-evolution)
+(`winget install --id=Logisim-evolution.Logisim-evolution  -e`)
 * [Arch User Repository](https://aur.archlinux.org/packages/logisim-evolution)
 
 ### Nightly builds ###

--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ network connections. You can click "Deny" as we do not need network access curre
 ### Package Manager ###
 
 `Logisim-evolution` is available from a bunch of package managers.  
-Note that these are not mentained by the core developers.
+Note that these (except of Snap) exare not maintained by the core developers.
+If you should observe a bug in Logisim-evolution while using one of these packages, first make sure that it can be reproduced with the most recent official packages [provided through this repository](https://github.com/logisim-evolution/logisim-evolution/releases) and ideally the HEAD of our [develop branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop) before [creating an issue](https://github.com/logisim-evolution/logisim-evolution/issues) on the official [Logisim-evolution repository](https://github.com/logisim-evolution/logisim-evolution). Otherwise, report the issue to the package maintainer!
 
+* [Snap](https://snapcraft.io/logisim-evolution) (`snap install logisim-evolution`)
 * [Flathub](https://flathub.org/apps/details/com.github.reds.LogisimEvolution) (`flatpak install flathub com.github.reds.LogisimEvolution`)
-* [Snap](https://snapcraft.io/logisim-evolution-snapcraft) (`snap install logisim-evolution-snapcraft`)
 * [Homebrew](https://formulae.brew.sh/cask/logisim-evolution) (`brew install --cask logisim-evolution`)
 * [MacPorts](https://ports.macports.org/port/logisim-evolution/details/) (`port install logisim-evolution`)
 * [Chocolatey](https://community.chocolatey.org/packages/logisim-evolution) (`choco install logisim-evolution`)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ network connections. You can click "Deny" as we do not need network access curre
 ### Package Manager ###
 
 `Logisim-evolution` is available from a bunch of package managers.  
-Note that these (except of Snap) exare not maintained by the core developers.  
+Note that these (except for Snap) are not maintained by the core developers.  
 If you should observe a bug in Logisim-evolution while using one of these packages,
 first make sure that it can be reproduced with the most recent official packages
 [provided through this repository](https://github.com/logisim-evolution/logisim-evolution/releases)

--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ network connections. You can click "Deny" as we do not need network access curre
 
 `Logisim-evolution` is available from a bunch of package managers.  
 Note that these (except of Snap) exare not maintained by the core developers.
-If you should observe a bug in Logisim-evolution while using one of these packages, first make sure that it can be reproduced with the most recent official packages [provided through this repository](https://github.com/logisim-evolution/logisim-evolution/releases) and ideally the HEAD of our [develop branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop) before [creating an issue](https://github.com/logisim-evolution/logisim-evolution/issues) on the official [Logisim-evolution repository](https://github.com/logisim-evolution/logisim-evolution). Otherwise, report the issue to the package maintainer!
+If you should observe a bug in Logisim-evolution while using one of these packages,
+first make sure that it can be reproduced with the most recent official packages [provided through this repository](https://github.com/logisim-evolution/logisim-evolution/releases)
+and ideally the HEAD of our [develop branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop) before [creating an issue](https://github.com/logisim-evolution/logisim-evolution/issues) on the official [Logisim-evolution repository](https://github.com/logisim-evolution/logisim-evolution).
+Otherwise, report the issue to the package maintainer!
 
 * [Snap](https://snapcraft.io/logisim-evolution) (`snap install logisim-evolution`)
 * [Flathub](https://flathub.org/apps/details/com.github.reds.LogisimEvolution) (`flatpak install flathub com.github.reds.LogisimEvolution`)


### PR DESCRIPTION
We already list [MacPorts](https://www.macports.org/) and [Homebrew](https://brew.sh/), so I don't see a reason not to mention the other packet manager as well.

The downside of listing these is that we are promoting sources that are not controlled by us. To see why this can be a problem, take a look in #743.