### PR TITLE
Fixes in VHDL generation of RAM in #1598 

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/HdlTypes.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/HdlTypes.java
@@ -93,7 +93,7 @@ public class HdlTypes {
             .append(
                 LineBuffer.formatVhdl(
                     "{{type}} {{1}} {{is}} {{array}} ( {{2}} {{downto}} 0 ) {{of}} std_logic_vector( ",
-                    myTypeName, myNrOfEntries))
+                    myTypeName, myNrOfEntries - 1))
             .append(
                 myGenericBitWidth == null
                     ? Integer.toString(myBitWidth - 1)
@@ -108,7 +108,7 @@ public class HdlTypes {
                 myGenericBitWidth == null
                     ? Integer.toString(myBitWidth - 1)
                     : String.format("%s - 1", myGenericBitWidth))
-            .append(String.format(":0] %s [%d:0];", myTypeName, myNrOfEntries));
+            .append(String.format(":0] %s [%d:0];", myTypeName, myNrOfEntries - 1));
       }
       return contents.toString();
     }

--- a/src/main/java/com/cburch/logisim/std/memory/RamHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamHdlGeneratorFactory.java
@@ -44,21 +44,8 @@ public class RamHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     final var async = StdAttr.TRIG_HIGH.equals(trigger) || StdAttr.TRIG_LOW.equals(trigger);
     final var ramEntries = (1 << nrOfaddressLines);
     final var truncated = (nrOfBits % 8) != 0;
-    myWires
-        .addWire("s_ramdataOut", nrOfBits)
-        .addRegister("s_tickDelayLine", 3)
-        .addRegister("s_dataInReg", nrOfBits)
-        .addRegister("s_addressReg", nrOfaddressLines)
-        .addRegister("s_weReg", 1)
-        .addRegister("s_oeReg", 1)
-        .addRegister("s_dataOutReg", nrOfBits);
     if (byteEnables) {
-      myWires
-          .addRegister("s_byteEnableReg", nrBePorts);
       for (var idx = 0; idx < nrBePorts; idx++) {
-        myWires
-            .addWire(String.format("s_byteEnable%d", idx), 1)
-            .addWire(String.format("s_we%d", idx), 1);
         myPorts
             .add(Port.INPUT, String.format("byteEnable%d", idx), 1, byteEnableOffset + nrBePorts - idx - 1);
       }
@@ -76,13 +63,10 @@ public class RamHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
         myTypedWires
             .addWire(String.format("s_byteMem%dContents", mem), ByteArrayId);
     } else {
-      myPorts.add(Port.INPUT, "oe", 1, Hdl.oneBit());
+      myPorts.add(Port.INPUT, "oe", 1, RamAppearance.getOEIndex(0, attrs));
       myTypedWires
           .addArray(MemArrayId, MemArrayStr, nrOfBits, ramEntries)
           .addWire("s_memContents", MemArrayId);
-      myWires
-          .addWire("s_we", 1)
-          .addWire("s_oe", 1);
     }
     myPorts
         .add(Port.INPUT, "address", nrOfaddressLines, RamAppearance.getAddrIndex(0, attrs))
@@ -101,61 +85,17 @@ public class RamHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     final var byteEnables = be != null && be.equals(RamAttributes.BUS_WITH_BYTEENABLES);
     if (Hdl.isVhdl()) {
       contents.empty().addVhdlKeywords().addRemarkBlock("The control signals are defined here");
-      if (byteEnables) {
-        for (var i = 0; i < RamAppearance.getNrBEPorts(attrs); i++) {
-          contents
-              .add("s_byteEnable{{1}} <= s_byteEnableReg({{1}}) {{and}} s_tickDelayLine(2) {{and}} s_oeReg;", i)
-              .add("s_we{{1}}         <= s_byteEnableReg({{1}}) {{and}} s_tickDelayLine(0) {{and}} s_weReg;", i);
-        }
-      } else {
-        contents.add("""
-            s_oe <= s_tickDelayLine(2) {{and}} s_oeReg;
-            s_we <= s_tickDelayLine(0) {{and}} s_weReg;
-            """);
-      }
       contents
-          .empty()
-          .addRemarkBlock("The input registers are defined here")
-          .add("""
-              inputRegs : {{process}}({{clock}}, {{tick}}, address, dataIn, we, oe) {{is}}
-              {{begin}}
-                 {{if}} (rising_edge({{clock}})) {{then}}
-                    {{if}} ({{tick}} = '1') {{then}}
-                        s_dataInReg  <= dataIn;
-                        s_addressReg <= address;
-                        s_weReg      <= we;
-                        s_oeReg      <= oe;
-              """);
-      if (byteEnables) {
-        for (var i = 0; i < RamAppearance.getNrBEPorts(attrs); i++)
-          contents.add("         s_byteEnableReg({{1}}) <= byteEnable{{1}}};", i);
-      }
-      contents
-          .add("""
-                    {{end}} {{if}};
-                 {{end}} {{if}};
-              {{end}} {{process}} inputRegs;
-              """)
-          .empty()
-          .add("""
-              tickPipeReg : {{process}}({{clock}}) {{is}}
-              {{begin}}
-                 {{if}} (rising_edge({{clock}})) {{then}}
-                     s_tickDelayLine(0)          <= {{tick}};
-                     s_tickDelayLine(2 {{downto}} 1) <= s_tickDelayLine(1 {{downto}} 0);
-                 {{end}} {{if}};
-              {{end}} {{process}} tickPipeReg;
-              """)
-          .empty()
           .addRemarkBlock("The actual memorie(s) is(are) defined here");
       if (byteEnables) {
         final var truncated = (attrs.getValue(Mem.DATA_ATTR).getWidth() % 8) != 0;
         for (var i = 0; i < RamAppearance.getNrBEPorts(attrs); i++) {
           contents
-              .add("mem{{1}} : {{process}}({{clock}}, s_we{{1}}, s_dataInReg, s_addressReg) {{is}}", i)
+              .add("mem{{1}} : {{process}}({{clock}}, oe, we, byteEnable{{1}}, dataIn, address) {{is}}", i)
               .add("{{begin}}")
               .add("   {{if}} (rising_edge({{clock}})) {{then}}")
-              .add("      {{if}} (s_we{{1}} = '1') {{then}}", i);
+              .add("      {{if}} (byteEnable{{1}} = '1') {{then}}", i)
+              .add("         {{if}} (we = '1') {{then}}", i);
           final var startIndex = i * 8;
           final var endIndex =
               (i == (RamAppearance.getNrBEPorts(attrs) - 1))
@@ -166,9 +106,12 @@ public class RamHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
                   ? "s_truncMemContents"
                   : String.format("s_byteMem%dContents", i);
           contents
-              .add("         {{1}}(to_integer(unsigned(s_addressReg))) <= s_dataInReg({{2}} {{downto}} {{3}});", memName, endIndex, startIndex)
+              .add("            {{1}}(to_integer(unsigned(address))) <= dataIn({{2}} {{downto}} {{3}});", memName, endIndex, startIndex)
+              .add("         {{end}} {{if}};")
+              .add("         {{if}} (oe = '1') {{then}}", i)
+              .add("            dataOut({{1}} {{downto}} {{2}}) <= {{3}}(to_integer(unsigned(address)));", endIndex, startIndex, memName)
+              .add("         {{end}} {{if}};")
               .add("      {{end}} {{if}};")
-              .add("      s_ramdataOut({{1}} {{downto}} {{2}}) <= {{3}}(to_integer(unsigned(s_addressReg)));", endIndex, startIndex, memName)
               .add("   {{end}} {{if}};")
               .add("{{end}} {{process}} mem{{1}};", i)
               .add("");
@@ -176,47 +119,17 @@ public class RamHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
       } else {
         contents
             .add("""
-                mem : {{process}}({{clock}} , s_we, s_dataInReg, s_addressReg) {{is}}
+                mem : {{process}}({{clock}} , oe, we, dataIn, address) {{is}}
                 {{begin}}
                    {{if}} (rising_edge({{clock}})) {{then}}
-                      {{if}} (s_we = '1') {{then}}
-                         s_memContents(to_integer(unsigned(s_addressReg))) <= s_dataInReg;
+                      {{if}} (we = '1') {{then}}
+                         s_memContents(to_integer(unsigned(address))) <= dataIn;
                       {{end}} {{if}};
-                      s_ramdataOut <= s_memContents(to_integer(unsigned(s_addressReg)));
+                      {{if}} (oe = '1') {{then}}
+                        dataOut <= s_memContents(to_integer(unsigned(address)));
+                      {{end}} {{if}};
                    {{end}} {{if}};
                 {{end}} {{process}} mem;
-                """);
-      }
-      contents.empty().addRemarkBlock("The output register is defined here");
-      if (byteEnables) {
-        for (var i = 0; i < RamAppearance.getNrBEPorts(attrs); i++) {
-          contents
-              .add("res{{1}} : {{process}}({{clock}}, s_byteEnable{{1}}, s_ramdataOut) {{is}}", i)
-              .add("{{begin}}")
-              .add("   {{if}} (rising_edge({{clock}}) {{then}}")
-              .add("      {{if}} (s_byteEnable{{1}} = '1') {{then}}", i);
-          final var startIndex = i * 8;
-          final var endIndex =
-              (i == (RamAppearance.getNrBEPorts(attrs) - 1))
-                  ? attrs.getValue(Mem.DATA_ATTR).getWidth() - 1
-                  : (i + 1) * 8 - 1;
-          contents
-              .add("         dataOut({{1}} {{downto}} {{2}}) <= s_ramdataOut({{1}} {{downto}} {{2}});", endIndex, startIndex)
-              .add("      {{end}} {{if}};")
-              .add("   {{end}} {{if}};")
-              .add("{{end}} {{process}} res{{1}};", i);
-        }
-      } else {
-        contents
-            .add("""
-                res : {{process}}({{clock}}, s_oe, s_ramdataOut) {{is}}
-                {{begin}}
-                   {{if}} (rising_edge({{clock}})) {{then}}
-                      {{if}} (s_oe = '1') {{then}}
-                        dataOut <= s_ramdataOut;
-                      {{end}} {{if}};
-                   {{end}} {{if}};
-                {{end}} {{process}} res;
                 """);
       }
     }


### PR DESCRIPTION
Fixes #1598.
Mainly by removing registers in RAM architecture file.
I tested generated VHDL:

- can be compiled by quartus web edition 13.0.
- GHDL simulator gives consistent behavior with logisim.