### PR TITLE
Fix some of the narrowing conversions noted by CodeQL

### DIFF
--- a/src/main/java/com/cburch/draw/shapes/RoundRectangle.java
+++ b/src/main/java/com/cburch/draw/shapes/RoundRectangle.java
@@ -101,7 +101,7 @@ public class RoundRectangle extends Rectangular {
       y += r + (int) (u - 2 * horz);
     } else if (u < 2 * horz + 2 * vert) {
       x += w;
-      y += (u - 2 * w - h);
+      y += (int) (u - 2 * w - h);
     } else {
       var rx = radius;
       var ry = radius;

--- a/src/main/java/com/cburch/logisim/gui/main/TickCounter.java
+++ b/src/main/java/com/cburch/logisim/gui/main/TickCounter.java
@@ -88,7 +88,7 @@ public class TickCounter implements Simulator.Listener {
     if (tickCount > TICKS_THRESHOLD_BEFORE_HISTORY_WEIGHT_REDUCTION) {
       tickCount -= WEIGHT_REDUCTION_TICKS_COUNT;
       final var nanoseconds = WEIGHT_REDUCTION_TICKS_COUNT / ticksPerNanoseconds;
-      startTime += nanoseconds;
+      startTime += (long) nanoseconds;
     }
 
     if (useKiloHertz) {

--- a/src/main/java/com/cburch/logisim/std/io/extra/Buzzer.java
+++ b/src/main/java/com/cburch/logisim/std/io/extra/Buzzer.java
@@ -198,7 +198,7 @@ public class Buzzer extends InstanceFactory {
     g.fillOval(x, y, 40, 40);
     g.setColor(Color.GRAY);
     GraphicsUtil.switchToWidth(g, 2);
-    for (byte k = 8; k <= 16; k += 4) {
+    for (var k = 8; k <= 16; k += 4) {
       g.drawOval(x + 20 - k, y + 20 - k, k * 2, k * 2);
     }
     GraphicsUtil.switchToWidth(g, 2);
@@ -364,7 +364,7 @@ public class Buzzer extends InstanceFactory {
             if (wf != BuzzerWaveform.Sine && smoothLevel > 0 && smoothWidth > 0) {
               var nsig = new double[values.length];
               for (var k = 0; k < smoothLevel; k++) {
-                var sum = 0;
+                double sum = 0.0;
                 for (var i = 0; i < values.length; i++) {
                   if (i > 2 * smoothWidth) {
                     nsig[i - smoothWidth - 1] =

--- a/src/main/java/com/cburch/logisim/std/io/extra/ProgrammableGeneratorState.java
+++ b/src/main/java/com/cburch/logisim/std/io/extra/ProgrammableGeneratorState.java
@@ -126,7 +126,7 @@ public class ProgrammableGeneratorState implements InstanceData, Cloneable {
     gbc.gridx = 2;
     panel.add(down, gbc);
     // 2 inputs a row
-    for (byte i = 0; i < inputs.length; i += 2) {
+    for (var i = 0; i < inputs.length; i += 2) {
       // number of state to edit
       statenumber = new JLabel(String.valueOf(i / 2 + 1));
       statenumber.setFont(state);

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7400.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7400.java
@@ -58,10 +58,10 @@ public class Ttl7400 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 2; i < 6; i += 3) {
+    for (var i = 2; i < 6; i += 3) {
       state.setPort(i, (state.getPortValue(i - 1).and(state.getPortValue(i - 2)).not()), 1);
     }
-    for (byte i = 6; i < 12; i += 3) {
+    for (var i = 6; i < 12; i += 3) {
       state.setPort(i, (state.getPortValue(i + 1).and(state.getPortValue(i + 2)).not()), 1);
     }
   }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7402.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7402.java
@@ -57,10 +57,10 @@ public class Ttl7402 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 0; i < 6; i += 3) {
+    for (var i = 0; i < 6; i += 3) {
       state.setPort(i, (state.getPortValue(i + 1).or(state.getPortValue(i + 2)).not()), 1);
     }
-    for (byte i = 8; i < 12; i += 3) {
+    for (var i = 8; i < 12; i += 3) {
       state.setPort(i, (state.getPortValue(i - 1).or(state.getPortValue(i - 2)).not()), 1);
     }
   }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7404.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7404.java
@@ -60,10 +60,10 @@ public class Ttl7404 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 1; i < 6; i += 2) {
+    for (var i = 1; i < 6; i += 2) {
       state.setPort(i, state.getPortValue(i - 1).not(), 1);
     }
-    for (byte i = 6; i < 12; i += 2) {
+    for (var i = 6; i < 12; i += 2) {
       state.setPort(i, state.getPortValue(i + 1).not(), 1);
     }
   }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7408.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7408.java
@@ -50,10 +50,10 @@ public class Ttl7408 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 2; i < 6; i += 3) {
+    for (var i = 2; i < 6; i += 3) {
       state.setPort(i, state.getPortValue(i - 1).and(state.getPortValue(i - 2)), 1);
     }
-    for (byte i = 6; i < 12; i += 3) {
+    for (var i = 6; i < 12; i += 3) {
       state.setPort(i, state.getPortValue(i + 1).and(state.getPortValue(i + 2)), 1);
     }
   }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl74125.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl74125.java
@@ -51,12 +51,12 @@ public class Ttl74125 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 2; i < 6; i += 3) {
+    for (var i = 2; i < 6; i += 3) {
 
       if (state.getPortValue(i - 2) == Value.TRUE) state.setPort(i, Value.UNKNOWN, 1);
       else state.setPort(i, state.getPortValue(i - 1), 1);
     }
-    for (byte i = 6; i < 11; i += 3) {
+    for (var i = 6; i < 11; i += 3) {
       if (state.getPortValue(i + 2) == Value.TRUE) state.setPort(i, Value.UNKNOWN, 1);
       else state.setPort(i, state.getPortValue(i + 1), 1);
     }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl74266.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl74266.java
@@ -48,10 +48,10 @@ public class Ttl74266 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 2; i < 6; i += 3) {
+    for (var i = 2; i < 6; i += 3) {
       state.setPort(i, (state.getPortValue(i - 1).xor(state.getPortValue(i - 2)).not() == Value.TRUE) ? Value.UNKNOWN : Value.FALSE, 1);
     }
-    for (byte i = 6; i < 12; i += 3) {
+    for (var i = 6; i < 12; i += 3) {
       state.setPort(i, (state.getPortValue(i + 1).xor(state.getPortValue(i + 2)).not() == Value.TRUE) ? Value.UNKNOWN : Value.FALSE, 1);
     }
   }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7432.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7432.java
@@ -51,10 +51,10 @@ public class Ttl7432 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 2; i < 6; i += 3) {
+    for (var i = 2; i < 6; i += 3) {
       state.setPort(i, state.getPortValue(i - 1).or(state.getPortValue(i - 2)), 1);
     }
-    for (byte i = 6; i < 12; i += 3) {
+    for (var i = 6; i < 12; i += 3) {
       state.setPort(i, state.getPortValue(i + 1).or(state.getPortValue(i + 2)), 1);
     }
   }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7434.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7434.java
@@ -70,10 +70,10 @@ public class Ttl7434 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 1; i < 6; i += 2) {
+    for (var i = 1; i < 6; i += 2) {
       state.setPort(i, state.getPortValue(i - 1), 1);
     }
-    for (byte i = 6; i < 12; i += 2) {
+    for (var i = 6; i < 12; i += 2) {
       state.setPort(i, state.getPortValue(i + 1), 1);
     }
   }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7436.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7436.java
@@ -60,10 +60,10 @@ public class Ttl7436 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 2; i < 6; i += 3) {
+    for (var i = 2; i < 6; i += 3) {
       state.setPort(i, (state.getPortValue(i - 1).or(state.getPortValue(i - 2)).not()), 1);
     }
-    for (byte i = 6; i < 12; i += 3) {
+    for (var i = 6; i < 12; i += 3) {
       state.setPort(i, (state.getPortValue(i + 1).or(state.getPortValue(i + 2)).not()), 1);
     }
   }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl747266.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl747266.java
@@ -55,10 +55,10 @@ public class Ttl747266 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 2; i < 6; i += 3) {
+    for (var i = 2; i < 6; i += 3) {
       state.setPort(i, (state.getPortValue(i - 1).xor(state.getPortValue(i - 2)).not()), 1);
     }
-    for (byte i = 6; i < 12; i += 3) {
+    for (var i = 6; i < 12; i += 3) {
       state.setPort(i, (state.getPortValue(i + 1).xor(state.getPortValue(i + 2)).not()), 1);
     }
   }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7486.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7486.java
@@ -51,10 +51,10 @@ public class Ttl7486 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
-    for (byte i = 2; i < 6; i += 3) {
+    for (var i = 2; i < 6; i += 3) {
       state.setPort(i, state.getPortValue(i - 1).xor(state.getPortValue(i - 2)), 1);
     }
-    for (byte i = 6; i < 12; i += 3) {
+    for (var i = 6; i < 12; i += 3) {
       state.setPort(i, state.getPortValue(i + 1).xor(state.getPortValue(i + 2)), 1);
     }
   }


### PR DESCRIPTION
This PR addresses some of the issues noted by CodeQL.

I fixed the TTL issues by changing the type of the loop control variable from byte to int. In all these cases, the loop update adds an integer to the variable. This causes the conversion of the variable to int, the addition, and then conversion of the result to byte (the implicit narrowing conversion) to assign to the variable. The loop body converts the byte back to int to do more calculations and pass the value to integer parameters. It is clearly better to just use integer throughout.

The buzzer has a similar issue. It also has a place where an integer was used in repeated double calculations. In the latter case, I changed the declaration to make that a double throughout.

The TickCounter issue is an intended conversion that I made explicit. Likewise for the RoundRectangle issue.