### PR TITLE
Only run Nightly at midnight, not on closed pull requests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,15 +12,10 @@
 
 name: "Nightly"
 on:
-  # The "pull_request" trigger is here for debugging purposes and
-  # as work-around for having this worker not yet in main branch.
-  # Keep it disabled once it's merged into main branch as we only
-  # want "schedule" to be the trigger.
-  # NOTE: remove `if` condition marked with `HACK` once merged.
-  pull_request:
-  # Nightly must be run against "main" branch only.
-    branches: [ main ]
-    types: [ closed ]
+  # To enable "nightly" on closing pull requests uncomment the following:
+  #pull_request:
+  #  branches: [ main ]
+  #  types: [ closed ]
   schedule:
     # every day at midnight
     - cron: "0 0 * * *"
@@ -33,9 +28,6 @@ jobs:
   git_check:
     name: "Any changes since last run?"
     runs-on: ubuntu-latest
-    # HACK: Temporary workaround for `schedule` not working outside main
-    # branch and lack of `type: merged` for `pull_request` trigger.
-    # if: github.event.pull_request.merged == true
 
     # Export build vars so other steps can use it.
     outputs:


### PR DESCRIPTION
Nightly has been running on closed pull requests. When we switched to main as the default branch, it began working as intended at midnight UTC. The original intent was to run it Nightly (hence the name) but that required developing on the default branch. This PR drops running it on closed pull requests so it should only run once per day at midnight.