### PR TITLE
Added bound limits to exception message popups

### DIFF
--- a/src/main/java/com/cburch/logisim/data/Attributes.java
+++ b/src/main/java/com/cburch/logisim/data/Attributes.java
@@ -339,8 +339,8 @@ public class Attributes {
     @Override
     public Integer parse(String value) {
       int v = (int) Long.parseLong(value);
-      if (v < start) throw new NumberFormatException("integer too small");
-      if (v > end) throw new NumberFormatException("integer too large");
+      if (v < start) throw new NumberFormatException("integer must be at least " + start);
+      if (v > end) throw new NumberFormatException("integer must be at most " + end);
       return v;
     }
   }

--- a/src/main/java/com/cburch/logisim/data/BitWidth.java
+++ b/src/main/java/com/cburch/logisim/data/BitWidth.java
@@ -61,8 +61,8 @@ public class BitWidth implements Comparable<BitWidth> {
     @Override
     public BitWidth parse(String value) {
       int v = (int) Long.parseLong(value);
-      if (v < min) throw new NumberFormatException("integer too small");
-      if (v > max) throw new NumberFormatException("integer too large");
+      if (v < min) throw new NumberFormatException("bit width must be at least " + min);
+      if (v > max) throw new NumberFormatException("bit width must be at most " + max);
       return BitWidth.create(v);
     }
   }

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntityAttributes.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntityAttributes.java
@@ -57,8 +57,8 @@ public class VhdlEntityAttributes extends AbstractAttributeSet {
           || value.equals("(default)")
           || value.equals(toDisplayString(null))) return null;
       final var v = Long.parseLong(value);
-      if (v < start) throw new NumberFormatException("integer too small");
-      if (v > end) throw new NumberFormatException("integer too large");
+      if (v < start) throw new NumberFormatException("integer must be at least " + start);
+      if (v > end) throw new NumberFormatException("integer must be at most " + end);
       return (int) v;
     }
 


### PR DESCRIPTION
This pull request fixes issue #1979 by adding the upper or lower bound in the error message when the user enters a number that is out of the allowed bounds of the input field. 