### PR TITLE
Hotkey Settings TAB be available in the preferences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,32 +2,27 @@
 
 # Changes #
 
-* @dev (????-??-??)
-  * Added support for scanning 7-segment display on FPGA-boards
-  * Added first support for the openFpga toolchain for the ecp5 famely
-    Note that this is experimental for the moment, so use it at your own risk.
-  * Improved Chinese localization
-    * Changed language code from `cn` to `zh`.
-    * Chinese users (also including those who use other forks of Logisim
-      that are using `cn` language code) will be required to manually modify language settings.
-  * Fixed select port positioning on Multiplexer to be more consistent in some cases [#1734]
-  * Fixed appearance of LSe desktop icon [#1662]
-  * Update controlled buffer behavior to pass U and E inputs while enabled [#1642]
-  * Introduced user-defined color for components.
-  * Made component icons more uniform.
-  * Added architecture designation to macOS build.
-  * Fixed Karnaugh map color index bug.
-  * Attribute sheet now honors application color theme.
-  * Attribute sheet now displays HEX value of color properties.
-  * Fixed Wrong HDL generation bug in the PortIO component and added the single bit version.
-  * Added TTL 74151: 8-line to 1 line data selector
-  * Added TTL 74153: dual 4-line to 1 line data selector
-  * Added TTL 74181: arithmetic logic unit
-  * Added TTL 74182: look-ahead carry generator
-  * Added TTL 74299: 8-bit universal shift register with three-state outputs
-  * Added TTL 74381: arithmetic logic unit
-  * Added TTL 74541: Octal buffers with three-state outputs
-  * Added TTL 74670: 4-by-4 register file with three-state outputs
+* @gtxzsxxk (2023-07-27)
+  * Added a new class HotkeyOptions, a new TAB in the preferences.
+  * Modified Menu class, setting up a new abstract method so that the hotkey can be sync via the gui
+  * Modified MenuFile MenuEdit MenuSimulate to implement that abstract method
+  * After my modification, 11 menuitem in the menu-bar are now available in hotkey settings. Changes will be updated immediately.
+The 11 menuitem are as follows.
+    * ###### Simulation
+    * Auto-Propagate
+    * Reset Simulation
+    * Single-Step Propagation
+    * Manual Tick Half Cycle
+    * Manual Tick Full Cycle
+    * Auto-Tick Enabled
+    * ###### Edit
+    * Undo
+    * Redo
+    * ###### File
+    * Export
+    * Print
+    * Quit
+  * I'd like to insert more hotkeys to make logisim-evolution more fun. Such as press *SPACE* to rotate the component to be placed on.
 
 * v3.8.0 (2022-10-02)
   * Added reset value attribute to input pins

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,21 +8,19 @@
   * Modified MenuFile MenuEdit MenuSimulate to implement that abstract method
   * After my modification, 11 menuitem in the menu-bar are now available in hotkey settings. Changes will be updated immediately.
 The 11 menuitem are as follows.
-    * ###### Simulation
     * Auto-Propagate
     * Reset Simulation
     * Single-Step Propagation
     * Manual Tick Half Cycle
     * Manual Tick Full Cycle
     * Auto-Tick Enabled
-    * ###### Edit
     * Undo
     * Redo
-    * ###### File
     * Export
     * Print
     * Quit
-  * I'd like to insert more hotkeys to make logisim-evolution more fun. Such as press *SPACE* to rotate the component to be placed on.
+  * I'd like to insert more hotkeys to make logisim-evolution more fun. 
+  * Such as press *SPACE* to rotate the component to be placed on.
 
 * v3.8.0 (2022-10-02)
   * Added reset value attribute to input pins

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,119 +3,148 @@
 # Changes #
 
 * @gtxzsxxk (2023-07-27)
-  * Added a new class HotkeyOptions, a new TAB in the preferences.
-  * Modified Menu class, setting up a new abstract method so that the hotkey can be sync via the gui
-  * Modified MenuFile MenuEdit MenuSimulate to implement that abstract method
-  * After my modification, 11 menuitem in the menu-bar are now available in hotkey settings. Changes will be updated immediately.
-The 11 menuitem are as follows.
-    * Auto-Propagate
-    * Reset Simulation
-    * Single-Step Propagation
-    * Manual Tick Half Cycle
-    * Manual Tick Full Cycle
-    * Auto-Tick Enabled
-    * Undo
-    * Redo
-    * Export
-    * Print
-    * Quit
-  * I'd like to insert more hotkeys to make logisim-evolution more fun. 
-  * Such as press *SPACE* to rotate the component to be placed on.
+    * Added a new class HotkeyOptions, a new TAB in the preferences.
+    * Modified Menu class, setting up a new abstract method so that the hotkey can be sync via the gui
+    * Modified MenuFile MenuEdit MenuSimulate to implement that abstract method
+    * After my modification, 11 menuitem in the menu-bar are now available in hotkey settings. Changes will be updated
+      immediately.
+      The 11 menuitem are as follows.
+        * Auto-Propagate
+        * Reset Simulation
+        * Single-Step Propagation
+        * Manual Tick Half Cycle
+        * Manual Tick Full Cycle
+        * Auto-Tick Enabled
+        * Undo
+        * Redo
+        * Export
+        * Print
+        * Quit
+    * I'd like to insert more hotkeys to make logisim-evolution more fun.
+    * Such as press *SPACE* to rotate the component to be placed on.
+
+
+* @dev (????-??-??)
+    * Added support for scanning 7-segment display on FPGA-boards
+    * Added first support for the openFpga toolchain for the ecp5 famely
+      Note that this is experimental for the moment, so use it at your own risk.
+    * Improved Chinese localization
+        * Changed language code from `cn` to `zh`.
+        * Chinese users (also including those who use other forks of Logisim
+          that are using `cn` language code) will be required to manually modify language settings.
+    * Fixed select port positioning on Multiplexer to be more consistent in some cases [#1734]
+    * Fixed appearance of LSe desktop icon [#1662]
+    * Update controlled buffer behavior to pass U and E inputs while enabled [#1642]
+    * Introduced user-defined color for components.
+    * Made component icons more uniform.
+    * Added architecture designation to macOS build.
+    * Fixed Karnaugh map color index bug.
+    * Attribute sheet now honors application color theme.
+    * Attribute sheet now displays HEX value of color properties.
+    * Fixed Wrong HDL generation bug in the PortIO component and added the single bit version.
+    * Added TTL 74151: 8-line to 1 line data selector
+    * Added TTL 74153: dual 4-line to 1 line data selector
+    * Added TTL 74181: arithmetic logic unit
+    * Added TTL 74182: look-ahead carry generator
+    * Added TTL 74299: 8-bit universal shift register with three-state outputs
+    * Added TTL 74381: arithmetic logic unit
+    * Added TTL 74541: Octal buffers with three-state outputs
+    * Added TTL 74670: 4-by-4 register file with three-state outputs
 
 * v3.8.0 (2022-10-02)
-  * Added reset value attribute to input pins
-  * Fixed boolean algebra minimal form bug
-  * Fixed random fill Rom bug
-  * Added TTL 74164, 74192 and 74193.
-  * Fixed off grid components bug that could lead to OutOfMemory error.
-  * Removed autolabler for tunnels, such that all get the same label in case of renaming.
-  * Fixed bug preventing TTL 7442, 7443 and 7444 from being placed on the circuit canvas.
-  * Sub-circuit can now be deleted with `DELETE` key, along with `BACKSPACE` used so far.
-  * Fixed `Simulate` -> `Timing Diagram` not opening when using "Nimbus" look and feel.
-  * Fixed pressing `CTRL`+`0` selecting the wrong element in the toolbar.
-  * Fixed TTL 7485 `7485HdlGenerator` generating wrong HDL type.
-  * Fixed TTL 74139, 7447 outputting inverted logic
-  * Fixed TTL 74175, CLR inverted
-  * Fixed TTL 7436 pin arrangement
-  * Added TTL 74138: 3-line to 8-line decoder
-  * Added TTL 74240, 74241, 74244: octal buffers with three-state outputs.
-  * Added TTL 74245: octal bus transceivers with three-state outputs.
-  * Moved TTL 74266 to 747266, correctly reimplemented 74266 with open-collector outputs.
-  * Fixed TTL 74165, correct order of inputs, load asynchronously
-  * Added TTL 74166: 8-bit parallel-to-serial shift register with clear
-  * Removed fixed LM_Licence setting
+    * Added reset value attribute to input pins
+    * Fixed boolean algebra minimal form bug
+    * Fixed random fill Rom bug
+    * Added TTL 74164, 74192 and 74193.
+    * Fixed off grid components bug that could lead to OutOfMemory error.
+    * Removed autolabler for tunnels, such that all get the same label in case of renaming.
+    * Fixed bug preventing TTL 7442, 7443 and 7444 from being placed on the circuit canvas.
+    * Sub-circuit can now be deleted with `DELETE` key, along with `BACKSPACE` used so far.
+    * Fixed `Simulate` -> `Timing Diagram` not opening when using "Nimbus" look and feel.
+    * Fixed pressing `CTRL`+`0` selecting the wrong element in the toolbar.
+    * Fixed TTL 7485 `7485HdlGenerator` generating wrong HDL type.
+    * Fixed TTL 74139, 7447 outputting inverted logic
+    * Fixed TTL 74175, CLR inverted
+    * Fixed TTL 7436 pin arrangement
+    * Added TTL 74138: 3-line to 8-line decoder
+    * Added TTL 74240, 74241, 74244: octal buffers with three-state outputs.
+    * Added TTL 74245: octal bus transceivers with three-state outputs.
+    * Moved TTL 74266 to 747266, correctly reimplemented 74266 with open-collector outputs.
+    * Fixed TTL 74165, correct order of inputs, load asynchronously
+    * Added TTL 74166: 8-bit parallel-to-serial shift register with clear
+    * Removed fixed LM_Licence setting
 
 * v3.7.2 (2021-11-09)
-  * Fixed Preferences/Window "Reset window layout to defaults" not doing much.
-  * Fixed Gradle builder failing to compile LSe if sources were not checked out from Git.
-  * You can now swap the placement of main canvas and component tree/properties pane.
-  * Several bug fixes.
+    * Fixed Preferences/Window "Reset window layout to defaults" not doing much.
+    * Fixed Gradle builder failing to compile LSe if sources were not checked out from Git.
+    * You can now swap the placement of main canvas and component tree/properties pane.
+    * Several bug fixes.
 
 * v3.7.1 (2021-10-21)
-  * Logisim has now an internal font-chooser to comply to the font-values used.
-  * Several bug fixes.
+    * Logisim has now an internal font-chooser to comply to the font-values used.
+    * Several bug fixes.
 
 * v3.7.0 (2021-10-12)
-  * Reworked the slider component in the I/O extra library.
-  * Tick clock frequency display moved to left corner. It's also bigger and text color is configurable.
-  * Completely rewritten command line argument parser:
-    * All options have both short and long version now,
-    * All long arguments require `--` prefix i.e. `--version`,
-    * All short arguments require single `-` as prefix i.e. `-v`,
-    * `-clearprefs` is now `--clear-prefs`,
-    * `-clearprops` option is removed (use `--clear-prefs` instead),
-    * `-geom` is now `--geometry`,
-    * `-nosplash` is now `--no-splash` or `-ns`,
-    * `-sub` is now `--substitute` or `-s`,
-    * `-testvector` is now `--test-vector` or `-w`,
-    * `-test-fpga-implementation` is now `--test-fpga` or `-f`,
-    * `-questa` is removed.
-  * PortIO HDL generator and component bug-fixed.
-  * Cleanup/rework of the HDL-generation.
-  * Each circuit stores/restores the last board used for Download (handy for templates to give to students)
-  * Fixed startup crash related to incorrectly localized date format.
-  * Added a setting to select lower- or upper-case VHDL keywords.
-  * Added project export feature.
-  * Cleaned-up the written .circ file.
+    * Reworked the slider component in the I/O extra library.
+    * Tick clock frequency display moved to left corner. It's also bigger and text color is configurable.
+    * Completely rewritten command line argument parser:
+        * All options have both short and long version now,
+        * All long arguments require `--` prefix i.e. `--version`,
+        * All short arguments require single `-` as prefix i.e. `-v`,
+        * `-clearprefs` is now `--clear-prefs`,
+        * `-clearprops` option is removed (use `--clear-prefs` instead),
+        * `-geom` is now `--geometry`,
+        * `-nosplash` is now `--no-splash` or `-ns`,
+        * `-sub` is now `--substitute` or `-s`,
+        * `-testvector` is now `--test-vector` or `-w`,
+        * `-test-fpga-implementation` is now `--test-fpga` or `-f`,
+        * `-questa` is removed.
+    * PortIO HDL generator and component bug-fixed.
+    * Cleanup/rework of the HDL-generation.
+    * Each circuit stores/restores the last board used for Download (handy for templates to give to students)
+    * Fixed startup crash related to incorrectly localized date format.
+    * Added a setting to select lower- or upper-case VHDL keywords.
+    * Added project export feature.
+    * Cleaned-up the written .circ file.
 
 * v3.6.1 (2021-09-27)
-  * Fixed bug in LED-array
+    * Fixed bug in LED-array
 
 * v3.6.0 (2021-09-05)
-  * Introducing project logo.
-  * Fixed project loader to correctly handle hex values with a 1 in bit 63rd.
-  * Added TTL74x34 hex buffer gate.
-  * Made pins' tooltips more descriptive for 74161.
-  * Added new component LED Bar.
-  * Added 74157 and 74158: Quad 2-line to1-line selectors.
-  * Added option to configure canvas' and grid's colors.
-  * Added DIP switch state visual feedback for ON state.
-  * Augmented direction verbal labels (East, North, etc), with corresponding arrow symbols.
-  * Application title string now adds app name/version at the very end of the title.
-  * Added option to configure size of connection pin markers.
-  * Added TTL 74x139: dual 2-line to 4-lines decoders.
-  * Fixed missing port on DotMatrix.
-  * Combined `Select Location` from Plexers and `Gate Location` from Wiring to one attribute.
-    * Breaks backwards comparability for Transistors and Transmission Gates.
-      When opening old .circ files, they will have the default `Select Location` ("Bottom/Left").
-  * Replace DarkLaf with FlatLaf for better compatibility.
-  * Adds "Rotate Left" context menu action.
-  * Display "Too few inputs for table" if Karnaugh Map has only 1 input.
-  * HexDisplay is stays blank if no valid data is fed instead of showing "H" [#365].
-  * Project's "Dirty" (unsaved) state is now also reflected by adding `*` marker to the window title.
-  * Support for `AnimatedIcon` has been completely removed.
-  * Canvas Zoom controls new offer wider range of zoom and three level of granularity.
-  * Added predefined quick zoom buttons.
-  * Tons of code cleanup and internal improvements.
-  * Added duplicated component placement on same location refusal
-  * Fixed pin duplication on load in case a custom apearance is used for a circuit
-  * Added LED-array support for FPGA-boards
-  * Improved partial placement on FPGA-boards for multi-pin components
-  * Fixed several small bugs
-  * Each circuit will now remember, restore, and save:
-    * The last tick-frequency used for simulation
-    * The last download frequency used
-  * Removed obsolete VHDL-Architecture attribute from circuit
+    * Introducing project logo.
+    * Fixed project loader to correctly handle hex values with a 1 in bit 63rd.
+    * Added TTL74x34 hex buffer gate.
+    * Made pins' tooltips more descriptive for 74161.
+    * Added new component LED Bar.
+    * Added 74157 and 74158: Quad 2-line to1-line selectors.
+    * Added option to configure canvas' and grid's colors.
+    * Added DIP switch state visual feedback for ON state.
+    * Augmented direction verbal labels (East, North, etc), with corresponding arrow symbols.
+    * Application title string now adds app name/version at the very end of the title.
+    * Added option to configure size of connection pin markers.
+    * Added TTL 74x139: dual 2-line to 4-lines decoders.
+    * Fixed missing port on DotMatrix.
+    * Combined `Select Location` from Plexers and `Gate Location` from Wiring to one attribute.
+        * Breaks backwards comparability for Transistors and Transmission Gates.
+          When opening old .circ files, they will have the default `Select Location` ("Bottom/Left").
+    * Replace DarkLaf with FlatLaf for better compatibility.
+    * Adds "Rotate Left" context menu action.
+    * Display "Too few inputs for table" if Karnaugh Map has only 1 input.
+    * HexDisplay is stays blank if no valid data is fed instead of showing "H" [#365].
+    * Project's "Dirty" (unsaved) state is now also reflected by adding `*` marker to the window title.
+    * Support for `AnimatedIcon` has been completely removed.
+    * Canvas Zoom controls new offer wider range of zoom and three level of granularity.
+    * Added predefined quick zoom buttons.
+    * Tons of code cleanup and internal improvements.
+    * Added duplicated component placement on same location refusal
+    * Fixed pin duplication on load in case a custom apearance is used for a circuit
+    * Added LED-array support for FPGA-boards
+    * Improved partial placement on FPGA-boards for multi-pin components
+    * Fixed several small bugs
+    * Each circuit will now remember, restore, and save:
+        * The last tick-frequency used for simulation
+        * The last download frequency used
+    * Removed obsolete VHDL-Architecture attribute from circuit
 
 * v3.5.0 (2021-05-25)
-  * Many code-cleanups, bug fixes and again the chronogram.
+    * Many code-cleanups, bug fixes and again the chronogram.

--- a/src/main/java/com/cburch/logisim/gui/menu/Menu.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/Menu.java
@@ -11,8 +11,9 @@ package com.cburch.logisim.gui.menu;
 
 import javax.swing.JMenu;
 
-abstract class Menu extends JMenu {
+public abstract class Menu extends JMenu {
   private static final long serialVersionUID = 1L;
 
   abstract void computeEnabled();
+  public abstract void hotkeyUpdate();
 }

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
@@ -11,11 +11,15 @@ package com.cburch.logisim.gui.menu;
 
 import static com.cburch.logisim.gui.Strings.S;
 
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.prefs.PrefMonitorKeyStroke;
 import com.cburch.logisim.proj.ProjectEvent;
 import com.cburch.logisim.proj.ProjectListener;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import javax.swing.JMenuItem;
 import javax.swing.KeyStroke;
 
@@ -37,13 +41,14 @@ class MenuEdit extends Menu {
   private final MenuItemImpl addCtrl = new MenuItemImpl(this, LogisimMenuBar.ADD_CONTROL);
   private final MenuItemImpl remCtrl = new MenuItemImpl(this, LogisimMenuBar.REMOVE_CONTROL);
   private final MyListener myListener = new MyListener();
+  private int menuMask;
 
   public MenuEdit(LogisimMenuBar menubar) {
     this.menubar = menubar;
 
-    int menuMask = getToolkit().getMenuShortcutKeyMaskEx();
-    undo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, menuMask));
-    redo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, menuMask | KeyEvent.SHIFT_DOWN_MASK));
+    menuMask = getToolkit().getMenuShortcutKeyMaskEx();
+    undo.setAccelerator(((PrefMonitorKeyStroke) AppPreferences.HOTKEY_EDIT_UNDO).getWithMask(menuMask));
+    redo.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_EDIT_REDO).getWithMask(menuMask));
     cut.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X, menuMask));
     copy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, menuMask));
     paste.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_V, menuMask));
@@ -98,6 +103,11 @@ class MenuEdit extends Menu {
     menubar.registerItem(LogisimMenuBar.ADD_CONTROL, addCtrl);
     menubar.registerItem(LogisimMenuBar.REMOVE_CONTROL, remCtrl);
     computeEnabled();
+  }
+
+  public void hotkeyUpdate(){
+    undo.setAccelerator(((PrefMonitorKeyStroke) AppPreferences.HOTKEY_EDIT_UNDO).getWithMask(menuMask));
+    redo.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_EDIT_REDO).getWithMask(menuMask));
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
@@ -18,8 +18,6 @@ import com.cburch.logisim.proj.ProjectListener;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import javax.swing.JMenuItem;
 import javax.swing.KeyStroke;
 

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
@@ -62,6 +62,9 @@ class MenuEdit extends Menu {
     lowerBottom.setAccelerator(
         KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, menuMask | KeyEvent.SHIFT_DOWN_MASK));
 
+    /* add myself to hotkey sync */
+    AppPreferences.gui_sync_objects.add(this);
+
     add(undo);
     add(redo);
     addSeparator();

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuFile.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuFile.java
@@ -13,6 +13,8 @@ import static com.cburch.logisim.gui.Strings.S;
 
 import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.gui.prefs.PreferencesFrame;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.prefs.PrefMonitorKeyStroke;
 import com.cburch.logisim.proj.ProjectActions;
 import com.cburch.logisim.proj.Projects;
 import com.cburch.logisim.util.MacCompatibility;
@@ -20,6 +22,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import javax.swing.JMenuItem;
 import javax.swing.KeyStroke;
 
@@ -38,12 +42,13 @@ class MenuFile extends Menu implements ActionListener {
   private final MenuItemImpl exportImage = new MenuItemImpl(this, LogisimMenuBar.EXPORT_IMAGE);
   private final JMenuItem prefs = new JMenuItem();
   private final JMenuItem quit = new JMenuItem();
+  private final int menuMask;
 
   public MenuFile(LogisimMenuBar menubar) {
     this.menubar = menubar;
     openRecent = new OpenRecent(menubar);
 
-    final var menuMask = getToolkit().getMenuShortcutKeyMaskEx();
+    menuMask = getToolkit().getMenuShortcutKeyMaskEx();
 
     newi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, menuMask));
     merge.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, menuMask));
@@ -53,10 +58,10 @@ class MenuFile extends Menu implements ActionListener {
     save.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, menuMask));
     saveAs.setAccelerator(
         KeyStroke.getKeyStroke(KeyEvent.VK_S, menuMask | InputEvent.SHIFT_DOWN_MASK));
-    exportProj.setAccelerator(
-        KeyStroke.getKeyStroke(KeyEvent.VK_E, menuMask | InputEvent.SHIFT_DOWN_MASK));
-    print.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, menuMask));
-    quit.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, menuMask));
+    exportProj.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_FILE_EXPORT).getWithMask(menuMask));
+    print.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_FILE_PRINT).getWithMask(menuMask));
+    quit.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_FILE_QUIT).getWithMask(menuMask));
+
 
     add(newi);
     add(merge);
@@ -99,6 +104,12 @@ class MenuFile extends Menu implements ActionListener {
     menubar.registerItem(LogisimMenuBar.PRINT, print);
     prefs.addActionListener(this);
     quit.addActionListener(this);
+  }
+
+  public void hotkeyUpdate(){
+    exportProj.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_FILE_EXPORT).getWithMask(menuMask));
+    print.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_FILE_PRINT).getWithMask(menuMask));
+    quit.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_FILE_QUIT).getWithMask(menuMask));
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuFile.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuFile.java
@@ -62,6 +62,9 @@ class MenuFile extends Menu implements ActionListener {
     print.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_FILE_PRINT).getWithMask(menuMask));
     quit.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_FILE_QUIT).getWithMask(menuMask));
 
+    /* add myself to hotkey sync */
+    AppPreferences.gui_sync_objects.add(this);
+
 
     add(newi);
     add(merge);

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuProject.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuProject.java
@@ -117,6 +117,11 @@ class MenuProject extends Menu {
     menubar.fireEnableChanged();
   }
 
+  @Override
+  public void hotkeyUpdate() {
+
+  }
+
   public void localeChanged() {
     setText(S.get("projectMenu"));
     addCircuit.setText(S.get("projectAddCircuitItem"));

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuSimulate.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuSimulate.java
@@ -15,9 +15,14 @@ import com.cburch.logisim.circuit.CircuitEvent;
 import com.cburch.logisim.circuit.CircuitListener;
 import com.cburch.logisim.circuit.CircuitState;
 import com.cburch.logisim.circuit.Simulator;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.prefs.PrefMonitorKeyStroke;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.ButtonGroup;
@@ -59,6 +64,7 @@ public class MenuSimulate extends Menu {
   private CircuitState currentState = null;
   private CircuitState bottomState = null;
   private Simulator currentSim = null;
+  private final int menuMask;
 
   public MenuSimulate(LogisimMenuBar menubar) {
     this.menubar = menubar;
@@ -78,13 +84,13 @@ public class MenuSimulate extends Menu {
     menubar.registerItem(LogisimMenuBar.TICK_HALF, tickHalf);
     menubar.registerItem(LogisimMenuBar.TICK_FULL, tickFull);
 
-    final var menuMask = getToolkit().getMenuShortcutKeyMaskEx();
-    runToggle.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, menuMask));
-    reset.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, menuMask));
-    step.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, menuMask));
-    tickHalf.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_T, menuMask));
-    tickFull.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F9, 0));
-    ticksEnabled.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_K, menuMask));
+    menuMask = getToolkit().getMenuShortcutKeyMaskEx();
+    runToggle.setAccelerator(((PrefMonitorKeyStroke) AppPreferences.HOTKEY_SIM_AUTO_PROPAGATE).getWithMask(menuMask));
+    reset.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_RESET).getWithMask(menuMask));
+    step.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_STEP).getWithMask(menuMask));
+    tickHalf.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_TICK_HALF).getWithMask(menuMask));
+    tickFull.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_TICK_FULL).getWithMask(menuMask));
+    ticksEnabled.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_TICK_ENABLED).getWithMask(menuMask));
 
     final var bgroup = new ButtonGroup();
     for (var i = 0; i < SUPPORTED_TICK_FREQUENCIES.length; i++) {
@@ -144,6 +150,15 @@ public class MenuSimulate extends Menu {
     assemblyWindow.addActionListener(myListener);
 
     computeEnabled();
+  }
+
+  public void hotkeyUpdate(){
+    runToggle.setAccelerator(((PrefMonitorKeyStroke) AppPreferences.HOTKEY_SIM_AUTO_PROPAGATE).getWithMask(menuMask));
+    reset.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_RESET).getWithMask(menuMask));
+    step.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_STEP).getWithMask(menuMask));
+    tickHalf.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_TICK_HALF).getWithMask(menuMask));
+    tickFull.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_TICK_FULL).getWithMask(menuMask));
+    ticksEnabled.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_TICK_ENABLED).getWithMask(menuMask));
   }
 
   public static List<String> getTickFrequencyStrings() {

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuSimulate.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuSimulate.java
@@ -92,6 +92,9 @@ public class MenuSimulate extends Menu {
     tickFull.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_TICK_FULL).getWithMask(menuMask));
     ticksEnabled.setAccelerator(((PrefMonitorKeyStroke)AppPreferences.HOTKEY_SIM_TICK_ENABLED).getWithMask(menuMask));
 
+    /* add myself to hotkey sync */
+    AppPreferences.gui_sync_objects.add(this);
+
     final var bgroup = new ButtonGroup();
     for (var i = 0; i < SUPPORTED_TICK_FREQUENCIES.length; i++) {
       tickFreqs[i] = new TickFrequencyChoice(SUPPORTED_TICK_FREQUENCIES[i]);

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -17,197 +17,192 @@ import com.cburch.logisim.util.TableLayout;
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
+import java.awt.event.*;
 import java.util.prefs.BackingStoreException;
 
 import static com.cburch.logisim.gui.Strings.S;
 
 class HotkeyOptions extends OptionsPanel {
-  private static final long serialVersionUID = 1L;
-  public static final PrefMonitor<KeyStroke>[] hotkeys=new PrefMonitor[]{
-          AppPreferences.HOTKEY_SIM_AUTO_PROPAGATE,
-          AppPreferences.HOTKEY_SIM_RESET,
-          AppPreferences.HOTKEY_SIM_STEP,
-          AppPreferences.HOTKEY_SIM_TICK_HALF,
-          AppPreferences.HOTKEY_SIM_TICK_FULL,
-          AppPreferences.HOTKEY_SIM_TICK_ENABLED,
-          AppPreferences.HOTKEY_EDIT_UNDO,
-          AppPreferences.HOTKEY_EDIT_REDO,
-          AppPreferences.HOTKEY_FILE_EXPORT,
-          AppPreferences.HOTKEY_FILE_PRINT,
-          AppPreferences.HOTKEY_FILE_QUIT,
-  };
+    private static final long serialVersionUID = 1L;
+    public static final PrefMonitor<KeyStroke>[] hotkeys = new PrefMonitor[]{
+            AppPreferences.HOTKEY_SIM_AUTO_PROPAGATE,
+            AppPreferences.HOTKEY_SIM_RESET,
+            AppPreferences.HOTKEY_SIM_STEP,
+            AppPreferences.HOTKEY_SIM_TICK_HALF,
+            AppPreferences.HOTKEY_SIM_TICK_FULL,
+            AppPreferences.HOTKEY_SIM_TICK_ENABLED,
+            AppPreferences.HOTKEY_EDIT_UNDO,
+            AppPreferences.HOTKEY_EDIT_REDO,
+            AppPreferences.HOTKEY_FILE_EXPORT,
+            AppPreferences.HOTKEY_FILE_PRINT,
+            AppPreferences.HOTKEY_FILE_QUIT,
+    };
 
-  private final JLabel[] key_labels=new JLabel[hotkeys.length];
-  private final JButton[] key_buttons=new JButton[hotkeys.length];
-  private final JLabel headerLabel;
+    private final JLabel[] key_labels = new JLabel[hotkeys.length];
+    private final JButton[] key_buttons = new JButton[hotkeys.length];
+    private final JLabel headerLabel;
 
-  public HotkeyOptions(PreferencesFrame window) {
-    super(window);
-    this.setLayout(new TableLayout(1));
-    final var listener = new SettingsChangeListener(this);
-    headerLabel=new JLabel();
-    add(headerLabel);
-    add(new JLabel(" "));
+    public HotkeyOptions(PreferencesFrame window) {
+        super(window);
+        this.setLayout(new TableLayout(1));
+        final var listener = new SettingsChangeListener(this);
+        headerLabel = new JLabel();
+        add(headerLabel);
+        add(new JLabel(" "));
 
-    JPanel p=new JPanel();
-    p.setLayout(new TableLayout(2));
-    for(int i=0;i<hotkeys.length;i++){
-      key_labels[i] = new JLabel(S.get(((PrefMonitorKeyStroke)hotkeys[i]).getName())+"  ");
-      key_buttons[i]=new JButton(((PrefMonitorKeyStroke) hotkeys[i]).getString());
-      key_buttons[i].addActionListener(listener);
-      key_buttons[i].setActionCommand(i+"");
-      p.add(key_labels[i]);
-      p.add(key_buttons[i]);
-    }
-    add(p);
-
-    JButton resetBtn=new JButton(S.get("hotkeyOptResetBtn"));
-    resetBtn.addActionListener(e -> {
-      AppPreferences.resetHotkeys();
-      try {
-        AppPreferences.getPrefs().flush();
-        for(int i=0;i<hotkeys.length;i++){
-          key_buttons[i].setText(((PrefMonitorKeyStroke) hotkeys[i]).getString());
+        JPanel p = new JPanel();
+        p.setLayout(new TableLayout(2));
+        for (int i = 0; i < hotkeys.length; i++) {
+            key_labels[i] = new JLabel(S.get(((PrefMonitorKeyStroke) hotkeys[i]).getName()) + "  ");
+            key_buttons[i] = new JButton(((PrefMonitorKeyStroke) hotkeys[i]).getString());
+            key_buttons[i].addActionListener(listener);
+            key_buttons[i].setActionCommand(i + "");
+            p.add(key_labels[i]);
+            p.add(key_buttons[i]);
         }
-        AppPreferences.hotkeySync();
-      } catch (BackingStoreException ex) {
-        throw new RuntimeException(ex);
-      }
-    });
-    add(new JLabel(" "));
-    add(resetBtn);
-    AppPreferences.addPropertyChangeListener(evt -> AppPreferences.hotkeySync());
-  }
+        add(p);
 
-  @Override
-  public String getHelpText() {
-    return S.get("hotkeyOptHelp");
-  }
-
-  @Override
-  public String getTitle() {
-    return S.get("hotkeyOptTitle");
-  }
-
-  @Override
-  public void localeChanged() {
-    /* TODO: localize */
-    headerLabel.setText(S.get("hotkeyOptHeader"));
-  }
-
-  private class SettingsChangeListener implements ChangeListener, ActionListener {
-    HotkeyOptions owner;
-    public int code;
-    public int modifier;
-    public SettingsChangeListener(HotkeyOptions ht){
-      owner=ht;
+        JButton resetBtn = new JButton(S.get("hotkeyOptResetBtn"));
+        resetBtn.addActionListener(e -> {
+            AppPreferences.resetHotkeys();
+            try {
+                AppPreferences.getPrefs().flush();
+                for (int i = 0; i < hotkeys.length; i++) {
+                    key_buttons[i].setText(((PrefMonitorKeyStroke) hotkeys[i]).getString());
+                }
+                AppPreferences.hotkeySync();
+            } catch (BackingStoreException ex) {
+                throw new RuntimeException(ex);
+            }
+        });
+        add(new JLabel(" "));
+        add(resetBtn);
+        AppPreferences.addPropertyChangeListener(evt -> AppPreferences.hotkeySync());
     }
-    @Override
-    public void actionPerformed(ActionEvent e) {
-      int index=Integer.parseInt(e.getActionCommand());
-      JDialog dl=new JDialog(
-              owner.getPreferencesFrame(),
-              S.get(((PrefMonitorKeyStroke)hotkeys[index]).getName()),
-              true);
-      JPanel p=new JPanel();
-      JPanel sub=new JPanel();
-      JButton ok=new JButton("OK");
-      JButton cancel=new JButton("Cancel");
 
-      ok.setFocusable(false);
-      ok.addActionListener(e1 -> {
-        if(code!=0){
-          HotkeyOptions.hotkeys[index].set(KeyStroke.getKeyStroke(code,modifier));
-          try {
-            AppPreferences.getPrefs().flush();
-            owner.key_buttons[index].setText(((PrefMonitorKeyStroke)HotkeyOptions.hotkeys[index]).getString());
-            AppPreferences.hotkeySync();
-          } catch (BackingStoreException ex) {
-            throw new RuntimeException(ex);
-          }
+    @Override
+    public String getHelpText() {
+        return S.get("hotkeyOptHelp");
+    }
+
+    @Override
+    public String getTitle() {
+        return S.get("hotkeyOptTitle");
+    }
+
+    @Override
+    public void localeChanged() {
+        /* TODO: localize */
+        headerLabel.setText(S.get("hotkeyOptHeader"));
+    }
+
+    private class SettingsChangeListener implements ChangeListener, ActionListener {
+        HotkeyOptions owner;
+        public int code;
+        public int modifier;
+
+        public SettingsChangeListener(HotkeyOptions ht) {
+            owner = ht;
         }
-        dl.setVisible(false);
-      });
-      cancel.setFocusable(false);
-      cancel.addActionListener(ev -> dl.setVisible(false));
 
-      sub.setLayout(new TableLayout(2));
-      p.setLayout(new TableLayout(1));
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            int index = Integer.parseInt(e.getActionCommand());
+            JDialog dl = new JDialog(
+                    owner.getPreferencesFrame(),
+                    S.get(((PrefMonitorKeyStroke) hotkeys[index]).getName()),
+                    true);
+            JPanel p = new JPanel();
+            JPanel sub = new JPanel();
+            JButton ok = new JButton("OK");
+            JButton cancel = new JButton("Cancel");
 
-      sub.add(ok);
-      sub.add(cancel);
+            ok.setFocusable(false);
+            ok.addActionListener(e1 -> {
+                if (code != 0) {
+                    HotkeyOptions.hotkeys[index].set(KeyStroke.getKeyStroke(code, modifier));
+                    try {
+                        AppPreferences.getPrefs().flush();
+                        owner.key_buttons[index].setText(((PrefMonitorKeyStroke) HotkeyOptions.hotkeys[index]).getString());
+                        AppPreferences.hotkeySync();
+                    } catch (BackingStoreException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }
+                dl.setVisible(false);
+            });
+            cancel.setFocusable(false);
+            cancel.addActionListener(ev -> dl.setVisible(false));
 
-      JLabel waitingLabel=new JLabel("Receiving Your Input Key");
-      p.add(waitingLabel);
-      p.add(sub);
+            sub.setLayout(new TableLayout(2));
+            p.setLayout(new TableLayout(1));
 
-      dl.addKeyListener(new keycaptureListener(dl,waitingLabel,((PrefMonitorKeyStroke)hotkeys[index]).isMenuHotkey(),this));
-      dl.setContentPane(p);
-      dl.setLocationRelativeTo(null);
-      dl.setSize(400,200);
-      dl.setVisible(true);
-    }
+            sub.add(ok);
+            sub.add(cancel);
 
-    @Override
-    public void stateChanged(ChangeEvent e) {
+            JLabel waitingLabel = new JLabel("Receiving Your Input Key");
+            p.add(waitingLabel);
+            p.add(sub);
 
-    }
-  }
+            dl.addKeyListener(new keycaptureListener(waitingLabel, ((PrefMonitorKeyStroke) hotkeys[index]).isMenuHotkey(), this));
+            dl.setContentPane(p);
+            dl.setLocationRelativeTo(null);
+            dl.setSize(400, 200);
+            dl.setVisible(true);
+        }
 
-  private class keycaptureListener implements KeyListener {
-    private final JDialog dialog;
-    private final JLabel label;
-    private final boolean isMenuKey;
-    private final SettingsChangeListener scl;
-
-    public keycaptureListener(JDialog j,JLabel l, boolean is_menu_key,SettingsChangeListener se){
-      dialog=j;
-      label=l;
-      isMenuKey=is_menu_key;
-      scl=se;
-    }
-    @Override
-    public void keyTyped(KeyEvent e) {
-
-    }
-
-    @Override
-    public void keyPressed(KeyEvent e) {
-      if(e.getKeyCode()>=32) {
-        int modifier=e.getModifiersEx();
-        int code=e.getKeyCode();
-        /* TODO: be compatible with other scenes */
-        if(isMenuKey){
-          if((modifier&KeyEvent.CTRL_DOWN_MASK)!=KeyEvent.CTRL_DOWN_MASK){
-            label.setText(S.get("hotkeyErrCtrl"));
-            scl.code=0;
-            scl.modifier=0;
+        @Override
+        public void stateChanged(ChangeEvent e) {
             return;
-          }
         }
-        for(var item:hotkeys){
-          if((KeyEvent.getModifiersExText(modifier)+" + "+KeyEvent.getKeyText(code)).equals(((PrefMonitorKeyStroke)item).getString())){
-            label.setText(S.get("hotkeyErrConflict")+ S.get(((PrefMonitorKeyStroke)item).getName()));
-            scl.code=0;
-            scl.modifier=0;
+    }
+
+    private class keycaptureListener implements KeyListener {
+        private final JLabel label;
+        private final boolean isMenuKey;
+        private final SettingsChangeListener scl;
+
+        public keycaptureListener(JLabel l, boolean is_menu_key, SettingsChangeListener se) {
+            label = l;
+            isMenuKey = is_menu_key;
+            scl = se;
+        }
+
+        @Override
+        public void keyTyped(KeyEvent e) {
             return;
-          }
         }
-        scl.code=code;
-        scl.modifier=modifier;
-        label.setText(KeyEvent.getModifiersExText(modifier)+" + "+KeyEvent.getKeyText(code));
-      }
-    }
 
-    @Override
-    public void keyReleased(KeyEvent e) {
+        @Override
+        public void keyPressed(KeyEvent e) {
+            if (e.getKeyCode() >= 32) {
+                int modifier = e.getModifiersEx();
+                int code = e.getKeyCode();
+                /* TODO: be compatible with other scenes */
+                if (isMenuKey && (modifier & InputEvent.CTRL_DOWN_MASK) != InputEvent.CTRL_DOWN_MASK) {
+                    label.setText(S.get("hotkeyErrCtrl"));
+                    scl.code = 0;
+                    scl.modifier = 0;
+                    return;
+                }
 
+                for (var item : hotkeys) {
+                    if ((InputEvent.getModifiersExText(modifier) + " + " + KeyEvent.getKeyText(code)).equals(((PrefMonitorKeyStroke) item).getString())) {
+                        label.setText(S.get("hotkeyErrConflict") + S.get(((PrefMonitorKeyStroke) item).getName()));
+                        scl.code = 0;
+                        scl.modifier = 0;
+                        return;
+                    }
+                }
+                scl.code = code;
+                scl.modifier = modifier;
+                label.setText(InputEvent.getModifiersExText(modifier) + " + " + KeyEvent.getKeyText(code));
+            }
+        }
+
+        @Override
+        public void keyReleased(KeyEvent e) {
+            return;
+        }
     }
-  }
 }

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -26,12 +26,13 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.util.prefs.BackingStoreException;
 
 import static com.cburch.logisim.gui.Strings.S;
 
 class HotkeyOptions extends OptionsPanel {
   private static final long serialVersionUID = 1L;
-  private static final PrefMonitor<KeyStroke>[] hotkeys=new PrefMonitor[]{
+  public static final PrefMonitor<KeyStroke>[] hotkeys=new PrefMonitor[]{
           AppPreferences.HOTKEY_SIM_AUTO_PROPAGATE,
           AppPreferences.HOTKEY_SIM_RESET,
           AppPreferences.HOTKEY_SIM_STEP,
@@ -50,17 +51,32 @@ class HotkeyOptions extends OptionsPanel {
 
   public HotkeyOptions(PreferencesFrame window) {
     super(window);
-    this.setLayout(new TableLayout(2));
+    this.setLayout(new TableLayout(1));
     final var listener = new SettingsChangeListener(this);
+    /* TODO: localize */
+    JLabel headerLabel=new JLabel("Note that the hotkeys on the menubar need to be started with CTRL.");
+    add(headerLabel);
+
+    JPanel p=new JPanel();
+    p.setLayout(new TableLayout(2));
     for(int i=0;i<hotkeys.length;i++){
       key_labels[i] = new JLabel(((PrefMonitorKeyStroke)hotkeys[i]).getName()+"  ");
-      key_buttons[i]=new JButton(hotkeys[i].get().toString());
+      key_buttons[i]=new JButton(((PrefMonitorKeyStroke) hotkeys[i]).getString());
       key_buttons[i].addActionListener(listener);
       key_buttons[i].setActionCommand(i+"");
-      add(key_labels[i]);
-      add(key_buttons[i]);
+      p.add(key_labels[i]);
+      p.add(key_buttons[i]);
     }
+    add(p);
 
+    JButton resetBtn=new JButton("Reset to default");
+    resetBtn.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        AppPreferences.resetHotkeys();
+      }
+    });
+    add(resetBtn);
   }
 
   @Override
@@ -82,6 +98,8 @@ class HotkeyOptions extends OptionsPanel {
 
   private class SettingsChangeListener implements ChangeListener, ActionListener {
     HotkeyOptions owner;
+    public int code;
+    public int modifier;
     public SettingsChangeListener(HotkeyOptions ht){
       owner=ht;
     }
@@ -95,15 +113,47 @@ class HotkeyOptions extends OptionsPanel {
               true);
       JPanel p=new JPanel();
       JPanel sub=new JPanel();
-      JButton
+      JButton ok=new JButton("OK");
+      JButton cancel=new JButton("Cancel");
+
+      ok.setFocusable(false);
+      ok.addActionListener(new ActionListener() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+          if(code!=0){
+            HotkeyOptions.hotkeys[index].set(KeyStroke.getKeyStroke(code,modifier));
+            try {
+              AppPreferences.getPrefs().flush();
+              owner.key_buttons[index].setText(((PrefMonitorKeyStroke)HotkeyOptions.hotkeys[index]).getString());
+            } catch (BackingStoreException ex) {
+              throw new RuntimeException(ex);
+            }
+          }
+          dl.setVisible(false);
+        }
+      });
+      cancel.setFocusable(false);
+      cancel.addActionListener(new ActionListener() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+          dl.setVisible(false);
+        }
+      });
+
       sub.setLayout(new TableLayout(2));
       p.setLayout(new TableLayout(1));
+
+      sub.add(ok);
+      sub.add(cancel);
+
       JLabel waitingLabel=new JLabel("Receiving Your Input Key");
       p.add(waitingLabel);
-      dl.addKeyListener(new keycaptureListener(dl,waitingLabel));
+      p.add(sub);
+
+      dl.addKeyListener(new keycaptureListener(dl,waitingLabel,((PrefMonitorKeyStroke)owner.hotkeys[index]).isMenuHotkey(),this));
       dl.setContentPane(p);
       dl.setLocationRelativeTo(null);
-      dl.setSize(300,100);
+      dl.setSize(400,100);
       dl.setVisible(true);
     }
 
@@ -116,10 +166,14 @@ class HotkeyOptions extends OptionsPanel {
   private class keycaptureListener implements KeyListener {
     private JDialog dialog;
     private JLabel label;
+    private boolean isMenuKey;
+    private SettingsChangeListener scl;
 
-    public keycaptureListener(JDialog j,JLabel l){
+    public keycaptureListener(JDialog j,JLabel l, boolean is_menu_key,SettingsChangeListener se){
       dialog=j;
       label=l;
+      isMenuKey=is_menu_key;
+      scl=se;
     }
     @Override
     public void keyTyped(KeyEvent e) {
@@ -130,7 +184,18 @@ class HotkeyOptions extends OptionsPanel {
     public void keyPressed(KeyEvent e) {
       if(e.getKeyCode()>=32) {
         int modifier=e.getModifiersEx();
+        if(isMenuKey){
+          if((modifier&KeyEvent.CTRL_DOWN_MASK)!=KeyEvent.CTRL_DOWN_MASK){
+            /* TODO: localize */
+            label.setText("This key combo must start with CTRL.");
+            scl.code=0;
+            scl.modifier=0;
+            return;
+          }
+        }
         int code=e.getKeyCode();
+        scl.code=code;
+        scl.modifier=modifier;
         label.setText(KeyEvent.getModifiersExText(modifier)+" + "+KeyEvent.getKeyText(code));
       }
     }

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -12,6 +12,8 @@ package com.cburch.logisim.gui.prefs;
 import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.fpga.gui.ZoomSlider;
 import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.prefs.PrefMonitor;
+import com.cburch.logisim.prefs.PrefMonitorKeyStroke;
 import com.cburch.logisim.proj.Projects;
 import com.cburch.logisim.util.TableLayout;
 
@@ -27,37 +29,37 @@ import static com.cburch.logisim.gui.Strings.S;
 
 class HotkeyOptions extends OptionsPanel {
   private static final long serialVersionUID = 1L;
+  private static final PrefMonitor<KeyStroke>[] hotkeys=new PrefMonitor[]{
+          AppPreferences.HOTKEY_SIM_AUTO_PROPAGATE,
+          AppPreferences.HOTKEY_SIM_RESET,
+          AppPreferences.HOTKEY_SIM_STEP,
+          AppPreferences.HOTKEY_SIM_TICK_HALF,
+          AppPreferences.HOTKEY_SIM_TICK_FULL,
+          AppPreferences.HOTKEY_SIM_TICK_ENABLED,
+          AppPreferences.HOTKEY_EDIT_UNDO,
+          AppPreferences.HOTKEY_EDIT_REDO,
+          AppPreferences.HOTKEY_EDIT_EXPORT,
+          AppPreferences.HOTKEY_EDIT_PRINT,
+          AppPreferences.HOTKEY_EDIT_QUIT,
+  };
 
+  private JLabel[] key_labels=new JLabel[hotkeys.length];
+  private JButton[] key_buttons=new JButton[hotkeys.length];
 
   public HotkeyOptions(PreferencesFrame window) {
     super(window);
-
+    this.setLayout(new TableLayout(1));
     final var listener = new SettingsChangeListener();
-    final var panel = new JPanel(new TableLayout(2));
+    for(int i=0;i<hotkeys.length;i++){
+      final var panel = new JPanel(new TableLayout(2));
+      key_labels[i] = new JLabel(((PrefMonitorKeyStroke)hotkeys[i]).getName());
+      key_buttons[i]=new JButton(hotkeys[i].get().toString());
+      key_buttons[i].addActionListener(listener);
+      panel.add(key_labels[i]);
+      panel.add(key_buttons[i]);
+      add(panel);
+    }
 
-
-
-    final var gridColorsResetButton = new JButton();
-    gridColorsResetButton.addActionListener(listener);
-    gridColorsResetButton.setText(S.get("windowGridColorsReset"));
-    panel.add(new JLabel());
-    panel.add(gridColorsResetButton);
-
-    panel.add(new JLabel(" "));
-    panel.add(new JLabel(" "));
-
-
-
-    panel.add(new JLabel(" "));
-    panel.add(new JLabel(" "));
-
-
-    setLayout(new TableLayout(1));
-    final var but = new JButton();
-    but.addActionListener(listener);
-    but.setText(S.get("windowToolbarReset"));
-    add(but);
-    add(panel);
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -94,6 +94,9 @@ class HotkeyOptions extends OptionsPanel {
               ((PrefMonitorKeyStroke)hotkeys[index]).getName(),
               true);
       JPanel p=new JPanel();
+      JPanel sub=new JPanel();
+      JButton
+      sub.setLayout(new TableLayout(2));
       p.setLayout(new TableLayout(1));
       JLabel waitingLabel=new JLabel("Receiving Your Input Key");
       p.add(waitingLabel);

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -24,6 +24,8 @@ import javax.swing.event.ChangeListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 
 import static com.cburch.logisim.gui.Strings.S;
 
@@ -49,11 +51,12 @@ class HotkeyOptions extends OptionsPanel {
   public HotkeyOptions(PreferencesFrame window) {
     super(window);
     this.setLayout(new TableLayout(2));
-    final var listener = new SettingsChangeListener();
+    final var listener = new SettingsChangeListener(this);
     for(int i=0;i<hotkeys.length;i++){
       key_labels[i] = new JLabel(((PrefMonitorKeyStroke)hotkeys[i]).getName()+"  ");
       key_buttons[i]=new JButton(hotkeys[i].get().toString());
       key_buttons[i].addActionListener(listener);
+      key_buttons[i].setActionCommand(i+"");
       add(key_labels[i]);
       add(key_buttons[i]);
     }
@@ -78,35 +81,60 @@ class HotkeyOptions extends OptionsPanel {
   }
 
   private class SettingsChangeListener implements ChangeListener, ActionListener {
-
+    HotkeyOptions owner;
+    public SettingsChangeListener(HotkeyOptions ht){
+      owner=ht;
+    }
     @Override
-    public void stateChanged(ChangeEvent e) {
-      /* TODO: Update Settings */
+    public void actionPerformed(ActionEvent e) {
+      int index=Integer.parseInt(e.getActionCommand());
+      /* TODO:localize */
+      JDialog dl=new JDialog(
+              owner.getPreferencesFrame(),
+              ((PrefMonitorKeyStroke)hotkeys[index]).getName(),
+              true);
+      JPanel p=new JPanel();
+      p.setLayout(new TableLayout(1));
+      JLabel waitingLabel=new JLabel("Receiving Your Input Key");
+      p.add(waitingLabel);
+      dl.addKeyListener(new keycaptureListener(dl,waitingLabel));
+      dl.setContentPane(p);
+      dl.setLocationRelativeTo(null);
+      dl.setSize(300,100);
+      dl.setVisible(true);
     }
 
     @Override
-    public void actionPerformed(ActionEvent e) {
-//      if (e.getActionCommand().equals(cmdResetWindowLayout)) {
-//        AppPreferences.resetWindow();
-//        final var nowOpen = Projects.getOpenProjects();
-//        for (final var proj : nowOpen) {
-//          proj.getFrame().resetLayout();
-//          proj.getFrame().revalidate();
-//          proj.getFrame().repaint();
-//        }
-//      } else if (e.getActionCommand().equals(cmdResetGridColors)) {
-//        //        AppPreferences.resetWindow();
-//        final var nowOpen = Projects.getOpenProjects();
-//        AppPreferences.setDefaultGridColors();
-//        for (final var proj : nowOpen) {
-//          proj.getFrame().repaint();
-//        }
-//      } else if (e.getActionCommand().equals(cmdSetAutoScaleFactor)) {
-//        final var tmp = AppPreferences.getAutoScaleFactor();
-//        AppPreferences.SCALE_FACTOR.set(tmp);
-//        AppPreferences.getPrefs().remove(AppPreferences.SCALE_FACTOR.getIdentifier());
-//        zoomValue.setValue((int) (tmp * 100));
-//      }
+    public void stateChanged(ChangeEvent e) {
+
+    }
+  }
+
+  private class keycaptureListener implements KeyListener {
+    private JDialog dialog;
+    private JLabel label;
+
+    public keycaptureListener(JDialog j,JLabel l){
+      dialog=j;
+      label=l;
+    }
+    @Override
+    public void keyTyped(KeyEvent e) {
+
+    }
+
+    @Override
+    public void keyPressed(KeyEvent e) {
+      if(e.getKeyCode()>=32) {
+        int modifier=e.getModifiersEx();
+        int code=e.getKeyCode();
+        label.setText(KeyEvent.getModifiersExText(modifier)+" + "+KeyEvent.getKeyText(code));
+      }
+    }
+
+    @Override
+    public void keyReleased(KeyEvent e) {
+
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -1,0 +1,282 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.prefs;
+
+import com.cburch.logisim.data.Direction;
+import com.cburch.logisim.fpga.gui.ZoomSlider;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.proj.Projects;
+import com.cburch.logisim.util.TableLayout;
+
+import javax.swing.*;
+import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import static com.cburch.logisim.gui.Strings.S;
+
+class HotkeyOptions extends OptionsPanel {
+  private static final long serialVersionUID = 1L;
+  private final PrefBoolean[] checks;
+  private final PrefOptionList toolbarPlacement;
+  private final PrefOptionList canvasPlacement;
+  private final ZoomSlider zoomValue;
+  private final JButton zoomAutoButton;
+  private final JLabel lookfeelLabel;
+  private final JLabel zoomLabel;
+  private final JLabel importantA;
+  private final JTextArea importantB;
+  private final JPanel previewContainer;
+  private final JComboBox<String> lookAndFeel;
+  private final LookAndFeelInfo[] lookAndFeelInfos;
+  private JPanel previewPanel;
+  private int index = 0;
+
+  private final ColorChooserButton canvasBgColor;
+  private final JLabel canvasBgColorTitle;
+  private final ColorChooserButton gridBgColor;
+  private final JLabel gridBgColorTitle;
+  private final ColorChooserButton gridDotColor;
+  private final JLabel gridDotColorTitle;
+  private final ColorChooserButton gridZoomedDotColor;
+  private final JLabel gridZoomedDotColorTitle;
+  private final ColorChooserButton componentColor;
+  private final JLabel componentColorTitle;
+
+  protected final String cmdResetWindowLayout = "reset-window-layout";
+  protected final String cmdResetGridColors = "reset-grid-colors";
+  protected final String cmdSetAutoScaleFactor = "set-auto-scale-factor";
+
+  public HotkeyOptions(PreferencesFrame window) {
+    super(window);
+
+    final var listener = new SettingsChangeListener();
+    final var panel = new JPanel(new TableLayout(2));
+
+    checks =
+        new PrefBoolean[] {
+          new PrefBoolean(AppPreferences.SHOW_TICK_RATE, S.getter("windowTickRate")),
+        };
+
+    canvasPlacement =
+        new PrefOptionList(
+            AppPreferences.CANVAS_PLACEMENT,
+            S.getter("windowCanvasLocation"),
+            new PrefOption[] {
+              new PrefOption(Direction.EAST.toString(), Direction.EAST.getDisplayGetter()),
+              new PrefOption(Direction.WEST.toString(), Direction.WEST.getDisplayGetter())
+            });
+
+    toolbarPlacement =
+        new PrefOptionList(
+            AppPreferences.TOOLBAR_PLACEMENT,
+            S.getter("windowToolbarLocation"),
+            new PrefOption[] {
+              new PrefOption(Direction.NORTH.toString(), Direction.NORTH.getDisplayGetter()),
+              new PrefOption(Direction.SOUTH.toString(), Direction.SOUTH.getDisplayGetter()),
+              new PrefOption(Direction.EAST.toString(), Direction.EAST.getDisplayGetter()),
+              new PrefOption(Direction.WEST.toString(), Direction.WEST.getDisplayGetter()),
+              new PrefOption(AppPreferences.TOOLBAR_HIDDEN, S.getter("windowToolbarHidden"))
+            });
+
+    panel.add(canvasPlacement.getJLabel());
+    panel.add(canvasPlacement.getJComboBox());
+
+    panel.add(toolbarPlacement.getJLabel());
+    panel.add(toolbarPlacement.getJComboBox());
+
+    canvasBgColorTitle = new JLabel(S.get("windowCanvasBgColor"));
+    canvasBgColor = new ColorChooserButton(window, AppPreferences.CANVAS_BG_COLOR);
+    panel.add(canvasBgColorTitle);
+    panel.add(canvasBgColor);
+    gridBgColorTitle = new JLabel(S.get("windowGridBgColor"));
+    gridBgColor = new ColorChooserButton(window, AppPreferences.GRID_BG_COLOR);
+    panel.add(gridBgColorTitle);
+    panel.add(gridBgColor);
+    gridDotColorTitle = new JLabel(S.get("windowGridDotColor"));
+    gridDotColor = new ColorChooserButton(window, AppPreferences.GRID_DOT_COLOR);
+    panel.add(gridDotColorTitle);
+    panel.add(gridDotColor);
+    gridZoomedDotColorTitle = new JLabel(S.get("windowGridZoomedDotColor"));
+    gridZoomedDotColor = new ColorChooserButton(window, AppPreferences.GRID_ZOOMED_DOT_COLOR);
+    panel.add(gridZoomedDotColorTitle);
+    panel.add(gridZoomedDotColor);
+    componentColorTitle = new JLabel(S.get("windowComponentColor"));
+    componentColor = new ColorChooserButton(window, AppPreferences.COMPONENT_COLOR);
+    panel.add(componentColorTitle);
+    panel.add(componentColor);
+
+    final var gridColorsResetButton = new JButton();
+    gridColorsResetButton.addActionListener(listener);
+    gridColorsResetButton.setActionCommand(cmdResetGridColors);
+    gridColorsResetButton.setText(S.get("windowGridColorsReset"));
+    panel.add(new JLabel());
+    panel.add(gridColorsResetButton);
+
+    panel.add(new JLabel(" "));
+    panel.add(new JLabel(" "));
+
+    importantA = new JLabel(S.get("windowToolbarPleaserestart"));
+    importantA.setFont(importantA.getFont().deriveFont(Font.ITALIC));
+    panel.add(importantA);
+
+    importantB = new JTextArea(S.get("windowToolbarImportant"));
+    importantB.setFont(importantB.getFont().deriveFont(Font.ITALIC));
+    panel.add(importantB);
+
+    zoomLabel = new JLabel(S.get("windowToolbarZoomfactor"));
+    zoomValue =
+        new ZoomSlider(
+            JSlider.HORIZONTAL, 100, 300, (int) (AppPreferences.SCALE_FACTOR.get() * 100));
+    zoomAutoButton = new JButton();
+    zoomAutoButton.addActionListener(listener);
+    zoomAutoButton.setActionCommand(cmdSetAutoScaleFactor);
+    zoomAutoButton.setText(S.get("windowSetAutoScaleFactor"));
+    panel.add(zoomLabel);
+    panel.add(zoomValue);
+    panel.add(new JLabel(" "));
+    panel.add(zoomAutoButton);
+    zoomValue.addChangeListener(listener);
+
+    panel.add(new JLabel(" "));
+    panel.add(new JLabel(" "));
+
+    var index = 0;
+    lookAndFeel = new JComboBox<>();
+    lookAndFeel.setSize(50, 20);
+
+    lookAndFeelInfos = UIManager.getInstalledLookAndFeels();
+    for (final var info : lookAndFeelInfos) {
+      lookAndFeel.insertItemAt(info.getName(), index);
+      if (info.getClassName().equals(AppPreferences.LookAndFeel.get())) {
+        lookAndFeel.setSelectedIndex(index);
+        this.index = index;
+      }
+      index++;
+    }
+    lookfeelLabel = new JLabel(S.get("windowToolbarLookandfeel"));
+    panel.add(lookfeelLabel);
+    panel.add(lookAndFeel);
+    lookAndFeel.addActionListener(listener);
+
+    final var previewLabel = new JLabel(S.get("windowToolbarPreview"));
+    panel.add(previewLabel);
+    previewContainer = new JPanel();
+    panel.add(previewContainer);
+    initThemePreviewer();
+
+    setLayout(new TableLayout(1));
+    final var but = new JButton();
+    but.addActionListener(listener);
+    but.setActionCommand(cmdResetWindowLayout);
+    but.setText(S.get("windowToolbarReset"));
+    add(but);
+    for (final var check : checks) {
+      add(check);
+    }
+    add(panel);
+  }
+
+  private void initThemePreviewer() {
+    if (previewPanel != null) previewContainer.remove(previewPanel);
+    javax.swing.LookAndFeel previousLF = UIManager.getLookAndFeel();
+    try {
+      UIManager.setLookAndFeel(AppPreferences.LookAndFeel.get());
+      previewPanel = new JPanel();
+      previewPanel.add(new JButton("Preview"));
+      previewPanel.add(new JCheckBox("Preview"));
+      previewPanel.add(new JRadioButton("Preview"));
+      previewPanel.add(new JComboBox<>(new String[]{"Preview 1", "Preview 2"}));
+      previewContainer.add(previewPanel);
+      UIManager.setLookAndFeel(previousLF);
+    } catch (IllegalAccessException
+        | UnsupportedLookAndFeelException
+        | InstantiationException
+        | ClassNotFoundException ignored) {
+    }
+    previewContainer.repaint();
+    previewContainer.revalidate();
+  }
+
+  @Override
+  public String getHelpText() {
+    /* TODO: localize */
+    return S.get("windowHelp");
+  }
+
+  @Override
+  public String getTitle() {
+    /* TODO: localize */
+    return "Hotkey Settings";
+  }
+
+  @Override
+  public void localeChanged() {
+    for (final var check : checks) {
+      check.localeChanged();
+    }
+    toolbarPlacement.localeChanged();
+    zoomLabel.setText(S.get("windowToolbarZoomfactor"));
+    lookfeelLabel.setText(S.get("windowToolbarLookandfeel"));
+    importantA.setText(S.get("windowToolbarPleaserestart"));
+    importantB.setText(S.get("windowToolbarImportant"));
+  }
+
+  private class SettingsChangeListener implements ChangeListener, ActionListener {
+
+    @Override
+    public void stateChanged(ChangeEvent e) {
+      final var source = (JSlider) e.getSource();
+      if (!source.getValueIsAdjusting()) {
+        int value = source.getValue();
+        AppPreferences.SCALE_FACTOR.set((double) value / 100.0);
+        final var nowOpen = Projects.getOpenProjects();
+        for (final var proj : nowOpen) {
+          proj.getFrame().revalidate();
+          proj.getFrame().repaint();
+        }
+      }
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+      if (e.getSource().equals(lookAndFeel)) {
+        if (lookAndFeel.getSelectedIndex() != index) {
+          index = lookAndFeel.getSelectedIndex();
+          AppPreferences.LookAndFeel.set(lookAndFeelInfos[index].getClassName());
+          initThemePreviewer();
+        }
+      } else if (e.getActionCommand().equals(cmdResetWindowLayout)) {
+        AppPreferences.resetWindow();
+        final var nowOpen = Projects.getOpenProjects();
+        for (final var proj : nowOpen) {
+          proj.getFrame().resetLayout();
+          proj.getFrame().revalidate();
+          proj.getFrame().repaint();
+        }
+      } else if (e.getActionCommand().equals(cmdResetGridColors)) {
+        //        AppPreferences.resetWindow();
+        final var nowOpen = Projects.getOpenProjects();
+        AppPreferences.setDefaultGridColors();
+        for (final var proj : nowOpen) {
+          proj.getFrame().repaint();
+        }
+      } else if (e.getActionCommand().equals(cmdSetAutoScaleFactor)) {
+        final var tmp = AppPreferences.getAutoScaleFactor();
+        AppPreferences.SCALE_FACTOR.set(tmp);
+        AppPreferences.getPrefs().remove(AppPreferences.SCALE_FACTOR.getIdentifier());
+        zoomValue.setValue((int) (tmp * 100));
+      }
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -58,7 +58,7 @@ class HotkeyOptions extends OptionsPanel {
     JPanel p=new JPanel();
     p.setLayout(new TableLayout(2));
     for(int i=0;i<hotkeys.length;i++){
-      key_labels[i] = new JLabel(((PrefMonitorKeyStroke)hotkeys[i]).getName()+"  ");
+      key_labels[i] = new JLabel(S.get(((PrefMonitorKeyStroke)hotkeys[i]).getName())+"  ");
       key_buttons[i]=new JButton(((PrefMonitorKeyStroke) hotkeys[i]).getString());
       key_buttons[i].addActionListener(listener);
       key_buttons[i].setActionCommand(i+"");

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -56,6 +56,7 @@ class HotkeyOptions extends OptionsPanel {
     /* TODO: localize */
     JLabel headerLabel=new JLabel("Note that the hotkeys on the menubar need to be started with CTRL.");
     add(headerLabel);
+    add(new JLabel(" "));
 
     JPanel p=new JPanel();
     p.setLayout(new TableLayout(2));
@@ -74,8 +75,17 @@ class HotkeyOptions extends OptionsPanel {
       @Override
       public void actionPerformed(ActionEvent e) {
         AppPreferences.resetHotkeys();
+        try {
+          AppPreferences.getPrefs().flush();
+          for(int i=0;i<hotkeys.length;i++){
+            key_buttons[i].setText(((PrefMonitorKeyStroke) hotkeys[i]).getString());
+          }
+        } catch (BackingStoreException ex) {
+          throw new RuntimeException(ex);
+        }
       }
     });
+    add(new JLabel(" "));
     add(resetBtn);
   }
 

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -45,13 +45,13 @@ class HotkeyOptions extends OptionsPanel {
 
   private final JLabel[] key_labels=new JLabel[hotkeys.length];
   private final JButton[] key_buttons=new JButton[hotkeys.length];
+  private final JLabel headerLabel;
 
   public HotkeyOptions(PreferencesFrame window) {
     super(window);
     this.setLayout(new TableLayout(1));
     final var listener = new SettingsChangeListener(this);
-    /* TODO: localize */
-    JLabel headerLabel=new JLabel("Note that the hotkeys on the menubar need to be started with CTRL.");
+    headerLabel=new JLabel();
     add(headerLabel);
     add(new JLabel(" "));
 
@@ -67,7 +67,7 @@ class HotkeyOptions extends OptionsPanel {
     }
     add(p);
 
-    JButton resetBtn=new JButton("Reset to default");
+    JButton resetBtn=new JButton(S.get("hotkeyOptResetBtn"));
     resetBtn.addActionListener(e -> {
       AppPreferences.resetHotkeys();
       try {
@@ -87,19 +87,18 @@ class HotkeyOptions extends OptionsPanel {
 
   @Override
   public String getHelpText() {
-    /* TODO: localize */
-    return "This is the help of hotkey settings. Remember to localize it.";
+    return S.get("hotkeyOptHelp");
   }
 
   @Override
   public String getTitle() {
-    /* TODO: localize */
-    return "Hotkey Settings";
+    return S.get("hotkeyOptTitle");
   }
 
   @Override
   public void localeChanged() {
     /* TODO: localize */
+    headerLabel.setText(S.get("hotkeyOptHeader"));
   }
 
   private class SettingsChangeListener implements ChangeListener, ActionListener {
@@ -112,10 +111,9 @@ class HotkeyOptions extends OptionsPanel {
     @Override
     public void actionPerformed(ActionEvent e) {
       int index=Integer.parseInt(e.getActionCommand());
-      /* TODO:localize */
       JDialog dl=new JDialog(
               owner.getPreferencesFrame(),
-              ((PrefMonitorKeyStroke)hotkeys[index]).getName(),
+              S.get(((PrefMonitorKeyStroke)hotkeys[index]).getName()),
               true);
       JPanel p=new JPanel();
       JPanel sub=new JPanel();
@@ -152,7 +150,7 @@ class HotkeyOptions extends OptionsPanel {
       dl.addKeyListener(new keycaptureListener(dl,waitingLabel,((PrefMonitorKeyStroke)hotkeys[index]).isMenuHotkey(),this));
       dl.setContentPane(p);
       dl.setLocationRelativeTo(null);
-      dl.setSize(400,100);
+      dl.setSize(400,200);
       dl.setVisible(true);
     }
 
@@ -187,8 +185,7 @@ class HotkeyOptions extends OptionsPanel {
         /* TODO: be compatible with other scenes */
         if(isMenuKey){
           if((modifier&KeyEvent.CTRL_DOWN_MASK)!=KeyEvent.CTRL_DOWN_MASK){
-            /* TODO: localize */
-            label.setText("This key combo must start with CTRL.");
+            label.setText(S.get("hotkeyErrCtrl"));
             scl.code=0;
             scl.modifier=0;
             return;
@@ -196,9 +193,7 @@ class HotkeyOptions extends OptionsPanel {
         }
         for(var item:hotkeys){
           if((KeyEvent.getModifiersExText(modifier)+" + "+KeyEvent.getKeyText(code)).equals(((PrefMonitorKeyStroke)item).getString())){
-            /* TODO: localize */
-            /* TODO: the name of the key */
-            label.setText("This key combo is conflicted with "+ ((PrefMonitorKeyStroke)item).getName());
+            label.setText(S.get("hotkeyErrConflict")+ S.get(((PrefMonitorKeyStroke)item).getName()));
             scl.code=0;
             scl.modifier=0;
             return;

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -27,35 +27,7 @@ import static com.cburch.logisim.gui.Strings.S;
 
 class HotkeyOptions extends OptionsPanel {
   private static final long serialVersionUID = 1L;
-  private final PrefBoolean[] checks;
-  private final PrefOptionList toolbarPlacement;
-  private final PrefOptionList canvasPlacement;
-  private final ZoomSlider zoomValue;
-  private final JButton zoomAutoButton;
-  private final JLabel lookfeelLabel;
-  private final JLabel zoomLabel;
-  private final JLabel importantA;
-  private final JTextArea importantB;
-  private final JPanel previewContainer;
-  private final JComboBox<String> lookAndFeel;
-  private final LookAndFeelInfo[] lookAndFeelInfos;
-  private JPanel previewPanel;
-  private int index = 0;
 
-  private final ColorChooserButton canvasBgColor;
-  private final JLabel canvasBgColorTitle;
-  private final ColorChooserButton gridBgColor;
-  private final JLabel gridBgColorTitle;
-  private final ColorChooserButton gridDotColor;
-  private final JLabel gridDotColorTitle;
-  private final ColorChooserButton gridZoomedDotColor;
-  private final JLabel gridZoomedDotColorTitle;
-  private final ColorChooserButton componentColor;
-  private final JLabel componentColorTitle;
-
-  protected final String cmdResetWindowLayout = "reset-window-layout";
-  protected final String cmdResetGridColors = "reset-grid-colors";
-  protected final String cmdSetAutoScaleFactor = "set-auto-scale-factor";
 
   public HotkeyOptions(PreferencesFrame window) {
     super(window);
@@ -63,62 +35,10 @@ class HotkeyOptions extends OptionsPanel {
     final var listener = new SettingsChangeListener();
     final var panel = new JPanel(new TableLayout(2));
 
-    checks =
-        new PrefBoolean[] {
-          new PrefBoolean(AppPreferences.SHOW_TICK_RATE, S.getter("windowTickRate")),
-        };
 
-    canvasPlacement =
-        new PrefOptionList(
-            AppPreferences.CANVAS_PLACEMENT,
-            S.getter("windowCanvasLocation"),
-            new PrefOption[] {
-              new PrefOption(Direction.EAST.toString(), Direction.EAST.getDisplayGetter()),
-              new PrefOption(Direction.WEST.toString(), Direction.WEST.getDisplayGetter())
-            });
-
-    toolbarPlacement =
-        new PrefOptionList(
-            AppPreferences.TOOLBAR_PLACEMENT,
-            S.getter("windowToolbarLocation"),
-            new PrefOption[] {
-              new PrefOption(Direction.NORTH.toString(), Direction.NORTH.getDisplayGetter()),
-              new PrefOption(Direction.SOUTH.toString(), Direction.SOUTH.getDisplayGetter()),
-              new PrefOption(Direction.EAST.toString(), Direction.EAST.getDisplayGetter()),
-              new PrefOption(Direction.WEST.toString(), Direction.WEST.getDisplayGetter()),
-              new PrefOption(AppPreferences.TOOLBAR_HIDDEN, S.getter("windowToolbarHidden"))
-            });
-
-    panel.add(canvasPlacement.getJLabel());
-    panel.add(canvasPlacement.getJComboBox());
-
-    panel.add(toolbarPlacement.getJLabel());
-    panel.add(toolbarPlacement.getJComboBox());
-
-    canvasBgColorTitle = new JLabel(S.get("windowCanvasBgColor"));
-    canvasBgColor = new ColorChooserButton(window, AppPreferences.CANVAS_BG_COLOR);
-    panel.add(canvasBgColorTitle);
-    panel.add(canvasBgColor);
-    gridBgColorTitle = new JLabel(S.get("windowGridBgColor"));
-    gridBgColor = new ColorChooserButton(window, AppPreferences.GRID_BG_COLOR);
-    panel.add(gridBgColorTitle);
-    panel.add(gridBgColor);
-    gridDotColorTitle = new JLabel(S.get("windowGridDotColor"));
-    gridDotColor = new ColorChooserButton(window, AppPreferences.GRID_DOT_COLOR);
-    panel.add(gridDotColorTitle);
-    panel.add(gridDotColor);
-    gridZoomedDotColorTitle = new JLabel(S.get("windowGridZoomedDotColor"));
-    gridZoomedDotColor = new ColorChooserButton(window, AppPreferences.GRID_ZOOMED_DOT_COLOR);
-    panel.add(gridZoomedDotColorTitle);
-    panel.add(gridZoomedDotColor);
-    componentColorTitle = new JLabel(S.get("windowComponentColor"));
-    componentColor = new ColorChooserButton(window, AppPreferences.COMPONENT_COLOR);
-    panel.add(componentColorTitle);
-    panel.add(componentColor);
 
     final var gridColorsResetButton = new JButton();
     gridColorsResetButton.addActionListener(listener);
-    gridColorsResetButton.setActionCommand(cmdResetGridColors);
     gridColorsResetButton.setText(S.get("windowGridColorsReset"));
     panel.add(new JLabel());
     panel.add(gridColorsResetButton);
@@ -126,92 +46,24 @@ class HotkeyOptions extends OptionsPanel {
     panel.add(new JLabel(" "));
     panel.add(new JLabel(" "));
 
-    importantA = new JLabel(S.get("windowToolbarPleaserestart"));
-    importantA.setFont(importantA.getFont().deriveFont(Font.ITALIC));
-    panel.add(importantA);
 
-    importantB = new JTextArea(S.get("windowToolbarImportant"));
-    importantB.setFont(importantB.getFont().deriveFont(Font.ITALIC));
-    panel.add(importantB);
-
-    zoomLabel = new JLabel(S.get("windowToolbarZoomfactor"));
-    zoomValue =
-        new ZoomSlider(
-            JSlider.HORIZONTAL, 100, 300, (int) (AppPreferences.SCALE_FACTOR.get() * 100));
-    zoomAutoButton = new JButton();
-    zoomAutoButton.addActionListener(listener);
-    zoomAutoButton.setActionCommand(cmdSetAutoScaleFactor);
-    zoomAutoButton.setText(S.get("windowSetAutoScaleFactor"));
-    panel.add(zoomLabel);
-    panel.add(zoomValue);
-    panel.add(new JLabel(" "));
-    panel.add(zoomAutoButton);
-    zoomValue.addChangeListener(listener);
 
     panel.add(new JLabel(" "));
     panel.add(new JLabel(" "));
 
-    var index = 0;
-    lookAndFeel = new JComboBox<>();
-    lookAndFeel.setSize(50, 20);
-
-    lookAndFeelInfos = UIManager.getInstalledLookAndFeels();
-    for (final var info : lookAndFeelInfos) {
-      lookAndFeel.insertItemAt(info.getName(), index);
-      if (info.getClassName().equals(AppPreferences.LookAndFeel.get())) {
-        lookAndFeel.setSelectedIndex(index);
-        this.index = index;
-      }
-      index++;
-    }
-    lookfeelLabel = new JLabel(S.get("windowToolbarLookandfeel"));
-    panel.add(lookfeelLabel);
-    panel.add(lookAndFeel);
-    lookAndFeel.addActionListener(listener);
-
-    final var previewLabel = new JLabel(S.get("windowToolbarPreview"));
-    panel.add(previewLabel);
-    previewContainer = new JPanel();
-    panel.add(previewContainer);
-    initThemePreviewer();
 
     setLayout(new TableLayout(1));
     final var but = new JButton();
     but.addActionListener(listener);
-    but.setActionCommand(cmdResetWindowLayout);
     but.setText(S.get("windowToolbarReset"));
     add(but);
-    for (final var check : checks) {
-      add(check);
-    }
     add(panel);
-  }
-
-  private void initThemePreviewer() {
-    if (previewPanel != null) previewContainer.remove(previewPanel);
-    javax.swing.LookAndFeel previousLF = UIManager.getLookAndFeel();
-    try {
-      UIManager.setLookAndFeel(AppPreferences.LookAndFeel.get());
-      previewPanel = new JPanel();
-      previewPanel.add(new JButton("Preview"));
-      previewPanel.add(new JCheckBox("Preview"));
-      previewPanel.add(new JRadioButton("Preview"));
-      previewPanel.add(new JComboBox<>(new String[]{"Preview 1", "Preview 2"}));
-      previewContainer.add(previewPanel);
-      UIManager.setLookAndFeel(previousLF);
-    } catch (IllegalAccessException
-        | UnsupportedLookAndFeelException
-        | InstantiationException
-        | ClassNotFoundException ignored) {
-    }
-    previewContainer.repaint();
-    previewContainer.revalidate();
   }
 
   @Override
   public String getHelpText() {
     /* TODO: localize */
-    return S.get("windowHelp");
+    return "This is the help of hotkey settings. Remember to localize it.";
   }
 
   @Override
@@ -222,61 +74,39 @@ class HotkeyOptions extends OptionsPanel {
 
   @Override
   public void localeChanged() {
-    for (final var check : checks) {
-      check.localeChanged();
-    }
-    toolbarPlacement.localeChanged();
-    zoomLabel.setText(S.get("windowToolbarZoomfactor"));
-    lookfeelLabel.setText(S.get("windowToolbarLookandfeel"));
-    importantA.setText(S.get("windowToolbarPleaserestart"));
-    importantB.setText(S.get("windowToolbarImportant"));
+    /* TODO: localize */
   }
 
   private class SettingsChangeListener implements ChangeListener, ActionListener {
 
     @Override
     public void stateChanged(ChangeEvent e) {
-      final var source = (JSlider) e.getSource();
-      if (!source.getValueIsAdjusting()) {
-        int value = source.getValue();
-        AppPreferences.SCALE_FACTOR.set((double) value / 100.0);
-        final var nowOpen = Projects.getOpenProjects();
-        for (final var proj : nowOpen) {
-          proj.getFrame().revalidate();
-          proj.getFrame().repaint();
-        }
-      }
+      /* TODO: Update Settings */
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-      if (e.getSource().equals(lookAndFeel)) {
-        if (lookAndFeel.getSelectedIndex() != index) {
-          index = lookAndFeel.getSelectedIndex();
-          AppPreferences.LookAndFeel.set(lookAndFeelInfos[index].getClassName());
-          initThemePreviewer();
-        }
-      } else if (e.getActionCommand().equals(cmdResetWindowLayout)) {
-        AppPreferences.resetWindow();
-        final var nowOpen = Projects.getOpenProjects();
-        for (final var proj : nowOpen) {
-          proj.getFrame().resetLayout();
-          proj.getFrame().revalidate();
-          proj.getFrame().repaint();
-        }
-      } else if (e.getActionCommand().equals(cmdResetGridColors)) {
-        //        AppPreferences.resetWindow();
-        final var nowOpen = Projects.getOpenProjects();
-        AppPreferences.setDefaultGridColors();
-        for (final var proj : nowOpen) {
-          proj.getFrame().repaint();
-        }
-      } else if (e.getActionCommand().equals(cmdSetAutoScaleFactor)) {
-        final var tmp = AppPreferences.getAutoScaleFactor();
-        AppPreferences.SCALE_FACTOR.set(tmp);
-        AppPreferences.getPrefs().remove(AppPreferences.SCALE_FACTOR.getIdentifier());
-        zoomValue.setValue((int) (tmp * 100));
-      }
+//      if (e.getActionCommand().equals(cmdResetWindowLayout)) {
+//        AppPreferences.resetWindow();
+//        final var nowOpen = Projects.getOpenProjects();
+//        for (final var proj : nowOpen) {
+//          proj.getFrame().resetLayout();
+//          proj.getFrame().revalidate();
+//          proj.getFrame().repaint();
+//        }
+//      } else if (e.getActionCommand().equals(cmdResetGridColors)) {
+//        //        AppPreferences.resetWindow();
+//        final var nowOpen = Projects.getOpenProjects();
+//        AppPreferences.setDefaultGridColors();
+//        for (final var proj : nowOpen) {
+//          proj.getFrame().repaint();
+//        }
+//      } else if (e.getActionCommand().equals(cmdSetAutoScaleFactor)) {
+//        final var tmp = AppPreferences.getAutoScaleFactor();
+//        AppPreferences.SCALE_FACTOR.set(tmp);
+//        AppPreferences.getPrefs().remove(AppPreferences.SCALE_FACTOR.getIdentifier());
+//        zoomValue.setValue((int) (tmp * 100));
+//      }
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -38,9 +38,9 @@ class HotkeyOptions extends OptionsPanel {
           AppPreferences.HOTKEY_SIM_TICK_ENABLED,
           AppPreferences.HOTKEY_EDIT_UNDO,
           AppPreferences.HOTKEY_EDIT_REDO,
-          AppPreferences.HOTKEY_EDIT_EXPORT,
-          AppPreferences.HOTKEY_EDIT_PRINT,
-          AppPreferences.HOTKEY_EDIT_QUIT,
+          AppPreferences.HOTKEY_FILE_EXPORT,
+          AppPreferences.HOTKEY_FILE_PRINT,
+          AppPreferences.HOTKEY_FILE_QUIT,
   };
 
   private JLabel[] key_labels=new JLabel[hotkeys.length];
@@ -48,16 +48,14 @@ class HotkeyOptions extends OptionsPanel {
 
   public HotkeyOptions(PreferencesFrame window) {
     super(window);
-    this.setLayout(new TableLayout(1));
+    this.setLayout(new TableLayout(2));
     final var listener = new SettingsChangeListener();
     for(int i=0;i<hotkeys.length;i++){
-      final var panel = new JPanel(new TableLayout(2));
-      key_labels[i] = new JLabel(((PrefMonitorKeyStroke)hotkeys[i]).getName());
+      key_labels[i] = new JLabel(((PrefMonitorKeyStroke)hotkeys[i]).getName()+"  ");
       key_buttons[i]=new JButton(hotkeys[i].get().toString());
       key_buttons[i].addActionListener(listener);
-      panel.add(key_labels[i]);
-      panel.add(key_buttons[i]);
-      add(panel);
+      add(key_labels[i]);
+      add(key_buttons[i]);
     }
 
   }

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -26,6 +26,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.prefs.BackingStoreException;
 
 import static com.cburch.logisim.gui.Strings.S;
@@ -80,6 +82,7 @@ class HotkeyOptions extends OptionsPanel {
           for(int i=0;i<hotkeys.length;i++){
             key_buttons[i].setText(((PrefMonitorKeyStroke) hotkeys[i]).getString());
           }
+          AppPreferences.hotkeySync();
         } catch (BackingStoreException ex) {
           throw new RuntimeException(ex);
         }
@@ -87,6 +90,12 @@ class HotkeyOptions extends OptionsPanel {
     });
     add(new JLabel(" "));
     add(resetBtn);
+    AppPreferences.addPropertyChangeListener(new PropertyChangeListener() {
+      @Override
+      public void propertyChange(PropertyChangeEvent evt) {
+        AppPreferences.hotkeySync();
+      }
+    });
   }
 
   @Override
@@ -135,6 +144,7 @@ class HotkeyOptions extends OptionsPanel {
             try {
               AppPreferences.getPrefs().flush();
               owner.key_buttons[index].setText(((PrefMonitorKeyStroke)HotkeyOptions.hotkeys[index]).getString());
+              AppPreferences.hotkeySync();
             } catch (BackingStoreException ex) {
               throw new RuntimeException(ex);
             }

--- a/src/main/java/com/cburch/logisim/gui/prefs/PreferencesFrame.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/PreferencesFrame.java
@@ -44,6 +44,7 @@ public class PreferencesFrame extends LFrame.Dialog {
           new ExperimentalOptions(this),
           new SoftwaresOptions(this),
           new FpgaOptions(this),
+          new HotkeyOptions(this),
         };
     tabbedPane = new JTabbedPane();
     int intlIndex = -1;

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -864,6 +864,11 @@ public class AppPreferences {
     HOTKEY_FILE_EXPORT.set(KeyStroke.getKeyStroke(KeyEvent.VK_E,KeyEvent.SHIFT_DOWN_MASK|KeyEvent.CTRL_DOWN_MASK));
     HOTKEY_FILE_PRINT.set(KeyStroke.getKeyStroke(KeyEvent.VK_P,KeyEvent.CTRL_DOWN_MASK));
     HOTKEY_FILE_QUIT.set(KeyStroke.getKeyStroke(KeyEvent.VK_Q,KeyEvent.CTRL_DOWN_MASK));
+    try {
+      AppPreferences.getPrefs().flush();
+    } catch (BackingStoreException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public static final ArrayList<Menu> gui_sync_objects=new ArrayList<>();

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -847,12 +847,12 @@ public class AppPreferences {
   public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_REDO=
           create(new PrefMonitorKeyStroke("hotkeyEditRedo", KeyEvent.VK_Z,KeyEvent.SHIFT_DOWN_MASK));
 
-  public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_EXPORT=
+  public static final PrefMonitor<KeyStroke> HOTKEY_FILE_EXPORT=
           create(new PrefMonitorKeyStroke("hotkeyFileExport", KeyEvent.VK_E,KeyEvent.SHIFT_DOWN_MASK));
 
-  public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_PRINT=
+  public static final PrefMonitor<KeyStroke> HOTKEY_FILE_PRINT=
           create(new PrefMonitorKeyStroke("hotkeyFilePrint", KeyEvent.VK_P,0));
 
-  public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_QUIT=
+  public static final PrefMonitor<KeyStroke> HOTKEY_FILE_QUIT=
           create(new PrefMonitorKeyStroke("hotkeyFileQuit", KeyEvent.VK_Q,0));
 }

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -26,6 +26,7 @@ import java.awt.Font;
 import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileInputStream;
@@ -821,4 +822,32 @@ public class AppPreferences {
 
   public static final PrefMonitor<String> DIALOG_DIRECTORY =
       create(new PrefMonitorString("dialogDirectory", ""));
+
+  /* Hotkey Settings */
+  public static final PrefMonitor<Integer> HOTKEY_SIM_AUTO_PROPAGATE=
+          create(new PrefMonitorInt("hotkeySimAutoPropagate", KeyEvent.VK_E));
+
+  public static final PrefMonitor<Integer> HOTKEY_SIM_RESET=
+          create(new PrefMonitorInt("hotkeySimReset", KeyEvent.VK_R));
+
+  public static final PrefMonitor<Integer> HOTKEY_SIM_STEP=
+          create(new PrefMonitorInt("hotkeySimStep", KeyEvent.VK_I));
+
+  public static final PrefMonitor<Integer> HOTKEY_SIM_TICK_HALF=
+          create(new PrefMonitorInt("hotkeySimTickHalf", KeyEvent.VK_T));
+
+  public static final PrefMonitor<Integer> HOTKEY_SIM_TICK_FULL=
+          create(new PrefMonitorInt("hotkeySimTickFull", KeyEvent.VK_F9));
+
+  public static final PrefMonitor<Integer> HOTKEY_SIM_TICK_ENABLED=
+          create(new PrefMonitorInt("hotkeySimTickEnabled", KeyEvent.VK_K));
+
+  public static final PrefMonitor<Integer> HOTKEY_EDIT_UNDO=
+          create(new PrefMonitorInt("hotkeyEditUndo", KeyEvent.VK_Z));
+
+  public static final PrefMonitor<Integer> HOTKEY_EDIT_REDO=
+          create(new PrefMonitorInt("hotkeyEditRedo", KeyEvent.VK_Z|KeyEvent.SHIFT_DOWN_MASK));
+
+  public static final PrefMonitor<Integer> HOTKEY_EDIT_REDO=
+          create(new PrefMonitorInt("hotkeyEditRedo", KeyEvent.VK_Z|KeyEvent.SHIFT_DOWN_MASK));
 }

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -824,35 +824,49 @@ public class AppPreferences {
 
   /* Hotkey Settings */
   public static final PrefMonitor<KeyStroke> HOTKEY_SIM_AUTO_PROPAGATE=
-          create(new PrefMonitorKeyStroke("hotkeySimAutoPropagate", KeyEvent.VK_E,0));
+          create(new PrefMonitorKeyStroke("hotkeySimAutoPropagate", KeyEvent.VK_E,KeyEvent.CTRL_DOWN_MASK));
 
   public static final PrefMonitor<KeyStroke> HOTKEY_SIM_RESET=
-          create(new PrefMonitorKeyStroke("hotkeySimReset", KeyEvent.VK_R,0));
+          create(new PrefMonitorKeyStroke("hotkeySimReset", KeyEvent.VK_R,KeyEvent.CTRL_DOWN_MASK));
 
   public static final PrefMonitor<KeyStroke> HOTKEY_SIM_STEP=
-          create(new PrefMonitorKeyStroke("hotkeySimStep", KeyEvent.VK_I,0));
+          create(new PrefMonitorKeyStroke("hotkeySimStep", KeyEvent.VK_I,KeyEvent.CTRL_DOWN_MASK));
 
   public static final PrefMonitor<KeyStroke> HOTKEY_SIM_TICK_HALF=
-          create(new PrefMonitorKeyStroke("hotkeySimTickHalf", KeyEvent.VK_T,0));
+          create(new PrefMonitorKeyStroke("hotkeySimTickHalf", KeyEvent.VK_T,KeyEvent.CTRL_DOWN_MASK));
 
   public static final PrefMonitor<KeyStroke> HOTKEY_SIM_TICK_FULL=
-          create(new PrefMonitorKeyStroke("hotkeySimTickFull", KeyEvent.VK_F9,0));
+          create(new PrefMonitorKeyStroke("hotkeySimTickFull", KeyEvent.VK_F9,KeyEvent.CTRL_DOWN_MASK));
 
   public static final PrefMonitor<KeyStroke> HOTKEY_SIM_TICK_ENABLED=
-          create(new PrefMonitorKeyStroke("hotkeySimTickEnabled", KeyEvent.VK_K,0));
+          create(new PrefMonitorKeyStroke("hotkeySimTickEnabled", KeyEvent.VK_K,KeyEvent.CTRL_DOWN_MASK));
 
   public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_UNDO=
-          create(new PrefMonitorKeyStroke("hotkeyEditUndo", KeyEvent.VK_Z,0));
+          create(new PrefMonitorKeyStroke("hotkeyEditUndo", KeyEvent.VK_Z,KeyEvent.CTRL_DOWN_MASK));
 
   public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_REDO=
-          create(new PrefMonitorKeyStroke("hotkeyEditRedo", KeyEvent.VK_Z,KeyEvent.SHIFT_DOWN_MASK));
+          create(new PrefMonitorKeyStroke("hotkeyEditRedo", KeyEvent.VK_Z,KeyEvent.SHIFT_DOWN_MASK|KeyEvent.CTRL_DOWN_MASK));
 
   public static final PrefMonitor<KeyStroke> HOTKEY_FILE_EXPORT=
-          create(new PrefMonitorKeyStroke("hotkeyFileExport", KeyEvent.VK_E,KeyEvent.SHIFT_DOWN_MASK));
+          create(new PrefMonitorKeyStroke("hotkeyFileExport", KeyEvent.VK_E,KeyEvent.SHIFT_DOWN_MASK|KeyEvent.CTRL_DOWN_MASK));
 
   public static final PrefMonitor<KeyStroke> HOTKEY_FILE_PRINT=
-          create(new PrefMonitorKeyStroke("hotkeyFilePrint", KeyEvent.VK_P,0));
+          create(new PrefMonitorKeyStroke("hotkeyFilePrint", KeyEvent.VK_P,KeyEvent.CTRL_DOWN_MASK));
 
   public static final PrefMonitor<KeyStroke> HOTKEY_FILE_QUIT=
-          create(new PrefMonitorKeyStroke("hotkeyFileQuit", KeyEvent.VK_Q,0));
+          create(new PrefMonitorKeyStroke("hotkeyFileQuit", KeyEvent.VK_Q,KeyEvent.CTRL_DOWN_MASK));
+
+  public static void resetHotkeys(){
+    HOTKEY_SIM_AUTO_PROPAGATE.set(KeyStroke.getKeyStroke(KeyEvent.VK_E,KeyEvent.CTRL_DOWN_MASK));
+    HOTKEY_SIM_RESET.set(KeyStroke.getKeyStroke(KeyEvent.VK_R,KeyEvent.CTRL_DOWN_MASK));
+    HOTKEY_SIM_STEP.set(KeyStroke.getKeyStroke(KeyEvent.VK_I,KeyEvent.CTRL_DOWN_MASK));
+    HOTKEY_SIM_TICK_HALF.set(KeyStroke.getKeyStroke(KeyEvent.VK_T,KeyEvent.CTRL_DOWN_MASK));
+    HOTKEY_SIM_TICK_FULL.set(KeyStroke.getKeyStroke(KeyEvent.VK_F9,KeyEvent.CTRL_DOWN_MASK));
+    HOTKEY_SIM_TICK_ENABLED.set(KeyStroke.getKeyStroke(KeyEvent.VK_K,KeyEvent.CTRL_DOWN_MASK));
+    HOTKEY_EDIT_UNDO.set(KeyStroke.getKeyStroke(KeyEvent.VK_Z,KeyEvent.CTRL_DOWN_MASK));
+    HOTKEY_EDIT_REDO.set(KeyStroke.getKeyStroke(KeyEvent.VK_Z,KeyEvent.SHIFT_DOWN_MASK|KeyEvent.CTRL_DOWN_MASK));
+    HOTKEY_FILE_EXPORT.set(KeyStroke.getKeyStroke(KeyEvent.VK_E,KeyEvent.SHIFT_DOWN_MASK|KeyEvent.CTRL_DOWN_MASK));
+    HOTKEY_FILE_PRINT.set(KeyStroke.getKeyStroke(KeyEvent.VK_P,KeyEvent.CTRL_DOWN_MASK));
+    HOTKEY_FILE_QUIT.set(KeyStroke.getKeyStroke(KeyEvent.VK_Q,KeyEvent.CTRL_DOWN_MASK));
+  }
 }

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -20,20 +20,16 @@ import com.cburch.logisim.util.LocaleListener;
 import com.cburch.logisim.util.LocaleManager;
 import com.cburch.logisim.util.PropertyChangeWeakSupport;
 import com.formdev.flatlaf.FlatIntelliJLaf;
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.Font;
-import java.awt.GraphicsEnvironment;
-import java.awt.Image;
-import java.awt.Toolkit;
+import com.cburch.logisim.gui.menu.Menu;
+
+import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.*;
 import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
@@ -868,5 +864,18 @@ public class AppPreferences {
     HOTKEY_FILE_EXPORT.set(KeyStroke.getKeyStroke(KeyEvent.VK_E,KeyEvent.SHIFT_DOWN_MASK|KeyEvent.CTRL_DOWN_MASK));
     HOTKEY_FILE_PRINT.set(KeyStroke.getKeyStroke(KeyEvent.VK_P,KeyEvent.CTRL_DOWN_MASK));
     HOTKEY_FILE_QUIT.set(KeyStroke.getKeyStroke(KeyEvent.VK_Q,KeyEvent.CTRL_DOWN_MASK));
+  }
+
+  public static final ArrayList<Menu> gui_sync_objects=new ArrayList<>();
+
+  public static final void hotkeySync(){
+    try {
+      AppPreferences.getPrefs().flush();
+      for(Menu m:gui_sync_objects){
+        m.hotkeyUpdate();
+      }
+    } catch (BackingStoreException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -38,8 +38,7 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
-import javax.swing.ImageIcon;
-import javax.swing.JFrame;
+import javax.swing.*;
 
 public class AppPreferences {
   //
@@ -824,30 +823,36 @@ public class AppPreferences {
       create(new PrefMonitorString("dialogDirectory", ""));
 
   /* Hotkey Settings */
-  public static final PrefMonitor<Integer> HOTKEY_SIM_AUTO_PROPAGATE=
-          create(new PrefMonitorInt("hotkeySimAutoPropagate", KeyEvent.VK_E));
+  public static final PrefMonitor<KeyStroke> HOTKEY_SIM_AUTO_PROPAGATE=
+          create(new PrefMonitorKeyStroke("hotkeySimAutoPropagate", KeyEvent.VK_E,0));
 
-  public static final PrefMonitor<Integer> HOTKEY_SIM_RESET=
-          create(new PrefMonitorInt("hotkeySimReset", KeyEvent.VK_R));
+  public static final PrefMonitor<KeyStroke> HOTKEY_SIM_RESET=
+          create(new PrefMonitorKeyStroke("hotkeySimReset", KeyEvent.VK_R,0));
 
-  public static final PrefMonitor<Integer> HOTKEY_SIM_STEP=
-          create(new PrefMonitorInt("hotkeySimStep", KeyEvent.VK_I));
+  public static final PrefMonitor<KeyStroke> HOTKEY_SIM_STEP=
+          create(new PrefMonitorKeyStroke("hotkeySimStep", KeyEvent.VK_I,0));
 
-  public static final PrefMonitor<Integer> HOTKEY_SIM_TICK_HALF=
-          create(new PrefMonitorInt("hotkeySimTickHalf", KeyEvent.VK_T));
+  public static final PrefMonitor<KeyStroke> HOTKEY_SIM_TICK_HALF=
+          create(new PrefMonitorKeyStroke("hotkeySimTickHalf", KeyEvent.VK_T,0));
 
-  public static final PrefMonitor<Integer> HOTKEY_SIM_TICK_FULL=
-          create(new PrefMonitorInt("hotkeySimTickFull", KeyEvent.VK_F9));
+  public static final PrefMonitor<KeyStroke> HOTKEY_SIM_TICK_FULL=
+          create(new PrefMonitorKeyStroke("hotkeySimTickFull", KeyEvent.VK_F9,0));
 
-  public static final PrefMonitor<Integer> HOTKEY_SIM_TICK_ENABLED=
-          create(new PrefMonitorInt("hotkeySimTickEnabled", KeyEvent.VK_K));
+  public static final PrefMonitor<KeyStroke> HOTKEY_SIM_TICK_ENABLED=
+          create(new PrefMonitorKeyStroke("hotkeySimTickEnabled", KeyEvent.VK_K,0));
 
-  public static final PrefMonitor<Integer> HOTKEY_EDIT_UNDO=
-          create(new PrefMonitorInt("hotkeyEditUndo", KeyEvent.VK_Z));
+  public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_UNDO=
+          create(new PrefMonitorKeyStroke("hotkeyEditUndo", KeyEvent.VK_Z,0));
 
-  public static final PrefMonitor<Integer> HOTKEY_EDIT_REDO=
-          create(new PrefMonitorInt("hotkeyEditRedo", KeyEvent.VK_Z|KeyEvent.SHIFT_DOWN_MASK));
+  public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_REDO=
+          create(new PrefMonitorKeyStroke("hotkeyEditRedo", KeyEvent.VK_Z,KeyEvent.SHIFT_DOWN_MASK));
 
-  public static final PrefMonitor<Integer> HOTKEY_EDIT_REDO=
-          create(new PrefMonitorInt("hotkeyEditRedo", KeyEvent.VK_Z|KeyEvent.SHIFT_DOWN_MASK));
+  public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_EXPORT=
+          create(new PrefMonitorKeyStroke("hotkeyFileExport", KeyEvent.VK_E,KeyEvent.SHIFT_DOWN_MASK));
+
+  public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_PRINT=
+          create(new PrefMonitorKeyStroke("hotkeyFilePrint", KeyEvent.VK_P,0));
+
+  public static final PrefMonitor<KeyStroke> HOTKEY_EDIT_QUIT=
+          create(new PrefMonitorKeyStroke("hotkeyFileQuit", KeyEvent.VK_Q,0));
 }

--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
@@ -68,19 +68,24 @@ public class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
   private KeyStroke byteArrayToKeyStroke(byte[] b){
     /* Little Endian */
     int code=0,mod=0;
-    code|=b[0];
-    code|=(b[1]<<8);
-    code|=(b[2]<<16);
-    code|=(b[3]<<24);
+    code|=b[0]&0xff;
+    code|=(b[1]<<8)&0xff;
+    code|=(b[2]<<16)&0xff;
+    code|=(b[3]<<24)&0xff;
 
-    mod|=b[4];
-    mod|=(b[5]<<8);
-    mod|=(b[6]<<16);
-    mod|=(b[7]<<24);
+    mod|=b[4]&0xff;
+    mod|=(b[5]<<8)&0xff;
+    mod|=(b[6]<<16)&0xff;
+    mod|=(b[7]<<24)&0xff;
     return KeyStroke.getKeyStroke(code,mod);
   }
   public KeyStroke get() {
     return byteArrayToKeyStroke(value);
+  }
+
+  public String getString(){
+    KeyStroke tmp=byteArrayToKeyStroke(this.value);
+    return KeyEvent.getModifiersExText(tmp.getModifiers())+" + "+KeyEvent.getKeyText(tmp.getKeyCode());
   }
 
   public void preferenceChange(PreferenceChangeEvent event) {

--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
@@ -16,6 +16,7 @@ import java.util.prefs.PreferenceChangeEvent;
 public class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
   private final byte[] dflt;
   private byte[] value;
+  private boolean isMenuKey=true;
 
   private String _name;
 
@@ -29,8 +30,24 @@ public class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
     prefs.addPreferenceChangeListener(this);
   }
 
+  public PrefMonitorKeyStroke(String name, int keycode, int modifier, boolean notMenu) {
+    super(name);
+    _name=name;
+    if(notMenu){
+      isMenuKey=false;
+    }
+    this.dflt = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
+    this.value = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
+    final var prefs = AppPreferences.getPrefs();
+    set(prefs.getByteArray(name, dflt));
+    prefs.addPreferenceChangeListener(this);
+  }
+
   public String getName(){
     return _name;
+  }
+  public boolean isMenuHotkey(){
+    return isMenuKey;
   }
   private byte[] keystrokeToByteArray(KeyStroke k){
     /* Little Endian */

--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
@@ -83,6 +83,11 @@ public class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
     return byteArrayToKeyStroke(value);
   }
 
+  public KeyStroke getWithMask(int mask) {
+    KeyStroke tmp=byteArrayToKeyStroke(value);
+    return KeyStroke.getKeyStroke(tmp.getKeyCode(),tmp.getModifiers()|mask);
+  }
+
   public String getString(){
     KeyStroke tmp=byteArrayToKeyStroke(this.value);
     return KeyEvent.getModifiersExText(tmp.getModifiers())+" + "+KeyEvent.getKeyText(tmp.getKeyCode());

--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
@@ -54,14 +54,14 @@ public class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
     byte[] res=new byte[8];
     int code=k.getKeyCode();
     int mod=k.getModifiers();
-    res[0]=(byte)(code);
-    res[1]=(byte)(code>>8);
-    res[2]=(byte)(code>>16);
-    res[3]=(byte)(code>>24);
-    res[4]=(byte)(mod);
-    res[5]=(byte)(mod>>8);
-    res[6]=(byte)(mod>>16);
-    res[7]=(byte)(mod>>24);
+    res[0]=(byte)(code&0xff);
+    res[1]=(byte)((code>>8)&0xff);
+    res[2]=(byte)((code>>16)&0xff);
+    res[3]=(byte)((code>>24)&0xff);
+    res[4]=(byte)(mod&0xff);
+    res[5]=(byte)((mod>>8)&0xff);
+    res[6]=(byte)((mod>>16)&0xff);
+    res[7]=(byte)((mod>>24)&0xff);
     return res;
   }
 

--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
@@ -10,114 +10,118 @@
 package com.cburch.logisim.prefs;
 
 import javax.swing.*;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.util.prefs.PreferenceChangeEvent;
 
 public class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
-  private final byte[] dflt;
-  private byte[] value;
-  private boolean isMenuKey=true;
+    private final byte[] dflt;
+    private byte[] value;
+    private boolean isMenuKey = true;
 
-  private String _name;
+    private String _name;
 
-  public PrefMonitorKeyStroke(String name, int keycode, int modifier) {
-    super(name);
-    _name=name;
-    this.dflt = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
-    this.value = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
-    final var prefs = AppPreferences.getPrefs();
-    set(prefs.getByteArray(name, dflt));
-    prefs.addPreferenceChangeListener(this);
-  }
-
-  public PrefMonitorKeyStroke(String name, int keycode, int modifier, boolean notMenu) {
-    super(name);
-    _name=name;
-    if(notMenu){
-      isMenuKey=false;
+    public PrefMonitorKeyStroke(String name, int keycode, int modifier) {
+        super(name);
+        _name = name;
+        this.dflt = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
+        this.value = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
+        final var prefs = AppPreferences.getPrefs();
+        set(prefs.getByteArray(name, dflt));
+        prefs.addPreferenceChangeListener(this);
     }
-    this.dflt = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
-    this.value = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
-    final var prefs = AppPreferences.getPrefs();
-    set(prefs.getByteArray(name, dflt));
-    prefs.addPreferenceChangeListener(this);
-  }
 
-  public String getName(){
-    return _name;
-  }
-  public boolean isMenuHotkey(){
-    return isMenuKey;
-  }
-  private byte[] keystrokeToByteArray(KeyStroke k){
-    /* Little Endian */
-    byte[] res=new byte[8];
-    int code=k.getKeyCode();
-    int mod=k.getModifiers();
-    res[0]=(byte)(code&0xff);
-    res[1]=(byte)((code>>8)&0xff);
-    res[2]=(byte)((code>>16)&0xff);
-    res[3]=(byte)((code>>24)&0xff);
-    res[4]=(byte)(mod&0xff);
-    res[5]=(byte)((mod>>8)&0xff);
-    res[6]=(byte)((mod>>16)&0xff);
-    res[7]=(byte)((mod>>24)&0xff);
-    return res;
-  }
-
-  private KeyStroke byteArrayToKeyStroke(byte[] b){
-    /* Little Endian */
-    int code=0,mod=0;
-    code|=b[0]&0xff;
-    code|=(b[1]<<8)&0xff;
-    code|=(b[2]<<16)&0xff;
-    code|=(b[3]<<24)&0xff;
-
-    mod|=b[4]&0xff;
-    mod|=(b[5]<<8)&0xff;
-    mod|=(b[6]<<16)&0xff;
-    mod|=(b[7]<<24)&0xff;
-    return KeyStroke.getKeyStroke(code,mod);
-  }
-  public KeyStroke get() {
-    return byteArrayToKeyStroke(value);
-  }
-
-  public KeyStroke getWithMask(int mask) {
-    KeyStroke tmp=byteArrayToKeyStroke(value);
-    return KeyStroke.getKeyStroke(tmp.getKeyCode(),tmp.getModifiers()|mask);
-  }
-
-  public String getString(){
-    KeyStroke tmp=byteArrayToKeyStroke(this.value);
-    return KeyEvent.getModifiersExText(tmp.getModifiers())+" + "+KeyEvent.getKeyText(tmp.getKeyCode());
-  }
-
-  public void preferenceChange(PreferenceChangeEvent event) {
-    final var prefs = event.getNode();
-    final var prop = event.getKey();
-    final var name = getIdentifier();
-    if (prop.equals(name)) {
-      final var oldValue = value;
-      final var newValue = prefs.getByteArray(name, dflt);
-      if (newValue != oldValue) {
-        value = newValue;
-        AppPreferences.firePropertyChange(name, oldValue, newValue);
-      }
+    public PrefMonitorKeyStroke(String name, int keycode, int modifier, boolean notMenu) {
+        super(name);
+        _name = name;
+        if (notMenu) {
+            isMenuKey = false;
+        }
+        this.dflt = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
+        this.value = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
+        final var prefs = AppPreferences.getPrefs();
+        set(prefs.getByteArray(name, dflt));
+        prefs.addPreferenceChangeListener(this);
     }
-  }
 
-  public void set(byte[] newValue) {
-    final var newVal = newValue;
-    if (value != newVal) {
-      AppPreferences.getPrefs().putByteArray(getIdentifier(), newVal);
+    public String getName() {
+        return _name;
     }
-  }
 
-  public void set(KeyStroke newValue) {
-    final byte[] newVal = keystrokeToByteArray(newValue);
-    if (value != newVal) {
-      AppPreferences.getPrefs().putByteArray(getIdentifier(), newVal);
+    public boolean isMenuHotkey() {
+        return isMenuKey;
     }
-  }
+
+    private byte[] keystrokeToByteArray(KeyStroke k) {
+        /* Little Endian */
+        byte[] res = new byte[8];
+        int code = k.getKeyCode();
+        int mod = k.getModifiers();
+        res[0] = (byte) (code & 0xff);
+        res[1] = (byte) ((code >> 8) & 0xff);
+        res[2] = (byte) ((code >> 16) & 0xff);
+        res[3] = (byte) ((code >> 24) & 0xff);
+        res[4] = (byte) (mod & 0xff);
+        res[5] = (byte) ((mod >> 8) & 0xff);
+        res[6] = (byte) ((mod >> 16) & 0xff);
+        res[7] = (byte) ((mod >> 24) & 0xff);
+        return res;
+    }
+
+    private KeyStroke byteArrayToKeyStroke(byte[] b) {
+        /* Little Endian */
+        int code = 0, mod = 0;
+        code |= b[0] & 0xff;
+        code |= (b[1] << 8) & 0xff;
+        code |= (b[2] << 16) & 0xff;
+        code |= (b[3] << 24) & 0xff;
+
+        mod |= b[4] & 0xff;
+        mod |= (b[5] << 8) & 0xff;
+        mod |= (b[6] << 16) & 0xff;
+        mod |= (b[7] << 24) & 0xff;
+        return KeyStroke.getKeyStroke(code, mod);
+    }
+
+    public KeyStroke get() {
+        return byteArrayToKeyStroke(value);
+    }
+
+    public KeyStroke getWithMask(int mask) {
+        KeyStroke tmp = byteArrayToKeyStroke(value);
+        return KeyStroke.getKeyStroke(tmp.getKeyCode(), tmp.getModifiers() | mask);
+    }
+
+    public String getString() {
+        KeyStroke tmp = byteArrayToKeyStroke(this.value);
+        return InputEvent.getModifiersExText(tmp.getModifiers()) + " + " + KeyEvent.getKeyText(tmp.getKeyCode());
+    }
+
+    public void preferenceChange(PreferenceChangeEvent event) {
+        final var prefs = event.getNode();
+        final var prop = event.getKey();
+        final var name = getIdentifier();
+        if (prop.equals(name)) {
+            final var oldValue = value;
+            final var newValue = prefs.getByteArray(name, dflt);
+            if (newValue != oldValue) {
+                value = newValue;
+                AppPreferences.firePropertyChange(name, oldValue, newValue);
+            }
+        }
+    }
+
+    public void set(byte[] newValue) {
+        final var newVal = newValue;
+        if (value != newVal) {
+            AppPreferences.getPrefs().putByteArray(getIdentifier(), newVal);
+        }
+    }
+
+    public void set(KeyStroke newValue) {
+        final byte[] newVal = keystrokeToByteArray(newValue);
+        if (value != newVal) {
+            AppPreferences.getPrefs().putByteArray(getIdentifier(), newVal);
+        }
+    }
 }

--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
@@ -18,7 +18,6 @@ public class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
     private final byte[] dflt;
     private byte[] value;
     private boolean isMenuKey = true;
-
     private String _name;
 
     public PrefMonitorKeyStroke(String name, int keycode, int modifier) {

--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
@@ -13,27 +13,57 @@ import javax.swing.*;
 import java.awt.event.KeyEvent;
 import java.util.prefs.PreferenceChangeEvent;
 
-class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
-  private final KeyStroke dflt;
-  private KeyStroke value;
+public class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
+  private final byte[] dflt;
+  private byte[] value;
 
-  private byte[] keystrokeToByteArray(KeyStroke k){
-    byte[] res=new byte[8];
-    int code=k.getKeyCode();
-    int mod=k.getModifiers();
-  }
+  private String _name;
 
   public PrefMonitorKeyStroke(String name, int keycode, int modifier) {
     super(name);
-    this.dflt = KeyStroke.getKeyStroke(keycode, modifier);
-    this.value = KeyStroke.getKeyStroke(keycode, modifier);
+    _name=name;
+    this.dflt = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
+    this.value = keystrokeToByteArray(KeyStroke.getKeyStroke(keycode, modifier));
     final var prefs = AppPreferences.getPrefs();
     set(prefs.getByteArray(name, dflt));
     prefs.addPreferenceChangeListener(this);
   }
 
+  public String getName(){
+    return _name;
+  }
+  private byte[] keystrokeToByteArray(KeyStroke k){
+    /* Little Endian */
+    byte[] res=new byte[8];
+    int code=k.getKeyCode();
+    int mod=k.getModifiers();
+    res[0]=(byte)(code);
+    res[1]=(byte)(code>>8);
+    res[2]=(byte)(code>>16);
+    res[3]=(byte)(code>>24);
+    res[4]=(byte)(mod);
+    res[5]=(byte)(mod>>8);
+    res[6]=(byte)(mod>>16);
+    res[7]=(byte)(mod>>24);
+    return res;
+  }
+
+  private KeyStroke byteArrayToKeyStroke(byte[] b){
+    /* Little Endian */
+    int code=0,mod=0;
+    code|=b[0];
+    code|=(b[1]<<8);
+    code|=(b[2]<<16);
+    code|=(b[3]<<24);
+
+    mod|=b[4];
+    mod|=(b[5]<<8);
+    mod|=(b[6]<<16);
+    mod|=(b[7]<<24);
+    return KeyStroke.getKeyStroke(code,mod);
+  }
   public KeyStroke get() {
-    return value;
+    return byteArrayToKeyStroke(value);
   }
 
   public void preferenceChange(PreferenceChangeEvent event) {
@@ -42,7 +72,7 @@ class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
     final var name = getIdentifier();
     if (prop.equals(name)) {
       final var oldValue = value;
-      final var newValue = prefs.getInt(name, dflt);
+      final var newValue = prefs.getByteArray(name, dflt);
       if (newValue != oldValue) {
         value = newValue;
         AppPreferences.firePropertyChange(name, oldValue, newValue);
@@ -50,10 +80,17 @@ class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
     }
   }
 
-  public void set(Integer newValue) {
+  public void set(byte[] newValue) {
     final var newVal = newValue;
     if (value != newVal) {
-      AppPreferences.getPrefs().putInt(getIdentifier(), newVal);
+      AppPreferences.getPrefs().putByteArray(getIdentifier(), newVal);
+    }
+  }
+
+  public void set(KeyStroke newValue) {
+    final byte[] newVal = keystrokeToByteArray(newValue);
+    if (value != newVal) {
+      AppPreferences.getPrefs().putByteArray(getIdentifier(), newVal);
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorKeyStroke.java
@@ -1,0 +1,59 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.prefs;
+
+import javax.swing.*;
+import java.awt.event.KeyEvent;
+import java.util.prefs.PreferenceChangeEvent;
+
+class PrefMonitorKeyStroke extends AbstractPrefMonitor<KeyStroke> {
+  private final KeyStroke dflt;
+  private KeyStroke value;
+
+  private byte[] keystrokeToByteArray(KeyStroke k){
+    byte[] res=new byte[8];
+    int code=k.getKeyCode();
+    int mod=k.getModifiers();
+  }
+
+  public PrefMonitorKeyStroke(String name, int keycode, int modifier) {
+    super(name);
+    this.dflt = KeyStroke.getKeyStroke(keycode, modifier);
+    this.value = KeyStroke.getKeyStroke(keycode, modifier);
+    final var prefs = AppPreferences.getPrefs();
+    set(prefs.getByteArray(name, dflt));
+    prefs.addPreferenceChangeListener(this);
+  }
+
+  public KeyStroke get() {
+    return value;
+  }
+
+  public void preferenceChange(PreferenceChangeEvent event) {
+    final var prefs = event.getNode();
+    final var prop = event.getKey();
+    final var name = getIdentifier();
+    if (prop.equals(name)) {
+      final var oldValue = value;
+      final var newValue = prefs.getInt(name, dflt);
+      if (newValue != oldValue) {
+        value = newValue;
+        AppPreferences.firePropertyChange(name, oldValue, newValue);
+      }
+    }
+  }
+
+  public void set(Integer newValue) {
+    final var newVal = newValue;
+    if (value != newVal) {
+      AppPreferences.getPrefs().putInt(getIdentifier(), newVal);
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/util/HotkeyMiddleware.java
+++ b/src/main/java/com/cburch/logisim/util/HotkeyMiddleware.java
@@ -1,0 +1,5 @@
+package com.cburch.logisim.util;
+
+public class HotkeyMiddleware {
+
+}

--- a/src/main/java/com/cburch/logisim/util/HotkeyMiddleware.java
+++ b/src/main/java/com/cburch/logisim/util/HotkeyMiddleware.java
@@ -1,5 +1,0 @@
-package com.cburch.logisim.util;
-
-public class HotkeyMiddleware {
-
-}

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -621,6 +621,26 @@ windowGridColorsReset = Reset grid colors to Logisim's defaults
 windowSetAutoScaleFactor = Set zoom factor to Logisim's default
 windowCanvasLocation = Main canvas location:
 #
+# prefs/HotkeyOptions.java
+#
+hotkeyOptHeader = This Tab allows users to dynamically change the shortcut keys.Note that the hotkeys on the menubar need to be started with CTRL.
+hotkeyOptHelp = To change the key, simply click the button right-side. Then directly press the keys you want, and press OK to save the result.
+hotkeyOptTitle = Hotkey Settings
+hotkeyOptResetBtn = Reset to Default
+hotkeySimAutoPropagate = Auto-Propagate
+hotkeySimReset = Reset Simulation
+hotkeySimStep = Single-Step Propagation
+hotkeySimTickHalf = Manual Tick Half Cycle
+hotkeySimTickFull = Manual Tick Full Cycle
+hotkeySimTickEnabled = Auto-Tick Enabled
+hotkeyEditUndo = Edit Undo
+hotkeyEditRedo = Edit Redo
+hotkeyFileExport = Export File
+hotkeyFilePrint = Print File
+hotkeyFileQuit = Quit Logisim
+hotkeyErrCtrl = This key combo must start with CTRL.
+hotkeyErrConflict = This key is comflicted with :
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = Fork from original project

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -621,6 +621,26 @@ windowGridColorsReset = Grid Farbe auf den Logisim standart zurücksetzen
 # ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = Fork des Originalprojekt

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -621,6 +621,26 @@ windowToolbarLocation = Θέση Εργαλειοθήκης
 # ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 # ==> creditsRoleFork =

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -621,6 +621,26 @@ windowToolbarZoomfactor = Factor de zoom
 # ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = Bifurcación del proyecto original

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -621,6 +621,26 @@ windowGridColorsReset = Réinitialiser les couleurs de la grille aux valeurs par
 windowSetAutoScaleFactor = Régler le facteur de zoom sur la valeur par défaut de Logisim
 windowCanvasLocation = Emplacement principal du canevas :
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = Fork du projet originel

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -621,6 +621,26 @@ windowToolbarZoomfactor = Fattore di zoom
 # ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = Forchetta dal progetto originale

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -621,6 +621,26 @@ windowToolbarZoomfactor = ズームファクタ
 # ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = オリジナルプロジェクトからのフォーク

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -621,6 +621,26 @@ windowGridColorsReset = Herstel logisims standard grid kleuren
 # ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = Vork van origineel project

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -621,6 +621,26 @@ windowGridColorsReset = Przywróć kolory domyślne
 # ==> windowSetAutoScaleFactor =
 windowCanvasLocation = Położenie płótna edytora:
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = Fork z oryginalnego projektu

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -621,6 +621,26 @@ windowGridColorsReset = Resetar as cores da grade para o padrão do Logisim
 # ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = Fork do projeto original

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -621,6 +621,26 @@ windowToolbarZoomfactor = коэффициент масштабирования
 # ==> windowSetAutoScaleFactor =
 # ==> windowCanvasLocation =
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = Вилы из оригинального проекта

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -621,6 +621,26 @@ windowGridColorsReset = 将网格颜色重置为 Logisim 的默认值
 windowSetAutoScaleFactor = 将缩放比例重置为 Logisim 的默认值
 windowCanvasLocation = 主要画布位置
 #
+# prefs/HotkeyOptions.java
+#
+# ==> hotkeyOptHeader =
+# ==> hotkeyOptHelp =
+# ==> hotkeyOptTitle =
+# ==> hotkeyOptResetBtn =
+# ==> hotkeySimAutoPropagate =
+# ==> hotkeySimReset =
+# ==> hotkeySimStep =
+# ==> hotkeySimTickHalf =
+# ==> hotkeySimTickFull =
+# ==> hotkeySimTickEnabled =
+# ==> hotkeyEditUndo =
+# ==> hotkeyEditRedo =
+# ==> hotkeyFileExport =
+# ==> hotkeyFilePrint =
+# ==> hotkeyFileQuit =
+# ==> hotkeyErrCtrl =
+# ==> hotkeyErrConflict =
+#
 # start/AboutCredits.java
 #
 creditsRoleFork = 从原始项目派生的分支


### PR DESCRIPTION
Dear maintainers,
Different people have different using habits. Such as the undo. Many people will set them as "Ctrl+Y" rather than "Ctrl+Shift+Z". So I spend some time creating a new tab in the preferences, allowing users to change the hotkeys to whatever they like.
My changes are as follows.
* @gtxzsxxk (2023-07-27)
  * Added a new class HotkeyOptions, a new TAB in the preferences.
  * Modified Menu class, setting up a new abstract method so that the hotkey can be sync via the gui
  * Modified MenuFile MenuEdit MenuSimulate to implement that abstract method
  * After my modification, 11 menuitem in the menu-bar are now available in hotkey settings. Changes will be updated immediately.
The 11 menuitem are as follows.
    * Auto-Propagate
    * Reset Simulation
    * Single-Step Propagation
    * Manual Tick Half Cycle
    * Manual Tick Full Cycle
    * Auto-Tick Enabled
    * Undo
    * Redo
    * Export
    * Print
    * Quit
  * I'd like to insert more hotkeys to make logisim-evolution more fun. Such as press *SPACE* to rotate the component to be placed on.
 

Looking forward to your acceptance.
