### PR TITLE
Removed unreliable build status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 ---
 
-Branch [master](https://github.com/logisim-evolution/logisim-evolution/tree/master): [![Build](https://github.com/logisim-evolution/logisim-evolution/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/logisim-evolution/logisim-evolution/actions/workflows/build.yml)
-
-Branch [develop](https://github.com/logisim-evolution/logisim-evolution/tree/develop): [![Build](https://github.com/logisim-evolution/logisim-evolution/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/logisim-evolution/logisim-evolution/actions/workflows/build.yml)
-
----
-
 # Logisim-evolution #
 
 * **Table of contents**


### PR DESCRIPTION
Removed unreliable build status badges that we used to display in the main page. These are not working for a while now despite being set up according to official docs. It'd probably be handy to get rid of them from the `master` branch's `README.md` as well as all they display now is `failed` for `master` and no status for `develop`. We eventually might want them back once figured out how to make them really work.

EDIT: Added PR #1574 for `master` too.
