### PR TITLE
Update sonar in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,4 +87,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: ([ -z $SONAR_TOKEN ] || ./gradlew sonarqube)
+      run: ([ -z $SONAR_TOKEN ] || ./gradlew sonar)


### PR DESCRIPTION
Our build workflow just failed because sonarqube changed its gradle action name to just sonar.