### PR TITLE
Remove outdated mockito-inline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
 
   testImplementation(platform("org.junit:junit-bom:5.9.2"))
   testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
-  testImplementation("org.mockito:mockito-inline:5.2.0")
   testImplementation("org.mockito:mockito-junit-jupiter:5.3.0")
 }
 


### PR DESCRIPTION
mockito-inline is now included in mockito-core which is a dependency of mockito-junit-jupiter. Thus we do not need to list it in build.gradle.kts.