### PR TITLE
Fix Zip Slip security issue in reading jar

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/settings/BoardList.java
+++ b/src/main/java/com/cburch/logisim/fpga/settings/BoardList.java
@@ -77,6 +77,15 @@ public class BoardList {
       final var fileName = ze.getName();
       final var accept = pattern.matcher(fileName).matches() && fileName.contains(match);
       if (accept) {
+        // Check that fileName doesn't stray outside target directory: Zip Slip security test.
+        if (!(new File(dir, fileName)).toPath().normalize().startsWith(dir.toPath())) {
+          try {
+            zf.close();
+          } catch (IOException e1) {
+            // Do nothing since we are about to throw an Error anyway.
+          }
+          throw new Error("Bad entry: " + fileName + " in " + dir);
+        }
         ret.add("url:" + fileName);
       }
     }


### PR DESCRIPTION
This PR fixes the remaining security issue and should close #1794.