### PR TITLE
Group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     target-branch: "main"
     ignore:
       - dependency-name: "de.jflex:jflex"
+    groups:
+      slf4j:
+         patterns:
+           - "org.slf4j*"
+      junit:
+         patterns:
+           - "org.junit*"
 
   - package-ecosystem: "github-actions"
     # directory of "/" for github-actions means .github/workflows


### PR DESCRIPTION
Github has added a groups option for checking dependencies with dependabot. This PR will have dependabot place updates of the slf4j and junit pairs into respective groups when making PRs for those dependencies. I hope that will be more convenient and make it easier to ensure that both are updated at the same time. 