### PR TITLE
Use dependabot to generate PRs to update dependencies (master branch)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    ignore:
+      - dependency-name: "de.jflex:jflex"
+
+  - package-echosystem: "github-actions"
+    # directory of "/" for github-actions means .github/workflows
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"


### PR DESCRIPTION
In #1649, I noted that it might be necessary to make this change in the master branch to trigger it to start running. Since it has not generated any PRs for updates, it does appear to be necessary. Hence this PR.

Note that this should only create update PRs for the develop branch, not master.
