### PR TITLE
S-R flip-flops behave different in HDL

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/SRFlipFlop.java
+++ b/src/main/java/com/cburch/logisim/std/memory/SRFlipFlop.java
@@ -36,7 +36,7 @@ public class SRFlipFlop extends AbstractFlipFlop {
     @Override
     public LineBuffer getUpdateLogic() {
       return LineBuffer.getHdlBuffer()
-          .add("{{assign}} s_nextState{{=}}(s_currentState{{or}}s){{and}}{{not}}(r);");
+          .add("{{assign}} s_nextState{{=}}(s_currentState{{and}}s){{or}}({{not}}(r){{and}}s){{or}}(s_currentState{{and}}{{not}}(r));");
     }
   }
 


### PR DESCRIPTION
Although the behaviour of S-R flip-flops is undefined when both inputs are high, it should be consistent in simulation and HDL export.
Fixes Issue #1874