### PR TITLE
Update workflows and documentation for changing default branch to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
+    target-branch: "main"
     ignore:
       - dependency-name: "de.jflex:jflex"
 
@@ -13,4 +13,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
+    target-branch: "main"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,10 @@
 name: "Build"
 on:
   push:
-    # No need to run on push to "develop" as there should not be any direct pushes.
-    # master is left just for emergency cases.
-    branches: [ master ]
+    # main is left just for emergency cases.
+    branches: [ main ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main ]
 
 env:
   JDK_VERSION: 16

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -8,11 +8,10 @@
 name: "Code style"
 on:
   push:
-    # No need to run on push to "develop" as there should not be any direct pushes.
-    # master is left just for emergency cases.
-    branches: [ master ]
+    # main is left just for emergency cases.
+    branches: [ main ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main ]
 
 jobs:
   analyze_sources:
@@ -99,8 +98,8 @@ jobs:
           echo "*********************************************************"
           echo "* FIXME! Code style guide violations detected: ${cnt}"
           echo "*"
-          echo "* For more information about used code style guile see:"
-          echo "* https://github.com/logisim-evolution/logisim-evolution/blob/develop/docs/style.md"
+          echo "* For more information about used code style guide see:"
+          echo "* https://github.com/logisim-evolution/logisim-evolution/blob/main/docs/style.md"
           echo "*********************************************************"
           cat "${REPORT_FILE}"
           exit 1

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -4,9 +4,9 @@ name: "MD Lint"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main ]
 
 jobs:
   markdown_lint:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@
 # https://github.com/logisim-evolution/logisim-evolution
 #
 # Cron driven Github Action builder, intended to create nightly builds
-# from Logisim-evolution's "develop" branch. It assumes to be invoked
+# from Logisim-evolution's "main" branch. It assumes to be invoked
 # daily (once per 24 hrs) and skips building if there was no repo activity
 # during last 24 hours.
 #
@@ -18,8 +18,8 @@ on:
   # want "schedule" to be the trigger.
   # NOTE: remove `if` condition marked with `HACK` once merged.
   pull_request:
-  # Nightly must be run against "develop" branch only.
-    branches: [ develop ]
+  # Nightly must be run against "main" branch only.
+    branches: [ main ]
     types: [ closed ]
   schedule:
     # every day at midnight
@@ -77,7 +77,7 @@ jobs:
             echo "*** No code changes since yesterday. Skipping."
           fi
 
-          # I need to export current version, even if is incorrect for develop branch as it
+          # I need to export current version, even if is incorrect for main branch as it
           # is part of produced artifacts. We will strip it prior uploading anyway.
 
           # LSe version string can have additional "unstable" indicator (i.e. "-dev") but
@@ -114,7 +114,7 @@ jobs:
       - name: 'Checkout branch: ${{ env.GITHUB_REF }}'
         uses: actions/checkout@v3
         with:
-          ref: 'develop'
+          ref: 'main'
 
       - name: 'Build Snap package'
         # https://github.com/snapcore/action-build

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -13,9 +13,9 @@ name: "Translations"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main ]
 
 jobs:
   translations_lint:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Note that these (except for Snap) are not maintained by the core developers.
 If you should observe a bug in Logisim-evolution while using one of these packages,
 first make sure that it can be reproduced with the most recent official packages
 [provided through this repository](https://github.com/logisim-evolution/logisim-evolution/releases)
-and ideally the HEAD of our [develop branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop)
+and ideally the HEAD of our [main branch](https://github.com/logisim-evolution/logisim-evolution/tree/main)
 before [creating an issue](https://github.com/logisim-evolution/logisim-evolution/issues) on
 the official [Logisim-evolution repository](https://github.com/logisim-evolution/logisim-evolution).  
 Otherwise, report the issue to the package maintainer!
@@ -114,11 +114,11 @@ Otherwise, report the issue to the package maintainer!
 ### Nightly builds ###
 
 We also offer builds based on the current state of the
-[develop](https://github.com/logisim-evolution/logisim-evolution/tree/develop) branch.
-If the develop branch has been changed,
+[main](https://github.com/logisim-evolution/logisim-evolution/tree/main) branch.
+If the main branch has been changed,
 a new `Nightly build` is created at midnight [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
-Note that these builds may be unstable since the develop branch is a work in progress.
+Note that these builds may be unstable since the main branch is a work in progress.
 
 To get nightly downloads, please
 [click here](https://github.com/logisim-evolution/logisim-evolution/actions/workflows/nightly.yml)
@@ -133,5 +133,5 @@ if you found a bug or have suggestions for improvement.
 
 ## License ##
 
-* `Logisim-evolution` is copyrighted ©2001-2022 by Logisim-evolution [developers](docs/credits.md).
+* `Logisim-evolution` is copyrighted ©2001-2023 by Logisim-evolution [developers](docs/credits.md).
 * This is free software licensed under [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -115,11 +115,11 @@ To see all available tasks run: `./gradlew tasks --all`
 ## Testing development code ##
 
 `Logisim-evolution` is often updated.
-The [branch `develop`](https://github.com/logisim-evolution/logisim-evolution/tree/develop)
+The [branch `main`](https://github.com/logisim-evolution/logisim-evolution/tree/main)
 is the place where all the work on next release happens.
 Once the code reaches the point it is ready for the next public release, it will
 be merged into the [`master` branch](https://github.com/logisim-evolution/logisim-evolution/tree/master) and released.
-But if you want to contribute, or even just see what we are currently working on, checkout the `develop` branch
+But if you want to contribute, or even just see what we are currently working on, checkout the `main` branch
 and build `Logisim-evolution` from source as described above.
 
 **If you see any issues or have any ideas for improvement, please
@@ -134,11 +134,11 @@ If you want to contribute to Logisim-evolution, this is how to do it:
 * Make a local *fork* of `Logisim-evolution` by clicking the *Fork* button on the
   [project GitHub page](https://github.com/logisim-evolution/logisim-evolution). This will create
   a copy of the `Logisim-evolution` repository on your own GitHub account.
-* As all the development happens on [`develop` branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop),
-  ensure you checkout [`develop` branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop) before you
+* As all the development happens on [`main` branch](https://github.com/logisim-evolution/logisim-evolution/tree/main),
+  ensure you checkout [`main` branch](https://github.com/logisim-evolution/logisim-evolution/tree/main) before you
   create your own branch.
 * Fix the bugs you want to fix on your local fork in the
-  [`develop` branch](https://github.com/logisim-evolution/logisim-evolution/tree/develop).
+  [`main` branch](https://github.com/logisim-evolution/logisim-evolution/tree/main).
 * Add the features you want to add on your local fork.
 * Add/modify the documentation/language support on your local fork.
 
@@ -148,8 +148,8 @@ Once it is running without bugs on your local fork, request a *Pull request* by:
 * Click on *compare across forks*.
 * On the right-hand side select your fork, for example: *head repository: BFH-ktt1/logisim-evolution*
 * On the right-hand side select your branch, for example: *base: bugfixes*
-* On the left-hand side select the development branch *base: develop* (**Important:** All pull requests **MUST**
-  be on the [branch `develop`](https://github.com/logisim-evolution/logisim-evolution/tree/develop) as
+* On the left-hand side select the main branch *base: main* (**Important:** All pull requests **MUST**
+  be on the [branch `main`](https://github.com/logisim-evolution/logisim-evolution/tree/main) as
   the [branch `master`](https://github.com/logisim-evolution/logisim-evolution/tree/master) only
   holds the code of the latest stable release, and we do not allow any external contributions to that
   particular branch.


### PR DESCRIPTION
This should update our actions to work with the renaming of branches. It also updates the documentation to refer to main rather than develop.