### PR TITLE
Fix TruthtableTextFile pattern match

### DIFF
--- a/src/main/java/com/cburch/logisim/analyze/file/TruthtableTextFile.java
+++ b/src/main/java/com/cburch/logisim/analyze/file/TruthtableTextFile.java
@@ -295,7 +295,7 @@ public class TruthtableTextFile {
         int ix = line.indexOf('#');
         if (ix >= 0) line = line.substring(0, ix);
         line = line.trim();
-        if (line.equals("") || (line.matches("\\s*[~_=-][ ~_=-|]*"))) {
+        if (line.equals("") || (line.matches("\\s*[-~_=][- ~_=|]*"))) {
           continue;
         } else if (inputs.vars.isEmpty()) {
           validateHeader(line, inputs, outputs, lineno);


### PR DESCRIPTION
This is another problem noted by codeQL and #1794. After this, there will be one problem remaining.

The problem here is that using the `-` character in square brackets in a pattern generally designates a range. The intent in our code here is clearly to actually match the `-` character since the range `=-|` includes lots of characters including all upper and lower case letters. The standard way to do match just the character is to put the `-` character first in the list. I have modified the code to do that.