### PR TITLE
Fix typo in dependabot.yml and add myself to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # See: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
 # Default owners or everything in the repo. Unless a later match takes precedence,
-*	@BFH-ktt1 @maehne @MarcinOrlowski @zdimension
+*	@BFH-ktt1 @davidhutchens @maehne @MarcinOrlowski @zdimension

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     ignore:
       - dependency-name: "de.jflex:jflex"
 
-  - package-echosystem: "github-actions"
+  - package-ecosystem: "github-actions"
     # directory of "/" for github-actions means .github/workflows
     directory: "/"
     schedule:


### PR DESCRIPTION
The reason dependabot is not generating PRs for updates is that I can't type, nor apparently read. I mispelled a keyword the second time it occurs.

I am also adding myself to the CODEOWNERS file since I expect to review the updates in particular. Besides, I've written a lot of reviews.

I took the time to set up a test Project to see exactly what it will do. It is necessary to make the change in master. So there is a paired PR.