### PR TITLE
Controlled buff wide inputs patch

### DIFF
--- a/src/main/java/com/cburch/logisim/std/gates/ControlledBuffer.java
+++ b/src/main/java/com/cburch/logisim/std/gates/ControlledBuffer.java
@@ -247,13 +247,7 @@ class ControlledBuffer extends InstanceFactory {
     final var width = state.getAttributeValue(StdAttr.WIDTH);
     if (control == Value.TRUE) {
       final var in = state.getPortValue(1);
-      if (in == Value.TRUE || in == Value.FALSE) {
-        state.setPort(0, isInverter ? in.not() : in, GateAttributes.DELAY);
-      } else if (in == Value.UNKNOWN) {
-        state.setPort(0, Value.createUnknown(width), GateAttributes.DELAY);
-      } else if (in == Value.ERROR) {
-        state.setPort(0, Value.createError(width), GateAttributes.DELAY);
-      }
+      state.setPort(0, isInverter ? in.not() : in, GateAttributes.DELAY);
     } else if (control == Value.ERROR) {
       state.setPort(0, Value.createError(width), GateAttributes.DELAY);
     } else {

--- a/src/main/resources/doc/en/html/libs/gates/controlled.html
+++ b/src/main/resources/doc/en/html/libs/gates/controlled.html
@@ -176,8 +176,8 @@
               <td class="uvalue">
                 U
               </td>
-              <td class="uvalue">
-                U
+              <td class="evalue">
+                E
               </td>
             </tr>
             <tr>

--- a/src/main/resources/doc/fr/html/libs/gates/controlled.html
+++ b/src/main/resources/doc/fr/html/libs/gates/controlled.html
@@ -176,8 +176,8 @@
               <td class="uvalue">
                 U
               </td>
-              <td class="uvalue">
-                U
+              <td class="evalue">
+                E
               </td>
             </tr>
             <tr>

--- a/src/main/resources/doc/pt/html/libs/gates/controlled.html
+++ b/src/main/resources/doc/pt/html/libs/gates/controlled.html
@@ -175,8 +175,8 @@
               <td class="uvalue">
                 U
               </td>
-              <td class="uvalue">
-                U
+              <td class="evalue">
+                E
               </td>
             </tr>
             <tr>

--- a/src/main/resources/doc/ru/html/libs/gates/controlled.html
+++ b/src/main/resources/doc/ru/html/libs/gates/controlled.html
@@ -176,8 +176,8 @@
               <td class="uvalue">
                 U
               </td>
-              <td class="uvalue">
-                U
+              <td class="evalue">
+                E
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Fix for #1725, fix > 1 bit width regression introduced by #1704

# Test plan

[test_controlled_buff_fix_wide_in.zip](https://github.com/logisim-evolution/logisim-evolution/files/11240647/test_controlled_buff_fix_wide_in.zip)

![image](https://user-images.githubusercontent.com/8419070/232252696-d6dfc3e4-b8c8-419a-9dc9-58b2f51e428e.png)
