### PR TITLE
Canonicalize both paths before comparing

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/settings/BoardList.java
+++ b/src/main/java/com/cburch/logisim/fpga/settings/BoardList.java
@@ -77,16 +77,19 @@ public class BoardList {
       final var fileName = ze.getName();
       final var accept = pattern.matcher(fileName).matches() && fileName.contains(match);
       if (accept) {
-        // Check that fileName doesn't stray outside target directory: Zip Slip security test.
-        if (!(new File(dir, fileName)).toPath().normalize().startsWith(dir.toPath())) {
-          try {
-            zf.close();
-          } catch (IOException e1) {
-            // Do nothing since we are about to throw an Error anyway.
+        try {
+          // Check that fileName doesn't stray outside target directory: Zip Slip security test.
+          // if getCanonicalFile throws IOException, then assume the worst.
+          if ((new File(dir, fileName)).getCanonicalFile().toPath().startsWith(dir.getCanonicalFile().toPath())) {
+            ret.add("url:" + fileName);
+            continue;
           }
-          throw new Error("Bad entry: " + fileName + " in " + dir);
+
+          zf.close();
+        } catch (IOException e1) {
+          // Do nothing since we are about to throw an Error anyway.
         }
-        ret.add("url:" + fileName);
+        throw new Error("Bad entry: " + fileName + " in " + dir);
       }
     }
     try {


### PR DESCRIPTION
Fix #1879 

If we can't resolve the canonical path, then treat it as an error.

I believe this is a minor enough to not require a `CHANGES.md` update.

On a separate note, the contribution guidelines should probably be updated since the there is no branch named **develop**.