### PR TITLE
Remove main method from Analyzer

### DIFF
--- a/src/main/java/com/cburch/logisim/analyze/gui/Analyzer.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/Analyzer.java
@@ -133,34 +133,6 @@ public class Analyzer extends LFrame.SubWindow {
     }
   }
 
-  public static void main(String[] args) throws Exception {
-    final var frame = new Analyzer();
-    final var model = frame.getModel();
-
-    if (args.length >= 2) {
-      final var inputs = new ArrayList<Var>();
-      final var outputs = new ArrayList<Var>();
-      for (String s : args[0].split(",")) inputs.add(Var.parse(s));
-      for (String s : args[1].split(",")) outputs.add(Var.parse(s));
-      model.setVariables(inputs, outputs);
-    }
-    for (var i = 2; i < args.length; i++) {
-      final var s = args[i];
-      final var idx = s.indexOf('=');
-      if (idx >= 0) {
-        final var name = s.substring(0, idx);
-        final var exprString = s.substring(idx + 1);
-        final var expr = Parser.parse(exprString, model);
-        model.getOutputExpressions().setExpression(name, expr, exprString);
-      } else {
-        Parser.parse(s, model); // for testing Parser.parse
-      }
-    }
-    frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-    frame.pack();
-    frame.setVisible(true);
-  }
-
   private static final long serialVersionUID = 1L;
   // used by circuit analysis to select the relevant tab automatically.
   public static final int IO_TAB = 0;


### PR DESCRIPTION
This PR removes the main test method from Analyzer. In PR #1938, @superenginegit provided JUnit test cases for this piece of code. Thank you, @superenginegit.

This completes the examination and removal of main methods used as test tools, by moving the testing to JUnit. It therefore closes issue #1415.