### PR TITLE
RAM negated enable

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -321,7 +321,7 @@ public class Ram extends Mem {
     Object trigger = state.getAttributeValue(StdAttr.TRIGGER);
     final var rawWeValue = state.getPortValue(RamAppearance.getWEIndex(0, attrs));
     final var weValue = state.getAttributeValue(RamAttributes.INVERT_WRITE_ENABLE)
-        ? invertValue(rawWeValue) : rawWeValue;
+        ? rawWeValue.not() : rawWeValue;
     final var async = trigger.equals(StdAttr.TRIG_HIGH) || trigger.equals(StdAttr.TRIG_LOW);
     final var edge =
         !async && myState
@@ -387,16 +387,6 @@ public class Ram extends Mem {
       else
         setValue.accept(Value.createKnown(dataBits, oldMemValue));
     }
-  }
-
-  private Value invertValue(Value input) {
-    if (input == Value.TRUE) {
-      return Value.FALSE;
-    } else if (input == Value.FALSE) {
-      return Value.TRUE;
-    }
-
-    return input;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -295,8 +295,8 @@ public class Ram extends Mem {
     // perform reads
     final var width = state.getAttributeValue(DATA_ATTR);
     final var readOffValue = attrs.getValue(RamAttributes.INVERT_OUTPUT_ENABLE) ? Value.TRUE : Value.FALSE;
-    final var outputEnabled = separate ||
-        !state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(readOffValue);
+    final var outputEnabled = separate
+        || !state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(readOffValue);
     if (outputEnabled && goodAddr && !misalignError) {
       for (var i = 0; i < dataLines; i++) {
         long val = myState.getContents().get(addr + i);
@@ -392,8 +392,7 @@ public class Ram extends Mem {
   private Value invertValue(Value input) {
     if (input == Value.TRUE) {
       return Value.FALSE;
-    }
-    else if (input == Value.FALSE) {
+    } else if (input == Value.FALSE) {
       return Value.TRUE;
     }
 

--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -209,7 +209,9 @@ public class Ram extends Mem {
         || (attr == StdAttr.APPEARANCE)
         || (attr == Mem.LINE_ATTR)
         || (attr == RamAttributes.CLEAR_PIN)
-        || (attr == Mem.ENABLES_ATTR)) {
+        || (attr == Mem.ENABLES_ATTR
+        || (attr == RamAttributes.INVERT_OUTPUT_ENABLE)
+        || (attr == RamAttributes.INVERT_WRITE_ENABLE))) {
       instance.recomputeBounds();
       configurePorts(instance);
     }

--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -210,8 +210,8 @@ public class Ram extends Mem {
         || (attr == Mem.LINE_ATTR)
         || (attr == RamAttributes.CLEAR_PIN)
         || (attr == Mem.ENABLES_ATTR
-        || (attr == RamAttributes.INVERT_OUTPUT_ENABLE)
-        || (attr == RamAttributes.INVERT_WRITE_ENABLE))) {
+        || (attr == RamAttributes.OUTPUT_ENABLE_MODE)
+        || (attr == RamAttributes.WRITE_ENABLE_MODE))) {
       instance.recomputeBounds();
       configurePorts(instance);
     }
@@ -278,7 +278,8 @@ public class Ram extends Mem {
     // perform writes
     Object trigger = state.getAttributeValue(StdAttr.TRIGGER);
     final var triggered = myState.setClock(state.getPortValue(RamAppearance.getClkIndex(0, attrs)), trigger);
-    final var writeOnValue = attrs.getValue(RamAttributes.INVERT_WRITE_ENABLE) ? Value.FALSE : Value.TRUE;
+    final var writeOnValue = attrs.getValue(RamAttributes.WRITE_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH
+        ? Value.FALSE : Value.TRUE;
     final var writeEnabled = triggered && (state.getPortValue(RamAppearance.getWEIndex(0, attrs)) == writeOnValue);
     if (writeEnabled && goodAddr && !misalignError) {
       for (var i = 0; i < dataLines; i++) {
@@ -294,7 +295,8 @@ public class Ram extends Mem {
 
     // perform reads
     final var width = state.getAttributeValue(DATA_ATTR);
-    final var readOffValue = attrs.getValue(RamAttributes.INVERT_OUTPUT_ENABLE) ? Value.TRUE : Value.FALSE;
+    final var readOffValue = attrs.getValue(RamAttributes.OUTPUT_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH
+        ? Value.TRUE : Value.FALSE;
     final var outputEnabled = separate
         || !state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(readOffValue);
     if (outputEnabled && goodAddr && !misalignError) {
@@ -320,7 +322,7 @@ public class Ram extends Mem {
     // perform writes
     Object trigger = state.getAttributeValue(StdAttr.TRIGGER);
     final var rawWeValue = state.getPortValue(RamAppearance.getWEIndex(0, attrs));
-    final var weValue = state.getAttributeValue(RamAttributes.INVERT_WRITE_ENABLE)
+    final var weValue = state.getAttributeValue(RamAttributes.WRITE_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH
         ? rawWeValue.not() : rawWeValue;
     final var async = trigger.equals(StdAttr.TRIG_HIGH) || trigger.equals(StdAttr.TRIG_LOW);
     final var edge =
@@ -349,7 +351,7 @@ public class Ram extends Mem {
 
     // perform reads
     final var dataBits = state.getAttributeValue(DATA_ATTR);
-    final var outputOffValue = state.getAttributeValue(RamAttributes.INVERT_OUTPUT_ENABLE) ? Value.TRUE : Value.FALSE;
+    final var outputOffValue = state.getAttributeValue(RamAttributes.OUTPUT_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH ? Value.TRUE : Value.FALSE;
     final var outputNotEnabled = state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(outputOffValue);
 
     Consumer<Value> setValue = (Value value) -> state.setPort(RamAppearance.getDataOutIndex(0, attrs), value, DELAY);

--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -278,7 +278,8 @@ public class Ram extends Mem {
     // perform writes
     Object trigger = state.getAttributeValue(StdAttr.TRIGGER);
     final var triggered = myState.setClock(state.getPortValue(RamAppearance.getClkIndex(0, attrs)), trigger);
-    final var writeEnabled = triggered && (state.getPortValue(RamAppearance.getWEIndex(0, attrs)) == Value.TRUE);
+    final var writeOnValue = attrs.getValue(RamAttributes.INVERT_WRITE_ENABLE) ? Value.FALSE : Value.TRUE;
+    final var writeEnabled = triggered && (state.getPortValue(RamAppearance.getWEIndex(0, attrs)) == writeOnValue);
     if (writeEnabled && goodAddr && !misalignError) {
       for (var i = 0; i < dataLines; i++) {
         if (dataLines > 1) {
@@ -293,7 +294,9 @@ public class Ram extends Mem {
 
     // perform reads
     final var width = state.getAttributeValue(DATA_ATTR);
-    final var outputEnabled = separate || !state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(Value.FALSE);
+    final var readOffValue = attrs.getValue(RamAttributes.INVERT_OUTPUT_ENABLE) ? Value.TRUE : Value.FALSE;
+    final var outputEnabled = separate ||
+        !state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(readOffValue);
     if (outputEnabled && goodAddr && !misalignError) {
       for (var i = 0; i < dataLines; i++) {
         long val = myState.getContents().get(addr + i);
@@ -316,7 +319,9 @@ public class Ram extends Mem {
     long newMemValue = oldMemValue;
     // perform writes
     Object trigger = state.getAttributeValue(StdAttr.TRIGGER);
-    final var weValue = state.getPortValue(RamAppearance.getWEIndex(0, attrs));
+    final var rawWeValue = state.getPortValue(RamAppearance.getWEIndex(0, attrs));
+    final var weValue = state.getAttributeValue(RamAttributes.INVERT_WRITE_ENABLE)
+        ? invertValue(rawWeValue) : rawWeValue;
     final var async = trigger.equals(StdAttr.TRIG_HIGH) || trigger.equals(StdAttr.TRIG_LOW);
     final var edge =
         !async && myState
@@ -344,7 +349,8 @@ public class Ram extends Mem {
 
     // perform reads
     final var dataBits = state.getAttributeValue(DATA_ATTR);
-    final var outputNotEnabled = state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(Value.FALSE);
+    final var outputOffValue = state.getAttributeValue(RamAttributes.INVERT_OUTPUT_ENABLE) ? Value.TRUE : Value.FALSE;
+    final var outputNotEnabled = state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(outputOffValue);
 
     Consumer<Value> setValue = (Value value) -> state.setPort(RamAppearance.getDataOutIndex(0, attrs), value, DELAY);
 
@@ -381,6 +387,17 @@ public class Ram extends Mem {
       else
         setValue.accept(Value.createKnown(dataBits, oldMemValue));
     }
+  }
+
+  private Value invertValue(Value input) {
+    if (input == Value.TRUE) {
+      return Value.FALSE;
+    }
+    else if (input == Value.FALSE) {
+      return Value.TRUE;
+    }
+
+    return input;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/memory/RamAppearance.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAppearance.java
@@ -25,8 +25,6 @@ import com.cburch.logisim.util.GraphicsUtil;
 import java.awt.Color;
 import java.awt.BasicStroke;
 import java.awt.Graphics2D;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 
 public class RamAppearance {
@@ -694,7 +692,8 @@ public class RamAppearance {
       label = !classic ? "" : getNrOEPorts(attrs) == 1 ? "OE" : "OE" + i;
       final var idx = getOEIndex(i, attrs);
       if (!classic) {
-        drawCable(g, inst.getPortLocation(idx), attrs.getValue(RamAttributes.INVERT_OUTPUT_ENABLE));
+        drawCable(g, inst.getPortLocation(idx),
+            attrs.getValue(RamAttributes.OUTPUT_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH);
       }
       painter.drawPort(idx, label, Direction.EAST);
     }
@@ -703,7 +702,8 @@ public class RamAppearance {
       label = !classic ? "" : getNrWEPorts(attrs) == 1 ? "WE" : "WE" + i;
       final var idx = getWEIndex(i, attrs);
       if (!classic) {
-        drawCable(g, inst.getPortLocation(idx), attrs.getValue(RamAttributes.INVERT_WRITE_ENABLE));
+        drawCable(g, inst.getPortLocation(idx),
+            attrs.getValue(RamAttributes.WRITE_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH);
       }
       painter.drawPort(idx, label, Direction.EAST);
     }

--- a/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
@@ -91,8 +91,8 @@ public class RamAttributes extends AbstractAttributeSet {
     newList.add(Mem.ENABLES_ATTR);
     newList.add(ATTR_TYPE);
     newList.add(CLEAR_PIN);
-    newList.add(INVERT_OUTPUT_ENABLE);
     newList.add(INVERT_WRITE_ENABLE);
+    newList.add(INVERT_OUTPUT_ENABLE);
     if (typeOfEnables.equals(Mem.USEBYTEENABLES)) {
       newList.add(StdAttr.TRIGGER);
       if (trigger.equals(StdAttr.TRIG_RISING) || trigger.equals(StdAttr.TRIG_FALLING)) {

--- a/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
@@ -72,9 +72,7 @@ public class RamAttributes extends AbstractAttributeSet {
   private Boolean allowMisaligned = false;
   private AttributeOption typeOfEnables = Mem.USEBYTEENABLES;
   private AttributeOption ramType = VOLATILE;
-
   private Boolean invertOutputEnable = false;
-
   private Boolean invertWriteEnable = false;
 
   RamAttributes() {

--- a/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
@@ -50,6 +50,12 @@ public class RamAttributes extends AbstractAttributeSet {
           new AttributeOption[] {BUS_WITH_BYTEENABLES, BUS_WITHOUT_BYTE_ENABLES});
   static final Attribute<Boolean> CLEAR_PIN =
       Attributes.forBoolean("clearpin", S.getter("RamClearPin"));
+
+  static final Attribute<Boolean> INVERT_OUTPUT_ENABLE =
+      Attributes.forBoolean("invertOE", S.getter("memInvertOutputEnable"));
+
+  static final Attribute<Boolean> INVERT_WRITE_ENABLE =
+      Attributes.forBoolean("invertWE", S.getter("memInvertWriteEnable"));
   private final ArrayList<Attribute<?>> myAttributes = new ArrayList<>();
 
   private BitWidth addrBits = BitWidth.create(8);
@@ -69,6 +75,10 @@ public class RamAttributes extends AbstractAttributeSet {
   private AttributeOption typeOfEnables = Mem.USEBYTEENABLES;
   private AttributeOption ramType = VOLATILE;
 
+  private Boolean invertOutputEnable = false;
+
+  private Boolean invertWriteEnable = false;
+
   RamAttributes() {
     updateAttributes();
   }
@@ -81,6 +91,8 @@ public class RamAttributes extends AbstractAttributeSet {
     newList.add(Mem.ENABLES_ATTR);
     newList.add(ATTR_TYPE);
     newList.add(CLEAR_PIN);
+    newList.add(INVERT_OUTPUT_ENABLE);
+    newList.add(INVERT_WRITE_ENABLE);
     if (typeOfEnables.equals(Mem.USEBYTEENABLES)) {
       newList.add(StdAttr.TRIGGER);
       if (trigger.equals(StdAttr.TRIG_RISING) || trigger.equals(StdAttr.TRIG_FALLING)) {
@@ -134,6 +146,8 @@ public class RamAttributes extends AbstractAttributeSet {
     d.allowMisaligned = allowMisaligned;
     d.typeOfEnables = typeOfEnables;
     d.ramType = ramType;
+    d.invertWriteEnable = invertWriteEnable;
+    d.invertOutputEnable = invertOutputEnable;
   }
 
   @Override
@@ -191,6 +205,12 @@ public class RamAttributes extends AbstractAttributeSet {
     }
     if (attr == Mem.ENABLES_ATTR) {
       return (V) typeOfEnables;
+    }
+    if (attr == INVERT_OUTPUT_ENABLE) {
+      return (V) invertOutputEnable;
+    }
+    if (attr == INVERT_WRITE_ENABLE) {
+      return (V) invertWriteEnable;
     }
     return null;
   }
@@ -295,6 +315,20 @@ public class RamAttributes extends AbstractAttributeSet {
       if (appearance.equals(option)) return;
       appearance = option;
       fireAttributeValueChanged(attr, value, null);
+    }
+    else if (attr == INVERT_OUTPUT_ENABLE) {
+      final var val = (Boolean) value;
+      if (invertOutputEnable != val) {
+        invertOutputEnable = val;
+        fireAttributeValueChanged(attr, value, null);
+      }
+    }
+    else if (attr == INVERT_WRITE_ENABLE) {
+      final var val = (Boolean) value;
+      if (invertWriteEnable != val) {
+        invertWriteEnable = val;
+        fireAttributeValueChanged(attr, value, null);
+      }
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
@@ -52,10 +52,10 @@ public class RamAttributes extends AbstractAttributeSet {
       Attributes.forBoolean("clearpin", S.getter("RamClearPin"));
 
   static final Attribute<Boolean> INVERT_OUTPUT_ENABLE =
-      Attributes.forBoolean("invertOE", S.getter("memInvertOutputEnable"));
+      Attributes.forBoolean("invertOE", S.getter("ramInvertOutputEnable"));
 
   static final Attribute<Boolean> INVERT_WRITE_ENABLE =
-      Attributes.forBoolean("invertWE", S.getter("memInvertWriteEnable"));
+      Attributes.forBoolean("invertWE", S.getter("ramInvertWriteEnable"));
   private final ArrayList<Attribute<?>> myAttributes = new ArrayList<>();
 
   private BitWidth addrBits = BitWidth.create(8);

--- a/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
@@ -315,15 +315,13 @@ public class RamAttributes extends AbstractAttributeSet {
       if (appearance.equals(option)) return;
       appearance = option;
       fireAttributeValueChanged(attr, value, null);
-    }
-    else if (attr == INVERT_OUTPUT_ENABLE) {
+    } else if (attr == INVERT_OUTPUT_ENABLE) {
       final var val = (Boolean) value;
       if (invertOutputEnable != val) {
         invertOutputEnable = val;
         fireAttributeValueChanged(attr, value, null);
       }
-    }
-    else if (attr == INVERT_WRITE_ENABLE) {
+    } else if (attr == INVERT_WRITE_ENABLE) {
       final var val = (Boolean) value;
       if (invertWriteEnable != val) {
         invertWriteEnable = val;

--- a/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
@@ -50,10 +50,14 @@ public class RamAttributes extends AbstractAttributeSet {
           new AttributeOption[] {BUS_WITH_BYTEENABLES, BUS_WITHOUT_BYTE_ENABLES});
   static final Attribute<Boolean> CLEAR_PIN =
       Attributes.forBoolean("clearpin", S.getter("RamClearPin"));
-  static final Attribute<Boolean> INVERT_OUTPUT_ENABLE =
-      Attributes.forBoolean("invertOE", S.getter("ramInvertOutputEnable"));
-  static final Attribute<Boolean> INVERT_WRITE_ENABLE =
-      Attributes.forBoolean("invertWE", S.getter("ramInvertWriteEnable"));
+  static final AttributeOption ENABLE_ACTIVE_HIGH = new AttributeOption("activeHigh", S.getter("ramActiveHigh"));
+  static final AttributeOption ENABLE_ACTIVE_LOW = new AttributeOption("activeLow", S.getter("ramActiveLow"));
+  static final Attribute<AttributeOption> OUTPUT_ENABLE_MODE =
+      Attributes.forOption("outputEnableMode", S.getter("ramOutputEnableMode"),
+          new AttributeOption[] {ENABLE_ACTIVE_HIGH, ENABLE_ACTIVE_LOW});
+  static final Attribute<AttributeOption> WRITE_ENABLE_MODE =
+      Attributes.forOption("writeEnableMode", S.getter("ramWriteEnableMode"),
+          new AttributeOption[] {ENABLE_ACTIVE_HIGH, ENABLE_ACTIVE_LOW});
   private final ArrayList<Attribute<?>> myAttributes = new ArrayList<>();
 
   private BitWidth addrBits = BitWidth.create(8);
@@ -72,8 +76,8 @@ public class RamAttributes extends AbstractAttributeSet {
   private Boolean allowMisaligned = false;
   private AttributeOption typeOfEnables = Mem.USEBYTEENABLES;
   private AttributeOption ramType = VOLATILE;
-  private Boolean invertOutputEnable = false;
-  private Boolean invertWriteEnable = false;
+  private AttributeOption outputEnableMode = ENABLE_ACTIVE_HIGH;
+  private AttributeOption writeEnableMode = ENABLE_ACTIVE_HIGH;
 
   RamAttributes() {
     updateAttributes();
@@ -87,8 +91,8 @@ public class RamAttributes extends AbstractAttributeSet {
     newList.add(Mem.ENABLES_ATTR);
     newList.add(ATTR_TYPE);
     newList.add(CLEAR_PIN);
-    newList.add(INVERT_WRITE_ENABLE);
-    newList.add(INVERT_OUTPUT_ENABLE);
+    newList.add(WRITE_ENABLE_MODE);
+    newList.add(OUTPUT_ENABLE_MODE);
     if (typeOfEnables.equals(Mem.USEBYTEENABLES)) {
       newList.add(StdAttr.TRIGGER);
       if (trigger.equals(StdAttr.TRIG_RISING) || trigger.equals(StdAttr.TRIG_FALLING)) {
@@ -142,8 +146,8 @@ public class RamAttributes extends AbstractAttributeSet {
     d.allowMisaligned = allowMisaligned;
     d.typeOfEnables = typeOfEnables;
     d.ramType = ramType;
-    d.invertWriteEnable = invertWriteEnable;
-    d.invertOutputEnable = invertOutputEnable;
+    d.writeEnableMode = writeEnableMode;
+    d.outputEnableMode = outputEnableMode;
   }
 
   @Override
@@ -202,11 +206,11 @@ public class RamAttributes extends AbstractAttributeSet {
     if (attr == Mem.ENABLES_ATTR) {
       return (V) typeOfEnables;
     }
-    if (attr == INVERT_OUTPUT_ENABLE) {
-      return (V) invertOutputEnable;
+    if (attr == OUTPUT_ENABLE_MODE) {
+      return (V) outputEnableMode;
     }
-    if (attr == INVERT_WRITE_ENABLE) {
-      return (V) invertWriteEnable;
+    if (attr == WRITE_ENABLE_MODE) {
+      return (V) writeEnableMode;
     }
     return null;
   }
@@ -311,16 +315,16 @@ public class RamAttributes extends AbstractAttributeSet {
       if (appearance.equals(option)) return;
       appearance = option;
       fireAttributeValueChanged(attr, value, null);
-    } else if (attr == INVERT_OUTPUT_ENABLE) {
-      final var val = (Boolean) value;
-      if (invertOutputEnable != val) {
-        invertOutputEnable = val;
+    } else if (attr == OUTPUT_ENABLE_MODE) {
+      final var val = (AttributeOption) value;
+      if (outputEnableMode != val) {
+        outputEnableMode = val;
         fireAttributeValueChanged(attr, value, null);
       }
-    } else if (attr == INVERT_WRITE_ENABLE) {
-      final var val = (Boolean) value;
-      if (invertWriteEnable != val) {
-        invertWriteEnable = val;
+    } else if (attr == WRITE_ENABLE_MODE) {
+      final var val = (AttributeOption) value;
+      if (writeEnableMode != val) {
+        writeEnableMode = val;
         fireAttributeValueChanged(attr, value, null);
       }
     }

--- a/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
@@ -50,10 +50,8 @@ public class RamAttributes extends AbstractAttributeSet {
           new AttributeOption[] {BUS_WITH_BYTEENABLES, BUS_WITHOUT_BYTE_ENABLES});
   static final Attribute<Boolean> CLEAR_PIN =
       Attributes.forBoolean("clearpin", S.getter("RamClearPin"));
-
   static final Attribute<Boolean> INVERT_OUTPUT_ENABLE =
       Attributes.forBoolean("invertOE", S.getter("ramInvertOutputEnable"));
-
   static final Attribute<Boolean> INVERT_WRITE_ENABLE =
       Attributes.forBoolean("invertWE", S.getter("ramInvertWriteEnable"));
   private final ArrayList<Attribute<?>> myAttributes = new ArrayList<>();

--- a/src/main/java/com/cburch/logisim/std/memory/RamHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamHdlGeneratorFactory.java
@@ -234,7 +234,8 @@ public class RamHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     final var syncRead = !attrs.containsAttribute(Mem.ASYNC_READ) || !attrs.getValue(Mem.ASYNC_READ);
     final var clearPin = attrs.getValue(RamAttributes.CLEAR_PIN) == null ? false : attrs.getValue(RamAttributes.CLEAR_PIN);
     final var readAfterWrite = !attrs.containsAttribute(Mem.READ_ATTR) || attrs.getValue(Mem.READ_ATTR).equals(Mem.READAFTERWRITE);
-    final var invertEnable = attrs.getValue(RamAttributes.INVERT_OUTPUT_ENABLE) || attrs.getValue(RamAttributes.INVERT_WRITE_ENABLE);
+    final var invertEnable = attrs.getValue(RamAttributes.OUTPUT_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH ||
+        attrs.getValue(RamAttributes.WRITE_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH;
     return Hdl.isVhdl() && separate && !asynch && byteEnabled && syncRead && !clearPin
         && readAfterWrite && !invertEnable;
   }

--- a/src/main/java/com/cburch/logisim/std/memory/RamHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamHdlGeneratorFactory.java
@@ -234,6 +234,8 @@ public class RamHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     final var syncRead = !attrs.containsAttribute(Mem.ASYNC_READ) || !attrs.getValue(Mem.ASYNC_READ);
     final var clearPin = attrs.getValue(RamAttributes.CLEAR_PIN) == null ? false : attrs.getValue(RamAttributes.CLEAR_PIN);
     final var readAfterWrite = !attrs.containsAttribute(Mem.READ_ATTR) || attrs.getValue(Mem.READ_ATTR).equals(Mem.READAFTERWRITE);
-    return Hdl.isVhdl() && separate && !asynch && byteEnabled && syncRead && !clearPin && readAfterWrite;
+    final var invertEnable = attrs.getValue(RamAttributes.INVERT_OUTPUT_ENABLE) || attrs.getValue(RamAttributes.INVERT_WRITE_ENABLE);
+    return Hdl.isVhdl() && separate && !asynch && byteEnabled && syncRead && !clearPin
+        && readAfterWrite && !invertEnable;
   }
 }

--- a/src/main/java/com/cburch/logisim/std/memory/RamHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamHdlGeneratorFactory.java
@@ -234,8 +234,8 @@ public class RamHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     final var syncRead = !attrs.containsAttribute(Mem.ASYNC_READ) || !attrs.getValue(Mem.ASYNC_READ);
     final var clearPin = attrs.getValue(RamAttributes.CLEAR_PIN) == null ? false : attrs.getValue(RamAttributes.CLEAR_PIN);
     final var readAfterWrite = !attrs.containsAttribute(Mem.READ_ATTR) || attrs.getValue(Mem.READ_ATTR).equals(Mem.READAFTERWRITE);
-    final var invertEnable = attrs.getValue(RamAttributes.OUTPUT_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH ||
-        attrs.getValue(RamAttributes.WRITE_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH;
+    final var invertEnable = attrs.getValue(RamAttributes.OUTPUT_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH
+        || attrs.getValue(RamAttributes.WRITE_ENABLE_MODE) != RamAttributes.ENABLE_ACTIVE_HIGH;
     return Hdl.isVhdl() && separate && !asynch && byteEnabled && syncRead && !clearPin
         && readAfterWrite && !invertEnable;
   }

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -612,8 +612,10 @@ ramTypeAttr = Ram type
 ramTypeNonVolatile = non volatile
 ramTypeVolatile = volatile
 ramWithByteEnables = Use byte enables
-ramInvertOutputEnable = Invert output enable
-ramInvertWriteEnable = Invert write enable
+ramOutputEnableMode = Output enable Mode
+ramWriteEnableMode =  Write enable mode
+ramActiveHigh = Active High
+ramActiveLow = Active Low
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -612,6 +612,8 @@ ramTypeAttr = Ram type
 ramTypeNonVolatile = non volatile
 ramTypeVolatile = volatile
 ramWithByteEnables = Use byte enables
+ramInvertOutputEnable = Invert output enable
+ramInvertWriteEnable = Invert write enable
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -597,6 +597,8 @@ ramTypeAttr = Ram-Typ
 ramTypeNonVolatile = nichtflüchtig
 ramTypeVolatile = flüchtige
 ramWithByteEnables = Byte verwenden aktiviert
+# ==> ramInvertOutputEnable =
+# ==> ramInvertWriteEnable =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -597,8 +597,10 @@ ramTypeAttr = Ram-Typ
 ramTypeNonVolatile = nichtflüchtig
 ramTypeVolatile = flüchtige
 ramWithByteEnables = Byte verwenden aktiviert
-# ==> ramInvertOutputEnable =
-# ==> ramInvertWriteEnable =
+# ==> ramOutputEnableMode =
+# ==> ramWriteEnableMode =
+# ==> ramActiveHigh =
+# ==> ramActiveLow =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -597,8 +597,10 @@ ramWETip = Store: αν 1, αποθηκεύει την είσοδο στη μνή
 # ==> ramTypeNonVolatile =
 # ==> ramTypeVolatile =
 # ==> ramWithByteEnables =
-# ==> ramInvertOutputEnable =
-# ==> ramInvertWriteEnable =
+# ==> ramOutputEnableMode =
+# ==> ramWriteEnableMode =
+# ==> ramActiveHigh =
+# ==> ramActiveLow =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -597,6 +597,8 @@ ramWETip = Store: αν 1, αποθηκεύει την είσοδο στη μνή
 # ==> ramTypeNonVolatile =
 # ==> ramTypeVolatile =
 # ==> ramWithByteEnables =
+# ==> ramInvertOutputEnable =
+# ==> ramInvertWriteEnable =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -597,8 +597,10 @@ ramTypeAttr = Tipo de carnero
 ramTypeNonVolatile = no volátil
 ramTypeVolatile = volátil
 ramWithByteEnables = Usar byte enable (máscaras)
-# ==> ramInvertOutputEnable =
-# ==> ramInvertWriteEnable =
+# ==> ramOutputEnableMode =
+# ==> ramWriteEnableMode =
+# ==> ramActiveHigh =
+# ==> ramActiveLow =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -597,6 +597,8 @@ ramTypeAttr = Tipo de carnero
 ramTypeNonVolatile = no volátil
 ramTypeVolatile = volátil
 ramWithByteEnables = Usar byte enable (máscaras)
+# ==> ramInvertOutputEnable =
+# ==> ramInvertWriteEnable =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -612,6 +612,8 @@ ramTypeAttr = Type de RAM
 ramTypeNonVolatile = non volatile
 ramTypeVolatile = volatile
 ramWithByteEnables = Utiliser les activations par octet
+# ==> ramInvertOutputEnable =
+# ==> ramInvertWriteEnable =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -612,8 +612,10 @@ ramTypeAttr = Type de RAM
 ramTypeNonVolatile = non volatile
 ramTypeVolatile = volatile
 ramWithByteEnables = Utiliser les activations par octet
-# ==> ramInvertOutputEnable =
-# ==> ramInvertWriteEnable =
+# ==> ramOutputEnableMode =
+# ==> ramWriteEnableMode =
+# ==> ramActiveHigh =
+# ==> ramActiveLow =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -597,6 +597,8 @@ ramTypeAttr = Tipo di ariete
 ramTypeNonVolatile = non volatile
 ramTypeVolatile = Volubile
 ramWithByteEnables = Il byte di utilizzo abilita
+# ==> ramInvertOutputEnable =
+# ==> ramInvertWriteEnable =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -597,8 +597,10 @@ ramTypeAttr = Tipo di ariete
 ramTypeNonVolatile = non volatile
 ramTypeVolatile = Volubile
 ramWithByteEnables = Il byte di utilizzo abilita
-# ==> ramInvertOutputEnable =
-# ==> ramInvertWriteEnable =
+# ==> ramOutputEnableMode =
+# ==> ramWriteEnableMode =
+# ==> ramActiveHigh =
+# ==> ramActiveLow =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -597,6 +597,8 @@ ramTypeAttr = Ram type
 ramTypeNonVolatile = 不揮発性
 ramTypeVolatile = 揮発性
 ramWithByteEnables = バイト有効化使用
+# ==> ramInvertOutputEnable =
+# ==> ramInvertWriteEnable =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -597,8 +597,10 @@ ramTypeAttr = Ram type
 ramTypeNonVolatile = 不揮発性
 ramTypeVolatile = 揮発性
 ramWithByteEnables = バイト有効化使用
-# ==> ramInvertOutputEnable =
-# ==> ramInvertWriteEnable =
+# ==> ramOutputEnableMode =
+# ==> ramWriteEnableMode =
+# ==> ramActiveHigh =
+# ==> ramActiveLow =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -613,8 +613,10 @@ ramTypeAttr = ramtype
 ramTypeNonVolatile = niet-vluchtig
 ramTypeVolatile = onstabiel
 ramWithByteEnables = Met de byte kunt u
-# ==> ramInvertOutputEnable =
-# ==> ramInvertWriteEnable =
+# ==> ramOutputEnableMode =
+# ==> ramWriteEnableMode =
+# ==> ramActiveHigh =
+# ==> ramActiveLow =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -613,6 +613,8 @@ ramTypeAttr = ramtype
 ramTypeNonVolatile = niet-vluchtig
 ramTypeVolatile = onstabiel
 ramWithByteEnables = Met de byte kunt u
+# ==> ramInvertOutputEnable =
+# ==> ramInvertWriteEnable =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -597,8 +597,10 @@ ramTypeAttr = Typ pamięci
 ramTypeNonVolatile = Nieulotna
 ramTypeVolatile = ulotna
 ramWithByteEnables = Użycie bajtu umożliwia
-# ==> ramInvertOutputEnable =
-# ==> ramInvertWriteEnable =
+# ==> ramOutputEnableMode =
+# ==> ramWriteEnableMode =
+# ==> ramActiveHigh =
+# ==> ramActiveLow =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -597,6 +597,8 @@ ramTypeAttr = Typ pamięci
 ramTypeNonVolatile = Nieulotna
 ramTypeVolatile = ulotna
 ramWithByteEnables = Użycie bajtu umożliwia
+# ==> ramInvertOutputEnable =
+# ==> ramInvertWriteEnable =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -597,8 +597,10 @@ ramTypeAttr = Tipo de carneiro
 ramTypeNonVolatile = não volátil
 ramTypeVolatile = volátil
 ramWithByteEnables = Usar ativação de byte
-ramInvertOutputEnable = Inverter pino load
-ramInvertWriteEnable = Inverter pino store
+ramOutputEnableMode = Modo do pino load
+ramWriteEnableMode =  Modo do pino store
+ramActiveHigh = Ativo quando ligado
+ramActiveLow = Ativo quando desligado
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -597,6 +597,8 @@ ramTypeAttr = Tipo de carneiro
 ramTypeNonVolatile = não volátil
 ramTypeVolatile = volátil
 ramWithByteEnables = Usar ativação de byte
+ramInvertOutputEnable = Inverter pino load
+ramInvertWriteEnable = Inverter pino store
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -597,6 +597,8 @@ ramTypeAttr = Очистка при сбросе схемы
 ramTypeNonVolatile = Нет
 ramTypeVolatile = Да
 ramWithByteEnables = Байт использования позволяет
+# ==> ramInvertOutputEnable =
+# ==> ramInvertWriteEnable =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -597,8 +597,10 @@ ramTypeAttr = Очистка при сбросе схемы
 ramTypeNonVolatile = Нет
 ramTypeVolatile = Да
 ramWithByteEnables = Байт использования позволяет
-# ==> ramInvertOutputEnable =
-# ==> ramInvertWriteEnable =
+# ==> ramOutputEnableMode =
+# ==> ramWriteEnableMode =
+# ==> ramActiveHigh =
+# ==> ramActiveLow =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -597,8 +597,10 @@ ramTypeAttr = RAM 型
 ramTypeNonVolatile = 非易失性
 ramTypeVolatile = 挥发性的
 ramWithByteEnables = 使用字节启用
-# ==> ramInvertOutputEnable =
-# ==> ramInvertWriteEnable =
+# ==> ramOutputEnableMode =
+# ==> ramWriteEnableMode =
+# ==> ramActiveHigh =
+# ==> ramActiveLow =
 #
 # memory/Random.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -597,6 +597,8 @@ ramTypeAttr = RAM 型
 ramTypeNonVolatile = 非易失性
 ramTypeVolatile = 挥发性的
 ramWithByteEnables = 使用字节启用
+# ==> ramInvertOutputEnable =
+# ==> ramInvertWriteEnable =
 #
 # memory/Random.java
 #


### PR DESCRIPTION
This PR contains an implementation for a negated output and write enable for the RAM component as requested in issue  #1510. 
The implementation considers errors/unknowns as false values when the invert enable is activated (so it does enable read/write). When the output/write enable invert is on, a little circle shows up in the connection, just like the clock does.