### PR TITLE
Update contributing to branch main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,6 +2,6 @@ Contributing rules
 
 * Open issue/FR ticket **first** and discuss your intent,
 * Fork the repository,
-* You **MUST** put your work either in **develop** branch (or its branch),
-* Once done, create pull request against **develop** branch,
+* You **MUST** put your work either in the **main** branch or a branch of **main**,
+* Once done, create a pull request against the **main** branch,
 * Ensure your change is also listed in `CHANGES.md` (minor changes may be ommited).


### PR DESCRIPTION
This fixes CONTRIBUTING.md to refer to the main branch rather than develop.