### PR TITLE
Adding 16 bit float support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
   * Added TTL 74381: arithmetic logic unit
   * Added TTL 74541: Octal buffers with three-state outputs
   * Added TTL 74670: 4-by-4 register file with three-state outputs
+  * Added 16 bit floating point support for floating point arithmetic
 
 * v3.8.0 (2022-10-02)
   * Added reset value attribute to input pins

--- a/src/main/java/com/cburch/logisim/data/Value.java
+++ b/src/main/java/com/cburch/logisim/data/Value.java
@@ -545,89 +545,95 @@ public class Value {
 
   public float toFloatValueFromFP16() {
     if (error != 0 || unknown != 0 || width != 16) return Float.NaN;
+    // TODO: can replace fp16Tofp32_raw() with Float.float16ToFloat() in Java 20 or later
     return Float.intBitsToFloat(fp16Tofp32_raw((int) value));
   }
 
+  /**
+   * TODO: This function can be replaced with Float.Float.float16ToFloat() in Java 20 or later
+   */
   public static int fp16Tofp32_raw(int val) {
-    int oldExp = ((val >> 10) & 0b011111);
-    int oldFraction = (val & 0b0000001111111111);
-    boolean isEven = (val & 0b1000000000000000) == 0;
-    //check for zeros
+    final var oldExp = ((val >> 10) & 0b011111);
+    final var oldFraction = (val & 0b0000001111111111);
+    final var isEven = (val & 0b1000000000000000) == 0;
+    // check for zeros
     if (oldFraction == 0 && oldExp == 0) return isEven ? 0x00000000 : 0x80000000;
-    //figure out how much the exponent needs adjusted
-    int expAdjustment = 0;
-    //calculate adjustment if subnormal number
-    if (oldExp == 0 && oldFraction != 0)expAdjustment = Integer.numberOfLeadingZeros(oldFraction) - 21;
-    //get the new exponent while checking to see if is inf or NaN
-    int newExp = (oldExp == 0b11111) ? 0b11111111 : (oldExp - 15 + 127 - ((expAdjustment == 0) ? 0 : (expAdjustment - 1)));
-    //start putting together the float
-    //add the sign first
-    int out = isEven ? 0 : 0x80000000;
-    //add the exponent
+    // figure out how much the exponent needs adjusted
+    var expAdjustment = 0;
+    // calculate adjustment if subnormal number
+    if (oldExp == 0 && oldFraction != 0) expAdjustment = Integer.numberOfLeadingZeros(oldFraction) - 21;
+    // get the new exponent while checking to see if is inf or NaN
+    var newExp = (oldExp == 0b11111) ? 0b11111111 : (oldExp - 15 + 127 - ((expAdjustment == 0) ? 0 : (expAdjustment - 1)));
+    // start putting together the float
+    // add the sign first
+    var out = isEven ? 0 : 0x80000000;
+    // add the exponent
     out |= newExp << 23;
-    //add the fractional part accounting for any subnormal corrections
+    // add the fractional part accounting for any subnormal corrections
     out |= (oldFraction << (13 + expAdjustment)) & 0x007FFFFF;
-    //correct for NaNs
-    if (oldExp == 0b11111 && oldFraction != 0)out |= 0x0400000;
+    // correct for NaNs
+    if (oldExp == 0b11111 && oldFraction != 0) out |= 0x0400000;
     return out;
   }
 
+  /**
+   * TODO: This function can be replaced with Float.Float.floatToFloat16() in Java 20 or later
+   */
   public static int fp32Tofp16_raw(int val) {
-    //get the sign
-    boolean isEven = (val & 0x80000000) == 0;
-    //look at the exponent
-    int oldExp = ((val >> 23) & 0x0FF) - 127;
-    //get the fractional component
-    int oldFraction = (val & 0x007FFFFF);
-    //check for numbers that are too large or NaN
+    // get the sign
+    final var isEven = (val & 0x80000000) == 0;
+    // look at the exponent
+    final var oldExp = ((val >> 23) & 0x0FF) - 127;
+    // get the fractional component
+    final var oldFraction = (val & 0x007FFFFF);
+    // check for numbers that are too large or NaN
     if (oldExp > 15) {
       if (oldExp == 128 && oldFraction != 0) return (isEven ? 0x7E00 : 0xFE00) | (oldFraction >> 13); //NaN
       else return isEven ? 0x7C00 : 0xFC00; //Inf
     }
-    //check for numbers that are too small and will be zero
+    // check for numbers that are too small and will be zero
     if (oldExp < -25) return isEven ? 0x0000 : 0x8000;
-    //figure out wht the 16bit exponent will be
-    boolean isSubnormalNumber = oldExp <= -15;
-    int newExp;
+    // figure out wht the 16bit exponent will be
+    final var isSubnormalNumber = oldExp <= -15;
+    var newExp = oldExp;
     if (isSubnormalNumber) newExp = -15;
     else if (oldExp == 127) newExp = 15; //NaN
-    else newExp = oldExp;
-    //get the fraction with the hidden bit
-    int fraction = oldFraction | 0x00800000;
-    //handle numbers that will be subnormal at 16 bits
+    // get the fraction with the hidden bit
+    var fraction = oldFraction | 0x00800000;
+    // handle numbers that will be subnormal at 16 bits
     if (isSubnormalNumber) {
-      int fractionShift = -(oldExp + 14); //right shift amount fo fraction
-      //checking for rounding (round to nearest, ties to even)
-      int GRS = fraction & (0x1FFFFFFF >> (16 - fractionShift));
+      final var fractionShift = -(oldExp + 14); //right shift amount fo fraction
+      // checking for rounding (round to nearest, ties to even)
+      final var GRS = fraction & (0x1FFFFFFF >> (16 - fractionShift));
       if ((GRS > (0x1000 << fractionShift)) | (GRS == (0x1000 << fractionShift) & (fraction & (0x2000 << fractionShift)) != 0)) {
-        //need to round up
+        // need to round up
         fraction = (fraction >> (13 + fractionShift)) + 1;
         if (fraction >= 0x0400) {
-          //need to adjust exponent, but there is only one possibility
+          // need to adjust exponent, but there is only one possibility
           return isEven ? 0x0400 : 0x8400;
         }
       } else {
         fraction = fraction >> (13 + fractionShift);
       }
-    } else { //handle numbers that will be normal at 16 bits
-      //check for rounding (round to nearest, ties to even)
-      int GRS = fraction & 0x1FFF;
+    } else { // handle numbers that will be normal at 16 bits
+      // check for rounding (round to nearest, ties to even)
+      final var GRS = fraction & 0x1FFF;
       if ((GRS > 0x1000) | (GRS == 0x1000 & (fraction & 0x2000) != 0)) {
-        //need to round up
+        // need to round up
         fraction = (fraction >> 13) + 1;
         if (fraction >= 0x0800) {
-          //need to adjust exponent
+          // need to adjust exponent
           if (newExp == 15) return isEven ? 0x7C00 : 0xFC00; //rounded to infinity
           else if (newExp <= 14) newExp++;
-          //fix the fractional component
+          // fix the fractional component
           fraction = fraction >> 1;
         }
       } else {
         fraction = fraction >> 13;
       }
     }
-    //assemble
-    int out = isEven ? 0x0000 : 0x8000;
+    // assemble
+    var out = isEven ? 0x0000 : 0x8000;
     out |= (newExp + 15) << 10;
     out |= fraction & 0x03FF;
     return out & 0xFFFF;

--- a/src/main/java/com/cburch/logisim/instance/StdAttr.java
+++ b/src/main/java/com/cburch/logisim/instance/StdAttr.java
@@ -71,7 +71,7 @@ public interface StdAttr {
       Attributes.forOption(
           "fpwidth",
           S.getter("stdFPDataWidthAttr"),
-          new BitWidth[] {BitWidth.create(32), BitWidth.create(64)});
+          new BitWidth[] {BitWidth.create(16), BitWidth.create(32), BitWidth.create(64)});
 
   AttributeOption SELECT_BOTTOM_LEFT =
       new AttributeOption("bl", S.getter("stdSelectBottomLeftOption"));

--- a/src/main/java/com/cburch/logisim/std/arith/FpAdder.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpAdder.java
@@ -110,6 +110,7 @@ public class FpAdder extends InstanceFactory {
 
     final var out_val = a_val + b_val;
     final var out = switch (dataWidth.getWidth()) {
+      // TODO: can replace Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)) with Float.floatToFloat16((float) out_val) in Java 20 or later
       case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
       case 32 -> Value.createKnown((float) out_val);
       case 64 -> Value.createKnown(out_val);

--- a/src/main/java/com/cburch/logisim/std/arith/FpAdder.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpAdder.java
@@ -95,14 +95,26 @@ public class FpAdder extends InstanceFactory {
     final var a = state.getPortValue(IN0);
     final var b = state.getPortValue(IN1);
 
-    final var a_val = dataWidth.getWidth() == 64 ? a.toDoubleValue() : a.toFloatValue();
-    final var b_val = dataWidth.getWidth() == 64 ? b.toDoubleValue() : b.toFloatValue();
+    final var a_val = switch (dataWidth.getWidth()) {
+      case 16 -> a.toFloatValueFromFP16();
+      case 32 -> a.toFloatValue();
+      case 64 -> a.toDoubleValue();
+      default -> Double.NaN;
+    };
+    final var b_val = switch (dataWidth.getWidth()) {
+      case 16 -> b.toFloatValueFromFP16();
+      case 32 -> b.toFloatValue();
+      case 64 -> b.toDoubleValue();
+      default -> Double.NaN;
+    };
 
     final var out_val = a_val + b_val;
-    final var out =
-        dataWidth.getWidth() == 64
-            ? Value.createKnown(out_val)
-            : Value.createKnown((float) out_val);
+    final var out = switch (dataWidth.getWidth()) {
+      case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
+      case 32 -> Value.createKnown((float) out_val);
+      case 64 -> Value.createKnown(out_val);
+      default -> Value.ERROR;
+    };
 
     // propagate them
     final var delay = (dataWidth.getWidth() + 2) * PER_DELAY;

--- a/src/main/java/com/cburch/logisim/std/arith/FpComparator.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpComparator.java
@@ -113,8 +113,18 @@ public class FpComparator extends InstanceFactory {
     final var a = state.getPortValue(IN0);
     final var b = state.getPortValue(IN1);
 
-    final var a_val = dataWidth.getWidth() == 64 ? a.toDoubleValue() : a.toFloatValue();
-    final var b_val = dataWidth.getWidth() == 64 ? b.toDoubleValue() : b.toFloatValue();
+    final var a_val = switch (dataWidth.getWidth()) {
+      case 16 -> a.toFloatValueFromFP16();
+      case 32 -> a.toFloatValue();
+      case 64 -> a.toDoubleValue();
+      default -> Double.NaN;
+    };
+    final var b_val = switch (dataWidth.getWidth()) {
+      case 16 -> b.toFloatValueFromFP16();
+      case 32 -> b.toFloatValue();
+      case 64 -> b.toDoubleValue();
+      default -> Double.NaN;
+    };
 
     // propagate them
     final var delay = (dataWidth.getWidth() + 2) * PER_DELAY;

--- a/src/main/java/com/cburch/logisim/std/arith/FpDivider.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpDivider.java
@@ -111,6 +111,7 @@ public class FpDivider extends InstanceFactory {
 
     final var out_val = a_val / b_val;
     final var out = switch (dataWidth.getWidth()) {
+      // TODO: can replace Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)) with Float.floatToFloat16((float) out_val) in Java 20 or later
       case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
       case 32 -> Value.createKnown((float) out_val);
       case 64 -> Value.createKnown(out_val);

--- a/src/main/java/com/cburch/logisim/std/arith/FpDivider.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpDivider.java
@@ -96,14 +96,26 @@ public class FpDivider extends InstanceFactory {
     final var a = state.getPortValue(IN0);
     final var b = state.getPortValue(IN1);
 
-    final var a_val = dataWidth.getWidth() == 64 ? a.toDoubleValue() : a.toFloatValue();
-    final var b_val = dataWidth.getWidth() == 64 ? b.toDoubleValue() : b.toFloatValue();
+    final var a_val = switch (dataWidth.getWidth()) {
+      case 16 -> a.toFloatValueFromFP16();
+      case 32 -> a.toFloatValue();
+      case 64 -> a.toDoubleValue();
+      default -> Double.NaN;
+    };
+    final var b_val = switch (dataWidth.getWidth()) {
+      case 16 -> b.toFloatValueFromFP16();
+      case 32 -> b.toFloatValue();
+      case 64 -> b.toDoubleValue();
+      default -> Double.NaN;
+    };
 
     final var out_val = a_val / b_val;
-    final var out =
-        dataWidth.getWidth() == 64
-            ? Value.createKnown(out_val)
-            : Value.createKnown((float) out_val);
+    final var out = switch (dataWidth.getWidth()) {
+      case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
+      case 32 -> Value.createKnown((float) out_val);
+      case 64 -> Value.createKnown(out_val);
+      default -> Value.ERROR;
+    };
 
     // propagate them
     final var delay = (dataWidth.getWidth() + 2) * PER_DELAY;

--- a/src/main/java/com/cburch/logisim/std/arith/FpMultiplier.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpMultiplier.java
@@ -95,14 +95,26 @@ public class FpMultiplier extends InstanceFactory {
     final var a = state.getPortValue(IN0);
     final var b = state.getPortValue(IN1);
 
-    final var a_val = dataWidth.getWidth() == 64 ? a.toDoubleValue() : a.toFloatValue();
-    final var b_val = dataWidth.getWidth() == 64 ? b.toDoubleValue() : b.toFloatValue();
+    final var a_val = switch (dataWidth.getWidth()) {
+      case 16 -> a.toFloatValueFromFP16();
+      case 32 -> a.toFloatValue();
+      case 64 -> a.toDoubleValue();
+      default -> Double.NaN;
+    };
+    final var b_val = switch (dataWidth.getWidth()) {
+      case 16 -> b.toFloatValueFromFP16();
+      case 32 -> b.toFloatValue();
+      case 64 -> b.toDoubleValue();
+      default -> Double.NaN;
+    };
 
     final var out_val = a_val * b_val;
-    final var out =
-        dataWidth.getWidth() == 64
-            ? Value.createKnown(out_val)
-            : Value.createKnown((float) out_val);
+    final var out = switch (dataWidth.getWidth()) {
+      case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
+      case 32 -> Value.createKnown((float) out_val);
+      case 64 -> Value.createKnown(out_val);
+      default -> Value.ERROR;
+    };
 
     // propagate them
     final var delay = (dataWidth.getWidth() + 2) * PER_DELAY;

--- a/src/main/java/com/cburch/logisim/std/arith/FpMultiplier.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpMultiplier.java
@@ -110,6 +110,7 @@ public class FpMultiplier extends InstanceFactory {
 
     final var out_val = a_val * b_val;
     final var out = switch (dataWidth.getWidth()) {
+      // TODO: can replace Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)) with Float.floatToFloat16((float) out_val) in Java 20 or later
       case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
       case 32 -> Value.createKnown((float) out_val);
       case 64 -> Value.createKnown(out_val);

--- a/src/main/java/com/cburch/logisim/std/arith/FpNegator.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpNegator.java
@@ -94,6 +94,7 @@ public class FpNegator extends InstanceFactory {
 
     final var out_val = a_val * -1;
     final var out = switch (dataWidth.getWidth()) {
+      // TODO: can replace Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)) with Float.floatToFloat16((float) out_val) in Java 20 or later
       case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
       case 32 -> Value.createKnown((float) out_val);
       case 64 -> Value.createKnown(out_val);

--- a/src/main/java/com/cburch/logisim/std/arith/FpSubtractor.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpSubtractor.java
@@ -109,6 +109,7 @@ public class FpSubtractor extends InstanceFactory {
 
     final var out_val = a_val - b_val;
     final var out = switch (dataWidth.getWidth()) {
+      // TODO: can replace Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)) with Float.floatToFloat16((float) out_val) in Java 20 or later
       case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
       case 32 -> Value.createKnown((float) out_val);
       case 64 -> Value.createKnown(out_val);

--- a/src/main/java/com/cburch/logisim/std/arith/FpSubtractor.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpSubtractor.java
@@ -94,14 +94,26 @@ public class FpSubtractor extends InstanceFactory {
     final var a = state.getPortValue(IN0);
     final var b = state.getPortValue(IN1);
 
-    final var a_val = dataWidth.getWidth() == 64 ? a.toDoubleValue() : a.toFloatValue();
-    final var b_val = dataWidth.getWidth() == 64 ? b.toDoubleValue() : b.toFloatValue();
+    final var a_val = switch (dataWidth.getWidth()) {
+      case 16 -> a.toFloatValueFromFP16();
+      case 32 -> a.toFloatValue();
+      case 64 -> a.toDoubleValue();
+      default -> Double.NaN;
+    };
+    final var b_val = switch (dataWidth.getWidth()) {
+      case 16 -> b.toFloatValueFromFP16();
+      case 32 -> b.toFloatValue();
+      case 64 -> b.toDoubleValue();
+      default -> Double.NaN;
+    };
 
     final var out_val = a_val - b_val;
-    final var out =
-        dataWidth.getWidth() == 64
-            ? Value.createKnown(out_val)
-            : Value.createKnown((float) out_val);
+    final var out = switch (dataWidth.getWidth()) {
+      case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
+      case 32 -> Value.createKnown((float) out_val);
+      case 64 -> Value.createKnown(out_val);
+      default -> Value.ERROR;
+    };
 
     // propagate them
     final var delay = (dataWidth.getWidth() + 2) * PER_DELAY;

--- a/src/main/java/com/cburch/logisim/std/arith/FpToInt.java
+++ b/src/main/java/com/cburch/logisim/std/arith/FpToInt.java
@@ -95,7 +95,12 @@ public class FpToInt extends InstanceFactory {
 
     // compute outputs
     final var a = state.getPortValue(IN);
-    final var a_val = dataWidthIn.getWidth() == 64 ? a.toDoubleValue() : a.toFloatValue();
+    final var a_val = switch (dataWidthIn.getWidth()) {
+      case 16 -> a.toFloatValueFromFP16();
+      case 32 -> a.toFloatValue();
+      case 64 -> a.toDoubleValue();
+      default -> Double.NaN;
+    };
 
     long out_val;
 

--- a/src/main/java/com/cburch/logisim/std/arith/IntToFp.java
+++ b/src/main/java/com/cburch/logisim/std/arith/IntToFp.java
@@ -93,10 +93,12 @@ public class IntToFp extends InstanceFactory {
     final var a_val = extend(dataWidthIn.getWidth(), a.toLongValue(), unsigned);
 
     final var out_val = a.isFullyDefined() ? a_val.doubleValue() : Double.NaN;
-    final var out =
-        dataWidthOut.getWidth() == 64
-            ? Value.createKnown(out_val)
-            : Value.createKnown((float) out_val);
+    final var out = switch (dataWidthOut.getWidth()) {
+      case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
+      case 32 -> Value.createKnown((float) out_val);
+      case 64 -> Value.createKnown(out_val);
+      default -> Value.ERROR;
+    };
 
     // propagate them
     final var delay = (dataWidthIn.getWidth() + 2) * PER_DELAY;

--- a/src/main/java/com/cburch/logisim/std/arith/IntToFp.java
+++ b/src/main/java/com/cburch/logisim/std/arith/IntToFp.java
@@ -94,6 +94,7 @@ public class IntToFp extends InstanceFactory {
 
     final var out_val = a.isFullyDefined() ? a_val.doubleValue() : Double.NaN;
     final var out = switch (dataWidthOut.getWidth()) {
+      // TODO: can replace Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)) with Float.floatToFloat16((float) out_val) in Java 20 or later
       case 16 -> Value.createKnown(16, Value.fp32Tofp16_raw(Float.floatToRawIntBits((float) out_val)));
       case 32 -> Value.createKnown((float) out_val);
       case 64 -> Value.createKnown(out_val);


### PR DESCRIPTION
This is done by converting all 16 bit floats to 32 bit then back to 16 bit. Conversion functions were validated against `Float.float16ToFloat()` and `Float.floatToFloat16()` available in Java 20 and later. In the future if updated to use Java 20 or newer would recommend switching to built in functions.
This relates to #1610 
Attached is the conversion validation file, which only runs in Java 20 or newer. I am not sure if there is a better way to store it or if it is even needed.
[Main.txt](https://github.com/logisim-evolution/logisim-evolution/files/12741860/Main.txt)