### PR TITLE
Fix combinational analysis not fully minimizing

### DIFF
--- a/src/main/java/com/cburch/logisim/analyze/model/Implicant.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Implicant.java
@@ -387,9 +387,20 @@ public class Implicant implements Comparable<Implicant> {
       }
       
       final var minimumPrimes = results.get(Collections.min(results.keySet()));
-      // TODO: Select cheapest implicants.
+      // Select cheapest prime covers now, meaning the ones with most total unknowns
+      final var costMap = new HashMap<Integer, ArrayList<HashSet<Implicant>>>();
+      
+      for (final var cover : minimumPrimes) {
+    	  final var unknown = cover.stream().mapToInt(i -> i.getUnknownCount()).sum();
+    	  if (!costMap.keySet().contains(unknown)) {
+    		  costMap.put(unknown, new ArrayList<>());
+    	  }
+    	  costMap.get(unknown).add(cover);
+      }
+      
+      final var cheapestCover = costMap.get(Collections.max(costMap.keySet()));
       // TODO: Return all possible covers.
-      essentialPrimes.addAll(minimumPrimes.get(0));
+      essentialPrimes.addAll(cheapestCover.get(0));
     }
 
     // TODO: Return multiple minimal covers if present (Petrick's method)

--- a/src/main/java/com/cburch/logisim/analyze/model/Implicant.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Implicant.java
@@ -11,7 +11,15 @@ package com.cburch.logisim.analyze.model;
 
 import static com.cburch.logisim.analyze.Strings.S;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import javax.swing.JTextArea;
 

--- a/src/main/java/com/cburch/logisim/analyze/model/Implicant.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Implicant.java
@@ -285,94 +285,76 @@ public class Implicant implements Comparable<Implicant> {
         for (final var element : termsToCover.keySet()) termsToCover.get(element).remove(prime);
       }
     } while (couldDoRowReduction || couldDoColumnReduction);
-    // It can happen that we still have max/min terms left that are covered by multiple groups.
-    // To find the minimal cover here we should implement the Petrick's method (https://en.wikipedia.org/wiki/Petrick%27s_method)
-    // For the moment we are just going to greedyly pick
-    // TODO: Implement Petrick's method
-    /*if (!termsToCover.isEmpty()) report(outputArea, String.format("\n\n\s", S.get("implicantGreedy")));
-    nrEssentialPrimes = 0L;
-    while (!termsToCover.isEmpty()) {
-      final var termsToRemove = new ArrayList<Implicant>();
-      for (final var term : termsToCover.keySet()) {
-        if (termsToRemove.contains(term)) continue;
-        final var group = termsToCover.get(term).get(0);
-        essentialPrimes.add(group);
-        if ((nrEssentialPrimes++ % 16L) == 0) report(outputArea, "\n");
-        report(outputArea, String.format(" %s", getGroupRepresentation(group.values, group.unknowns, nrOfInputs)));
-        termsToRemove.addAll(primes.get(group));
-      }
-      for (final var term : termsToRemove) termsToCover.remove(term);
-    }*/
     
-    // It is possible that we still have min/max terms that are covered by multiple primes.
+    // It is possible that we still have multiple covers left.
     // The minimal cover can be found using Petrick's method
     if (!termsToCover.isEmpty()) {
       final var simplificationExpression = new ArrayList<HashSet<HashSet<Implicant>>>();
       
       // Populate the HashSet in order to begin Petrick's method
       for (final var term : termsToCover.keySet()) {
-    	final var group = new HashSet<HashSet<Implicant>>();
-    	for (final var impl : termsToCover.get(term)) {
+        final var group = new HashSet<HashSet<Implicant>>();
+        for (final var impl : termsToCover.get(term)) {
           final var impli = new HashSet<Implicant>();
-    	  impli.add(impl);
-    	  group.add(impli);
+          impli.add(impl);
+          group.add(impli);
         }
-    	simplificationExpression.add(group);
+        simplificationExpression.add(group);
       }
       
       do {
-    	  for (int i = 0; i < simplificationExpression.size(); i++) {
-    		  final var first = simplificationExpression.get(i);
-    		  if (i+1 >= simplificationExpression.size()) { // If there is only one left, skip it for this round
-    			  break;
-    		  }
-    		  final var second = simplificationExpression.remove(i+1);
-    		  
-    		  // If there are two elements left, then combine them
-    		  final var group = new HashSet<HashSet<Implicant>>();
-    		  for (final var firstConj : first) {
-    			  for (final var secondConj : second) {
-    				  final var conj = new HashSet<Implicant>();
-    				  conj.addAll(firstConj);
-    				  conj.addAll(secondConj);
-    				  group.add(conj);
-    			  }
-    		  }
-    		  simplificationExpression.set(i, group);
-    	  }
-    	  
-    	  // After combining elements, apply reductions
-    	  for (final var group : simplificationExpression) {
-    		  final var implGrpToRemove = new ArrayList<HashSet<Implicant>>();
-    		  for (final var conj1 : group) {
-    			  if (implGrpToRemove.contains(conj1)) continue;
-    			  for (final var conj2 : group) {
-    				  if (conj1 == conj2 || implGrpToRemove.contains(conj2)) continue;
-    				  if (conj2.containsAll(conj1)) {
-    					  implGrpToRemove.add(conj2);
-    					  continue;
-    				  }
-    				  if (conj1.containsAll(conj2)) {
-    					  implGrpToRemove.add(conj1);
-    					  break;
-    				  }
-    			  }
-    		  }
-    		  if (!implGrpToRemove.isEmpty()) {
-    			  group.removeAll(implGrpToRemove);
-    		  }
-    	  }
+        for (int i = 0; i < simplificationExpression.size(); i++) {
+          final var first = simplificationExpression.get(i);
+          if (i + 1 >= simplificationExpression.size()) { // If there is only one left, skip it
+            break;
+          }
+          final var second = simplificationExpression.remove(i + 1);
+
+          // If there are two elements left, then combine them
+          final var group = new HashSet<HashSet<Implicant>>();
+          for (final var firstConj : first) {
+            for (final var secondConj : second) {
+              final var conj = new HashSet<Implicant>();
+              conj.addAll(firstConj);
+              conj.addAll(secondConj);
+              group.add(conj);
+            }
+          }
+          simplificationExpression.set(i, group);
+        }
+
+        // After combining elements, apply reductions
+        for (final var group : simplificationExpression) {
+          final var implGrpToRemove = new ArrayList<HashSet<Implicant>>();
+          for (final var conj1 : group) {
+            if (implGrpToRemove.contains(conj1)) continue;
+            for (final var conj2 : group) {
+              if (conj1 == conj2 || implGrpToRemove.contains(conj2)) continue;
+              if (conj2.containsAll(conj1)) {
+                implGrpToRemove.add(conj2);
+                continue;
+              }
+              if (conj1.containsAll(conj2)) {
+                implGrpToRemove.add(conj1);
+                break;
+              }
+            }
+          }
+          if (!implGrpToRemove.isEmpty()) {
+            group.removeAll(implGrpToRemove);
+          }
+        }
       } while (simplificationExpression.size() > 1);
-      
-      // Get the possible covers, only one can be left here
+
+      // Get the possible covers, only one can element can be left in the ArrayList here
       final var resGroup = simplificationExpression.get(0);
-      
+
       final var results = new HashMap<Integer, ArrayList<HashSet<Implicant>>>();
       for (final var grp : resGroup) {
-    	  if (results.get(grp.size()) == null) {
-    		  results.put(grp.size(), new ArrayList<>());
-    	  }
-    	  results.get(grp.size()).add(grp);
+        if (results.get(grp.size()) == null) {
+          results.put(grp.size(), new ArrayList<>());
+        }
+        results.get(grp.size()).add(grp);
       }
       
       final var minimumPrimes = results.get(Collections.min(results.keySet()));
@@ -380,11 +362,11 @@ public class Implicant implements Comparable<Implicant> {
       final var costMap = new HashMap<Integer, ArrayList<HashSet<Implicant>>>();
       
       for (final var cover : minimumPrimes) {
-    	  final var unknown = cover.stream().mapToInt(i -> i.getUnknownCount()).sum();
-    	  if (!costMap.keySet().contains(unknown)) {
-    		  costMap.put(unknown, new ArrayList<>());
-    	  }
-    	  costMap.get(unknown).add(cover);
+        final var unknown = cover.stream().mapToInt(i -> i.getUnknownCount()).sum();
+        if (!costMap.keySet().contains(unknown)) {
+          costMap.put(unknown, new ArrayList<>());
+        }
+        costMap.get(unknown).add(cover);
       }
       
       final var cheapestCovers = costMap.get(Collections.max(costMap.keySet()));

--- a/src/main/java/com/cburch/logisim/analyze/model/Implicant.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/Implicant.java
@@ -491,7 +491,7 @@ public class Implicant implements Comparable<Implicant> {
         term = Expressions.or(term, literal);
       }
     }
-    return term == null ? Expressions.constant(1) : term;
+    return term == null ? Expressions.constant(0) : term;
   }
 
   static SortedMap<Implicant, String> computePartition(AnalyzerModel model) {

--- a/src/test/java/com/cburch/logisim/analyze/model/ImplicantTest.java
+++ b/src/test/java/com/cburch/logisim/analyze/model/ImplicantTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.Stream;
 
+import javax.swing.JTextArea;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -21,12 +23,22 @@ public class ImplicantTest {
         Arguments.of("a,b,c,d", "b'c+a b'+a'b c'+a'b d'+b c'd+c d'+a d",
             5, AnalyzerModel.FORMAT_SUM_OF_PRODUCTS),
         Arguments.of("a,b", "a b + a b'", 1, AnalyzerModel.FORMAT_SUM_OF_PRODUCTS),
+        Arguments.of("a,b", "a+a'", 1, AnalyzerModel.FORMAT_SUM_OF_PRODUCTS),
+        Arguments.of("a,b", "a a'", 0, AnalyzerModel.FORMAT_SUM_OF_PRODUCTS),
+        Arguments.of("a,b,c,d", "a'b'c'd'+a'b'c'd+a'b c'd+a b c'd'+a b c'd +a b'c'd'",
+            3, AnalyzerModel.FORMAT_SUM_OF_PRODUCTS),
+        Arguments.of("a,b,c,d,e,f", "a'b'd'+b'e'+b d e'+a b d'+b d'e", 4,
+            AnalyzerModel.FORMAT_SUM_OF_PRODUCTS),
         
         // Expressions to be minimized as CNF
         Arguments.of("a,b,c,d", "b c'd+a 'b'd'+a'b'c+a'c d'+b'c'd'+a b'd+a c'+b c d'",
             4, AnalyzerModel.FORMAT_PRODUCT_OF_SUMS),
         Arguments.of("a,b,c,d", "b'c+a b'+a'b c'+a'b d'+b c'd+c d'+a d",
-            3, AnalyzerModel.FORMAT_PRODUCT_OF_SUMS)
+            3, AnalyzerModel.FORMAT_PRODUCT_OF_SUMS),
+        Arguments.of("a,b", "a+a'", 0, AnalyzerModel.FORMAT_PRODUCT_OF_SUMS),
+        Arguments.of("a,b", "a a'", 1, AnalyzerModel.FORMAT_PRODUCT_OF_SUMS),
+        Arguments.of("a,b,c,d", "(a+b+c+d)(a+b+c+d')(a+b'+c+d')(a'+b'+c+d)(a'+b'+c+d')"
+            + "(a'+b+c+d)", 3, AnalyzerModel.FORMAT_PRODUCT_OF_SUMS)
       );
   }
   
@@ -66,8 +78,8 @@ public class ImplicantTest {
         () -> model.getOutputExpressions().setExpression("x", Parser.parse(expr, model)),
         "Failed to parse expression '" + expr + "'!");
     
-    // Minimize Expression
-    final var res = Implicant.computeMinimal(format, model, "x", null);
+    // Minimize Expression (use outputArea to allow for larger expressions)
+    final var res = Implicant.computeMinimal(format, model, "x", new JTextArea());
     
     // Add new Expression to the analyzer model (needed to verify Expression is equivalent)
     model.getOutputExpressions().setExpression("y", Implicant.toExpression(format, model, res));

--- a/src/test/java/com/cburch/logisim/analyze/model/ImplicantTest.java
+++ b/src/test/java/com/cburch/logisim/analyze/model/ImplicantTest.java
@@ -1,0 +1,83 @@
+package com.cburch.logisim.analyze.model;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ImplicantTest {
+
+  private static Stream<Arguments> expressionProvider() {
+    return Stream.of(
+        // List of variables, expression, amount of primes in the result, expression format
+        // Expressions to be minimized as DNF
+        Arguments.of("a,b,c,d", "b c'd+a'b'd'+a'b'c+a'c d'+b'c'd'+a b'd+a c'+b c d'",
+            5, AnalyzerModel.FORMAT_SUM_OF_PRODUCTS),
+        Arguments.of("a,b,c,d", "b'c+a b'+a'b c'+a'b d'+b c'd+c d'+a d",
+            5, AnalyzerModel.FORMAT_SUM_OF_PRODUCTS),
+        Arguments.of("a,b", "a b + a b'", 1, AnalyzerModel.FORMAT_SUM_OF_PRODUCTS),
+        
+        // Expressions to be minimized as CNF
+        Arguments.of("a,b,c,d", "b c'd+a 'b'd'+a'b'c+a'c d'+b'c'd'+a b'd+a c'+b c d'",
+            4, AnalyzerModel.FORMAT_PRODUCT_OF_SUMS),
+        Arguments.of("a,b,c,d", "b'c+a b'+a'b c'+a'b d'+b c'd+c d'+a d",
+            3, AnalyzerModel.FORMAT_PRODUCT_OF_SUMS)
+      );
+  }
+  
+  /** Test method for
+   * {@link com.cburch.logisim.analyze.model.Implicant#computeMinimal(int,
+   * AnalyzerModel, String, javax.swing.JTextArea)}.
+   *
+   * @param vars Names of the variables in Expression, seperated by commas
+   * @param expr String representation of the Expression, must be parsable by
+   *     {@link com.cburch.logisim.analyze.model.Parser#parse(String, AnalyzerModel)}
+   * @param cost Amount of expected Implicants in the minimized Expression
+   * @param format Format to be used for minimization. Formats declared in
+   *     {@link com.cburch.logisim.analyze.model.AnalyzerModel}
+   */
+  @ParameterizedTest
+  @MethodSource("expressionProvider")
+  public void testComputeMinimal(String vars, String expr, int cost, int format) {
+    // Create analyzer model
+    final AnalyzerModel model = new AnalyzerModel();
+    
+    // Get variables from String and add them to the analyzer model
+    final String[] varr = vars.split(",");
+    final var inputs = model.getInputs();
+    for (final var variable : varr) {
+      assertDoesNotThrow(() -> inputs.add(Var.parse(variable)),
+          "Parsing input variable '" + variable + "' failed!");
+    }
+    
+    // Register output variables to the analyzer model
+    assertDoesNotThrow(() -> model.getOutputs().add(Var.parse("x")),
+        "Failed to parse output variable");
+    assertDoesNotThrow(() -> model.getOutputs().add(Var.parse("y")),
+        "Failed to parse output variable");
+    
+    // Add original expression to the analyzer model
+    assertDoesNotThrow(
+        () -> model.getOutputExpressions().setExpression("x", Parser.parse(expr, model)),
+        "Failed to parse expression '" + expr + "'!");
+    
+    // Minimize Expression
+    final var res = Implicant.computeMinimal(format, model, "x", null);
+    
+    // Add new Expression to the analyzer model (needed to verify Expression is equivalent)
+    model.getOutputExpressions().setExpression("y", Implicant.toExpression(format, model, res));
+
+    // Compare outputs of old and minimized Expression to verify they are the same
+    assertArrayEquals(model.getTruthTable().getOutputColumn(0),
+        model.getTruthTable().getOutputColumn(1), "The truth table changed during minimization");
+    
+    // Check if the minimized Expression has the expected amount of primes
+    assertEquals(cost, res.size(),
+        "The amount of primes in the result does not match the expected value.");
+  }
+}


### PR DESCRIPTION
As described in issue #1889, some combinational formulae are not being fully minimized.

I've determined that this happens only if the McKluskey algorithm is not able to determine the best minimal cover. It appears that the current greedy algorithm sometimes does not select a minimal cover and can even include primes that are completely covered by other primes.

**What I have done:**
In order to fix this I implemented Petrick's Method. I implemented Petrick's Method in the same way as described on wikipedia([https://en.wikipedia.org/wiki/Petrick%27s_method](https://en.wikipedia.org/wiki/Petrick%27s_method)).

Before & after comparison: (Formulae from #1889)

1. Formula: bc'd+a'b'd'+a'b'c+a'cd'+b'c'd'+ab'd+ac'+bcd'
    Current Minimization: ![f1_before](https://github.com/logisim-evolution/logisim-evolution/assets/62105577/d74ce8ba-3332-4f8a-b257-9cc3b6539fdb)
     Petrick's Method: ![f1_after](https://github.com/logisim-evolution/logisim-evolution/assets/62105577/cf15c36a-85bd-4426-850b-5ec49c66082b)
2. Formula: b'c+ab'+a'bc'+a'bd'+bc'd+cd'+ad
    Current Minimization: ![f2_before](https://github.com/logisim-evolution/logisim-evolution/assets/62105577/d3149836-403c-4395-b190-7c14975c097a)
    Petrick's Method: ![f2_after](https://github.com/logisim-evolution/logisim-evolution/assets/62105577/d5831671-b00c-4eae-824e-01d78f650ee1)

**What I still plan to do:**
I would like to add some unit tests for the computeMinimal method

**Additional remarks:**
With this it would be possible to return multiple minimal covers, should they exist

I would appreciate all feedback on this.