### PR TITLE
Add clock acceleration for Xilinx 7 series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,6 @@ gradle-app.setting
 
 # default pre-commit config
 /.pre-commit-config.yaml
+
+# VSCode settins
+.vscode

--- a/src/main/java/com/cburch/logisim/fpga/download/Download.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/Download.java
@@ -64,7 +64,9 @@ public class Download extends DownloadBase implements Runnable, BaseWindowListen
       String mapFileName,
       boolean writeToFlash,
       boolean downloadOnly,
-      boolean gegerateHdlOnly,
+      boolean generateHdlOnly,
+      double preMultiplier,
+      double preDivider,
       JProgressBar progressBar,
       JFrame myParent) {
     this.progressBar = progressBar;
@@ -77,7 +79,9 @@ public class Download extends DownloadBase implements Runnable, BaseWindowListen
         mapFileName,
         writeToFlash,
         downloadOnly,
-        gegerateHdlOnly);
+        generateHdlOnly,
+        preMultiplier,
+        preDivider);
   }
 
   public Download(
@@ -88,7 +92,9 @@ public class Download extends DownloadBase implements Runnable, BaseWindowListen
       String mapFileName,
       boolean writeToFlash,
       boolean downloadOnly,
-      boolean generateHdlOnly) {
+      boolean generateHdlOnly,
+      double preMultiplier,
+      double preDivider) {
     setUpDownload(
         myProject,
         topLevelSheet,
@@ -97,7 +103,9 @@ public class Download extends DownloadBase implements Runnable, BaseWindowListen
         mapFileName,
         writeToFlash,
         downloadOnly,
-        generateHdlOnly);
+        generateHdlOnly,
+        preMultiplier,
+        preDivider);
   }
 
   private void setUpDownload(
@@ -108,11 +116,15 @@ public class Download extends DownloadBase implements Runnable, BaseWindowListen
       String mapFileName,
       boolean writeToFlash,
       boolean downloadOnly,
-      boolean generateHdlOnly) {
+      boolean generateHdlOnly,
+      double preMultiplier,
+      double preDivider) {
     this.myProject = myProject;
     this.myBoardInformation = myBoardInformation;
     this.downloadOnly = downloadOnly;
     this.generateHdlOnly = generateHdlOnly;
+    this.preDivider = preDivider;
+    this.preMultiplier = preMultiplier;
     if (myBoardInformation == null) {
       this.generateHdlOnly = true;
       this.vendor = ' ';
@@ -370,8 +382,8 @@ public class Download extends DownloadBase implements Runnable, BaseWindowListen
       progressBar.setString(S.get("FPGAState1"));
     }
     if (tickFrequency <= 0) tickFrequency = 1;
-    if (tickFrequency > (myBoardInformation.fpga.getClockFrequency() / 4))
-      tickFrequency = myBoardInformation.fpga.getClockFrequency() / 4;
+    if (tickFrequency > (getSynthesizedFrequency() / 4))
+      tickFrequency = getSynthesizedFrequency() / 4;
     if (!writeHDL(topLevelSheet, tickFrequency)) {
       return false;
     }

--- a/src/main/java/com/cburch/logisim/fpga/download/DownloadBase.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/DownloadBase.java
@@ -21,6 +21,8 @@ import com.cburch.logisim.fpga.file.FileWriter;
 import com.cburch.logisim.fpga.gui.Reporter;
 import com.cburch.logisim.fpga.hdlgenerator.Hdl;
 import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
+import com.cburch.logisim.fpga.hdlgenerator.SynthesizedClockHdlGeneratorFactory;
+import com.cburch.logisim.fpga.hdlgenerator.SynthesizedClockHdlGeneratorInstanceFactory;
 import com.cburch.logisim.fpga.hdlgenerator.TickComponentHdlGeneratorFactory;
 import com.cburch.logisim.fpga.hdlgenerator.ToplevelHdlGeneratorFactory;
 import com.cburch.logisim.fpga.settings.VendorSoftware;
@@ -40,6 +42,8 @@ public abstract class DownloadBase {
   protected Project myProject;
   protected BoardInformation myBoardInformation = null;
   protected MappableResourcesContainer myMappableResources;
+  protected double preMultiplier = 1.0;
+  protected double preDivider = 1.0;
   static final String[] HDLPaths = {
     HdlGeneratorFactory.VERILOG.toLowerCase(),
     HdlGeneratorFactory.VHDL.toLowerCase(),
@@ -54,6 +58,18 @@ public abstract class DownloadBase {
   public static final Integer SANDBOX_PATH = 3;
   public static final Integer UCF_PATH = 4;
   public static final Integer XDC_PATH = 5;
+
+  protected boolean isClockScalingRequested() {
+    return !(preDivider == 1.0 && preMultiplier == 1.0);
+  }
+
+  public long getSynthesizedFrequency() {
+    if (isClockScalingRequested()) {
+      return Math.round(myBoardInformation.fpga.getClockFrequency() * preMultiplier / preDivider);
+    } else {
+      return myBoardInformation.fpga.getClockFrequency();
+    }
+  }
 
   protected boolean isVendorSoftwarePresent() {
     return VendorSoftware.toolsPresent(
@@ -171,11 +187,41 @@ public abstract class DownloadBase {
     if (!worker.generateAllHDLDescriptions(generatedHDLComponents, projectDir, null)) {
       return false;
     }
+    // Instantiate the clock synthesizer component
+    SynthesizedClockHdlGeneratorFactory synthesizer;
+    try {
+      synthesizer = SynthesizedClockHdlGeneratorInstanceFactory.getSynthesizedClockHdlGeneratorFactory(
+        myBoardInformation.fpga.getTechnology(),
+        myBoardInformation.fpga.getVendor(),
+        isClockScalingRequested(), 
+        myBoardInformation.fpga.getClockFrequency(),
+        preMultiplier,
+        preDivider);
+    } catch(Exception e) {
+      Reporter.report.addFatalError(e.getMessage());
+      return false;
+    }
     /* Here we generate the top-level shell */
     if (rootSheet.getNetList().numberOfClockTrees() > 0) {
+      // Write the clock synthesizer component
+      if (!Hdl.writeEntity(
+          projectDir + synthesizer.getRelativeDirectory(),
+          synthesizer.getEntity(
+              rootSheet.getNetList(), null, SynthesizedClockHdlGeneratorFactory.HDL_IDENTIFIER),
+          SynthesizedClockHdlGeneratorFactory.HDL_IDENTIFIER)) {
+        return false;
+      }
+      if (!Hdl.writeArchitecture(
+          projectDir + synthesizer.getRelativeDirectory(),
+          synthesizer.getArchitecture(
+              rootSheet.getNetList(), null, SynthesizedClockHdlGeneratorFactory.HDL_IDENTIFIER),
+          SynthesizedClockHdlGeneratorFactory.HDL_IDENTIFIER)) {
+        return false;
+      }
+
       final var ticker =
           new TickComponentHdlGeneratorFactory(
-              myBoardInformation.fpga.getClockFrequency(),
+              getSynthesizedFrequency(),
               frequency /* , boardFreq.isSelected() */);
       if (!Hdl.writeEntity(
           projectDir + ticker.getRelativeDirectory(),
@@ -217,7 +263,7 @@ public abstract class DownloadBase {
     }
     final var top =
         new ToplevelHdlGeneratorFactory(
-            myBoardInformation.fpga.getClockFrequency(), frequency, rootSheet, myMappableResources);
+            getSynthesizedFrequency(), frequency, rootSheet, myMappableResources, synthesizer);
     if (top.hasLedArray()) {
       for (var type : LedArrayDriving.DRIVING_STRINGS) {
         if (top.hasLedArrayType(type)) {

--- a/src/main/java/com/cburch/logisim/fpga/download/DownloadBase.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/DownloadBase.java
@@ -197,7 +197,7 @@ public abstract class DownloadBase {
         myBoardInformation.fpga.getClockFrequency(),
         preMultiplier,
         preDivider);
-    } catch(Exception e) {
+    } catch (Exception e) {
       Reporter.report.addFatalError(e.getMessage());
       return false;
     }

--- a/src/main/java/com/cburch/logisim/fpga/gui/FpgaCommander.java
+++ b/src/main/java/com/cburch/logisim/fpga/gui/FpgaCommander.java
@@ -20,6 +20,7 @@ import com.cburch.logisim.file.LibraryListener;
 import com.cburch.logisim.fpga.data.BoardInformation;
 import com.cburch.logisim.fpga.download.Download;
 import com.cburch.logisim.fpga.file.BoardReaderClass;
+import com.cburch.logisim.fpga.hdlgenerator.SynthesizedClockHdlGeneratorInstanceFactory;
 import com.cburch.logisim.fpga.settings.VendorSoftware;
 import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.gui.icons.ProjectAddIcon;
@@ -93,6 +94,11 @@ public class FpgaCommander
       boardPic.setIcon(boardIcon);
       boardPic.repaint();
       FrequencyPanel.setFpgaClockFrequency(MyBoardInformation.fpga.getClockFrequency());
+      if (SynthesizedClockHdlGeneratorInstanceFactory.isClockScalingSupported(MyBoardInformation.fpga.getTechnology(), MyBoardInformation.fpga.getVendor())) {
+        FrequencyPanel.setClockScaling(true);
+      } else {
+        FrequencyPanel.setClockScaling(false);
+      }
       handleHdlOnly();
     }
   }
@@ -139,6 +145,11 @@ public class FpgaCommander
         new BoardReaderClass(AppPreferences.Boards.getSelectedBoardFileName())
             .getBoardInformation();
     MyBoardInformation.setBoardName(AppPreferences.SelectedBoard.get());
+    if (SynthesizedClockHdlGeneratorInstanceFactory.isClockScalingSupported(MyBoardInformation.fpga.getTechnology(), MyBoardInformation.fpga.getVendor())) {
+      FrequencyPanel.setClockScaling(true);
+    } else {
+      FrequencyPanel.setClockScaling(false);
+    }
     boardIcon = new BoardIcon(MyBoardInformation.getImage());
     JComboBox<String> selector = AppPreferences.Boards.boardSelector();
     selector.setPreferredSize(
@@ -376,6 +387,8 @@ public class FpgaCommander
               writeFlash,
               DownloadOnly,
               HdlOnly,
+              FrequencyPanel.getPreMultiplierValue(),
+              FrequencyPanel.getPreDividerValue(),
               Progress,
               panel);
       downloader.addListener(this);

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactory.java
@@ -446,7 +446,7 @@ public class AbstractHdlGeneratorFactory implements HdlGeneratorFactory {
     return directoryName.toString();
   }
 
-  private List<String> getVHDLBlackBox(Netlist theNetlist, AttributeSet attrs,
+  protected List<String> getVHDLBlackBox(Netlist theNetlist, AttributeSet attrs,
       String componentName, Boolean isEntity) {
     final var contents = LineBuffer.getHdlBuffer().addVhdlKeywords();
     var maxNameLength = 0;

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/SynthesizedClockHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/SynthesizedClockHdlGeneratorFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.fpga.hdlgenerator;
+
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.instance.Port;
+import com.cburch.logisim.util.LineBuffer;
+import java.util.SortedMap;
+import java.util.TreeMap;
+ 
+ /*
+  * Base class for generating a synthesized clock that hooks in to the clock
+  * chain right after the hardware clock. This class simply generates a loopback.
+  * Override this class to use a clock tile for a given vendor's chips to 
+  * in order to accelerate the clock for your project.
+  */
+public class SynthesizedClockHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
+
+  public static final String FPGA_CLOCK = "fpgaGlobalClock";
+  public static final String SYNTHESIZED_CLOCK = "s_synthesizedClock";
+  public static final String HDL_IDENTIFIER = "synthesizedClockGenerator";
+  public static final String HDL_DIRECTORY = "base";
+
+  public SynthesizedClockHdlGeneratorFactory() {
+    super(HDL_DIRECTORY);
+    myPorts
+        .add(Port.INPUT, "FPGAClock", 1, FPGA_CLOCK)
+        .add(Port.OUTPUT, "SynthesizedClock", 1, SYNTHESIZED_CLOCK);
+  }
+
+  @Override
+  public SortedMap<String, String> getPortMap(Netlist nets, Object mapInfo) {
+    final var res = new TreeMap<String, String>();
+    for (var port : myPorts.keySet())
+      res.put(port, myPorts.getFixedMap(port));
+    return res;
+  }
+
+  @Override
+  public LineBuffer getModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
+    final var contents =
+        LineBuffer.getHdlBuffer()
+            .add("")
+            .addRemarkBlock("Here the update logic is defined. Loop back the global clock.")
+            .add("""
+              {{assign}} SynthesizedClock {{=}} FPGAClock;
+              """);
+
+    return contents;
+  }
+}

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/SynthesizedClockHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/SynthesizedClockHdlGeneratorFactory.java
@@ -16,12 +16,12 @@ import com.cburch.logisim.util.LineBuffer;
 import java.util.SortedMap;
 import java.util.TreeMap;
  
- /*
-  * Base class for generating a synthesized clock that hooks in to the clock
-  * chain right after the hardware clock. This class simply generates a loopback.
-  * Override this class to use a clock tile for a given vendor's chips to 
-  * in order to accelerate the clock for your project.
-  */
+/*
+ * Base class for generating a synthesized clock that hooks in to the clock
+ * chain right after the hardware clock. This class simply generates a loopback.
+ * Override this class to use a clock tile for a given vendor's chips to 
+ * in order to accelerate the clock for your project.
+ */
 public class SynthesizedClockHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
 
   public static final String FPGA_CLOCK = "fpgaGlobalClock";

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/SynthesizedClockHdlGeneratorInstanceFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/SynthesizedClockHdlGeneratorInstanceFactory.java
@@ -4,12 +4,12 @@ import com.cburch.logisim.fpga.settings.VendorSoftware;
 
 public class SynthesizedClockHdlGeneratorInstanceFactory {
   public static SynthesizedClockHdlGeneratorFactory getSynthesizedClockHdlGeneratorFactory(
-    String technology, 
-    char vendor, 
-    boolean clockScalingRequested, 
-    long clockFrequency, 
-    double preMultiplier, 
-    double preDivider) throws Exception {
+      String technology, 
+      char vendor, 
+      boolean clockScalingRequested, 
+      long clockFrequency, 
+      double preMultiplier, 
+      double preDivider) throws Exception {
     if (technology.endsWith("-7") && vendor == VendorSoftware.VENDOR_VIVADO && clockScalingRequested) {
       return new XilinxSeries7SynthesizedClockHdlGeneratorFactory(
         clockFrequency, 

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/SynthesizedClockHdlGeneratorInstanceFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/SynthesizedClockHdlGeneratorInstanceFactory.java
@@ -1,0 +1,30 @@
+package com.cburch.logisim.fpga.hdlgenerator;
+
+import com.cburch.logisim.fpga.settings.VendorSoftware;
+
+public class SynthesizedClockHdlGeneratorInstanceFactory {
+  public static SynthesizedClockHdlGeneratorFactory getSynthesizedClockHdlGeneratorFactory(
+    String technology, 
+    char vendor, 
+    boolean clockScalingRequested, 
+    long clockFrequency, 
+    double preMultiplier, 
+    double preDivider) throws Exception {
+    if (technology.endsWith("-7") && vendor == VendorSoftware.VENDOR_VIVADO && clockScalingRequested) {
+      return new XilinxSeries7SynthesizedClockHdlGeneratorFactory(
+        clockFrequency, 
+        preMultiplier, 
+        preDivider);
+    } else {
+      return new SynthesizedClockHdlGeneratorFactory();
+    }
+  }
+
+  public static boolean isClockScalingSupported(String technology, char vendor) {
+    if (technology.endsWith("-7") && vendor == VendorSoftware.VENDOR_VIVADO) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/TickComponentHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/TickComponentHdlGeneratorFactory.java
@@ -53,7 +53,7 @@ public class TickComponentHdlGeneratorFactory extends AbstractHdlGeneratorFactor
         .addRegister("s_tickReg", 1)
         .addRegister("s_countReg", NR_OF_COUNTER_BITS_ID);
     myPorts
-         .add(Port.INPUT, "FPGAClock", 1, FPGA_CLOCK)
+         .add(Port.INPUT, "FPGAClock", 1, SynthesizedClockHdlGeneratorFactory.SYNTHESIZED_CLOCK)
          .add(Port.OUTPUT, "FPGATick", 1, FPGA_TICK);
   }
 

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/XilinxSeries7SynthesizedClockHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/XilinxSeries7SynthesizedClockHdlGeneratorFactory.java
@@ -30,7 +30,8 @@ public class XilinxSeries7SynthesizedClockHdlGeneratorFactory extends Synthesize
    * Instantiates an HDL clock generator for the Xilinx 7-series FPGA.
    * A pre-multiplier and a pre-divider can be specified to set the output
    * frequency. There are limitations for the settings of each of these parameters.
-   * Base frequency must be 10Mhz or greater, which is edited here.
+   * See referenced docs. Base frequency must be 10Mhz or greater, which is edited here.
+   * 
    * @param fpga_clock_frequency  Clock frequency in hertz.
    * @param preMultiplier         A double to three decimals that will multiply the 
    *                              clock frequency.

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/XilinxSeries7SynthesizedClockHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/XilinxSeries7SynthesizedClockHdlGeneratorFactory.java
@@ -37,7 +37,7 @@ public class XilinxSeries7SynthesizedClockHdlGeneratorFactory extends Synthesize
    * @param preDivider            A double to three decimals that will divide the
    *                              clock frequency.
    * @throws Exception
-   * @see                         https://docs.xilinx.com/v/u/en-US/ug472_7Series_Clocking
+   * @see                         <a href="https://docs.xilinx.com/v/u/en-US/ug472_7Series_Clocking" target="_top">Xilinx 7-Series Clocking</a>
    */
   public XilinxSeries7SynthesizedClockHdlGeneratorFactory(long fpga_clock_frequency, double preMultiplier, double preDivider) throws Exception {
     super();
@@ -52,25 +52,25 @@ public class XilinxSeries7SynthesizedClockHdlGeneratorFactory extends Synthesize
     // Get precision to the ps
     mmcmPeriodNs = Math.round(1000000000000.0 / (double) fpgaClockFrequency) / 1000.0;
     myWires
-    .addWire(SYNTHESIZED_CLOCK, 1)
-    .addWire("s_unbufferedSynthClk", 1)
-    .addWire("s_clkfbout", 1)
-    .addWire("s_bufferedFPGAClock", 1);
+        .addWire(SYNTHESIZED_CLOCK, 1)
+        .addWire("s_unbufferedSynthClk", 1)
+        .addWire("s_clkfbout", 1)
+        .addWire("s_bufferedFPGAClock", 1);
   }
 
   @Override
   public LineBuffer getModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
     final var contents =
-      LineBuffer.getHdlBuffer()
-        .pair("synthesizedClock", SYNTHESIZED_CLOCK)
-        .pair("preDivider", String.valueOf(preDivider))
-        .pair("preMultiplier", String.valueOf(preMultiplier))
-        .pair("clkInPeriodNs", String.valueOf(mmcmPeriodNs))
-        .add("")
-        .addRemarkBlock("Here the output is defined.")
-        .add("{{assign}} SynthesizedClock {{=}} {{synthesizedClock}};")
-        .add("")
-        .addRemarkBlock("Here the update logic is defined.");
+        LineBuffer.getHdlBuffer()
+          .pair("synthesizedClock", SYNTHESIZED_CLOCK)
+          .pair("preDivider", String.valueOf(preDivider))
+          .pair("preMultiplier", String.valueOf(preMultiplier))
+          .pair("clkInPeriodNs", String.valueOf(mmcmPeriodNs))
+          .add("")
+          .addRemarkBlock("Here the output is defined.")
+          .add("{{assign}} SynthesizedClock {{=}} {{synthesizedClock}};")
+          .add("")
+          .addRemarkBlock("Here the update logic is defined.");
 
     if (Hdl.isVhdl()) {
       contents.addVhdlKeywords().add("""
@@ -129,10 +129,10 @@ public class XilinxSeries7SynthesizedClockHdlGeneratorFactory extends Synthesize
     final var lines = LineBuffer.getBuffer();
     lines.addVhdlKeywords().add("""
 
-      {{library}} unisim;
-      {{use}} unisim.vcomponents.all;
+          {{library}} unisim;
+          {{use}} unisim.vcomponents.all;
 
-    """);
+        """);
     return lines.get();
   }
 
@@ -142,9 +142,9 @@ public class XilinxSeries7SynthesizedClockHdlGeneratorFactory extends Synthesize
     final var contents = LineBuffer.getHdlBuffer();
     if (Hdl.isVhdl()) {
       contents.add(FileWriter.getGenerateRemark(componentName, theNetlist.projName()))
-        .add(Hdl.getExtendedLibrary())
-        .add(getUnisimLibrary())
-        .add(getVHDLBlackBox(theNetlist, attrs, componentName, true));
+          .add(Hdl.getExtendedLibrary())
+          .add(getUnisimLibrary())
+          .add(getVHDLBlackBox(theNetlist, attrs, componentName, true));
     }
     return contents.get();
   }

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/XilinxSeries7SynthesizedClockHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/XilinxSeries7SynthesizedClockHdlGeneratorFactory.java
@@ -1,0 +1,151 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.fpga.hdlgenerator;
+
+import java.util.List;
+
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.fpga.file.FileWriter;
+import com.cburch.logisim.util.LineBuffer;
+
+/**
+ * Use Xilinx MMCM clock tile to accelerate hardware clock.
+ */
+public class XilinxSeries7SynthesizedClockHdlGeneratorFactory extends SynthesizedClockHdlGeneratorFactory {
+
+  private final long fpgaClockFrequency;
+  private double preMultiplier;
+  private double preDivider;
+  private final double mmcmPeriodNs;
+
+  /**
+   * Instantiates an HDL clock generator for the Xilinx 7-series FPGA.
+   * A pre-multiplier and a pre-divider can be specified to set the output
+   * frequency. There are limitations for the settings of each of these parameters.
+   * Base frequency must be 10Mhz or greater, which is edited here.
+   * @param fpga_clock_frequency  Clock frequency in hertz.
+   * @param preMultiplier         A double to three decimals that will multiply the 
+   *                              clock frequency.
+   * @param preDivider            A double to three decimals that will divide the
+   *                              clock frequency.
+   * @throws Exception
+   * @see                         https://docs.xilinx.com/v/u/en-US/ug472_7Series_Clocking
+   */
+  public XilinxSeries7SynthesizedClockHdlGeneratorFactory(long fpga_clock_frequency, double preMultiplier, double preDivider) throws Exception {
+    super();
+    fpgaClockFrequency = fpga_clock_frequency;
+    this.preDivider = preDivider;
+    this.preMultiplier = preMultiplier;
+    // Compute the period of the system clock in nanoseconds to three decimals
+    // (must be 10mhz or greater for mmcm)
+    if (fpga_clock_frequency < 10000000) {
+      throw new Exception("MMCM requires external FPGA clock of 10MHz or greater.");
+    }
+    // Get precision to the ps
+    mmcmPeriodNs = Math.round(1000000000000.0 / (double) fpgaClockFrequency) / 1000.0;
+    myWires
+    .addWire(SYNTHESIZED_CLOCK, 1)
+    .addWire("s_unbufferedSynthClk", 1)
+    .addWire("s_clkfbout", 1)
+    .addWire("s_bufferedFPGAClock", 1);
+  }
+
+  @Override
+  public LineBuffer getModuleFunctionality(Netlist TheNetlist, AttributeSet attrs) {
+    final var contents =
+      LineBuffer.getHdlBuffer()
+        .pair("synthesizedClock", SYNTHESIZED_CLOCK)
+        .pair("preDivider", String.valueOf(preDivider))
+        .pair("preMultiplier", String.valueOf(preMultiplier))
+        .pair("clkInPeriodNs", String.valueOf(mmcmPeriodNs))
+        .add("")
+        .addRemarkBlock("Here the output is defined.")
+        .add("{{assign}} SynthesizedClock {{=}} {{synthesizedClock}};")
+        .add("")
+        .addRemarkBlock("Here the update logic is defined.");
+
+    if (Hdl.isVhdl()) {
+      contents.addVhdlKeywords().add("""
+        clkbuf: BUFG port map (I=>s_unbufferedSynthClk, O=>{{synthesizedClock}});
+        iclkbuf: BUFG port map (I=>FPGAClock, O=>s_bufferedFPGAClock);
+
+        clock: MMCM_BASE generic map (
+          clkin1_period  => {{clkInPeriodNs}},
+          clkfbout_mult_f => {{preMultiplier}},
+          clkout0_divide_f => {{preDivider}}
+        )
+        port map(
+            rst      => '0',
+            pwrdwn   => '0',
+            clkin1   => s_bufferedFPGAClock,
+            clkfbin  => s_clkfbout,
+            clkfbout => s_clkfbout,
+            clkout0  => s_unbufferedSynthClk
+        );
+      """).empty();
+    } else {
+      contents.add("""
+        BUFG clkbuf (.I(s_unbufferedSynthClk), .O({{synthesizedClock}}));
+        BUFG iclkbuf (.I(FPGAClock), .O(s_bufferedFPGAClock));
+
+        MMCME2_BASE #(
+          .CLKIN1_PERIOD({{clkInPeriodNs}}),
+          .CLKFBOUT_MULT_F({{preMultiplier}}),
+          .CLKOUT0_DIVIDE_F({{preDivider}})
+        ) clock (
+          .RST(1'b0),
+          .PWRDWN(1'b0),
+          .CLKIN1(s_bufferedFPGAClock),
+          .CLKFBIN(s_clkfbout),
+          .CLKFBOUT(s_clkfbout),
+          .CLKOUT0(s_unbufferedSynthClk),
+          .CLKOUT0B(),
+          .CLKOUT1(),
+          .CLKOUT1B(),
+          .CLKOUT2(),
+          .CLKOUT2B(),
+          .CLKOUT3(),
+          .CLKOUT3B(),
+          .CLKOUT4(),
+          .CLKOUT5(),
+          .CLKOUT6(),
+          .CLKFBOUTB(),
+          .LOCKED()
+        );
+      """).empty();
+    }
+    return contents;
+  }
+
+  public static List<String> getUnisimLibrary() {
+    final var lines = LineBuffer.getBuffer();
+    lines.addVhdlKeywords().add("""
+
+      {{library}} unisim;
+      {{use}} unisim.vcomponents.all;
+
+    """);
+    return lines.get();
+  }
+
+  // Override entity creator to add unisim library. Only works for Xilinx.
+  @Override
+  public List<String> getEntity(Netlist theNetlist, AttributeSet attrs, String componentName) {
+    final var contents = LineBuffer.getHdlBuffer();
+    if (Hdl.isVhdl()) {
+      contents.add(FileWriter.getGenerateRemark(componentName, theNetlist.projName()))
+        .add(Hdl.getExtendedLibrary())
+        .add(getUnisimLibrary())
+        .add(getVHDLBlackBox(theNetlist, attrs, componentName, true));
+    }
+    return contents.get();
+  }
+}

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/XilinxSeries7SynthesizedClockHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/XilinxSeries7SynthesizedClockHdlGeneratorFactory.java
@@ -31,7 +31,7 @@ public class XilinxSeries7SynthesizedClockHdlGeneratorFactory extends Synthesize
    * A pre-multiplier and a pre-divider can be specified to set the output
    * frequency. There are limitations for the settings of each of these parameters.
    * See referenced docs. Base frequency must be 10Mhz or greater, which is edited here.
-   * 
+
    * @param fpga_clock_frequency  Clock frequency in hertz.
    * @param preMultiplier         A double to three decimals that will multiply the 
    *                              clock frequency.

--- a/src/main/java/com/cburch/logisim/gui/start/Startup.java
+++ b/src/main/java/com/cburch/logisim/gui/start/Startup.java
@@ -821,7 +821,9 @@ public class Startup implements AWTEventListener {
             testCircuitImpMapFile,
             false,
             false,
-            testCircuitHdlOnly);
+            testCircuitHdlOnly,
+            1.0,
+            1.0);
     return downloader.runTty();
   }
 

--- a/src/main/java/com/cburch/logisim/std/wiring/ClockHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/ClockHdlGeneratorFactory.java
@@ -17,6 +17,7 @@ import com.cburch.logisim.fpga.hdlgenerator.AbstractHdlGeneratorFactory;
 import com.cburch.logisim.fpga.hdlgenerator.Hdl;
 import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
 import com.cburch.logisim.fpga.hdlgenerator.HdlParameters;
+import com.cburch.logisim.fpga.hdlgenerator.SynthesizedClockHdlGeneratorFactory;
 import com.cburch.logisim.fpga.hdlgenerator.TickComponentHdlGeneratorFactory;
 import com.cburch.logisim.instance.Port;
 import com.cburch.logisim.util.LineBuffer;
@@ -64,7 +65,7 @@ public class ClockHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
   public SortedMap<String, String> getPortMap(Netlist nets, Object mapInfo) {
     final var map = new TreeMap<String, String>();
     if (!(mapInfo instanceof final netlistComponent componentInfo)) return map;
-    map.put("globalClock", TickComponentHdlGeneratorFactory.FPGA_CLOCK);
+    map.put("globalClock", SynthesizedClockHdlGeneratorFactory.SYNTHESIZED_CLOCK);
     map.put("clockTick", TickComponentHdlGeneratorFactory.FPGA_TICK);
     map.put("clockBus", getClockNetName(componentInfo.getComponent(), nets));
     return map;

--- a/src/main/resources/resources/logisim/strings/fpga/fpga.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga.properties
@@ -234,6 +234,8 @@ FpgaBoardClose = Close
 FpgaFreqDivider = Divider value:
 FpgaFreqFrequency = Frequency:
 FpgaFreqTitle = Clock settings
+FpgaFreqPreDivider = Pre-divider:
+FpgaFreqPreMultiplier = Pre-multiplier:
 #
 # gui/FPGACommander.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
@@ -234,6 +234,8 @@ FpgaBoardClose = Schließen
 FpgaFreqDivider = Teilerwert:
 FpgaFreqFrequency = Frequenz:
 FpgaFreqTitle = Takteinstellungen
+FpgaFreqPreDivider = Vor-teiler:
+FpgaFreqPreMultiplier = Vorvervielfacher:
 #
 # gui/FPGACommander.java
 #


### PR DESCRIPTION
I completed an initial attempt to add clock acceleration, or really re-clocking. The FPGA Commander dialog now has a pre multiplier and divider field that will display for Vivado Xilinx Series 7 chips (at this point it's the only thing I could confidently test...others could be added since I created a factory to generate the chip-specific code). An MMCM-based component is inserted into the clock chain. Tested with both Verilog and VHDL generation. If no pre-multiply and pre-divider factors are specified, a simple loopback component is generated. One of the things that is not coded for is that MMCM has parameter requirements that could be specified by the user that would result in synthesis failure. Relates to #1667.