### PR TITLE
TTY now loads RAM before first propagation - Fixes #1338

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
+++ b/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
@@ -318,9 +318,9 @@ public class TtyInterface {
     }
 
     CircuitState circState = new CircuitState(proj, circuit);
-    // we have to do our initial propagation before the simulation starts -
-    // it's necessary to populate the circuit with substates.
-    circState.getPropagator().propagate();
+
+    // we load the ram before first propagation
+    // so the first propagation emits correct values
     if (args.getLoadFile() != null) {
       try {
         final var loaded = loadRam(circState, args.getLoadFile());
@@ -333,6 +333,11 @@ public class TtyInterface {
         System.exit(-1);
       }
     }
+
+    // we have to do our initial propagation before the simulation starts -
+    // it's necessary to populate the circuit with substates.
+    circState.getPropagator().propagate();
+
     final var ttyFormat = args.getTtyFormat();
     final var simCode = runSimulation(circState, outputPins, haltPin, ttyFormat);
 


### PR DESCRIPTION
This small PR adjusts the TTY interface to load the ram file before doing the first propagation, solving #1338.
Testing with the ram.zip file provided by @ChristopherPAndrews yields 

```
0000 0001
0000 0010
0000 0011
0000 0100
0000 0101
0000 0110
0000 0111
0000 1000
0000 1001
0000 1010
0000 1011
0000 1100
0000 1101
0000 1110
0000 1111
1111 1111
```

as expected.