### PR TITLE
Add architecture to macOS and Windows build and package name.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -286,5 +286,5 @@ jobs:
         if: success()
         with:
           # NOTE: Gradle builder creates MSI file that always uses short version format in file name.
-          path: build\dist\${{ needs.git_check.outputs.lse_name }}-${{ needs.git_check.outputs.lse_version_short }}.msi
-          name: ${{ needs.git_check.outputs.base_name }}.msi
+          path: build\dist\${{ needs.git_check.outputs.lse_name }}-${{ needs.git_check.outputs.lse_version_short }}-x86_64.msi
+          name: ${{ needs.git_check.outputs.base_name }}-x86_64.msi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -255,8 +255,8 @@ jobs:
         uses: actions/upload-artifact@v3
         if: success()
         with:
-          path: build/dist/${{ needs.git_check.outputs.lse_name }}-${{ needs.git_check.outputs.lse_version }}.dmg
-          name: ${{ needs.git_check.outputs.base_name }}.dmg
+          path: build/dist/${{ needs.git_check.outputs.lse_name }}-${{ needs.git_check.outputs.lse_version }}-x86_64.dmg
+          name: ${{ needs.git_check.outputs.base_name }}-x86_64.dmg
 
   # ###############################################################################################
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Added architecture designation to macOS build
   * Added TTL 74182: look-ahead carry generator.
   * Added TTL 74181: arithmetic logic unit.
   * Fixed Karnaugh map color index bug.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ include the Java runtime and do not require it to be installed separately:
 * `logisim-evolution-<version>-1.x86_64.rpm`: Package for Fedora/Redhat/CentOS/SuSE Linux distributions,
 * `logisim-evolution-<version>_amd64.snap`: The [Snap](https://snapcraft.io/docs) archive for all
   supported Linux distributions (also available in [Snapcraft store](https://snapcraft.io/logisim-evolution)),
-* `logisim-evolution-<version>.msi`: Installer package for Microsoft Windows,
+* `logisim-evolution-<version>-AArch64.msi`: Installer package for Microsoft Windows for Arm processors,
+* `logisim-evolution-<version>-x86_64.msi`: Installer package for Microsoft Windows for Intel processors,
 * `logisim-evolution-<version>-AArch64.dmg`: macOS package for Apple processors,
 * `logisim-evolution-<version>-x86_64.dmg`: macOS package for Intel processors (also runs on Apple processors in simulation).
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ include the Java runtime and do not require it to be installed separately:
 * `logisim-evolution-<version>_amd64.snap`: The [Snap](https://snapcraft.io/docs) archive for all
   supported Linux distributions (also available in [Snapcraft store](https://snapcraft.io/logisim-evolution)),
 * `logisim-evolution-<version>.msi`: Installer package for Microsoft Windows,
-* `logisim-evolution-<version>.dmg`: macOS package.
+* `logisim-evolution-<version>-AArch64.dmg`: macOS package for Apple processors,
+* `logisim-evolution-<version>-x86_64.dmg`: macOS package for Intel processors (also runs on Apple processors in simulation).
 
 The Java JAR [`logisim-evolution-<version>-all.jar`](https://github.com/logisim-evolution/logisim-evolution/releases)
 is also available and can be run on any system with a supported Java runtime installed.


### PR DESCRIPTION
This PR changes ./gradlew createApp to place the app in build/macOS-arch where arch is the architecture of the build, then createDmg uses that to create a logisim-evolution-version-arch.dmg file. This ensures this architecture's parts are kept separate from the other architecture builds.

This should make it fairly easy to add support for the newer Apple CPUs in our version releases. The nightly is updated to contain the architecture in the name. But we do not yet have a github machine to actually build the Apple architecture in the nightly.

This PR addresses #1584.

@MarcinOrlowski, please have a look at this since you have worked on these parts.