### PR TITLE
Fix HexFile tests to never randomize memory.

### DIFF
--- a/src/test/java/com/cburch/logisim/gui/hex/HexFileTest.java
+++ b/src/test/java/com/cburch/logisim/gui/hex/HexFileTest.java
@@ -1,8 +1,6 @@
 package com.cburch.logisim.gui.hex;
 
-import com.cburch.logisim.Main;
 import com.cburch.logisim.std.memory.MemContents;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -95,9 +93,9 @@ public class HexFileTest {
     assertTrue(index >= 0);
     assertTrue(index < HexFile.formatDescriptions.length);
 
-    final var rng = new Random(index * addressSize * wordSize + 1);
+    final var rng = new Random((long) index * addressSize * wordSize + 1);
 
-    final var memoryContents = MemContents.create(addressSize, wordSize, true);
+    final var memoryContents = MemContents.create(addressSize, wordSize, false);
 
     final var values = new HashMap<Long, Long>();
     // (1L << size) doesn't work if size is 64


### PR DESCRIPTION
I found a bug in the HexFile memory tests. The tests require memory that starts all zeros, but it was paying attention to the user's setting for randomizing memory. That suddenly caused many tests to fail when I forgot I had changed that setting. This PR fixes it to always create the memory with all zeros.

I also cleaned up the imports and an implicit conversion.