### PR TITLE
Fix: multiple keyevent actions removal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
   * Added TTL 74541: Octal buffers with three-state outputs
   * Added TTL 74670: 4-by-4 register file with three-state outputs
   * Added 16 bit floating point support for floating point arithmetic
+  * Fixed the problem of keys getting assigned to focusing on the cell of the table in "properties" section along with its actual intent
 
 * v3.8.0 (2022-10-02)
   * Added reset value attribute to input pins

--- a/src/main/java/com/cburch/logisim/gui/generic/AttrTable.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/AttrTable.java
@@ -27,6 +27,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.EventObject;
 import java.util.LinkedList;
@@ -398,7 +400,15 @@ public class AttrTable extends JPanel implements LocaleListener {
 
     @Override
     public boolean isCellEditable(EventObject anEvent) {
-      // Asks the editor if it can start editing using anEvent.
+      if (anEvent instanceof KeyEvent) {
+        if (((KeyEvent) anEvent).getKeyCode() == KeyEvent.VK_SPACE) {
+          return true;
+        }
+        return false;
+      } 
+      if (anEvent instanceof MouseEvent) {
+        return ((MouseEvent) anEvent).getClickCount() >= 1;
+      }
       return true;
     }
 


### PR DESCRIPTION
Fixes #618 

The table in the "Properties" section would enter edit mode on any key press event if an editable cell in the table was clicked. This behaviour resulted in triggering two events simultaneously, causing unintended behaviour.

The fix implemented in this PR ensures that the table enters edit mode only when triggered by a mouse click or the space key. This change resolves the issue as intended.