### PR TITLE
Use dependabot to generate PRs to update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    ignore:
+      - dependency-name: "de.jflex:jflex"
+
+  - package-echosystem: "github-actions"
+    # directory of "/" for github-actions means .github/workflows
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"


### PR DESCRIPTION
This PR should cause dependabot to automatically generate a PR for each dependency that needs to be updated. It might be necessary to also apply this to master to turn it on.

Be aware that the only automatic test we do is to build the project.

This addresses the suggestion made by @maehne in #1331.