### PR TITLE
Add interactive mode

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/start/Startup.java
+++ b/src/main/java/com/cburch/logisim/gui/start/Startup.java
@@ -453,32 +453,35 @@ public class Startup implements AWTEventListener {
     // TTY format parsing
     final var ttyVal = opt.getValue();
     final var fmts = ttyVal.split(",");
-    if (fmts.length > 0) {
-      // FIXME: why we support multiple TTY types in one invocation? fallback?
-      for (final var singleFmt : fmts) {
-        final var val = switch (singleFmt.trim()) {
-          case "table" -> TtyInterface.FORMAT_TABLE;
-          case "speed" -> TtyInterface.FORMAT_SPEED;
-          case "tty" -> TtyInterface.FORMAT_TTY;
-          case "halt" -> TtyInterface.FORMAT_HALT;
-          case "stats" -> TtyInterface.FORMAT_STATISTICS;
-          case "binary" -> TtyInterface.FORMAT_TABLE_BIN;
-          case "hex" -> TtyInterface.FORMAT_TABLE_HEX;
-          case "csv" -> TtyInterface.FORMAT_TABLE_CSV;
-          case "tabs" -> TtyInterface.FORMAT_TABLE_TABBED;
-          default -> 0;
-        };
+    // FIXME: why we support multiple TTY types in one invocation? fallback?
+    // Because you can as the TtyInterface for multiple functionality
+    for (final var singleFmt : fmts) {
+      final var val = switch (singleFmt.trim()) {
+        case "table" -> TtyInterface.FORMAT_TABLE;
+        case "speed" -> TtyInterface.FORMAT_SPEED;
+        case "tty" -> TtyInterface.FORMAT_TTY;
+        case "halt" -> TtyInterface.FORMAT_HALT;
+        case "stats" -> TtyInterface.FORMAT_STATISTICS;
+        case "binary" -> TtyInterface.FORMAT_TABLE_BIN;
+        case "hex" -> TtyInterface.FORMAT_TABLE_HEX;
+        case "csv" -> TtyInterface.FORMAT_TABLE_CSV;
+        case "tabs" -> TtyInterface.FORMAT_TABLE_TABBED;
+        case "interactive" -> TtyInterface.FORMAT_INTERACTIVE;
+        default -> 0;
+      };
 
-        if (val == 0) {
-          logger.error(S.get("ttyFormatError"));
-          return RC.QUIT;
-        }
-        startup.ttyFormat |= val;
-        return RC.OK;
+      if (val == 0) {
+        logger.error(S.get("ttyFormatError"));
+        return RC.QUIT;
       }
+      startup.ttyFormat |= val;
     }
-    logger.error(S.get("ttyFormatError"));
-    return RC.QUIT;
+    if(startup.ttyFormat == 0) {
+      logger.error(S.get("ttyFormatError"));
+      return RC.QUIT;
+    } else {
+      return RC.OK;
+    }
   }
 
   private static RC handleArgSubstitute(Startup startup, Option opt) {


### PR DESCRIPTION
I added the ability to run the circuit and change the pins interactively to use in auto testing.
This is useful when the circuit has a complex state that might mutate itself based on the pin input (triggers or memory cells).

An example:
The RCS trigger:
<img width="360" alt="image" src="https://github.com/logisim-evolution/logisim-evolution/assets/8657078/60d7e54a-10ca-4cf2-a40f-1fc530bd24b5">


Here is how a user can interact with the circuit from the command line:
![telegram-cloud-photo-size-2-5298784097939870538-y](https://github.com/logisim-evolution/logisim-evolution/assets/8657078/e83bbd7a-850b-4e64-bebb-c49b97a7740a)


At this state this pr is a draft and some cleanup is needed before it can be merged.
I'm collecting contributors input on how to improve or what to add.

Related to #1581 #1546