### PR TITLE
Fixed misspelling of "RGB" in English in a few spots in the docs.

### DIFF
--- a/src/main/resources/doc/en/contents.xml
+++ b/src/main/resources/doc/en/contents.xml
@@ -173,7 +173,7 @@
 			<tocitem target="io_joystick" text="Joystick" image="icon_joystick" />
 			<tocitem target="io_keyboard" text="Keyboard" image="icon_keyboard" />
 			<tocitem target="io_led" text="LED" image="icon_led" />
-			<tocitem target="io_ledRVB" text="LED RVB" image="icon_rvbled" />
+			<tocitem target="io_ledRVB" text="LED RGB" image="icon_rvbled" />
 			<tocitem target="io_7seg" text="7-Segment Display" image="icon_7seg" />
 			<tocitem target="io_hexdig" text="Hex Digit Display" image="icon_hexdig" />
 			<tocitem target="io_dotmat" text="LED Matrix" image="icon_dotmat" />
@@ -181,7 +181,7 @@
 <!-- not documented 
      		<tocitem target="io_Port_IO" text="Port I/O" image="icon_Port_IO" />
 			<tocitem target="io_Repetar" text="Reptar Local Bus" image="icon_repetar" />
-			<tocitem target="io_videorvb" text="Video RVB" image="icon_videorvb" />
+			<tocitem target="io_videorvb" text="Video RGB" image="icon_videorvb" />
 -->	
 		</tocitem>
 <!-- not documented 

--- a/src/main/resources/doc/en/html/libs/index.html
+++ b/src/main/resources/doc/en/html/libs/index.html
@@ -714,7 +714,7 @@
             &nbsp;
           </td>
           <td>
-            <a href="io/rgbvideo.html">RVB Video</a>
+            <a href="io/rgbvideo.html">RGB Video</a>
           </td>
         </tr>
       </tbody>

--- a/src/main/resources/doc/en/html/libs/io/index.html
+++ b/src/main/resources/doc/en/html/libs/io/index.html
@@ -176,7 +176,7 @@
             &nbsp;
           </td>
           <td>
-            <a href="./rgbvideo.html">RVB Video</a>
+            <a href="./rgbvideo.html">RGB Video</a>
           </td>
         </tr>
       </tbody>

--- a/src/main/resources/doc/libstatus.html
+++ b/src/main/resources/doc/libstatus.html
@@ -1118,7 +1118,7 @@
 		<td height="17" align="center"></td>
 		<td align="left"></td>
 		<td align="left"></td>
-		<td align="left">Video RVB</td>
+		<td align="left">Video RGB</td>
 		<td align="left"></td>
 		<td align="center" bgcolor="#ED1C24"><a href="./en/html/libs/io/vidrvb.html">__</a></td>
 		<td align="center" bgcolor="#ED1C24"><a href="./fr/html/libs/io/vidrvb.html">__</a></td>


### PR DESCRIPTION
Hello,
I (https://ednovak.net/) am a Computer Science professor at a small private college in the United States.  I am teaching a course using this awesome software.  I noticed some misspellings in the English documentation and thought it might be helpful if I fixed them.  I wasn't as confident about the other translations (Russian, French, etc.), but it does seem to me that the same typo appears in those languages as well.

I am considering writing some documentation about the SOC components (especially the RISC-V simulator and VGA screen) since it seems like the project needs it.  Would that be welcome?

Thank you!