### PR TITLE
Fix: hotkey names are not localized immediately

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -72,6 +72,7 @@ class HotkeyOptions extends OptionsPanel {
     super(window);
     this.setLayout(new TableLayout(1));
 
+    /* settings the layout up */
     resetBtn = new JButton();
     resetBtn.addActionListener(e -> AppPreferences.resetHotkeys());
     add(resetBtn);
@@ -92,6 +93,12 @@ class HotkeyOptions extends OptionsPanel {
     JAdjustableScroll normalKeyScrollPane = new JAdjustableScroll(normalKeyPanel);
     add(normalKeyScrollPane);
 
+    menuKeyPanel.setMaximumSize(new Dimension(400, 400));
+    menuKeyPanel.setLayout(new TableLayout(2));
+    normalKeyPanel.setMaximumSize(new Dimension(400, 400));
+    normalKeyPanel.setLayout(new TableLayout(2));
+
+    /* bind up the hotkeys */
     Field[] fields = AppPreferences.class.getDeclaredFields();
     try {
       for (var f : fields) {
@@ -105,18 +112,11 @@ class HotkeyOptions extends OptionsPanel {
     } catch (Exception e) {
       AppPreferences.hotkeyReflectError(e);
     }
-
     keyInputList = new ArrayList<>();
     for (int i = 0; i < hotkeys.size(); i++) {
       keyInputList.add(new JHotkeyInput(window, ""));
     }
-
-
-    menuKeyPanel.setMaximumSize(new Dimension(400, 400));
-    menuKeyPanel.setLayout(new TableLayout(2));
-    normalKeyPanel.setMaximumSize(new Dimension(400, 400));
-    normalKeyPanel.setLayout(new TableLayout(2));
-
+    /* initialize the hotkey labels and hotkey-inputs */
     final JLabel[] keyLabels = new JLabel[hotkeys.size()];
     for (int i = 0; i < hotkeys.size(); i++) {
       /* I do this chore because they have a different layout */
@@ -158,7 +158,7 @@ class HotkeyOptions extends OptionsPanel {
       }
     }
 
-    /* Layout for arrow hotkeys */
+    /* adding layout for arrow hotkeys */
     normalKeyPanel.add(new JLabel(" "));
     normalKeyPanel.add(new JLabel(" "));
 

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -60,13 +60,19 @@ class HotkeyOptions extends OptionsPanel {
   private JHotkeyInput southBtn;
   private JHotkeyInput eastBtn;
   private JHotkeyInput westBtn;
+  private final JButton resetBtn;
+  private final JLabel orientDescLabel;
+  private final JLabel orientNorthLabel;
+  private final JLabel orientEastLabel;
+  private final JLabel orientSouthLabel;
+  private final JLabel orientWestLabel;
   private boolean preferredWidthSet = false;
 
   public HotkeyOptions(PreferencesFrame window) {
     super(window);
     this.setLayout(new TableLayout(1));
 
-    JButton resetBtn = new JButton(S.get("hotkeyOptResetBtn"));
+    resetBtn = new JButton();
     resetBtn.addActionListener(e -> AppPreferences.resetHotkeys());
     add(resetBtn);
     add(new JLabel(" "));
@@ -155,18 +161,25 @@ class HotkeyOptions extends OptionsPanel {
     /* Layout for arrow hotkeys */
     normalKeyPanel.add(new JLabel(" "));
     normalKeyPanel.add(new JLabel(" "));
-    normalKeyPanel.add(new JLabel(S.get("hotkeyOptOrientDesc")));
+
+    orientDescLabel = new JLabel();
+    normalKeyPanel.add(orientDescLabel);
     normalKeyPanel.add(new JLabel(" "));
     JPanel panelLeft = new JPanel();
     JPanel panelRight = new JPanel();
     panelLeft.setLayout(new TableLayout(3));
     panelRight.setLayout(new TableLayout(3));
+
+    orientEastLabel = new JLabel();
+    orientNorthLabel = new JLabel();
+    orientSouthLabel = new JLabel();
+    orientWestLabel = new JLabel();
     panelLeft.add(new JLabel(" "));
-    panelLeft.add(new JLabel(" " + S.get("hotkeyDirNorth") + " "));
+    panelLeft.add(orientNorthLabel);
     panelLeft.add(new JLabel(" "));
-    panelLeft.add(new JLabel(" " + S.get("hotkeyDirWest") + " "));
-    panelLeft.add(new JLabel(" " + S.get("hotkeyDirSouth") + " "));
-    panelLeft.add(new JLabel(" " + S.get("hotkeyDirEast") + " "));
+    panelLeft.add(orientWestLabel);
+    panelLeft.add(orientSouthLabel);
+    panelLeft.add(orientEastLabel);
     normalKeyPanel.add(panelLeft);
     panelRight.add(new JLabel(" "));
     panelRight.add(northBtn);
@@ -219,5 +232,11 @@ class HotkeyOptions extends OptionsPanel {
         InputEvent.getModifiersExText(AppPreferences.hotkeyMenuMask)));
     normalKeyHeaderLabel.setText(S.get("hotkeyOptNormalKeyHeader",
         InputEvent.getModifiersExText(AppPreferences.hotkeyMenuMask)));
+    resetBtn.setText(S.get("hotkeyOptResetBtn"));
+    orientDescLabel.setText(S.get("hotkeyOptOrientDesc"));
+    orientEastLabel.setText(" " + S.get("hotkeyDirEast") + " ");
+    orientWestLabel.setText(" " + S.get("hotkeyDirWest") + " ");
+    orientSouthLabel.setText(" " + S.get("hotkeyDirSouth") + " ");
+    orientNorthLabel.setText(" " + S.get("hotkeyDirNorth") + " ");
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/HotkeyOptions.java
@@ -54,6 +54,7 @@ class HotkeyOptions extends OptionsPanel {
    * */
   protected static List<PrefMonitor<KeyStroke>> hotkeys = new ArrayList<>();
   private final List<JHotkeyInput> keyInputList;
+  private final List<JLabel> keyLabels;
   private final JLabel menuKeyHeaderLabel;
   private final JLabel normalKeyHeaderLabel;
   private JHotkeyInput northBtn;
@@ -112,15 +113,17 @@ class HotkeyOptions extends OptionsPanel {
     } catch (Exception e) {
       AppPreferences.hotkeyReflectError(e);
     }
+
+    /* initialize the hotkey labels and hotkey-inputs */
     keyInputList = new ArrayList<>();
+    keyLabels = new ArrayList<>();
     for (int i = 0; i < hotkeys.size(); i++) {
       keyInputList.add(new JHotkeyInput(window, ""));
+      keyLabels.add(new JLabel());
     }
-    /* initialize the hotkey labels and hotkey-inputs */
-    final JLabel[] keyLabels = new JLabel[hotkeys.size()];
     for (int i = 0; i < hotkeys.size(); i++) {
       /* I do this chore because they have a different layout */
-      PrefMonitorKeyStroke prefKeyStroke = ((PrefMonitorKeyStroke) hotkeys.get(i));
+      var prefKeyStroke = ((PrefMonitorKeyStroke) hotkeys.get(i));
       if (hotkeys.get(i) == AppPreferences.HOTKEY_DIR_NORTH
           || hotkeys.get(i) == AppPreferences.HOTKEY_DIR_SOUTH
           || hotkeys.get(i) == AppPreferences.HOTKEY_DIR_EAST
@@ -145,15 +148,15 @@ class HotkeyOptions extends OptionsPanel {
         keyInputList.get(i).setBoundKeyStroke(prefKeyStroke);
         continue;
       }
-      keyLabels[i] = new JLabel(S.get(prefKeyStroke.getName()) + "  ");
+      keyLabels.get(i).setText(S.get(prefKeyStroke.getName()) + "  ");
       keyInputList.set(i, new JHotkeyInput(window, prefKeyStroke.getDisplayString()));
       keyInputList.get(i).setEnabled(prefKeyStroke.canModify());
       keyInputList.get(i).setBoundKeyStroke(prefKeyStroke);
       if (prefKeyStroke.needMetaKey()) {
-        menuKeyPanel.add(keyLabels[i]);
+        menuKeyPanel.add(keyLabels.get(i));
         menuKeyPanel.add(keyInputList.get(i));
       } else {
-        normalKeyPanel.add(keyLabels[i]);
+        normalKeyPanel.add(keyLabels.get(i));
         normalKeyPanel.add(keyInputList.get(i));
       }
     }
@@ -238,5 +241,15 @@ class HotkeyOptions extends OptionsPanel {
     orientWestLabel.setText(" " + S.get("hotkeyDirWest") + " ");
     orientSouthLabel.setText(" " + S.get("hotkeyDirSouth") + " ");
     orientNorthLabel.setText(" " + S.get("hotkeyDirNorth") + " ");
+    for (int i = 0; i < hotkeys.size(); i++) {
+      var prefKeyStroke = ((PrefMonitorKeyStroke) hotkeys.get(i));
+      if (hotkeys.get(i) == AppPreferences.HOTKEY_DIR_NORTH
+          || hotkeys.get(i) == AppPreferences.HOTKEY_DIR_SOUTH
+          || hotkeys.get(i) == AppPreferences.HOTKEY_DIR_EAST
+          || hotkeys.get(i) == AppPreferences.HOTKEY_DIR_WEST) {
+        continue;
+      }
+      keyLabels.get(i).setText(S.get(prefKeyStroke.getName()) + "  ");
+    }
   }
 }


### PR DESCRIPTION
I suddenly find that when we change the international settings, the strings in the hotkey tab are not localized timely, because I don't override the `public void localeChanged()` well.  Though after restarting the names are localized, it seems not good to break the original way that all the text are updated as long as the settings change. Now I have fixed the bug. Sorry to disturb.