### PR TITLE
Snap builder

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -235,8 +235,7 @@ jobs:
       - name: "Checkout sources"
         uses: actions/checkout@v2
         with:
-#          ref: ${{ github.ref_name }}
-          ref: snap-packages-test-1
+          ref: ${{ github.ref_name }}
       - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,13 +17,13 @@ on:
   # Keep it disabled once it's merged into main branch as we only
   # want "schedule" to be the trigger.
   # NOTE: remove `if` condition marked with `HACK` once merged.
-  pull_request:
-  # Nightly must be run against "develop" branch only.
-    branches: [ develop ]
-    types: [ closed ]
-  schedule:
-    # every day at midnight
-    - cron: "0 0 * * *"
+#  pull_request:
+#  # Nightly must be run against "develop" branch only.
+#    branches: [ develop ]
+#    types: [ closed ]
+#  schedule:
+#    # every day at midnight
+#    - cron: "0 0 * * *"
 
 env:
   JDK_VERSION: 16
@@ -161,7 +161,7 @@ jobs:
 
       # https://github.com/marketplace/actions/upload-a-build-artifact
       - name: 'Upload binary JAR'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           path: build/libs/${{ needs.git_check.outputs.lse_name }}-${{ needs.git_check.outputs.lse_version }}-all.jar
@@ -178,7 +178,7 @@ jobs:
           ./gradlew createDeb -x checkstyleMain -x checkstyleTest
 
       - name: 'Upload *.deb'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           path: build/dist/${{ needs.git_check.outputs.lse_name }}_${{ needs.git_check.outputs.lse_version }}-1_amd64.deb
@@ -196,7 +196,7 @@ jobs:
           ./gradlew createRpm -x checkstyleMain -x checkstyleTest
 
       - name: 'Upload *.rpm'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           path: build/dist/${{ needs.git_check.outputs.lse_name }}-${{ needs.git_check.outputs.lse_version }}-1.x86_64.rpm
@@ -215,7 +215,7 @@ jobs:
           ./gradlew sourcesJar
 
       - name: 'Upload sources JAR'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           path: build/libs/${{ needs.git_check.outputs.lse_name }}-${{ needs.git_check.outputs.lse_version }}-src.jar
@@ -252,7 +252,7 @@ jobs:
           ./gradlew createDmg -x checkstyleMain -x checkstyleTest
 
       - name: 'Upload DMG'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           path: build/dist/${{ needs.git_check.outputs.lse_name }}-${{ needs.git_check.outputs.lse_version }}.dmg
@@ -282,7 +282,7 @@ jobs:
         run: .\gradlew.bat createMsi -x checkstyleMain -x checkstyleTest
 
       - name: 'Upload MSI'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           # NOTE: Gradle builder creates MSI file that always uses short version format in file name.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,13 +18,12 @@ on:
   # want "schedule" to be the trigger.
   # NOTE: remove `if` condition marked with `HACK` once merged.
   pull_request:
-#  # Nightly must be run against "develop" branch only.
-#    branches: [ develop ]
-#    branches: [ snap-packages-test-1 ]
-#    types: [ closed ]
-#  schedule:
-#    # every day at midnight
-#    - cron: "0 0 * * *"
+  # Nightly must be run against "develop" branch only.
+    branches: [ develop ]
+    types: [ closed ]
+  schedule:
+    # every day at midnight
+    - cron: "0 0 * * *"
 
 env:
   JDK_VERSION: 16

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,11 +18,13 @@ on:
   # want "schedule" to be the trigger.
   # NOTE: remove `if` condition marked with `HACK` once merged.
   pull_request:
-    branches: [ develop ]
-    types: [ closed ]
-  schedule:
-    # every day at midnight
-    - cron: "0 0 * * *"
+#  # Nightly must be run against "develop" branch only.
+#    branches: [ develop ]
+#    branches: [ snap-packages-test-1 ]
+#    types: [ closed ]
+#  schedule:
+#    # every day at midnight
+#    - cron: "0 0 * * *"
 
 env:
   JDK_VERSION: 16
@@ -64,6 +66,7 @@ jobs:
 
           # Short name for branch in which action was triggered.
           declare -r branch_name="${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}"
+          echo "Triggered for branch: ${branch_name}"
 
           # Get SHA of last commit in that branch.
           declare -r last_commit_sha="$(git rev-parse HEAD)"
@@ -83,7 +86,6 @@ jobs:
           # Gradle artifact for "1.2.3-dev" uses "1.2.3dev" in file names, so we need to
           # consider that whlie looking for artifacts (i.e. for upload).
           declare -r version_prop=$(grep '^version\s*=.*' gradle.properties | awk '{print $3}')
-
 
           # Remove "-" (if present) from version string.
           declare -r lse_version=$(echo "${version_prop}" | awk '{gsub("-","", $0); print}')
@@ -109,12 +111,38 @@ jobs:
     needs: git_check
     if: needs.git_check.outputs.run_build == 'true'
     steps:
-      # https://github.com/marketplace/actions/checkout
-      - name: "Checkout sources"
+      - name: 'Checkout "develop" branch'
         uses: actions/checkout@v2
         with:
-          # We want develop branch only.
           ref: 'develop'
+
+      - name: 'Build Snap package'
+        # https://github.com/snapcore/action-build
+        uses: snapcore/action-build@v1
+        id: snapcraft
+
+      - name: 'Upload *.snap artifact.'
+        uses: actions/upload-artifact@v3
+        if: success()
+        with:
+           path: ${{ steps.snapcraft.outputs.snap }}
+           name: ${{ needs.git_check.outputs.base_name }}_amd64.snap
+
+#      - name: 'Pushing *.snap to snapcraft.io'
+#        # https://github.com/snapcore/action-publish
+#        uses: snapcore/action-publish@v1
+#        if: success()
+#        env:
+#          # Obtain Snapcraft.io store token:
+#          # $ snapcraft export-login --snaps=logisim-evolution --acls package_access,package_push,package_update,package_release token.txt
+#          # then open Github repository settings and add new secred named SNAPCRAFT_STORE_TOKEN with the value of token.txt
+#          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
+#        with:
+#          snap: ${{ steps.snapcraft.outputs.snap }}
+#          release: edge
+
+        # ###########################################################################################
+
       - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
         uses: actions/setup-java@v2
         with:
@@ -193,7 +221,7 @@ jobs:
           path: build/libs/${{ needs.git_check.outputs.lse_name }}-${{ needs.git_check.outputs.lse_version }}-src.jar
           name: ${{ needs.git_check.outputs.base_name }}-src.jar
 
-  # ##################################
+  # ###############################################################################################
 
   # Building for macOS.
   build_macos:
@@ -208,8 +236,8 @@ jobs:
       - name: "Checkout sources"
         uses: actions/checkout@v2
         with:
-          # We want develop branch only.
-          ref: 'develop'
+#          ref: ${{ github.ref_name }}
+          ref: snap-packages-test-1
       - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,7 +110,8 @@ jobs:
     needs: git_check
     if: needs.git_check.outputs.run_build == 'true'
     steps:
-      - name: 'Checkout "develop" branch'
+      # https://github.com/z0al/dependent-issues
+      - name: 'Checkout branch: ${{ env.GITHUB_REF }}'
         uses: actions/checkout@v2
         with:
           ref: 'develop'

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ include the Java runtime and do not require it to be installed separately:
 
 * `logisim-evolution_<version>-1_amd64.deb`: Debian package (also suitable for Ubuntu and derivatives),
 * `logisim-evolution-<version>-1.x86_64.rpm`: Package for Fedora/Redhat/CentOS/SuSE Linux distributions,
+* `logisim-evolution-<version>_amd64.snap`: The [Snap](https://snapcraft.io/docs) archive all
+  supported Linux distributions (also available in [Snapcraft store](https://snapcraft.io/logisim-evolution)),
 * `logisim-evolution-<version>.msi`: Installer package for Microsoft Windows,
 * `logisim-evolution-<version>.dmg`: macOS package. Note that `Logisim-evolution` may also be installed
   using [MacPorts](https://www.macports.org/) (by typing `sudo port install logisim-evolution`)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ include the Java runtime and do not require it to be installed separately:
 
 * `logisim-evolution_<version>-1_amd64.deb`: Debian package (also suitable for Ubuntu and derivatives),
 * `logisim-evolution-<version>-1.x86_64.rpm`: Package for Fedora/Redhat/CentOS/SuSE Linux distributions,
-* `logisim-evolution-<version>_amd64.snap`: The [Snap](https://snapcraft.io/docs) archive all
+* `logisim-evolution-<version>_amd64.snap`: The [Snap](https://snapcraft.io/docs) archive for all
   supported Linux distributions (also available in [Snapcraft store](https://snapcraft.io/logisim-evolution)),
 * `logisim-evolution-<version>.msi`: Installer package for Microsoft Windows,
 * `logisim-evolution-<version>.dmg`: macOS package. Note that `Logisim-evolution` may also be installed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ include the Java runtime and do not require it to be installed separately:
 The Java JAR [`logisim-evolution-<version>-all.jar`](https://github.com/logisim-evolution/logisim-evolution/releases)
 is also available and can be run on any system with a supported Java runtime installed.
 
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/logisim-evolution)
+
+---
+
 **Note for macOS users**:
 The Logisim-evolution.app is not signed with an Apple approved certificate.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,89 @@
+#
+# Logisim-evolution nightly builder
+# https://github.com/logisim-evolution/logisim-evolution
+#
+# Control file to build SNAP package of LSe
+# https://snapcraft.io/
+#
+# Marcin Orlowski
+#
+
+name: logisim-evolution
+base: core22
+confinement: strict
+icon: support/jpackage/linux/logisim-icon-128.png
+license: GPL-3.0
+summary: Digital logic design tool and simulator
+description: |
+ Logisim-evolution is educational software for designing and simulating digital logic circuits.
+ Logisim-evolution is free, open-source, and cross-platform.
+
+ Project highlights:
+  * easy to use circuit designer,
+  * logic circuit simulations,
+  * chronogram (to see the evolution of signals in your circuit),
+  * electronic board integration (schematics can be simulated on real hardware),
+  * VHDL components (components behavior can be specified in VHDL!),
+  * TCL/TK console (interfaces between the circuit and the user),
+  * huge library of components (LEDs, TTLs, switches, SoCs),
+  * supports multiple languages,
+  * and more!
+grade: stable
+
+adopt-info: logisim-evolution
+
+architectures:
+  - build-on: amd64
+
+layout:
+  /etc/fonts:
+    bind: $SNAP/etc/fonts
+  /usr/share/fonts:
+    bind: $SNAP/usr/share/fonts
+  /var/cache/fontconfig:
+    bind: $SNAP_DATA/var/cache/fontconfig
+
+apps:
+  logisim-evolution:
+    extensions: [gnome]
+    command: usr/lib/jvm/java-17-openjdk-$CRAFT_TARGET_ARCH/bin/java -jar $SNAP/logisim-evolution/logisim-evolution.jar
+    environment:
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
+      XDG_DATA_HOME: $SNAP/usr/share
+      FONTCONFIG_PATH: $SNAP/etc/fonts/conf.d
+      FONTCONFIG_FILE: $SNAP/etc/fonts/fonts.conf
+    plugs:
+      - desktop
+      - desktop-legacy
+      - gsettings
+      - home
+      - opengl
+      - unity7
+      - wayland
+      - x11
+
+parts:
+  logisim-evolution:
+    plugin: nil
+    source: https://github.com/MarcinOrlowski/logisim-evolution.git
+    source-type: git
+    override-pull: |
+      craftctl default
+      git checkout snap-packages-test-1
+      git status
+      LSE_VERSION="$(cat gradle.properties | grep '^version\s*=.*' | awk '{print $3}')"
+      craftctl set version="${LSE_VERSION}"
+    override-build: |
+      bash gradlew "$@" shadowJar && \
+      mkdir -p "$CRAFT_PART_INSTALL"/logisim-evolution && \
+        ls -ld build/libs/*
+        mv build/libs/logisim-evolution-*-all.jar "$CRAFT_PART_INSTALL"/logisim-evolution/logisim-evolution.jar
+    build-packages:
+      - git
+      - openjdk-17-jdk
+      - libfontconfig1-dev
+    stage-packages:
+      - openjdk-17-jre
+      - fonts-freefont-ttf
+      - fonts-arphic-uming
+      - fontconfig-config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,8 +1,6 @@
 #
-# Logisim-evolution nightly builder
-# https://github.com/logisim-evolution/logisim-evolution
-#
 # Control file to build SNAP package of LSe
+# https://github.com/logisim-evolution/logisim-evolution
 # https://snapcraft.io/
 #
 # Marcin Orlowski


### PR DESCRIPTION
I added support for [Snap] packages. Our stable build is already available as `*.snap` [here](https://snapcraft.io/logisim-evolution). This PR updated nightly builder to also create `*.snap` packages. 

I disabled pushing such packages to `edge` channel on snapcraft.io as I am not sure this is needed.

* #743