### PR TITLE
Fixed typo "Schift" to "Shift"

### DIFF
--- a/src/main/resources/doc/de/html/guide/gui/gui-toolsbar.html
+++ b/src/main/resources/doc/de/html/guide/gui/gui-toolsbar.html
@@ -134,7 +134,7 @@
               <img class=intxt src="../../../../img-guide/drawcurv.png" alt="#########" border="1">
             </td>
             <td>
-              <strong>Curve tool:</strong> Create a Bezier curve. The first <b class="tkeybd">click</b> and drag specifies the beginning of the line, the second <b class="tkeybd">click</b> and drag ends the line and sets the curvature. A <b class="tkeybd">click</b> on the line shows you the three control points. <b class="tkeybd">Schift</b> and click on central control point impose a symmetrical curve. <b class="tkeybd">Alt click</b> on center point draws the curve through the control point (under the mouse).
+              <strong>Curve tool:</strong> Create a Bezier curve. The first <b class="tkeybd">click</b> and drag specifies the beginning of the line, the second <b class="tkeybd">click</b> and drag ends the line and sets the curvature. A <b class="tkeybd">click</b> on the line shows you the three control points. <b class="tkeybd">Shift</b> and click on central control point impose a symmetrical curve. <b class="tkeybd">Alt click</b> on center point draws the curve through the control point (under the mouse).
             </td>
           </tr>
           <tr>

--- a/src/main/resources/doc/en/html/guide/gui/gui-canvas.html
+++ b/src/main/resources/doc/en/html/guide/gui/gui-canvas.html
@@ -32,7 +32,7 @@
         <li><b class="tkeybd">Mouse wheel</b> or keys <b class="tkeybd">up/down arrow</b> : vertical scrolling
         </li>
         <li>
-          <b class="tkeybd">Schift-Mouse wheel</b> or keys <b class="tkeybd">right/left arrow</b>: horizontal scrolling
+          <b class="tkeybd">Shift-Mouse wheel</b> or keys <b class="tkeybd">right/left arrow</b>: horizontal scrolling
         </li>
         <li>Key <b class="tkeybd">PgUp</b> : go to the top of the page
         </li>

--- a/src/main/resources/doc/en/html/guide/gui/gui-toolsbar.html
+++ b/src/main/resources/doc/en/html/guide/gui/gui-toolsbar.html
@@ -153,7 +153,7 @@
               <img class=inbullet src="../../../../img-guide/tooldrawcurv.png" alt="#########" border="1">
             </td>
             <td>
-              <strong>Curve tool:</strong> Create a Bezier curve. The first <b class="tkeybd">click</b> and drag specifies the beginning of the line, the second <b class="tkeybd">click</b> and drag ends the line and sets the curvature. A <b class="tkeybd">click</b> on the line shows you the three control points. <b class="tkeybd">Schift</b> and click on central control point impose a symmetrical curve. <b class="tkeybd">Alt click</b> on center point draws the curve through the control point (under the mouse).
+              <strong>Curve tool:</strong> Create a Bezier curve. The first <b class="tkeybd">click</b> and drag specifies the beginning of the line, the second <b class="tkeybd">click</b> and drag ends the line and sets the curvature. A <b class="tkeybd">click</b> on the line shows you the three control points. <b class="tkeybd">Shift</b> and click on central control point impose a symmetrical curve. <b class="tkeybd">Alt click</b> on center point draws the curve through the control point (under the mouse).
             </td>
           </tr>
           <tr>

--- a/src/main/resources/doc/en/html/guide/menu/edit.html
+++ b/src/main/resources/doc/en/html/guide/menu/edit.html
@@ -107,7 +107,7 @@
           </p>
         </dd>
         <dt>
-          <strong>Raise To Top</strong>&nbsp;&nbsp;<b class="tkeybd">Ctrl-Schift-Up</b>
+          <strong>Raise To Top</strong>&nbsp;&nbsp;<b class="tkeybd">Ctrl-Shift-Up</b>
         </dt>
         <dd>
           <p>
@@ -115,7 +115,7 @@
           </p>
         </dd>
         <dt>
-          <strong>Lower To Bottom</strong>&nbsp;&nbsp;<b class="tkeybd">Ctrl-Schift-Down</b>
+          <strong>Lower To Bottom</strong>&nbsp;&nbsp;<b class="tkeybd">Ctrl-Shift-Down</b>
         </dt>
         <dd>
           <p>

--- a/src/main/resources/doc/en/html/guide/subcirc/sub-personalise.html
+++ b/src/main/resources/doc/en/html/guide/subcirc/sub-personalise.html
@@ -103,7 +103,7 @@
             </td>
             <td>
               <strong>Curve tool:</strong> Create a quadratic Bezier curve. The first <b class="tkeybd">click</b> and drag specifies the beginning of the line, the second <b class="tkeybd">click</b> and drag ends the line and sets the curvature. A <b class="tkeybd">click</b> on the line shows you
-              the three control points. <b class="tkeybd">Schift</b> and click on central control point impose a symmetrical curve. <b class="tkeybd">Alt</b> and click on center point draws the curve through the control point (under the mouse).
+              the three control points. <b class="tkeybd">Shift</b> and click on central control point impose a symmetrical curve. <b class="tkeybd">Alt</b> and click on center point draws the curve through the control point (under the mouse).
             </td>
           </tr>
           <tr>

--- a/src/main/resources/doc/pt/html/guide/gui/gui-toolsbar.html
+++ b/src/main/resources/doc/pt/html/guide/gui/gui-toolsbar.html
@@ -134,7 +134,7 @@
               <img class=intxt src="../../../../img-guide/tooldrawcurv.png" alt="#########" border="1">
             </td>
             <td>
-              <strong>Curve tool:</strong> Create a Bezier curve. The first <b class="tkeybd">click</b> and drag specifies the beginning of the line, the second <b class="tkeybd">click</b> and drag ends the line and sets the curvature. A <b class="tkeybd">click</b> on the line shows you the three control points. <b class="tkeybd">Schift</b> and click on central control point impose a symmetrical curve. <b class="tkeybd">Alt click</b> on center point draws the curve through the control point (under the mouse).
+              <strong>Curve tool:</strong> Create a Bezier curve. The first <b class="tkeybd">click</b> and drag specifies the beginning of the line, the second <b class="tkeybd">click</b> and drag ends the line and sets the curvature. A <b class="tkeybd">click</b> on the line shows you the three control points. <b class="tkeybd">Shift</b> and click on central control point impose a symmetrical curve. <b class="tkeybd">Alt click</b> on center point draws the curve through the control point (under the mouse).
             </td>
           </tr>
           <tr>

--- a/src/main/resources/doc/pt/html/guide/mem/mem-hex.html
+++ b/src/main/resources/doc/pt/html/guide/mem/mem-hex.html
@@ -29,7 +29,7 @@
         Você poderá navegar através de memória usando a barra de rolagem, ou usando o teclado (as teclas <b class="tkeybd">de setas, home, end, page up e página para baixo</b>). Escrever caracteres hexadecimais alterará o valor selecionado.
       </p>
       <p>
-        Você poderá selecionar um intervalo de valores, arrastando o mouse, com  <b class="tkeybd">clique direito</b> do mouse, ou navegando através de memória com o teclado, enquanto pressionar a tecla <b class="tkeybd">Schift</b>. Os valores poderão ser copiados e colados usando o menu <b class=menu>|&nbsp;Editar&nbsp;|</b> ou com os atalhos associados <b class="tkeybd">Ctrl-C, Ctrl-V, Ctrl-X...</b>; a área de transferência também poderá ser usada em outras aplicações.
+        Você poderá selecionar um intervalo de valores, arrastando o mouse, com  <b class="tkeybd">clique direito</b> do mouse, ou navegando através de memória com o teclado, enquanto pressionar a tecla <b class="tkeybd">Shift</b>. Os valores poderão ser copiados e colados usando o menu <b class=menu>|&nbsp;Editar&nbsp;|</b> ou com os atalhos associados <b class="tkeybd">Ctrl-C, Ctrl-V, Ctrl-X...</b>; a área de transferência também poderá ser usada em outras aplicações.
       </p>
 	  <p>
 	   Dois botões (<b class="button">Abrir...</b>, <b class="button">Salvar...</b>) são usados para carregar ou salvar dados de um arquivo. Informações sobre tipos de arquivos podem ser encontradas em <a href="mem-menu.html"> Menus pop-up e arquivos</a>

--- a/src/main/resources/doc/pt/html/guide/subcirc/sub-personalise.html
+++ b/src/main/resources/doc/pt/html/guide/subcirc/sub-personalise.html
@@ -115,7 +115,7 @@
               <img class=inbullet src="../../../../img-guide/drawrect.png" alt="#########" border="1">
             </td>
             <td>
-              <strong>Ferramenta retangular :</strong> Cria um rectângulo ou quadrado (<b class="tkeybd">Schift</b>) arrastando de um canto para o canto oposto.
+              <strong>Ferramenta retangular :</strong> Cria um rectângulo ou quadrado (<b class="tkeybd">Shift</b>) arrastando de um canto para o canto oposto.
             </td>
           </tr>
           <tr>
@@ -123,7 +123,7 @@
               <img class=inbullet src="../../../../img-guide/drawrrct.png" alt="#########" border="1">
             </td>
             <td>
-              <strong>Ferramenta retangular :</strong> Cria um rectângulo ou quadrado (<b class="tkeybd">Schift</b>) com uma aresta arredondada arrastando de um canto para o canto oposto.
+              <strong>Ferramenta retangular :</strong> Cria um rectângulo ou quadrado (<b class="tkeybd">Shift</b>) com uma aresta arredondada arrastando de um canto para o canto oposto.
             </td>
           </tr>
           <tr>
@@ -131,7 +131,7 @@
               <img class=inbullet src="../../../../img-guide/drawoval.png" alt="#########" border="1">
             </td>
             <td>
-              <strong>Ferramenta oval :</strong> Cria um círculo ou oval (<b class="tkeybd">Schift</b>) deslizando de um canto do seu contorno para o canto oposto.
+              <strong>Ferramenta oval :</strong> Cria um círculo ou oval (<b class="tkeybd">Shift</b>) deslizando de um canto do seu contorno para o canto oposto.
             </td>
           </tr>
           <tr>

--- a/src/main/resources/doc/ru/html/guide/gui/gui-toolsbar.html
+++ b/src/main/resources/doc/ru/html/guide/gui/gui-toolsbar.html
@@ -134,7 +134,7 @@
               <img class=intxt src="../../../../img-guide/drawcurv.png" alt="#########" border="1">
             </td>
             <td>
-              <strong>Curve tool:</strong> Create a Bezier curve. The first <b class="tkeybd">click</b> and drag specifies the beginning of the line, the second <b class="tkeybd">click</b> and drag ends the line and sets the curvature. A <b class="tkeybd">click</b> on the line shows you the three control points. <b class="tkeybd">Schift</b> and click on central control point impose a symmetrical curve. <b class="tkeybd">Alt click</b> on center point draws the curve through the control point (under the mouse).
+              <strong>Curve tool:</strong> Create a Bezier curve. The first <b class="tkeybd">click</b> and drag specifies the beginning of the line, the second <b class="tkeybd">click</b> and drag ends the line and sets the curvature. A <b class="tkeybd">click</b> on the line shows you the three control points. <b class="tkeybd">Shift</b> and click on central control point impose a symmetrical curve. <b class="tkeybd">Alt click</b> on center point draws the curve through the control point (under the mouse).
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Went through the documentation and changed "Schift" to "Shift" in 12 different instances. Fixes #1687 