### PR TITLE
Add sonar host url to sonarqube build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,4 +87,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: ([ -z $SONAR_TOKEN ] || ./gradlew sonar)
+        SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      run: ([ -z $SONAR_TOKEN ] || [ -z $SONAR_HOST_URL ] || ./gradlew sonar)


### PR DESCRIPTION
This PR provides for a SONAR_HOST_URL secret to be passed to SonarQube. It silences SonarQube until that secret is provided.