### PR TITLE
RAM Module - Fixed byte-enable mask (literal cast)

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -329,7 +329,7 @@ public class Ram extends Mem {
         newMemValue = dataInValue;
       } else {
         for (var i = 0; i < RamAppearance.getNrBEPorts(attrs); i++) {
-          long mask = 0xFF << (i * 8);
+          long mask = 0xFFL << (i * 8);
           long andMask = ~mask;
           if (state.getPortValue(RamAppearance.getBEIndex(i, attrs)).equals(Value.TRUE)) {
             newMemValue &= andMask;


### PR DESCRIPTION
Changed the mask used on byte-enabled writes as to use a long literal instead of an integer literal.  This prevents undesired shift behaviour when said literal is shifted and then assigned to the mask long variable. This in turn prevents undesired byte-enable writes on RAM modules with 64-bit long words 

See issue: #2021 