### PR TITLE
Fixes RAM error output - #1747

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Changed RAM default output from error to undefined [#1747]
   * Added support for scanning 7-segment display on FPGA-boards
   * Added first support for the openFpga toolchain for the ecp5 famely
     Note that this is experimental for the moment, so use it at your own risk.

--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -348,7 +348,7 @@ public class Ram extends Mem {
 
     if (!separate && outputNotEnabled) {
       /* put the bus in tri-state in case of a combined bus and no output enable */
-      setValue.accept( Value.createUnknown(dataBits));
+      setValue.accept(Value.createUnknown(dataBits));
       return;
     }
     /* if the OE is not activated return */

--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -354,9 +354,15 @@ public class Ram extends Mem {
     /* if the OE is not activated return */
     if (outputNotEnabled) return;
 
-    /* if the address is bogus set error value */
-    if (!goodAddr || errorValue) {
+    /* if the address is bogus set error value accordingly */
+
+    if (errorValue) {
       setValue.accept(Value.createError(dataBits));
+      return;
+    }
+
+    if (!goodAddr) {
+      setValue.accept(Value.createUnknown(dataBits));
       return;
     }
 


### PR DESCRIPTION
This pull request contains simple fixes for the problem described in issue #1747. The main culpirit was the fact that that the code did not discern between error addresses and not fully specified addresses. This also contains a small refactoring of the repeated calls to `state.setPort(RamAppearance.getDataOutIndex(0, attrs), Value.createError(dataBits), DELAY);` to a separate function for the sake of readability.