### PR TITLE
Make a createPackageInput target in build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -239,11 +239,11 @@ fun runCommand(params: List<String>, exceptionMsg: String): String {
  * Helper function to remove all contents from the given directory
 */
 fun deleteDirectoryContents(directory: String) {
-    for (file in File(directory).list()) {
-      if (!delete("${directory}/${file}")) {
-        throw GradleException("Failed to remove old file: ${directory}${file}")
-      }
+  for (file in File(directory).list()) {
+    if (!delete("${directory}/${file}")) {
+      throw GradleException("Failed to remove old file: ${directory}${file}")
     }
+  }
 }
 
 /**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ val JPACKAGE = "jpackage"
 val LIBS_DIR = "libsDir"
 val LINUX_PARAMS = "linuxParameters"
 val OS_ARCH = "osArch"
+val PACKAGE_INPUT_DIR = "packageInputDir"
 val SHADOW_JAR_FILE_NAME = "shadowJarFilename"
 val SHARED_PARAMS = "sharedParameters"
 val SUPPORT_DIR = "supportDir"
@@ -112,6 +113,10 @@ extra.apply {
   val libsDir="${buildDir}/libs"
   set(LIBS_DIR, libsDir)
 
+  // PackageInput folder that hold the shadowJar
+  val packageInputDir="${buildDir}/packageInput"
+  set(PACKAGE_INPUT_DIR, packageInputDir)
+
   // The root dir for jpackage extra files.
   val supportDir="${projectDir}/support/jpackage"
   set(SUPPORT_DIR, supportDir)
@@ -144,7 +149,7 @@ extra.apply {
       // NOTE: we cannot use --app-version as part of platform agnostic set as i.e. both macOS and
       // Windows packages do not allow use of any suffixes like "-dev" etc, so --app-version is set
       // in these builders separately.
-      "--input", libsDir,
+      "--input", packageInputDir,
       "--main-class", "com.cburch.logisim.Main",
       "--main-jar", shadowJarFilename,
       "--copyright", copyrights,
@@ -194,59 +199,6 @@ task<Jar>("sourcesJar") {
 
 
 /**
- * Creates the distribution directory and removes any extra files from the libs directory
- * beyond the expected shadowJar file because jpackage puts everything from libs into the package.
- */
-tasks.register("createDistDir") {
-  val libsDir = ext.get(LIBS_DIR) as String
-
-  group = "build"
-  description = "Creates the directory for distribution."
-  dependsOn("shadowJar")
-
-  val shadowJarFilename = ext.get(SHADOW_JAR_FILE_NAME) as String
-
-  inputs.dir(libsDir)
-  outputs.dir(ext.get(TARGET_DIR) as String)
-
-  doFirst {
-    var jarFiles = File(libsDir).list()
-    var jarCount = jarFiles.count()
-
-    if ( jarCount > 1) {
-      logger.warn("Expected 1 shadowJar file, found ${jarCount} in: ${libsDir}")
-
-      val expectedShadowJar = File("${libsDir}/${shadowJarFilename}")
-      if (expectedShadowJar.exists()) {
-        logger.warn("Found needed: ${shadowJarFilename}")
-      }
-
-      for (file in jarFiles.filter { file -> file != shadowJarFilename }) {
-        logger.warn("Will remove: ${file}")
-      }
-    }
-  }
-
-  doLast {
-    val folder = File(libsDir)
-    if (!folder.exists() && !folder.mkdirs()) {
-      throw GradleException("Unable to create directory: ${folder.absolutePath}")
-    }
-
-    var jarFiles = File(libsDir).list()
-    var jarCount = jarFiles.count()
-    if ( jarCount > 1) {
-      // Value of shadowJarFileName is our needed JAR file. Remove the rest.
-      for (file in jarFiles.filter { file -> file != shadowJarFilename }) {
-        if (!delete("${libsDir}/${file}")) {
-          throw GradleException("Failed to remove orphaned file: ${file}")
-        }
-      }
-    }
-  }
-}
-
-/**
  * Helper method that simplifies runining external commands using ProcessBuilder().
  * Will throw GradleException on command failure (non-zero return code).
  *
@@ -284,6 +236,46 @@ fun runCommand(params: List<String>, exceptionMsg: String): String {
 }
 
 /**
+ * Helper function to remove all contents from the given directory
+*/
+fun deleteDirectoryContents(directory: String) {
+    for (file in File(directory).list()) {
+      if (!delete("${directory}/${file}")) {
+        throw GradleException("Failed to remove old file: ${directory}${file}")
+      }
+    }
+}
+
+/**
+ * Task createPackageInput
+ *
+ * Creates a packageInput directory containing only the current shadowJar file
+ * because jpackage includes everything in its input directory in the package.
+*/
+tasks.register("createPackageInput") {
+  group = "build"
+  description = "Creates a packageInput directory that only contains the current shadowJar file"
+  dependsOn("shadowJar")
+  val libsDir = ext.get(LIBS_DIR) as String
+  val shadowJarFilename = ext.get(SHADOW_JAR_FILE_NAME) as String
+  val packageInputDir = ext.get(PACKAGE_INPUT_DIR) as String
+  inputs.file("${libsDir}/${shadowJarFilename}")
+  outputs.dir(packageInputDir)
+
+  doLast {
+    deleteDirectoryContents(packageInputDir)
+    val copyReturn = copy {
+      from(libsDir)
+      into(packageInputDir)
+      include(shadowJarFilename)
+    }
+    if (!copyReturn.didWork) {
+      throw GradleException("createPackageInput failed to copy: ${shadowJarFilename}")
+    }
+  }
+}
+
+/**
  * Task: createDeb
  *
  * Creates the Linux DEB package file (Debian, Ubuntu and derrivatives).
@@ -291,8 +283,8 @@ fun runCommand(params: List<String>, exceptionMsg: String): String {
 tasks.register("createDeb") {
   group = "build"
   description = "Makes DEB Linux installation package."
-  dependsOn("shadowJar", "createDistDir")
-  inputs.dir(ext.get(LIBS_DIR) as String)
+  dependsOn("createPackageInput")
+  inputs.dir(ext.get(PACKAGE_INPUT_DIR) as String)
   inputs.dir("${ext.get(SUPPORT_DIR) as String}/linux")
 
   // Debian uses `_` to separate name from version string.
@@ -322,8 +314,8 @@ tasks.register("createDeb") {
 tasks.register("createRpm") {
   group = "build"
   description = "Makes RPM Linux installation package."
-  dependsOn("shadowJar", "createDistDir")
-  inputs.dir(ext.get(LIBS_DIR) as String)
+  dependsOn("createPackageInput")
+  inputs.dir(ext.get(PACKAGE_INPUT_DIR) as String)
   inputs.dir("${ext.get(SUPPORT_DIR) as String}/linux")
   outputs.file("${ext.get(TARGET_FILE_PATH_BASE) as String}-1.x86_64.rpm")
 
@@ -347,12 +339,12 @@ tasks.register("createRpm") {
 tasks.register("createMsi") {
   group = "build"
   description = "Makes the Windows installation package."
-  dependsOn("shadowJar", "createDistDir")
+  dependsOn("createPackageInput")
 
   val supportDir = ext.get(SUPPORT_DIR) as String
   val osArch = ext.get(OS_ARCH) as String
 
-  inputs.dir(ext.get(LIBS_DIR) as String)
+  inputs.dir(ext.get(PACKAGE_INPUT_DIR) as String)
   inputs.dir("${supportDir}/windows")
   outputs.file("${ext.get(TARGET_FILE_PATH_BASE_SHORT) as String}-${osArch}.msi")
 
@@ -382,11 +374,14 @@ tasks.register("createMsi") {
     )
     runCommand(params, "Error while creating the MSI package.")
     val fromFile = "${project.name}-${version}.msi"
-    copy {
+    val copyReturn = copy {
       from(targetDir)
       into(targetDir)
       include(fromFile)
       rename(fromFile, "${project.name}-${version}-${osArch}.msi")
+    }
+    if (!copyReturn.didWork) {
+      throw GradleException("createMsi failed to rename .msi file to include architecture ${osArch}")
     }
     delete("${targetDir}/${fromFile}")
   }
@@ -399,14 +394,14 @@ tasks.register("createMsi") {
  */
 tasks.register("createApp") {
   val supportDir = ext.get(SUPPORT_DIR) as String
-  val appDirName = ext.get(APP_DIR_NAME) as String
+  val dest = "${buildDir}/macOS-${ext.get(OS_ARCH) as String}"
 
   group = "build"
   description = "Makes the macOS application."
-  dependsOn("shadowJar", "createDistDir")
-  inputs.dir(ext.get(LIBS_DIR) as String)
+  dependsOn("createPackageInput")
+  inputs.dir(ext.get(PACKAGE_INPUT_DIR) as String)
   inputs.dir("${supportDir}/macos")
-  outputs.dir(appDirName)
+  outputs.dir(dest)
 
   doFirst {
     if (!OperatingSystem.current().isMacOsX) {
@@ -415,35 +410,36 @@ tasks.register("createApp") {
   }
 
   doLast {
-    delete(appDirName)
-
+    deleteDirectoryContents(dest)
     val params = (ext.get(SHARED_PARAMS) as List<Any?>).filterIsInstance<String>() + listOf(
-        "--dest", "${buildDir}/macOS-${ext.get(OS_ARCH) as String}",
+        "--dest", dest,
         "--name", ext.get(UPPERCASE_PROJECT_NAME) as String,
         "--file-associations", "${supportDir}/macos/file.jpackage",
         "--icon", "${supportDir}/macos/Logisim-evolution.icns",
         // app versioning is strictly checked for macOS. No suffix allowed for `app-image` type.
         "--app-version", ext.get(APP_VERSION_SHORT) as String,
         "--type", "app-image",
+        // Can't use until Java 17 // "--mac-app-category", "education"
     )
     runCommand(params, "Error while creating the .app directory.")
 
-    val targetDir = ext.get(TARGET_DIR) as String
+    val appDirName = ext.get(APP_DIR_NAME) as String
     val pListFilename = "${appDirName}/Contents/Info.plist"
+    val tempPList = "${dest}/Info.plist"
     runCommand(listOf(
         "awk",
         "/Unknown/{sub(/Unknown/,\"public.app-category.education\")};"
             + "/utilities/{sub(/public.app-category.utilities/,\"public.app-category.education\")};"
-            + "{print >\"${targetDir}/Info.plist\"};"
+            + "{print >\"${tempPList}\"};"
             + "/NSHighResolutionCapable/{"
-            + "print \"  <string>true</string>\" >\"${targetDir}/Info.plist\";"
-            + "print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"${targetDir}/Info.plist\""
+            + "print \"  <string>true</string>\" >\"${tempPList}\";"
+            + "print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"${tempPList}\""
             + "}",
         pListFilename,
     ), "Error while patching Info.plist file.")
 
     runCommand(listOf(
-        "mv", "${targetDir}/Info.plist", pListFilename
+        "mv", tempPList, pListFilename
     ), "Error while moving Info.plist into the .app directory.")
 
     runCommand(listOf(


### PR DESCRIPTION
I have been thinking about the createDistDir task in our build for a while. It is badly named. Its name made sense when I originally created it. But it hasn't been useful for that purpose since I fixed the outfile and outdir settings on the other tasks. Gradle automatically creates the path for those.

Now createDistDir is serving the purpose of cleaning up the libs directory so jpackage doesn't include garbage when building the package.

I started to just change the name. But it seems wrong to have a task that removes other tasks outputs (excepting clean, of course).

So I decided to create a task called createPackageInput that manages its own directory, called packageInput, and ensures it contains no other file than the desired shadowJar.

This seems cleaner to me.