### PR TITLE
Negated enable for multiplexer

### DIFF
--- a/src/main/java/com/cburch/logisim/std/plexers/Multiplexer.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/Multiplexer.java
@@ -226,17 +226,19 @@ public class Multiplexer extends InstanceFactory {
 
       if (invertEnable) {
         int ovalX, ovalY;
+        int radius = 8;
+        int halfRadius = radius / 2;
         if (vertical) {
-          ovalX = en.getX() - len * dx - 4;
-          ovalY = en.getY() - 2 * len * dy - 4;
+          ovalX = en.getX() - halfRadius;
+          ovalY = en.getY() - len - radius - halfRadius;
         }
         else {
-          ovalX = en.getX() - 2 * len * dx - 4;
-          ovalY = en.getY() - len * dy - 4;
+          ovalX = en.getX() + len + radius - halfRadius;
+          ovalY = en.getY() - halfRadius;
         }
 
         GraphicsUtil.switchToWidth(g, 2);
-        g.drawOval(ovalX, ovalY, 8, 8);
+        g.drawOval(ovalX, ovalY, radius, radius);
       }
     }
     GraphicsUtil.switchToWidth(g, 1);

--- a/src/main/java/com/cburch/logisim/std/plexers/PlexersLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/PlexersLibrary.java
@@ -125,6 +125,11 @@ public class PlexersLibrary extends Library {
 
   public static final int DELAY = 3;
 
+  public static final Attribute<Boolean> ATTR_INVERT_ENABLE =
+      Attributes.forBoolean("invertSelect", S.getter("plexerInvertSelectAttr"));
+
+  public static final Object DEFAULT_INVERT_ENABLE = Boolean.FALSE;
+
   private static final FactoryDescription[] DESCRIPTIONS = {
     new FactoryDescription(Multiplexer.class, S.getter("multiplexerComponent"), "multiplexer.gif"),
     new FactoryDescription(


### PR DESCRIPTION
This is an in-progress PR, consisting of an implementation for negated enables for the multiplexer, and eventually for the demultiplexer as well.

As of now, the feature adds a new attribute 'Invert Enable', that inverts the input for the enable in the component, as well as adding the little indication circle. 

![shot](https://github.com/logisim-evolution/logisim-evolution/assets/55855728/d14f5aba-1511-4041-8efd-d79b70525ca9)

However, I am currently in doubt on how to proceed with the organization of this new attribute into the component. Should it really be a new attribute (which wouldn't be useful when the enable attribute is disabled), or would it be better to modify the 'Include Enable' attribute to  include this option? 

If so, has this been done in the past without breaking previously created .circ files?