### PR TITLE
[TruthTable] don't throw on overlapping inputs with identical output

### DIFF
--- a/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
@@ -429,29 +429,23 @@ public class TruthTable {
       final var r = newRows.get(i);
       for (final var idx : r) {
         if (taken[idx] != 0 && !force) {
-          boolean outputsEqual = true;
           final var existingValues = newEntries.get(taken[idx] - 1);
           final var currentValues = newEntries.get(i);
           for (int col = 0; col < no; col++) {
             final var existingValue = existingValues[ni + col];
             final var currentValue = currentValues[ni + col];
-            if (existingValue == Entry.DONT_CARE || currentValue == Entry.DONT_CARE) {
-              continue;
+            if (existingValue != Entry.DONT_CARE && currentValue != Entry.DONT_CARE) {
+              if (!currentValue.equals(existingValue)) {
+                throw new IllegalArgumentException(
+                  String.format(
+                      "Some inputs are repeated."
+                          + " For example, rows %d and %d have overlapping input values %s and %s.",
+                      taken[idx],
+                      i + 1,
+                      newRows.get(taken[idx] - 1).toBitString(ivars),
+                      r.toBitString(ivars)));
+              }
             }
-            if (!currentValue.equals(existingValue)) {
-              outputsEqual = false;
-              break;
-            }
-          }
-          if (!outputsEqual) {
-            throw new IllegalArgumentException(
-              String.format(
-                  "Some inputs are repeated."
-                      + " For example, rows %d and %d have overlapping input values %s and %s.",
-                  taken[idx],
-                  i + 1,
-                  newRows.get(taken[idx] - 1).toBitString(ivars),
-                  r.toBitString(ivars)));
           }
         } else if (taken[idx] != 0) {
           // TODO: split row

--- a/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
@@ -429,7 +429,9 @@ public class TruthTable {
       final var r = newRows.get(i);
       for (final var idx : r) {
         if (taken[idx] != 0 && !force) {
-          throw new IllegalArgumentException(
+          boolean outputsEqual = getVisibleOutputs(taken[idx]).equals(getVisibleOutputs(i+1));
+          if(!outputsEqual) {
+            throw new IllegalArgumentException(
               String.format(
                   "Some inputs are repeated."
                       + " For example, rows %d and %d have overlapping input values %s and %s.",
@@ -437,6 +439,7 @@ public class TruthTable {
                   i + 1,
                   newRows.get(taken[idx] - 1).toBitString(ivars),
                   r.toBitString(ivars)));
+          }
         } else if (taken[idx] != 0) {
           // TODO: split row
           throw new IllegalArgumentException(

--- a/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
@@ -435,7 +435,7 @@ public class TruthTable {
           for (int col = 0; col < no; col++) {
             final var existingValue = existingValues[ni + col];
             final var currentValue = currentValues[ni + col];
-            if(existingValue == Entry.DONT_CARE || currentValue == Entry.DONT_CARE) {
+            if (existingValue == Entry.DONT_CARE || currentValue == Entry.DONT_CARE) {
               continue;
             }
             if (!currentValue.equals(existingValue)) {
@@ -443,7 +443,7 @@ public class TruthTable {
               break;
             }
           }
-          if(!outputsEqual) {
+          if (!outputsEqual) {
             throw new IllegalArgumentException(
               String.format(
                   "Some inputs are repeated."

--- a/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
@@ -429,7 +429,20 @@ public class TruthTable {
       final var r = newRows.get(i);
       for (final var idx : r) {
         if (taken[idx] != 0 && !force) {
-          boolean outputsEqual = getVisibleOutputs(taken[idx]).equals(getVisibleOutputs(i+1));
+          boolean outputsEqual = true;
+          final var existingValues = newEntries.get(taken[idx] - 1);
+          final var currentValues = newEntries.get(i);
+          for (int col = 0; col < no; col++) {
+            final var existingValue = existingValues[ni + col];
+            final var currentValue = currentValues[ni + col];
+            if(existingValue == Entry.DONT_CARE || currentValue == Entry.DONT_CARE) {
+              continue;
+            }
+            if (!currentValue.equals(existingValue)) {
+              outputsEqual = false;
+              break;
+            }
+          }
           if(!outputsEqual) {
             throw new IllegalArgumentException(
               String.format(


### PR DESCRIPTION
Handles the case where the valid table is imported, but the app throws an error, as described in #517.

New behavior: when identical inputs are found, also check output equality. If outputs are equal, do not throw.

# Test plan

Import valid truth table from #517 
[valid_truth.txt](https://github.com/logisim-evolution/logisim-evolution/files/11184237/valid_truth.txt)
Table imports successfully
![image](https://user-images.githubusercontent.com/8419070/230742561-be494da6-b284-466f-b599-462814c373be.png)

Import invalid truth table, where row 5 output is changed to 0

[invalid_truth.txt](https://github.com/logisim-evolution/logisim-evolution/files/11184523/invalid_truth.txt)
![image](https://user-images.githubusercontent.com/8419070/230748056-5465c8d1-d84d-4b68-81da-1c54fe107be6.png)

