### PR TITLE
Redrawing of GUI-windows (Close #786)

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
@@ -560,9 +560,9 @@ class CircuitWires {
   // create the new bundle map.
 
   /*synchronized*/ private BundleMap getBundleMap() {
+    if (masterBundleMap != null) return masterBundleMap;
     if (SwingUtilities.isEventDispatchThread()) {
       // AWT event thread.
-      if (masterBundleMap != null) return masterBundleMap;
       final var ret = new BundleMap();
       try {
         computeBundleMap(ret);

--- a/src/main/java/com/cburch/logisim/gui/main/Canvas.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Canvas.java
@@ -1112,7 +1112,6 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
     @Override
     public void propagationCompleted(Simulator.Event e) {
       paintThread.requestRepaint();
-      if (e.didTick()) waitForRepaintDone();
     }
 
     @Override


### PR DESCRIPTION
Hi everyone, 

While investigating the performance issues reported in different occasions:

* #786
* #1493
* #1544

using the IntelliJ profiler I have found the following:

1. The Simulation Thread spends ~17% of its CPU time on a `SwingUtilities.invokeAndWait` call in [com.cburch.logisim.circuit.CircuitWires#getBundleMap](https://github.com/logisim-evolution/logisim-evolution/blob/dab9166a79ef67dfd0f7e9496730ca96b453dc8b/src/main/java/com/cburch/logisim/circuit/CircuitWires.java#L579). 
    As the comment above the function explains, the bundle map must be computed by the AWT thread only: if the calling thread is anything other thant the AWT thread, the call is placed _at the end_ of the AWT event queue and the result is then awaited and returned.

The `Simulator` repeatedly calls `getBundleMap()` in its `propagate()` method, and each time it has to wait for the AWT thread to consume the entire event queue before the simulation can continue.
As the comment above  `CircuitWires.getBundleMap()` explains, in the AWT thread section the function checks whether `masterBundleMap ` is set and if it is (i.e. it hasn't been invalidated), it just returns that instance. By moving this check at the very beginning of the function, this value can be returned instantly to the calling simulation thread, without piling on the AWT Event Queue and waiting for it to be extinguished just to return a precomputed value. 

2. The event handler [com.cburch.logisim.gui.main.Canvas#propagationCompleted](https://github.com/logisim-evolution/logisim-evolution/blob/dab9166a79ef67dfd0f7e9496730ca96b453dc8b/src/main/java/com/cburch/logisim/gui/main/Canvas.java#L1115), called by the simulation thread as shown [here ](https://github.com/logisim-evolution/logisim-evolution/blob/dab9166a79ef67dfd0f7e9496730ca96b453dc8b/src/main/java/com/cburch/logisim/circuit/Simulator.java#L678)effectively blocks the simulation thread until redrawing is completed. As suggested [here](https://github.com/logisim-evolution/logisim-evolution/blob/dab9166a79ef67dfd0f7e9496730ca96b453dc8b/src/main/java/com/cburch/logisim/circuit/Simulator.java#L677C42-L677C49), the `propagationCompleted` event handlers could be called from the AWT thread, but I tried this and the event queue gets flooded with these events and the GUI quickly freezes. Instead, my solution is to simply remove the line in the handler that makes the simulator wait for the repaint to be done: I couldn't understand why does the simulator needs to wait in the first place.

By making these two changes, I managed to increase the tick speed of the project I used for testing (my own design of a 8-bit processor) from ~400 Hz before the changes to ~1.2kHz after the changes.

