### PR TITLE
Fix deprecated URL constructor

### DIFF
--- a/src/main/java/com/cburch/logisim/util/ZipClassLoader.java
+++ b/src/main/java/com/cburch/logisim/util/ZipClassLoader.java
@@ -12,6 +12,7 @@ package com.cburch.logisim.util;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -109,7 +110,7 @@ public class ZipClassLoader extends ClassLoader {
           final var zipEntry = zipFile.getEntry(res);
           if (zipEntry != null) {
             final var url = "jar:" + zipPath.toURI() + "!/" + res;
-            ret = new URL(url);
+            ret = URI.create(url).toURL();
             if (DEBUG >= 3) logger.debug("  found: " + url);
           }
         }


### PR DESCRIPTION
Java 20 will be released soon. As usual, I downloaded the release candidate and built the project. There is one line in our code that is deprecated in Java 20. This PR fixes it as suggested in the Java documentation.

@BFH-ktt1, I think this is code you added. The method is actually tagged to suppress the "unused" warning so it may not even be used and I don't know how to test it. Please check to see that this change makes sense.