### PR TITLE
Fixed mispositioned select/enable pins on Multiplexer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Fixed select port positioning on Multiplexer to be more consistent in some cases [#1734]
   * Fixed appearance of LSe desktop icon [#1662]
   * Update controlled buffer behavior to pass U and E inputs while enabled [#1642]
   * Introduced user-defined color for components.

--- a/src/main/java/com/cburch/logisim/std/plexers/Multiplexer.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Multiplexer.java
@@ -357,9 +357,9 @@ public class Multiplexer extends InstanceFactory {
         dy += ddy;
       }
     }
-    if (!wide && !vertical && botLeft)
+    if (!wide && !vertical && botLeft && inputs > 2)
       sel = sel.translate(-10, 0); // left side, adjust selector left
-    else if (!wide && vertical && !botLeft)
+    else if (!wide && vertical && !botLeft && inputs > 2)
       sel = sel.translate(0, -10); // top side, adjust selector up
     final var en = sel.translate(dir, 10);
     ps[inputs] = new Port(sel.getX(), sel.getY(), Port.INPUT, select.getWidth());


### PR DESCRIPTION
New pull request for issue #1733.

My guess was essentially spot-on. The select port on the Multiplexer now only adjusts for Narrow size when the number of inputs is greater than 2.

Before:
![before image](https://user-images.githubusercontent.com/46010001/234169506-4329e6e8-b3d8-4111-9d0f-2e14c0487071.png)
After:
![after image](https://user-images.githubusercontent.com/46010001/234169563-9d884963-5d35-4491-997a-cb207eada124.png)