### PR TITLE
Fix ReaderInputStream read

### DIFF
--- a/src/main/java/com/cburch/logisim/file/ReaderInputStream.java
+++ b/src/main/java/com/cburch/logisim/file/ReaderInputStream.java
@@ -111,19 +111,15 @@ public class ReaderInputStream extends InputStream {
   public synchronized int read() throws IOException {
     if (in == null) throw new IOException("Stream Closed");
 
-    byte result;
+    int result;
     if (slack != null && begin < slack.length) {
-      result = slack[begin];
+      result = slack[begin] & 0xff;
       if (++begin == slack.length) {
         slack = null;
       }
     } else {
       final var buf = new byte[1];
-      result = (read(buf, 0, 1) <= 0) ? -1 : buf[0];
-    }
-
-    if (result < -1) {
-      result += 256;
+      result = (read(buf, 0, 1) <= 0) ? -1 : (buf[0] & 0xff);
     }
 
     return result;


### PR DESCRIPTION
This PR fixes the read() method in ReaderInputStream.java as noted in #1770. This method is supposed to implement read() as defined in the Reader class Java documentation. As it was written, it clearly did not.

My research shows that it is unlikely that this method is ever actually called in our program. The only use of this class is in trying to read old original Logisim files. Even there it is only used in a BufferedReader that almost certainly uses one of the methods that reads many bytes at a time. I didn't come up with a test reading old files that got so far as to try this. Still. It is currently incorrect and so I fix it.

