### PR TITLE
Dual port RAM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
     * It's a type of memory RAM that is typically used to implement processor registers.
     * Added spanish translations related to it.
     * It doesn't supports bidirectional operations.
-    * It doesn't supports line sizes, as it's restricted to one input and two inputs.
+    * It doesn't supports line sizes, as it's restricted to one input and two outputs.
 
 * v3.9.0 (2024-08-15)
   * Updated Java requirement to Java 21.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,12 @@
 
 # Changes #
 
-* @dev (????-??-??)
+* @dev (2024-10-10)
+  * Added dual port RAM component. [#79]
+    * It's a type of memory RAM that is typically used to implement processor registers.
+    * Added spanish translations related to it.
+    * It doesn't supports bidirectional operations.
+    * It doesn't supports line sizes, as it's restricted to one input and two inputs.
 
 * v3.9.0 (2024-08-15)
   * Updated Java requirement to Java 21.

--- a/src/main/java/com/cburch/logisim/circuit/CircuitState.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitState.java
@@ -393,6 +393,9 @@ public class CircuitState implements InstanceData {
       if (comp.getFactory() instanceof Ram ram) {
         final var remove = ram.reset(this, Instance.getInstanceFor(comp));
         if (remove) componentData.put(comp, null);
+      } else if (comp.getFactory() instanceof DualportRam dpram) {
+        final var remove = dpram.reset(this, Instance.getInstanceFor(comp));
+        if (remove) componentData.put(comp, null);
       } else if (comp.getFactory() instanceof Buzzer) {
         Buzzer.stopBuzzerSound(comp, this);
       } else if (!(comp.getFactory() instanceof SubcircuitFactory)) {

--- a/src/main/java/com/cburch/logisim/circuit/CircuitState.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitState.java
@@ -22,6 +22,7 @@ import com.cburch.logisim.instance.InstanceState;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.io.extra.Buzzer;
 import com.cburch.logisim.std.memory.Ram;
+import com.cburch.logisim.std.memory.DualportRam;
 import com.cburch.logisim.std.memory.RamState;
 import com.cburch.logisim.std.wiring.Clock;
 import com.cburch.logisim.std.wiring.Pin;

--- a/src/main/java/com/cburch/logisim/circuit/CircuitState.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitState.java
@@ -118,7 +118,10 @@ public class CircuitState implements InstanceData {
               break;
             }
           }
-          if (!found && compState instanceof RamState state) Ram.closeHexFrame(state);
+          if (!found && compState instanceof RamState state){
+            Ram.closeHexFrame(state);
+            DualportRam.closeHexFrame(state);
+          }
           if (!found && compState instanceof CircuitState sub) {
             sub.parentState = null;
             subStates.remove(sub);

--- a/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
@@ -95,7 +95,7 @@ public class XmlCircuitReader extends CircuitTransaction {
     final var locStr = elt.getAttribute("loc");
     final var attrs = source.createAttributeSet();
     var defaults = source;
-    if (isHolyCross && source instanceof Ram) {
+    if (isHolyCross && (source instanceof Ram || source instanceof DualportRam)) {
       final var ramAttrs = (RamAttributes) attrs;
       ramAttrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
       ramAttrs.updateAttributes();

--- a/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
@@ -25,6 +25,7 @@ import com.cburch.logisim.data.Location;
 import com.cburch.logisim.std.base.Text;
 import com.cburch.logisim.std.memory.Mem;
 import com.cburch.logisim.std.memory.Ram;
+import com.cburch.logisim.std.memory.DualportRam;
 import com.cburch.logisim.std.memory.RamAttributes;
 import com.cburch.logisim.tools.AddTool;
 import com.cburch.logisim.util.CollectionUtil;

--- a/src/main/java/com/cburch/logisim/gui/main/SelectionBase.java
+++ b/src/main/java/com/cburch/logisim/gui/main/SelectionBase.java
@@ -18,6 +18,7 @@ import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Location;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.memory.Ram;
+import com.cburch.logisim.std.memory.DualportRam;
 import com.cburch.logisim.std.memory.Rom;
 import com.cburch.logisim.util.CollectionUtil;
 import java.awt.Graphics;

--- a/src/main/java/com/cburch/logisim/gui/main/SelectionBase.java
+++ b/src/main/java/com/cburch/logisim/gui/main/SelectionBase.java
@@ -176,7 +176,7 @@ class SelectionBase {
     for (final var comp : components) {
       final var oldLoc = comp.getLocation();
       final var attrs =
-          translate || (comp.getFactory() instanceof Rom) || (comp.getFactory() instanceof Ram)
+          translate || (comp.getFactory() instanceof Rom) || ((comp.getFactory() instanceof Ram || comp.getFactory() instanceof DualportRam))
               ? comp.getAttributeSet()
               : (AttributeSet) comp.getAttributeSet().clone();
       var newX = oldLoc.getX() + dx;

--- a/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
+++ b/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
@@ -219,6 +219,11 @@ public class TtyInterface {
         final var m = ramFactory.getContents(ramState);
         HexFile.open(m, loadFile);
         found = true;
+      } else if (comp.getFactory() instanceof DualportRam dpramFactory) {
+        final var dpramState = circState.getInstanceState(comp);
+        final var m = dpramFactory.getContents(dpramState);
+        HexFile.open(m, loadFile);
+        found = true;
       }
     }
 

--- a/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
+++ b/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
@@ -29,6 +29,7 @@ import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.io.Keyboard;
 import com.cburch.logisim.std.io.Tty;
 import com.cburch.logisim.std.memory.Ram;
+import com.cburch.logisim.std.memory.DualportRam;
 import com.cburch.logisim.std.wiring.Pin;
 import com.cburch.logisim.util.UniquelyNamedThread;
 import java.io.File;

--- a/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
+++ b/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
@@ -243,6 +243,11 @@ public class TtyInterface {
         final var m = ramFactory.getContents(ramState);
         HexFile.save(saveFile, m, "v3.0 hex words plain");
         found = true;
+      } else if (comp.getFactory() instanceof DualportRam dpramFactory) {
+        final var dpramState = circState.getInstanceState(comp);
+        final var m = dpramFactory.getContents(dpramState);
+        HexFile.save(saveFile, m, "v3.0 hex words plain");
+        found = true;
       }
     }
 

--- a/src/main/java/com/cburch/logisim/std/memory/DualportRam.java
+++ b/src/main/java/com/cburch/logisim/std/memory/DualportRam.java
@@ -1,0 +1,424 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.memory;
+
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.data.*;
+import com.cburch.logisim.fpga.designrulecheck.CorrectLabel;
+import com.cburch.logisim.fpga.designrulecheck.netlistComponent;
+import com.cburch.logisim.gui.hex.HexFrame;
+import com.cburch.logisim.gui.icons.ArithmeticIcon;
+import com.cburch.logisim.instance.*;
+import com.cburch.logisim.proj.Project;
+
+import java.util.WeakHashMap;
+import java.util.function.Consumer;
+
+import static com.cburch.logisim.std.Strings.S;
+
+public class DualportRam extends Mem {
+  /**
+   * Unique identifier of the tool, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value MUST be unique string among all tools.
+   */
+  public static final String _ID = "DPRAM";
+
+  public static class Logger extends InstanceLogger {
+
+    @Override
+    public String getLogName(InstanceState state, Object option) {
+      var label = state.getAttributeValue(StdAttr.LABEL);
+      if (label.equals("")) {
+        label = null;
+      }
+      if (option instanceof Long) {
+        final var disp = S.get("dpramComponent");
+        final var loc = state.getInstance().getLocation();
+        return (label == null) ? disp + loc + "[" + option + "]" : label + "[" + option + "]";
+      } else {
+        return label;
+      }
+    }
+
+    @Override
+    public BitWidth getBitWidth(InstanceState state, Object option) {
+      return state.getAttributeValue(Mem.DATA_ATTR);
+    }
+
+    @Override
+    public Object[] getLogOptions(InstanceState state) {
+      var addrBits = state.getAttributeValue(ADDR_ATTR).getWidth();
+      if (addrBits >= logOptions.length) {
+        addrBits = logOptions.length - 1;
+      }
+      synchronized (logOptions) {
+        var ret = logOptions[addrBits];
+        if (ret == null) {
+          ret = new Object[1 << addrBits];
+          logOptions[addrBits] = ret;
+          for (var i = 0; i < ret.length; i++) {
+            ret[i] = i;
+          }
+        }
+        return ret;
+      }
+    }
+
+    @Override
+    public Value getLogValue(InstanceState state, Object option) {
+      if (option instanceof Long addr) {
+        final var memState = (MemState) state.getData();
+        return Value.createKnown(BitWidth.create(memState.getDataBits()), memState.getContents().get(addr));
+      } else {
+        return Value.NIL;
+      }
+    }
+  }
+
+  private static final Object[][] logOptions = new Object[9][];
+  private static final WeakHashMap<MemContents, HexFrame> windowRegistry = new WeakHashMap<>();
+
+  public DualportRam() {
+    super(_ID, S.getter("dpramComponent"), 3, new DualportRamHdlGeneratorFactory(), true);
+    setIcon(new ArithmeticIcon("RAM", 3));
+    setInstanceLogger(Logger.class);
+  }
+
+  @Override
+  protected void configureNewInstance(Instance instance) {
+    super.configureNewInstance(instance);
+    instance.addAttributeListener();
+  }
+
+  @Override
+  void configurePorts(Instance instance) {
+    DualportRamAppearance.configurePorts(instance);
+  }
+
+  @Override
+  public AttributeSet createAttributeSet() {
+    return new DualportRamAttributes();
+  }
+
+  @Override
+  public String getHDLName(AttributeSet attrs) {
+    final var label = CorrectLabel.getCorrectLabel(attrs.getValue(StdAttr.LABEL));
+    return (label.length() == 0)
+            ? "DPRAM"
+            : "DPRAMCONTENTS_" + label;
+  }
+
+  private MemContents getNewContents(AttributeSet attrs) {
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(), attrs.getValue(Mem.DATA_ATTR).getWidth(), true);
+    contents.condFillRandom();
+    return contents;
+  }
+
+  private static HexFrame getHexFrame(MemContents value, Project proj, Instance instance) {
+    synchronized (windowRegistry) {
+      var ret = windowRegistry.get(value);
+      if (ret == null) {
+        ret = new HexFrame(proj, instance, value);
+        windowRegistry.put(value, ret);
+      }
+      return ret;
+    }
+  }
+
+  public static void closeHexFrame(RamState state) {
+    final var contents = state.getContents();
+    HexFrame ret;
+    synchronized (windowRegistry) {
+      ret = windowRegistry.remove(contents);
+    }
+    if (ret == null) return;
+    ret.closeAndDispose();
+  }
+
+  @Override
+  public HexFrame getHexFrame(Project proj, Instance instance, CircuitState circState) {
+    final var ret = (RamState) instance.getData(circState);
+    return getHexFrame((ret == null) ? getNewContents(instance.getAttributeSet()) : ret.getContents(), proj, instance);
+  }
+
+  public boolean reset(CircuitState state, Instance instance) {
+    final var ret = (RamState) instance.getData(state);
+    if (ret == null) return true;
+    final var contents = ret.getContents();
+    if (instance.getAttributeValue(DualportRamAttributes.ATTR_TYPE).equals(DualportRamAttributes.VOLATILE)) {
+      contents.condClear();
+    }
+    return false;
+  }
+
+  @Override
+  public Bounds getOffsetBounds(AttributeSet attrs) {
+    return DualportRamAppearance.getBounds(attrs);
+  }
+
+  public MemContents getContents(InstanceState ramState) {
+    return getState(ramState).getContents();
+  }
+
+  @Override
+  MemState getState(Instance instance, CircuitState state) {
+    return getState(state.getInstanceState(instance));
+  }
+
+  @Override
+  MemState getState(InstanceState state) {
+    var ret = (RamState) state.getData();
+    if (ret == null) {
+      final var instance = state.getInstance();
+      ret = new RamState(instance, getNewContents(instance.getAttributeSet()), new MemListener(instance));
+      state.setData(ret);
+    } else {
+      ret.setRam(state.getInstance());
+    }
+    return ret;
+  }
+
+  @Override
+  protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
+    super.instanceAttributeChanged(instance, attr);
+    if ((attr == Mem.DATA_ATTR)
+        || (attr == Mem.ADDR_ATTR)
+        || (attr == StdAttr.TRIGGER)
+        || (attr == DualportRamAttributes.ATTR_ByteEnables)
+        || (attr == StdAttr.APPEARANCE)
+        || (attr == Mem.LINE_ATTR)
+        || (attr == DualportRamAttributes.CLEAR_PIN)
+        || (attr == Mem.ENABLES_ATTR)) {
+      instance.recomputeBounds();
+      configurePorts(instance);
+    }
+  }
+
+  @Override
+  public void paintInstance(InstancePainter painter) {
+    if (DualportRamAppearance.classicAppearance(painter.getAttributeSet())) {
+      DualportRamAppearance.drawRamClassic(painter);
+    } else {
+      DualportRamAppearance.drawRamEvolution(painter);
+    }
+  }
+
+  @Override
+  public void propagate(InstanceState state) {
+    final var attrs = state.getAttributeSet();
+    final var myState = (RamState) getState(state);
+
+    // first we check the clear pin
+    if (attrs.getValue(DualportRamAttributes.CLEAR_PIN)) {
+      final var clearValue = state.getPortValue(DualportRamAppearance.getClrIndex(0, attrs));
+      if (clearValue.equals(Value.TRUE)) {
+        myState.getContents().clear();
+        final var dataBits = state.getAttributeValue(DATA_ATTR);
+
+        for (var i = 0; i < DualportRamAppearance.getNrDataOutPorts(attrs); i++) {
+          final var portVal = Value.createKnown(dataBits, 0);
+          state.setPort(DualportRamAppearance.getDataOutIndex(i, attrs), portVal, DELAY);
+        }
+
+        return;
+      }
+    }
+
+    // next we get the address and the mem value currently stored
+    final var addrValue = state.getPortValue(DualportRamAppearance.getAddrIndex(0, attrs));
+    final var addrValue2 = state.getPortValue(DualportRamAppearance.getAddrIndex(1, attrs));
+    final var addrValueWrite = state.getPortValue(DualportRamAppearance.getAddrIndex(2, attrs));
+    long addr = addrValue.toLongValue();
+    long addr2 = addrValue2.toLongValue();
+    long addrWrite = addrValueWrite.toLongValue();
+    final var goodAddr = addrValue.isFullyDefined() && addr >= 0;
+    final var goodAddr2 = addrValue2.isFullyDefined() && addr >= 0;
+    final var goodAddrWrite = addrValueWrite.isFullyDefined() && addr >= 0;
+    if (goodAddrWrite && addrWrite != myState.getCurrent()) {
+      myState.setCurrent(addrWrite);
+      myState.scrollToShow(addrWrite);
+    }
+
+    // now we handle the two different behaviors, line-enables or byte-enables
+    if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES)) {
+      propagateLineEnables(state, addr, goodAddr, addr2, goodAddr2, addrWrite, goodAddrWrite, addrValue.isErrorValue(), addrValue2.isErrorValue(), addrValueWrite.isErrorValue());
+    } else {
+      propagateByteEnables(state, addr, goodAddr, addr2, goodAddr2, addrWrite, goodAddrWrite, addrValue.isErrorValue(), addrValue2.isErrorValue(), addrValueWrite.isErrorValue());
+    }
+  }
+
+  private void propagateLineEnables(InstanceState state, long addr, boolean goodAddr,
+                                    long addr2, boolean goodAddr2,
+                                    long addrWrite, boolean goodAddrWrite,
+                                    boolean errorValue, boolean errorValue2,
+                                    boolean errorValueWrite) {
+    final var attrs = state.getAttributeSet();
+    final var myState = (RamState) getState(state);
+
+    final var dataLines = Math.max(1, DualportRamAppearance.getNrLEPorts(attrs));
+    final var misaligned = addr % dataLines != 0;
+    final var misalignError = misaligned && !state.getAttributeValue(ALLOW_MISALIGNED);
+
+    // perform writes
+    Object trigger = state.getAttributeValue(StdAttr.TRIGGER);
+    final var triggered = myState.setClock(state.getPortValue(DualportRamAppearance.getClkIndex(0, attrs)), trigger);
+    final var writeEnabled = triggered && (state.getPortValue(DualportRamAppearance.getWEIndex(0, attrs)) == Value.TRUE);
+    if (writeEnabled && goodAddrWrite && !misalignError) {
+      long dataValue = state.getPortValue(DualportRamAppearance.getDataInIndex(0, attrs)).toLongValue();
+      myState.getContents().set(addrWrite, dataValue);
+    }
+
+    // perform reads
+    final var width = state.getAttributeValue(DATA_ATTR);
+    final var outputEnabled = !state.getPortValue(DualportRamAppearance.getLEIndex(0, attrs)).equals(Value.FALSE);
+    final var outputEnabled2 = !state.getPortValue(DualportRamAppearance.getLEIndex(1, attrs)).equals(Value.FALSE);
+    if (outputEnabled && goodAddr && !misalignError) {
+      //for (var i = 0; i < dataLines; i++) {
+        long val = myState.getContents().get(addr);
+        state.setPort(DualportRamAppearance.getDataOutIndex(0, attrs), Value.createKnown(width, val), DELAY);
+      //}
+    } else if (outputEnabled && (errorValue || (goodAddr && misalignError))) {
+      //for (var i = 0; i < dataLines; i++)
+        state.setPort(DualportRamAppearance.getDataOutIndex(0, attrs), Value.createError(width), DELAY);
+    } else {
+      //for (var i = 0; i < dataLines; i++)
+        state.setPort(DualportRamAppearance.getDataOutIndex(0, attrs), Value.createUnknown(width), DELAY);
+    }
+    if (outputEnabled2 && goodAddr2 && !misalignError) {
+      long val2 = myState.getContents().get(addr2);
+      state.setPort(DualportRamAppearance.getDataOutIndex(1, attrs), Value.createKnown(width, val2), DELAY);
+    } else if (outputEnabled2 && (errorValue2 || (goodAddr2 && misalignError))) {
+      state.setPort(DualportRamAppearance.getDataOutIndex(1, attrs), Value.createError(width), DELAY);
+    } else {
+      state.setPort(DualportRamAppearance.getDataOutIndex(1, attrs), Value.createUnknown(width), DELAY);
+    }
+  }
+
+  private void propagateByteEnables(InstanceState state, long addr, boolean goodAddr,
+                                    long addr2, boolean goodAddr2,
+                                    long addrWrite, boolean goodAddrWrite,
+                                    boolean errorValue, boolean errorValue2,
+                                    boolean errorValueWrite) {
+    final var attrs = state.getAttributeSet();
+    final var myState = (RamState) getState(state);
+    long newMemValue = myState.getContents().get(myState.getCurrent());
+    long oldMemValue1 = myState.getContents().get(addr);
+    long oldMemValue2 = myState.getContents().get(addr2);
+    // perform writes
+    Object trigger = state.getAttributeValue(StdAttr.TRIGGER);
+    final var weValue = state.getPortValue(DualportRamAppearance.getWEIndex(0, attrs));
+    final var async = trigger.equals(StdAttr.TRIG_HIGH) || trigger.equals(StdAttr.TRIG_LOW);
+    final var edge =
+        !async && myState
+            .setClock(state.getPortValue(DualportRamAppearance.getClkIndex(0, attrs)), trigger);
+    final var weAsync =
+        (trigger.equals(StdAttr.TRIG_HIGH) && weValue.equals(Value.TRUE))
+            || (trigger.equals(StdAttr.TRIG_LOW) && weValue.equals(Value.FALSE));
+    final var weTriggered = (async && weAsync) || (edge && weValue.equals(Value.TRUE));
+    if (goodAddrWrite && weTriggered) {
+      long dataInValue = state.getPortValue(DualportRamAppearance.getDataInIndex(0, attrs)).toLongValue();
+      if (DualportRamAppearance.getNrBEPorts(attrs) == 0) {
+        newMemValue = dataInValue;
+      } else {
+        for (var i = 0; i < DualportRamAppearance.getNrBEPorts(attrs); i++) {
+          long mask = 0xFFL << (i * 8);
+          long andMask = ~mask;
+          if (state.getPortValue(DualportRamAppearance.getBEIndex(i, attrs)).equals(Value.TRUE)) {
+            newMemValue &= andMask;
+            newMemValue |= (dataInValue & mask);
+          }
+        }
+      }
+      myState.getContents().set(addrWrite, newMemValue);
+    }
+
+    // perform reads
+    final var dataBits = state.getAttributeValue(DATA_ATTR);
+    final var outputNotEnabled = state.getPortValue(DualportRamAppearance.getOEIndex(0, attrs)).equals(Value.FALSE);
+    final var outputNotEnabled2 = state.getPortValue(DualportRamAppearance.getOEIndex(1, attrs)).equals(Value.FALSE);
+
+    Consumer<Value> setValue = (Value value) -> state.setPort(DualportRamAppearance.getDataOutIndex(0, attrs), value, DELAY);
+    Consumer<Value> setValue2 = (Value value) -> state.setPort(DualportRamAppearance.getDataOutIndex(1, attrs), value, DELAY);
+
+    /* if both OEs are not activated, just return */
+    if (outputNotEnabled && outputNotEnabled2) return;
+
+    /* if the address is bogus set error value accordingly */
+
+    if (errorValue && !outputNotEnabled) {
+      setValue.accept(Value.createError(dataBits));
+      return;
+    }
+
+    if (errorValue2 && !outputNotEnabled2) {
+      setValue2.accept(Value.createError(dataBits));
+      return;
+    }
+
+    if (!goodAddr && !outputNotEnabled) {
+      setValue.accept(Value.createUnknown(dataBits));
+      return;
+    }
+
+    if (!goodAddr2 && !outputNotEnabled2) {
+      setValue.accept(Value.createUnknown(dataBits));
+      return;
+    }
+
+    final var asyncRead = async || attrs.getValue(Mem.ASYNC_READ);
+
+    if (asyncRead) {
+      if (!outputNotEnabled)
+        setValue.accept(Value.createKnown(dataBits, myState.getContents().get(addr)));
+      if (!outputNotEnabled2)
+        setValue2.accept(Value.createKnown(dataBits, myState.getContents().get(addr2)));
+      return;
+    }
+
+    if (edge) {
+      if (attrs.getValue(Mem.READ_ATTR).equals(Mem.READAFTERWRITE)) {
+        if (!outputNotEnabled) {
+          setValue.accept(Value.createKnown(dataBits, myState.getContents().get(addr)));
+        }
+        if (!outputNotEnabled2) {
+          setValue2.accept(Value.createKnown(dataBits, myState.getContents().get(addr2)));
+        }
+      } else {
+        if (!outputNotEnabled) {
+          setValue.accept(Value.createKnown(dataBits, oldMemValue1));
+        }
+        if (!outputNotEnabled2) {
+          setValue2.accept(Value.createKnown(dataBits, oldMemValue2));
+        }
+      }
+    }
+  }
+
+  @Override
+  public void removeComponent(Circuit circ, Component c, CircuitState state) {
+    if (state != null) closeHexFrame((RamState) state.getData(c));
+  }
+
+  @Override
+  public boolean checkForGatedClocks(netlistComponent comp) {
+    return true;
+  }
+
+  @Override
+  public int[] clockPinIndex(netlistComponent comp) {
+    return new int[] {DualportRamAppearance.getClkIndex(0, comp.getComponent().getAttributeSet())};
+  }
+}

--- a/src/main/java/com/cburch/logisim/std/memory/DualportRamAppearance.java
+++ b/src/main/java/com/cburch/logisim/std/memory/DualportRamAppearance.java
@@ -331,7 +331,9 @@ public class DualportRamAppearance {
   }
 
   private static Port getAddrPort(int portIndex, AttributeSet attrs) {
-    final var result = new Port(0, 10+(40*portIndex), Port.INPUT, attrs.getValue(Mem.ADDR_ATTR));
+    final var classic = classicAppearance(attrs);
+    final var yoffset = classic ? (20 * portIndex) : (40 * portIndex);
+    final var result = new Port(0, 10 + yoffset, Port.INPUT, attrs.getValue(Mem.ADDR_ATTR));
     switch(portIndex){
       case 0:
         result.setToolTip(S.getter("memAddr1Tip"));
@@ -413,7 +415,7 @@ public class DualportRamAppearance {
     if (portIndex >= nrWEs) return null;
     var ypos = 180+(portIndex*10);
     if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES) && classicAppearance(attrs))
-      ypos = 30;
+      ypos = 140;
     final var result = new Port(0, ypos, Port.INPUT, 1);
     result.setToolTip(S.getter("dpramWETip"));
     return result;
@@ -425,7 +427,7 @@ public class DualportRamAppearance {
     if (portIndex >= nrClks) return null;
     var ypos = 200;
     if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES) && classicAppearance(attrs))
-      ypos = 40;
+      ypos = 170;
     final var result = new Port(0, ypos, Port.INPUT, 1);
     result.setToolTip(S.getter("ramClkTip"));
     return result;
@@ -437,7 +439,7 @@ public class DualportRamAppearance {
     if (portIndex >= nrLEs) return null;
     var ypos = 140+(portIndex*20);
     if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES) && classicAppearance(attrs))
-      ypos = 40;
+      ypos = 100+(portIndex*20);
     final var result = new Port(0, ypos, Port.INPUT, 1);
     switch (portIndex) {
       case 0 -> result.setToolTip(S.getter("dpramLETip1"));

--- a/src/main/java/com/cburch/logisim/std/memory/DualportRamAppearance.java
+++ b/src/main/java/com/cburch/logisim/std/memory/DualportRamAppearance.java
@@ -1,0 +1,897 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.memory;
+
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.data.Bounds;
+import com.cburch.logisim.data.Direction;
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.instance.Instance;
+import com.cburch.logisim.instance.InstancePainter;
+import com.cburch.logisim.instance.Port;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.util.GraphicsUtil;
+
+import java.awt.*;
+
+import static com.cburch.logisim.std.Strings.S;
+
+
+public class DualportRamAppearance {
+
+  public static int getNrAddrPorts(AttributeSet attrs) {
+    return 3; //Addr1, Addr2, AddrWrite
+  }
+
+  public static int getNrDataInPorts(AttributeSet attrs) {
+    return 1;
+  }
+
+  public static int getNrDataOutPorts(AttributeSet attrs) {
+    return 2;
+  }
+
+  public static int getNrDataPorts(AttributeSet attrs) {
+    return getNrDataInPorts(attrs) + getNrDataOutPorts(attrs);
+  }
+
+  public static int getNrOEPorts(AttributeSet attrs) {
+    if (!attrs.containsAttribute(Mem.ENABLES_ATTR)) return 0;
+    if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USEBYTEENABLES))
+      return 2;
+    else
+      return 0;
+  }
+
+  public static int getNrWEPorts(AttributeSet attrs) {
+    if (!attrs.containsAttribute(Mem.ENABLES_ATTR)) return 0;
+    return 1;
+  }
+
+  public static int getNrClkPorts(AttributeSet attrs) {
+    if (!attrs.containsAttribute(Mem.ENABLES_ATTR))
+      return 0;
+    boolean async = !synchronous(attrs);
+    if (async && attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USEBYTEENABLES))
+      return 0;
+    else
+      return 1;
+  }
+
+  public static int getNrLEPorts(AttributeSet attrs) {
+    if (!attrs.containsAttribute(Mem.ENABLES_ATTR)) return 0;
+    if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES)) {
+        return 2;
+    }
+    return 0;
+  }
+
+  public static int getNrBEPorts(AttributeSet attrs) {
+    if (!attrs.containsAttribute(Mem.ENABLES_ATTR)) return 0;
+    final var async = !synchronous(attrs);
+    if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USEBYTEENABLES)
+        && attrs.getValue(DualportRamAttributes.ATTR_ByteEnables).equals(DualportRamAttributes.BUS_WITH_BYTEENABLES)
+        && !async) {
+      final var nrBits = attrs.getValue(Mem.DATA_ATTR).getWidth();
+      return (nrBits < 9) ? 0 : (nrBits + 7) >> 3;
+    }
+    return 0;
+  }
+
+  public static int getNrClrPorts(AttributeSet attrs) {
+    return (attrs.containsAttribute(DualportRamAttributes.CLEAR_PIN) && attrs.getValue(DualportRamAttributes.CLEAR_PIN))
+        ? 1
+        : 0;
+  }
+
+  public static int getNrOfPorts(AttributeSet attrs) {
+    return getNrAddrPorts(attrs) + getNrDataPorts(attrs) + getNrOEPorts(attrs) + getNrWEPorts(attrs)
+            + getNrClkPorts(attrs) + getNrLEPorts(attrs) + getNrBEPorts(attrs) + getNrClrPorts(attrs);
+  }
+
+  public static int getAddrIndex(int portIndex, AttributeSet attrs) {
+    return (portIndex <= 2) ? portIndex : -1;
+  }
+
+  public static int getDataInIndex(int portIndex, AttributeSet attrs) {
+    int portOffset = getNrAddrPorts(attrs) + getNrDataOutPorts(attrs);
+    return getDataOffset(portOffset, portIndex, attrs);
+  }
+
+  public static int getDataOutIndex(int portIndex, AttributeSet attrs) {
+    int portOffset = getNrAddrPorts(attrs);
+    return getDataOffset(portOffset, portIndex, attrs);
+  }
+
+  public static int getOEIndex(int portIndex, AttributeSet attrs) {
+    int portOffset = getNrAddrPorts(attrs) + getNrDataPorts(attrs);
+    int nrOEs = getNrOEPorts(attrs);
+    if (nrOEs == 0 || portIndex < 0) return -1;
+    if (portIndex < nrOEs) return portOffset + portIndex;
+    return -1;
+  }
+
+  public static int getWEIndex(int portIndex, AttributeSet attrs) {
+    int portOffset = getNrAddrPorts(attrs) + getNrDataPorts(attrs) + getNrOEPorts(attrs);
+    int nrWEs = getNrWEPorts(attrs);
+    if (nrWEs == 0 || portIndex < 0) return -1;
+    if (portIndex < nrWEs) return portOffset + portIndex;
+    return -1;
+  }
+
+  public static int getClkIndex(int portIndex, AttributeSet attrs) {
+    int portOffset = getNrAddrPorts(attrs) + getNrDataPorts(attrs) + getNrOEPorts(attrs) + getNrWEPorts(attrs);
+    if (getNrClkPorts(attrs) == 0 || portIndex != 0) return -1;
+    return portOffset;
+  }
+
+  public static int getLEIndex(int portIndex, AttributeSet attrs) {
+    int portOffset = getNrAddrPorts(attrs) + getNrDataPorts(attrs) + getNrOEPorts(attrs) + getNrWEPorts(attrs) + getNrClkPorts(attrs);
+    int nrLEs = getNrLEPorts(attrs);
+    if (nrLEs == 0 || portIndex < 0) return -1;
+    if (portIndex < nrLEs) return portOffset + portIndex;
+    return -1;
+  }
+
+  public static int getBEIndex(int portIndex, AttributeSet attrs) {
+    int portOffset = getNrAddrPorts(attrs) + getNrDataPorts(attrs) + getNrOEPorts(attrs) + getNrWEPorts(attrs)
+                      + getNrClkPorts(attrs) + getNrLEPorts(attrs);
+    int nrBEs = getNrBEPorts(attrs);
+    if (nrBEs == 0 || portIndex < 0) return -1;
+    if (portIndex < nrBEs) return portOffset + portIndex;
+    return -1;
+  }
+
+  public static int getClrIndex(int portIndex, AttributeSet attrs) {
+    int portOffset = getNrAddrPorts(attrs) + getNrDataPorts(attrs) + getNrOEPorts(attrs) + getNrWEPorts(attrs)
+                    + getNrClkPorts(attrs) + getNrLEPorts(attrs) + getNrBEPorts(attrs);
+    int nrClrs = getNrClrPorts(attrs);
+    if (nrClrs == 0 || portIndex < 0) return -1;
+    if (portIndex < nrClrs) return portOffset + portIndex;
+    return -1;
+  }
+
+  public static void configurePorts(Instance instance) {
+    final var attrs = instance.getAttributeSet();
+    final var ps = new Port[getNrOfPorts(attrs)];
+    for (var i = 0; i < getNrAddrPorts(attrs); i++)
+      ps[getAddrIndex(i, attrs)] = getAddrPort(i, attrs);
+    for (var i = 0; i < getNrDataInPorts(attrs); i++)
+      ps[getDataInIndex(i, attrs)] = getDataInPort(i, attrs);
+    for (var i = 0; i < getNrDataOutPorts(attrs); i++)
+      ps[getDataOutIndex(i, attrs)] = getDataOutPort(i, attrs, instance.getBounds().getWidth());
+    for (var i = 0; i < getNrOEPorts(attrs); i++)
+      ps[getOEIndex(i, attrs)] = getOEPort(i, attrs);
+    for (var i = 0; i < getNrWEPorts(attrs); i++)
+      ps[getWEIndex(i, attrs)] = getWEPort(i, attrs);
+    for (var i = 0; i < getNrClkPorts(attrs); i++)
+      ps[getClkIndex(i, attrs)] = getClkPort(i, attrs);
+    for (var i = 0; i < getNrLEPorts(attrs); i++)
+      ps[getLEIndex(i, attrs)] = getLEPort(i, attrs);
+    for (var i = 0; i < getNrBEPorts(attrs); i++)
+      ps[getBEIndex(i, attrs)] = getBEPort(i, attrs);
+    for (var i = 0; i < getNrClrPorts(attrs); i++)
+      ps[getClrIndex(i, attrs)] = getClrPort(i, attrs);
+    instance.setPorts(ps);
+  }
+
+  public static Bounds getBounds(AttributeSet attrs) {
+    int xoffset = 40;
+  
+    if (classicAppearance(attrs)) {
+      int len = Math.max(64, (getNrLEPorts(attrs) + 1) * 10);
+      return Bounds.create(0, 0, Mem.SymbolWidth + 40, getControlHeight(attrs) + len);
+    } else {
+      int len = Math.max(attrs.getValue(Mem.DATA_ATTR).getWidth() * 20, (getNrLEPorts(attrs) + 1) * 10);
+      return Bounds.create(0, 0, Mem.SymbolWidth + xoffset, getControlHeight(attrs) + len);
+    }
+    
+  }
+
+  public static boolean classicAppearance(AttributeSet attrs) {
+    return attrs.getValue(StdAttr.APPEARANCE).equals(StdAttr.APPEAR_CLASSIC);
+  }
+
+  public static void drawRamClassic(InstancePainter painter) {
+    final var attrs = painter.getAttributeSet();
+    final var g = painter.getGraphics();
+    final var bds = painter.getBounds();
+    final var inst = painter.getInstance();
+    g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
+    /* draw label */
+    final var Label = painter.getAttributeValue(StdAttr.LABEL);
+    if (Label != null && painter.getAttributeValue(StdAttr.LABEL_VISIBILITY)) {
+      final var font = g.getFont();
+      g.setFont(painter.getAttributeValue(StdAttr.LABEL_FONT));
+      GraphicsUtil.drawCenteredText(g, Label, bds.getX() + bds.getWidth() / 2, bds.getY() - g.getFont().getSize());
+      g.setFont(font);
+    }
+    /* draw body */
+    painter.drawBounds();
+    /* draw connections */
+    drawConnections(inst, attrs, painter);
+    /* draw the size */
+    final var type = inst.getFactory() instanceof DualportRam ? "DUALPORT-RAM " : "ROM ";  // FIXME: hardcoded string
+    GraphicsUtil.drawCenteredText(g,
+            type + Mem.getSizeLabel(painter.getAttributeValue(Mem.ADDR_ATTR).getWidth())
+                + " x " + painter.getAttributeValue(Mem.DATA_ATTR).getWidth(),
+            bds.getX() + (Mem.SymbolWidth / 2) + 20,
+            bds.getY() + 6);
+    /* draw the contents */
+    if (painter.getShowState()) {
+      MemState state = (MemState) inst.getData(painter.getCircuitState());
+      if (state != null)
+        state.paint(
+            painter.getGraphics(),
+            bds.getX(),
+            bds.getY(),
+            30,
+            15,
+            bds.getWidth() - 60,
+            bds.getHeight() - 20,
+            getNrToHighlight(attrs));
+    }
+  }
+
+  public static void drawRamEvolution(InstancePainter painter) {
+    final var attrs = painter.getAttributeSet();
+    final var g = painter.getGraphics();
+    final var bds = painter.getBounds();
+    final var inst = painter.getInstance();
+    g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
+    /* draw label */
+    final var Label = painter.getAttributeValue(StdAttr.LABEL);
+    if (Label != null && painter.getAttributeValue(StdAttr.LABEL_VISIBILITY)) {
+      final var font = g.getFont();
+      g.setFont(painter.getAttributeValue(StdAttr.LABEL_FONT));
+      GraphicsUtil.drawCenteredText(g, Label, bds.getX() + bds.getWidth() / 2, bds.getY() - g.getFont().getSize());
+      g.setFont(font);
+    }
+    /* draw shape */
+    drawControlBlock(inst, attrs, painter);
+    drawDataBlocks(inst, attrs, painter);
+    /* draw connections */
+    drawConnections(inst, attrs, painter);
+    /* draw the size */
+    final var type = inst.getFactory() instanceof DualportRam ? "DUALPORT-RAM " : "ROM ";  // FIXME hardcoded string
+    GraphicsUtil.drawCenteredText(g,
+            type + Mem.getSizeLabel(painter.getAttributeValue(Mem.ADDR_ATTR).getWidth())
+                + " x " + painter.getAttributeValue(Mem.DATA_ATTR).getWidth(),
+            bds.getX() + (Mem.SymbolWidth / 2) + 20, bds.getY() + 6);
+    /* draw the contents */
+    if (painter.getShowState()) {
+      final var state = (MemState) inst.getData(painter.getCircuitState());
+      if (state != null)
+        state.paint(
+            painter.getGraphics(),
+            bds.getX(),
+            bds.getY(),
+            50,
+            getControlHeight(attrs) + 5,
+            bds.getWidth() - 100,
+            bds.getHeight() - 10 - getControlHeight(attrs),
+            getNrToHighlight(attrs));
+    }
+  }
+
+  public static int getControlHeight(AttributeSet attrs) {
+    var result = 70;
+    if (attrs.containsAttribute(Mem.ENABLES_ATTR) && attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES)) {
+      if (!classicAppearance(attrs)) result += 30;
+      result += getNrLEPorts(attrs) * 10;
+    } else if (attrs.containsAttribute(StdAttr.TRIGGER)) {
+      final var async = !synchronous(attrs);
+      result += 20;
+      if (!async) result += 10;
+      result += getNrBEPorts(attrs) * 10;
+    }
+    result += getNrAddrPorts(attrs) * 30;
+    result += getNrOEPorts(attrs) * 10;
+    result += getNrWEPorts(attrs) * 10;
+    return result;
+  }
+
+  /* here all private handles are defined */
+  private static int getNrToHighlight(AttributeSet attrs) {
+    return 1;
+  }
+
+  private static int getDataOffset(int portOffset, int portIndex, AttributeSet attrs) {
+    switch (portIndex) {
+      case 0:
+        return portOffset;
+      case 1:
+        return portOffset + 1;
+      case 2:
+      case 3:
+        if ((!attrs.containsAttribute(Mem.ENABLES_ATTR)
+                || attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES))
+            && (attrs.getValue(Mem.LINE_ATTR).equals(Mem.QUAD)
+                || attrs.getValue(Mem.LINE_ATTR).equals(Mem.OCTO))) return portOffset + portIndex;
+        else return -1;
+      case 4:
+      case 5:
+      case 6:
+      case 7:
+        if ((!attrs.containsAttribute(Mem.ENABLES_ATTR)
+                || attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES))
+            && attrs.getValue(Mem.LINE_ATTR).equals(Mem.OCTO)) return portOffset + portIndex;
+        else return -1;
+      default:
+        return -1;
+    }
+  }
+
+  private static Port getAddrPort(int portIndex, AttributeSet attrs) {
+    final var result = new Port(0, 10+(40*portIndex), Port.INPUT, attrs.getValue(Mem.ADDR_ATTR));
+    switch(portIndex){
+      case 0:
+        result.setToolTip(S.getter("memAddr1Tip"));
+        break;
+      case 1:
+        result.setToolTip(S.getter("memAddr2Tip"));
+        break;
+      case 2:
+        result.setToolTip(S.getter("memAddrWriteTip"));
+        break;
+      default:
+        // none
+    }
+    return result;
+  }
+
+  private static Port getDataInPort(int portIndex, AttributeSet attrs) {
+    final var nrDins = getNrDataInPorts(attrs);
+    if (nrDins == 0 || portIndex < 0) return null;
+    if (portIndex >= nrDins) return null;
+    var ypos = getControlHeight(attrs);
+    final var classic = classicAppearance(attrs);
+    final var bits = attrs.getValue(Mem.DATA_ATTR);
+    if (!classic && bits.getWidth() == 1) ypos += 10;
+    ypos += portIndex * 10;
+    final var result = new Port(0, ypos, Port.INPUT, bits);
+    result.setToolTip(S.getter("dpramInTip"));
+    return result;
+  }
+
+  private static Port getDataOutPort(int portIndex, AttributeSet attrs, int xpos) {
+    final var nrDouts = getNrDataOutPorts(attrs);
+    if (nrDouts == 0 || portIndex < 0) return null;
+    if (portIndex >= nrDouts) return null;
+    var ypos = getControlHeight(attrs);
+    var portType = Port.OUTPUT;
+    final var classic = classicAppearance(attrs);
+    final var bits = attrs.getValue(Mem.DATA_ATTR);
+    if (!classic && bits.getWidth() == 1) ypos += 10;
+    ypos += portIndex * 10;
+    final var result = new Port(xpos, ypos, portType, bits);
+    switch (portIndex) {
+      case 0:
+        result.setToolTip(S.getter("memData1Tip"));
+        break;
+      case 1:
+        result.setToolTip(S.getter("memData2Tip"));
+        break;
+      default:
+        // none
+    }
+    return result;
+  }
+
+  private static Port getOEPort(int portIndex, AttributeSet attrs) {
+    final var nrOEs = getNrOEPorts(attrs);
+    if (nrOEs == 0 || portIndex < 0) return null;
+    if (portIndex >= nrOEs) return null;
+    var ypos = 140+(portIndex*20);
+    if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES) && classicAppearance(attrs))
+      ypos = 20;
+    final var result = new Port(0, ypos, Port.INPUT, 1);
+    switch (portIndex) {
+      case 0:
+        result.setToolTip(S.getter("dpramOETip1"));
+        break;
+      case 1:
+        result.setToolTip(S.getter("dpramOETip2"));
+        break;
+      default:
+        // none
+    }
+    return result;
+  }
+
+  private static Port getWEPort(int portIndex, AttributeSet attrs) {
+    final var nrWEs = getNrWEPorts(attrs);
+    if (nrWEs == 0 || portIndex < 0) return null;
+    if (portIndex >= nrWEs) return null;
+    var ypos = 180+(portIndex*10);
+    if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES) && classicAppearance(attrs))
+      ypos = 30;
+    final var result = new Port(0, ypos, Port.INPUT, 1);
+    result.setToolTip(S.getter("dpramWETip"));
+    return result;
+  }
+
+  private static Port getClkPort(int portIndex, AttributeSet attrs) {
+    final var nrClks = getNrClkPorts(attrs);
+    if (nrClks == 0 || portIndex < 0) return null;
+    if (portIndex >= nrClks) return null;
+    var ypos = 200;
+    if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES) && classicAppearance(attrs))
+      ypos = 40;
+    final var result = new Port(0, ypos, Port.INPUT, 1);
+    result.setToolTip(S.getter("ramClkTip"));
+    return result;
+  }
+
+  private static Port getLEPort(int portIndex, AttributeSet attrs) {
+    final var nrLEs = getNrLEPorts(attrs);
+    if (nrLEs == 0 || portIndex < 0) return null;
+    if (portIndex >= nrLEs) return null;
+    var ypos = 140+(portIndex*20);
+    if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES) && classicAppearance(attrs))
+      ypos = 40;
+    final var result = new Port(0, ypos, Port.INPUT, 1);
+    switch (portIndex) {
+      case 0 -> result.setToolTip(S.getter("dpramLETip1"));
+      case 1 -> result.setToolTip(S.getter("dpramLETip2"));
+      default -> {
+        // none
+      }
+    }
+    return result;
+  }
+
+  private static Port getBEPort(int portIndex, AttributeSet attrs) {
+    final var nrBEs = getNrBEPorts(attrs);
+    if (nrBEs == 0 || portIndex < 0) return null;
+    if (portIndex >= nrBEs) return null;
+    final var ypos = 70 + (nrBEs - portIndex - 1) * 10;
+    final var result = new Port(0, ypos, Port.INPUT, 1);
+    switch (portIndex) {
+      case 0 -> result.setToolTip(S.getter("ramByteEnableTip0"));
+      case 1 -> result.setToolTip(S.getter("ramByteEnableTip1"));
+      case 2 -> result.setToolTip(S.getter("ramByteEnableTip2"));
+      case 3 -> result.setToolTip(S.getter("ramByteEnableTip3"));
+      default -> {
+        // none
+      }
+    }
+    return result;
+  }
+
+  private static Port getClrPort(int portIndex, AttributeSet attrs) {
+    if (getNrClrPorts(attrs) == 0 || portIndex != 0) return null;
+    final var result = new Port(40, 0, Port.INPUT, 1);
+    result.setToolTip(S.getter("ramClrPin"));
+    return result;
+  }
+
+  private static boolean synchronous(AttributeSet attrs) {
+    return attrs.containsAttribute(StdAttr.TRIGGER)
+        && (attrs.getValue(StdAttr.TRIGGER).equals(StdAttr.TRIG_RISING)
+            || attrs.getValue(StdAttr.TRIGGER).equals(StdAttr.TRIG_FALLING));
+  }
+
+  private static void drawConnections(Instance inst, AttributeSet attrs, InstancePainter painter) {
+    boolean classic = classicAppearance(attrs);
+    final var g = (Graphics2D) painter.getGraphics().create();
+    final var font = g.getFont();
+    g.setStroke(new BasicStroke(4));
+    String label;
+    final var nrOfBits = attrs.getValue(Mem.DATA_ATTR).getWidth();
+    final var nrOfDataPorts = Math.max(getNrDataInPorts(attrs), getNrDataOutPorts(attrs));
+
+    /* Draw data input connections */
+    for (var i = 0; i < getNrDataInPorts(attrs); i++) {
+      label = !classic ? "" : getNrDataInPorts(attrs) == 1 ? "D" : "D" + i;
+      final var idx = getDataInIndex(i, attrs);
+      if (!classic) {
+        final var loc = inst.getPortLocation(idx);
+        final var x = loc.getX();
+        final var y = loc.getY();
+        if (nrOfBits == 1) {
+          g.setStroke(new BasicStroke(2));
+          if (nrOfDataPorts > 1) {
+            final var xpos = new int[4];
+            final var ypos = new int[4];
+            xpos[0] = x;
+            xpos[1] = xpos[2] = x + 4 + i * 4;
+            xpos[3] = x + 20;
+            ypos[0] = ypos[1] = y;
+            ypos[2] = ypos[3] = y - (i + 1) * 6;
+            g.drawPolyline(xpos, ypos, 4);
+          } else {
+            g.drawLine(x, y, x + 20, y);
+          }
+          g.setStroke(new BasicStroke(4));
+        } else {
+          if (i != 0) {
+            if (i == 3 && nrOfBits == 2)
+              g.drawLine(loc.getX(), loc.getY(), loc.getX() + 4, loc.getY() - 4);
+            else
+              g.drawLine(loc.getX(), loc.getY(), loc.getX() + 4, loc.getY() + 4);
+          } else {
+            final var xpos = new int[3];
+            final var ypos = new int[3];
+            g.setStroke(new BasicStroke(2));
+            xpos[0] = x + 5;
+            xpos[1] = x + 10;
+            xpos[2] = x + 20;
+            ypos[0] = y + 5;
+            ypos[1] = ypos[2] = y + 10;
+            g.setFont(font.deriveFont(7.0f));
+            g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
+            for (var j = 0; j < nrOfBits; j++) {
+              g.drawPolyline(xpos, ypos, 3);
+              GraphicsUtil.drawText(g, Integer.toString(j), xpos[2] - 3, ypos[2] - 3, GraphicsUtil.H_RIGHT, GraphicsUtil.V_BASELINE);
+              ypos[0] += 20;
+              ypos[1] += 20;
+              ypos[2] += 20;
+            }
+            g.setColor(Value.multiColor);
+            g.setStroke(new BasicStroke(4));
+            xpos[0] = x;
+            xpos[1] = xpos[2] = x + 5;
+            ypos[0] = y;
+            ypos[1] = y + 5;
+            ypos[2] = y + 5 + (nrOfBits - 1) * 20;
+            g.drawPolyline(xpos, ypos, 3);
+          }
+        }
+      }
+      painter.drawPort(idx, label, Direction.EAST);
+    }
+
+    /* Draw data output connections (& in/out)*/
+    for (var i = 0; i < getNrDataOutPorts(attrs); i++) {
+      label = !classic ? "" : getNrDataOutPorts(attrs) == 1 ? "D" : "D" + i;
+      int idx = getDataOutIndex(i, attrs);
+      if (!classic) {
+        final var loc = inst.getPortLocation(idx);
+        final var x = loc.getX();
+        final var y = loc.getY();
+        if (nrOfBits == 1) {
+          g.setStroke(new BasicStroke(2));
+          if (nrOfDataPorts > 1) {
+            final var xpos = new int[4];
+            final var ypos = new int[4];
+            xpos[0] = x;
+            xpos[1] = xpos[2] = x - (i + 1) * 4;
+            xpos[3] = x - 20;
+            ypos[0] = ypos[1] = y;
+            ypos[2] = ypos[3] = y - (i + 1) * 6;
+            g.drawPolyline(xpos, ypos, 4);
+          } else {
+            g.drawLine(x, y, x - 20, y);
+          }
+          g.setStroke(new BasicStroke(4));
+        } else {
+          if (i != 0) {
+            if (i == 3 && nrOfBits == 2)
+              g.drawLine(x - 4, y - 4, x, y);
+            else
+              g.drawLine(x - 4, y + 4, x, y);
+          } else {
+            final var xpos = new int[3];
+            final var ypos = new int[3];
+            g.setStroke(new BasicStroke(2));
+            xpos[0] = x - 5;
+            xpos[1] = x - 10;
+            xpos[2] = x - 20;
+            ypos[0] = y + 5;
+            ypos[1] = ypos[2] = y + 10;
+            g.setFont(font.deriveFont(7.0f));
+            g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
+            for (var j = 0; j < nrOfBits; j++) {
+              g.drawPolyline(xpos, ypos, 3);
+              GraphicsUtil.drawText(g, Integer.toString(j), xpos[2] + 3, ypos[2] - 3, GraphicsUtil.H_LEFT, GraphicsUtil.V_BASELINE);
+              ypos[0] += 20;
+              ypos[1] += 20;
+              ypos[2] += 20;
+            }
+            g.setStroke(new BasicStroke(4));
+            g.setColor(Value.multiColor);
+            xpos[0] = x;
+            xpos[1] = xpos[2] = x - 5;
+            ypos[0] = y;
+            ypos[1] = y + 5;
+            ypos[2] = y + 5 + (nrOfBits - 1) * 20;
+            g.drawPolyline(xpos, ypos, 3);
+          }
+        }
+      }
+      painter.drawPort(idx, label, Direction.WEST);
+    }
+
+    for (var i = 0; i < getNrAddrPorts(attrs); i++) {
+      label = !classic ? "" : getNrAddrPorts(attrs) == 1 ? "A" : "A" + i;
+      int idx = getAddrIndex(i, attrs);
+      if (!classic) {
+        final var loc = inst.getPortLocation(idx);
+        int x = loc.getX();
+        int y = loc.getY();
+        final var xpos = new int[3];
+        final var ypos = new int[3];
+        g.setStroke(new BasicStroke(2));
+        g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
+        xpos[0] = x + 5;
+        xpos[1] = x + 10;
+        xpos[2] = x + 20;
+        ypos[0] = y + 5;
+        ypos[1] = ypos[2] = y + 10;
+        g.drawPolyline(xpos, ypos, 3);
+        for (var j = 0; j < 3; j++) {
+          ypos[j] += 20;
+          if (attrs.getValue(Mem.ADDR_ATTR).getWidth() > 2)
+            g.drawLine(x + 15, y + 13 + j * 6, x + 15, y + 15 + j * 6);
+        }
+        g.drawPolyline(xpos, ypos, 3);
+        g.setColor(Value.multiColor);
+        g.setStroke(new BasicStroke(4));
+        xpos[0] = x;
+        xpos[1] = xpos[2] = x + 5;
+        ypos[0] = y;
+        ypos[1] = y + 5;
+        ypos[2] = y + 25;
+        g.drawPolyline(xpos, ypos, 3);
+      }
+      painter.drawPort(idx, label, Direction.EAST);
+    }
+
+
+    /* draw control block connections */
+    g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
+
+    g.setStroke(new BasicStroke(2));
+    for (var i = 0; i < getNrOEPorts(attrs); i++) {
+      label = !classic ? "" : getNrOEPorts(attrs) == 1 ? "OE" : "OE" + i;
+      final var idx = getOEIndex(i, attrs);
+      if (!classic) {
+        final var loc = inst.getPortLocation(idx);
+        g.drawLine(loc.getX(), loc.getY(), loc.getX() + 20, loc.getY());
+      }
+      painter.drawPort(idx, label, Direction.EAST);
+    }
+
+    for (var i = 0; i < getNrWEPorts(attrs); i++) {
+      label = !classic ? "" : getNrWEPorts(attrs) == 1 ? "WE" : "WE" + i;
+      final var idx = getWEIndex(i, attrs);
+      if (!classic) {
+        final var loc = inst.getPortLocation(idx);
+        g.drawLine(loc.getX(), loc.getY(), loc.getX() + 20, loc.getY());
+      }
+      painter.drawPort(idx, label, Direction.EAST);
+    }
+
+    for (var i = 0; i < getNrClkPorts(attrs); i++) {
+      final var idx = getClkIndex(i, attrs);
+      if (!classic) {
+        final var loc = inst.getPortLocation(idx);
+        var xend = 20;
+        if (attrs.getValue(StdAttr.TRIGGER).equals(StdAttr.TRIG_FALLING)
+            || attrs.getValue(StdAttr.TRIGGER).equals(StdAttr.TRIG_LOW)) {
+          xend -= 8;
+          g.drawOval(loc.getX() + 12, loc.getY() - 4, 8, 8);
+        }
+        g.drawLine(loc.getX(), loc.getY(), loc.getX() + xend, loc.getY());
+        if (synchronous(attrs)) painter.drawClockSymbol(loc.getX() + 20, loc.getY());
+        painter.drawPort(idx);
+      } else {
+        if (synchronous(attrs))
+          painter.drawClock(idx, Direction.EAST);
+        else
+          painter.drawPort(idx, getNrClkPorts(attrs) == 1 ? "E" : "E" + i, Direction.EAST);
+      }
+    }
+
+    for (var i = 0; i < getNrLEPorts(attrs); i++) {
+      label = !classic ? "" : getNrLEPorts(attrs) == 1 ? "LE" : "LE" + i;
+      final var idx = getLEIndex(i, attrs);
+      if (!classic) {
+        final var loc = inst.getPortLocation(idx);
+        g.drawLine(loc.getX(), loc.getY(), loc.getX() + 20, loc.getY());
+      }
+      painter.drawPort(idx, label, Direction.EAST);
+    }
+
+    for (var i = 0; i < getNrBEPorts(attrs); i++) {
+      label = !classic ? "" : getNrBEPorts(attrs) == 1 ? "BE" : "BE" + i;
+      int idx = getBEIndex(i, attrs);
+      if (!classic) {
+        final var loc = inst.getPortLocation(idx);
+        g.drawLine(loc.getX(), loc.getY(), loc.getX() + 20, loc.getY());
+      }
+      painter.drawPort(idx, label, Direction.EAST);
+    }
+
+    for (var i = 0; i < getNrClrPorts(attrs); i++) {
+      final var idx = getClrIndex(i, attrs);
+      painter.drawPort(idx);
+    }
+    g.dispose();
+  }
+
+  private static void drawControlBlock(Instance inst, AttributeSet attrs, InstancePainter painter) {
+    final var g = (Graphics2D) painter.getGraphics().create();
+    /* draw outer line of the controlblock */
+    final var xpos = new int[8];
+    final var ypos = new int[8];
+    final var x = painter.getBounds().getX();
+    final var y = painter.getBounds().getY();
+    xpos[0] = xpos[1] = x + 30;
+    xpos[2] = xpos[3] = x + 20;
+    xpos[4] = xpos[5] = x + Mem.SymbolWidth + 20;
+    xpos[6] = xpos[7] = x + Mem.SymbolWidth + 10;
+    ypos[0] = ypos[7] = y + getControlHeight(attrs);
+    ypos[1] = ypos[2] = ypos[5] = ypos[6] = ypos[0] - 10;
+    ypos[3] = ypos[4] = y;
+    GraphicsUtil.switchToWidth(g, 2);
+    g.drawPolyline(xpos, ypos, 8);
+
+    /* draw address text*/
+    for (var i = 0; i < getNrAddrPorts(attrs); i++) {
+      final var idx = getAddrIndex(i, attrs);
+      final var loc = inst.getPortLocation(idx);
+      drawAddress(g, loc.getX(), loc.getY(), attrs.getValue(Mem.ADDR_ATTR).getWidth());
+    }
+
+    var cidx = 1;
+    /* draw clock port text*/
+    for (var i = 0; i < getNrClkPorts(attrs); i++) {
+      final var idx = getClkIndex(i, attrs);
+      final var loc = inst.getPortLocation(idx);
+      final var label = synchronous(attrs) ? "C" + cidx : "E" + cidx;
+      cidx++;
+      g.drawString(label, loc.getX() + 33, loc.getY() + 5);
+    }
+    
+    /* draw output enable text*/
+    for (var i = 0; i < getNrOEPorts(attrs); i++) {
+      final var idx = getOEIndex(i, attrs);
+      final var loc = inst.getPortLocation(idx);
+      final var label = "M" + cidx + " [Output enable "+ (i + 1) +"]";
+      cidx++;
+      g.drawString(label, loc.getX() + 33, loc.getY() + 5);
+    }
+
+    /* draw write enable text */
+    for (var i = 0; i < getNrWEPorts(attrs); i++) {
+      final var idx = getWEIndex(i, attrs);
+      final var loc = inst.getPortLocation(idx);
+      final var label = "M" + cidx + " [Write enable]";
+      cidx++;
+      g.drawString(label, loc.getX() + 33, loc.getY() + 5);
+    }
+
+    /* draw line enable text */
+    for (var i = 0; i < getNrLEPorts(attrs); i++) {
+      final var idx = getLEIndex(i, attrs);
+      final var loc = inst.getPortLocation(idx);
+      final var label = "M" + cidx + " [Line enable " + (i + 1) + "]";
+      cidx++;
+      g.drawString(label, loc.getX() + 33, loc.getY() + 5);
+    }
+
+    /* draw byte enable text */
+    for (var i = 0; i < getNrBEPorts(attrs); i++) {
+      final var idx = getBEIndex(i, attrs);
+      final var loc = inst.getPortLocation(idx);
+      final var label = "M" + cidx + " [Byte enable " + i + "]";
+      cidx++;
+      g.drawString(label, loc.getX() + 33, loc.getY() + 5);
+    }
+    g.dispose();
+  }
+
+  private static void drawDataBlocks(Instance inst, AttributeSet attrs, InstancePainter painter) {
+    final var g = (Graphics2D) painter.getGraphics().create();
+    final var x = painter.getBounds().getX() + 20;
+    var y = painter.getBounds().getY() + getControlHeight(attrs);
+    final var width = Mem.SymbolWidth;
+    final var height = 20;
+    g.setFont(g.getFont().deriveFont(9.0f));
+    final var nrOfBits = attrs.getValue(Mem.DATA_ATTR).getWidth();
+    final var doutLabel = new StringBuilder();
+    final var dinLabel = new StringBuilder();
+    doutLabel.append("A");
+    dinLabel.append("A");
+    var cidx = 1;
+    final var async = !synchronous(attrs) || (attrs.containsAttribute(Mem.ASYNC_READ) && attrs.getValue(Mem.ASYNC_READ));
+    for (var i = 0; i < getNrClkPorts(attrs); i++) {
+      if (!async) doutLabel.append(",").append(cidx);
+      dinLabel.append(",").append(cidx);
+      cidx++;
+    }
+    for (var i = 0; i < getNrOEPorts(attrs); i++) {
+      doutLabel.append(",").append(cidx);
+      cidx++;
+    }
+    for (var i = 0; i < getNrWEPorts(attrs); i++) {
+      dinLabel.append(",").append(cidx);
+      cidx++;
+    }
+    for (var i = 0; i < getNrLEPorts(attrs); i++) {
+      dinLabel.append(",").append(cidx);
+      cidx++;
+    }
+    final var appendBE = getNrBEPorts(attrs) > 0;
+    final var DLabel = "D";
+    for (var i = 0; i < nrOfBits; i++) {
+      g.setStroke(new BasicStroke(2));
+      g.drawRect(x, y, width, height);
+      g.setStroke(new BasicStroke(1));
+      GraphicsUtil.drawText(g, doutLabel.toString(), x - 3 + Mem.SymbolWidth, y + 10, GraphicsUtil.H_RIGHT, GraphicsUtil.V_CENTER);
+      var BEIndex = "";
+      if (appendBE) {
+        final var beIdx = cidx + (i >> 3);
+        BEIndex = "," + beIdx;
+      }
+      GraphicsUtil.drawText(
+              g,
+              dinLabel + BEIndex + DLabel,
+              x + 3,
+              y + 10,
+              GraphicsUtil.H_LEFT,
+              GraphicsUtil.V_CENTER);
+      y += 20;
+    }
+    g.dispose();
+  }
+
+  private static void drawBidir(Graphics2D g, int x, int y) {
+    final var xpos = new int[4];
+    final var ypos = new int[4];
+    xpos[0] = xpos[3] = x - 10;
+    xpos[1] = xpos[2] = x;
+    ypos[0] = ypos[1] = y - 5;
+    ypos[2] = ypos[3] = y + 5;
+    g.drawPolyline(xpos, ypos, 4);
+    xpos[0] = xpos[2] = x - 4;
+    xpos[1] = x - 8;
+    ypos[0] = y + 2;
+    ypos[1] = y + 5;
+    ypos[2] = y + 8;
+    g.drawPolyline(xpos, ypos, 3);
+    xpos[0] = xpos[2] = x - 6;
+    xpos[1] = x - 2;
+    ypos[0] = y - 8;
+    ypos[1] = y - 5;
+    ypos[2] = y - 2;
+    g.drawPolyline(xpos, ypos, 3);
+  }
+
+  private static void drawAddress(Graphics2D g, int xpos, int ypos, int nrAddressBits) {
+    GraphicsUtil.switchToWidth(g, 1);
+    GraphicsUtil.drawText(g, "0", xpos + 22, ypos + 10, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
+    GraphicsUtil.drawText(
+        g,
+        Integer.toString(nrAddressBits - 1),
+        xpos + 22,
+        ypos + 30,
+        GraphicsUtil.H_LEFT,
+        GraphicsUtil.V_CENTER);
+    GraphicsUtil.drawText(g, "A", xpos + 50, ypos + 20, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
+    g.drawLine(xpos + 40, ypos + 5, xpos + 45, ypos + 10);
+    g.drawLine(xpos + 45, ypos + 10, xpos + 45, ypos + 17);
+    g.drawLine(xpos + 45, ypos + 17, xpos + 48, ypos + 20);
+    g.drawLine(xpos + 48, ypos + 20, xpos + 45, ypos + 23);
+    g.drawLine(xpos + 45, ypos + 23, xpos + 45, ypos + 30);
+    g.drawLine(xpos + 40, ypos + 35, xpos + 45, ypos + 30);
+    final var size = Long.toString((1 << nrAddressBits) - 1);
+    final var font = g.getFont();
+    final var fm = g.getFontMetrics(font);
+    final var StrSize = fm.stringWidth(size);
+    g.drawLine(xpos + 60, ypos + 20, xpos + 60 + StrSize, ypos + 20);
+    GraphicsUtil.drawText(g, "0", xpos + 60 + (StrSize / 2), ypos + 19, GraphicsUtil.H_CENTER, GraphicsUtil.V_BOTTOM);
+    GraphicsUtil.drawText(g, size, xpos + 60 + (StrSize / 2), ypos + 21, GraphicsUtil.H_CENTER, GraphicsUtil.V_TOP);
+  }
+
+}

--- a/src/main/java/com/cburch/logisim/std/memory/DualportRamAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/DualportRamAttributes.java
@@ -1,0 +1,280 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.memory;
+
+import com.cburch.logisim.data.*;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.prefs.AppPreferences;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.cburch.logisim.std.Strings.S;
+
+public class DualportRamAttributes extends AbstractAttributeSet {
+
+  /* here the rest is defined */
+  static final AttributeOption VOLATILE =
+      new AttributeOption("volatile", S.getter("ramTypeVolatile"));
+  static final AttributeOption NONVOLATILE =
+      new AttributeOption("nonvolatile", S.getter("ramTypeNonVolatile"));
+  static final Attribute<AttributeOption> ATTR_TYPE =
+      Attributes.forOption(
+          "type", S.getter("ramTypeAttr"), new AttributeOption[] {VOLATILE, NONVOLATILE});
+  static final AttributeOption BUS_BIDIR =
+      new AttributeOption("bidir", S.getter("ramBidirDataBus"));
+  //static final AttributeOption BUS_SEP =
+  //    new AttributeOption("bibus", S.getter("ramSeparateDataBus"));
+  //static final Attribute<AttributeOption> ATTR_DBUS =
+  //    Attributes.forOption(
+  //        "databus", S.getter("ramDataAttr"), new AttributeOption[] {BUS_BIDIR, BUS_SEP});
+  static final AttributeOption BUS_WITH_BYTEENABLES =
+      new AttributeOption("byteEnables", S.getter("ramWithByteEnables"));
+  static final AttributeOption BUS_WITHOUT_BYTE_ENABLES =
+      new AttributeOption("NobyteEnables", S.getter("ramNoByteEnables"));
+  static final Attribute<AttributeOption> ATTR_ByteEnables =
+      Attributes.forOption(
+          "byteenables",
+          S.getter("ramByteEnables"),
+          new AttributeOption[] {BUS_WITH_BYTEENABLES, BUS_WITHOUT_BYTE_ENABLES});
+  static final Attribute<Boolean> CLEAR_PIN =
+      Attributes.forBoolean("clearpin", S.getter("RamClearPin"));
+  private final ArrayList<Attribute<?>> myAttributes = new ArrayList<>();
+
+  private BitWidth addrBits = BitWidth.create(8);
+  private BitWidth dataBits = BitWidth.create(8);
+  private String label = "";
+  private AttributeOption trigger = StdAttr.TRIG_RISING;
+  //private AttributeOption busStyle = BUS_SEP;
+  private Font labelFont = StdAttr.DEFAULT_LABEL_FONT;
+  private Boolean labelVisible = false;
+  private AttributeOption byteEnables = BUS_WITHOUT_BYTE_ENABLES;
+  private Boolean asynchronousRead = false;
+  private AttributeOption appearance = AppPreferences.getDefaultAppearance();
+  private AttributeOption readWriteBehavior = Mem.READAFTERWRITE;
+  private Boolean clearPin = false;
+  private AttributeOption lineSize = Mem.SINGLE;
+  private Boolean allowMisaligned = false;
+  private AttributeOption typeOfEnables = Mem.USEBYTEENABLES;
+  private AttributeOption ramType = VOLATILE;
+
+  DualportRamAttributes() {
+    updateAttributes();
+  }
+
+  public boolean updateAttributes() {
+    final var newList = new ArrayList<Attribute<?>>();
+    var changes = false;
+    newList.add(Mem.ADDR_ATTR);
+    newList.add(Mem.DATA_ATTR);
+    newList.add(Mem.ENABLES_ATTR);
+    newList.add(ATTR_TYPE);
+    newList.add(CLEAR_PIN);
+    if (typeOfEnables.equals(Mem.USEBYTEENABLES)) {
+      newList.add(StdAttr.TRIGGER);
+      if (trigger.equals(StdAttr.TRIG_RISING) || trigger.equals(StdAttr.TRIG_FALLING)) {
+        changes |= !myAttributes.contains(Mem.ASYNC_READ);
+        newList.add(Mem.ASYNC_READ);
+        if (!asynchronousRead) {
+          changes |= !myAttributes.contains(Mem.READ_ATTR);
+          newList.add(Mem.READ_ATTR);
+        } else changes |= myAttributes.contains(Mem.READ_ATTR);
+        if (dataBits.getWidth() > 8) {
+          changes |= !myAttributes.contains(ATTR_ByteEnables);
+          newList.add(ATTR_ByteEnables);
+        } else changes |= myAttributes.contains(ATTR_ByteEnables);
+      } else changes |= myAttributes.contains(Mem.ASYNC_READ);
+      //changes |= myAttributes.contains(Mem.LINE_ATTR);
+      changes |= myAttributes.contains(Mem.ALLOW_MISALIGNED);
+    } else {
+      //newList.add(Mem.LINE_ATTR);
+      newList.add(Mem.ALLOW_MISALIGNED);
+      newList.add(StdAttr.TRIGGER);
+      //changes |= !myAttributes.contains(Mem.LINE_ATTR);
+      changes |= !myAttributes.contains(Mem.ALLOW_MISALIGNED);
+    }
+    newList.add(StdAttr.LABEL);
+    newList.add(StdAttr.LABEL_FONT);
+    newList.add(StdAttr.LABEL_VISIBILITY);
+    newList.add(StdAttr.APPEARANCE);
+    if (changes) {
+      myAttributes.clear();
+      myAttributes.addAll(newList);
+    }
+    return changes;
+  }
+
+  @Override
+  protected void copyInto(AbstractAttributeSet dest) {
+    final var d = (DualportRamAttributes) dest;
+    d.addrBits = addrBits;
+    d.dataBits = dataBits;
+    d.trigger = trigger;
+    d.labelFont = labelFont;
+    d.appearance = appearance;
+    d.byteEnables = byteEnables;
+    d.asynchronousRead = asynchronousRead;
+    d.readWriteBehavior = readWriteBehavior;
+    d.clearPin = clearPin;
+    d.lineSize = lineSize;
+    d.allowMisaligned = allowMisaligned;
+    d.typeOfEnables = typeOfEnables;
+    d.ramType = ramType;
+  }
+
+  @Override
+  public List<Attribute<?>> getAttributes() {
+    return myAttributes;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <V> V getValue(Attribute<V> attr) {
+    if (attr == Mem.ADDR_ATTR) {
+      return (V) addrBits;
+    }
+    if (attr == Mem.DATA_ATTR) {
+      return (V) dataBits;
+    }
+    if (attr == ATTR_TYPE) {
+      return (V) ramType;
+    }
+    if (attr == StdAttr.LABEL) {
+      return (V) label;
+    }
+    if (attr == StdAttr.TRIGGER) {
+      return (V) trigger;
+    }
+    if (attr == Mem.ASYNC_READ) {
+      return (V) asynchronousRead;
+    }
+    if (attr == Mem.READ_ATTR) {
+      return (V) readWriteBehavior;
+    }
+    if (attr == StdAttr.LABEL_FONT) {
+      return (V) labelFont;
+    }
+    if (attr == StdAttr.LABEL_VISIBILITY) {
+      return (V) labelVisible;
+    }
+    if (attr == ATTR_ByteEnables) {
+      return (V) byteEnables;
+    }
+    if (attr == StdAttr.APPEARANCE) {
+      return (V) appearance;
+    }
+    if (attr == Mem.LINE_ATTR) {
+      return (V) lineSize;
+    }
+    if (attr == Mem.ALLOW_MISALIGNED) {
+      return (V) allowMisaligned;
+    }
+    if (attr == CLEAR_PIN) {
+      return (V) clearPin;
+    }
+    if (attr == Mem.ENABLES_ATTR) {
+      return (V) typeOfEnables;
+    }
+    return null;
+  }
+
+  @Override
+  public <V> void setValue(Attribute<V> attr, V value) {
+    if (attr == Mem.ADDR_ATTR) {
+      final var newAddr = (BitWidth) value;
+      if (addrBits == newAddr) return;
+      addrBits = newAddr;
+      fireAttributeValueChanged(attr, value, null);
+    } else if (attr == Mem.DATA_ATTR) {
+      final var newData = (BitWidth) value;
+      if (dataBits == newData) return;
+      dataBits = newData;
+      if (typeOfEnables.equals(Mem.USEBYTEENABLES) && updateAttributes())
+        fireAttributeListChanged();
+      fireAttributeValueChanged(attr, value, null);
+    } else if (attr == Mem.ENABLES_ATTR) {
+      final var val = (AttributeOption) value;
+      if (!typeOfEnables.equals(val)) {
+        typeOfEnables = val;
+        if (updateAttributes()) fireAttributeListChanged();
+        fireAttributeValueChanged(attr, value, null);
+      }
+    } else if (attr == ATTR_TYPE) {
+      final var val = (AttributeOption) value;
+      if (!ramType.equals(val)) {
+        ramType = val;
+        fireAttributeValueChanged(attr, value, null);
+      }
+    } else if (attr == StdAttr.LABEL) {
+      final var newLabel = (String) value;
+      if (label.equals(newLabel)) return;
+      @SuppressWarnings("unchecked")
+      V oldlabel = (V) label;
+      label = newLabel;
+      fireAttributeValueChanged(attr, value, oldlabel);
+    } else if (attr == StdAttr.TRIGGER) {
+      final var newTrigger = (AttributeOption) value;
+      if (trigger.equals(newTrigger)) return;
+      trigger = newTrigger;
+      if (typeOfEnables.equals(Mem.USEBYTEENABLES) && updateAttributes())
+        fireAttributeListChanged();
+      fireAttributeValueChanged(attr, value, null);
+    } else if (attr == Mem.ASYNC_READ) {
+      final var val = (Boolean) value;
+      if (asynchronousRead != val) {
+        asynchronousRead = val;
+        if (updateAttributes()) fireAttributeListChanged();
+        fireAttributeValueChanged(attr, value, null);
+      }
+    } else if (attr == Mem.READ_ATTR) {
+      final var val = (AttributeOption) value;
+      if (!readWriteBehavior.equals(val)) {
+        readWriteBehavior = val;
+        fireAttributeValueChanged(attr, value, null);
+      }
+    } else if (attr == StdAttr.LABEL_FONT) {
+      final var newFont = (Font) value;
+      if (labelFont.equals(newFont)) {
+        return;
+      }
+      labelFont = newFont;
+      fireAttributeValueChanged(attr, value, null);
+    } else if (attr == StdAttr.LABEL_VISIBILITY) {
+      final var newVis = (Boolean) value;
+      if (labelVisible.equals(newVis)) return;
+      labelVisible = newVis;
+      fireAttributeValueChanged(attr, value, null);
+    } else if (attr == ATTR_ByteEnables) {
+      var newBE = (AttributeOption) value;
+      if (byteEnables.equals(newBE)) return;
+      if (dataBits.getWidth() < 9) newBE = BUS_WITHOUT_BYTE_ENABLES;
+      byteEnables = newBE;
+      fireAttributeValueChanged(attr, value, null);
+    } else if (attr == CLEAR_PIN) {
+      final var val = (Boolean) value;
+      if (clearPin != val) {
+        clearPin = val;
+        fireAttributeValueChanged(attr, value, null);
+      }
+    } else if (attr == Mem.ALLOW_MISALIGNED) {
+      final var val = (Boolean) value;
+      if (allowMisaligned != val) {
+        allowMisaligned = val;
+        fireAttributeValueChanged(attr, value, null);
+      }
+    } else if (attr == StdAttr.APPEARANCE) {
+      final var option = (AttributeOption) value;
+      if (appearance.equals(option)) return;
+      appearance = option;
+      fireAttributeValueChanged(attr, value, null);
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/std/memory/DualportRamHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/DualportRamHdlGeneratorFactory.java
@@ -1,0 +1,237 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.memory;
+
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.fpga.hdlgenerator.AbstractHdlGeneratorFactory;
+import com.cburch.logisim.fpga.hdlgenerator.Hdl;
+import com.cburch.logisim.fpga.hdlgenerator.HdlPorts;
+import com.cburch.logisim.instance.Port;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.util.LineBuffer;
+
+public class DualportRamHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
+  //TODO: fix HDL generation
+  private static final String ByteArrayStr = "byteArray";
+  private static final int ByteArrayId = -1;
+  private static final String RestArrayStr = "restArray";
+  private static final int RestArrayId = -2;
+  private static final String MemArrayStr = "memoryArray";
+  private static final int MemArrayId = -3;
+
+  public DualportRamHdlGeneratorFactory() {
+    super();
+    getWiresPortsDuringHDLWriting = true;
+  }
+
+  @Override
+  public void getGenerationTimeWiresPorts(Netlist theNetlist, AttributeSet attrs) {
+    final var nrOfBits = attrs.getValue(Mem.DATA_ATTR).getWidth();
+    final var be = attrs.getValue(DualportRamAttributes.ATTR_ByteEnables);
+    final var byteEnables = be != null && be.equals(DualportRamAttributes.BUS_WITH_BYTEENABLES);
+    final var byteEnableOffset = DualportRamAppearance.getBEIndex(0, attrs);
+    final var nrBePorts = DualportRamAppearance.getNrBEPorts(attrs);
+    final var nrOfaddressLines = attrs.getValue(Mem.ADDR_ATTR).getWidth();
+    final var trigger = attrs.getValue(StdAttr.TRIGGER);
+    final var async = StdAttr.TRIG_HIGH.equals(trigger) || StdAttr.TRIG_LOW.equals(trigger);
+    final var ramEntries = (1 << nrOfaddressLines);
+    final var truncated = (nrOfBits % 8) != 0;
+    myWires
+        .addWire("s_ramdataOut", nrOfBits)
+        .addRegister("s_tickDelayLine", 3)
+        .addRegister("s_dataInReg", nrOfBits)
+        .addRegister("s_addressReg", nrOfaddressLines)
+        .addRegister("s_weReg", 1)
+        .addRegister("s_oeReg", 1)
+        .addRegister("s_dataOutReg", nrOfBits);
+    if (byteEnables) {
+      myWires
+          .addRegister("s_byteEnableReg", nrBePorts);
+      for (var idx = 0; idx < nrBePorts; idx++) {
+        myWires
+            .addWire(String.format("s_byteEnable%d", idx), 1)
+            .addWire(String.format("s_we%d", idx), 1);
+        myPorts
+            .add(Port.INPUT, String.format("byteEnable%d", idx), 1, byteEnableOffset + nrBePorts - idx - 1);
+      }
+      myPorts.add(Port.INPUT, "oe", 1, DualportRamAppearance.getOEIndex(0, attrs));
+      var nrOfMems = nrBePorts;
+      if (truncated) {
+        myTypedWires
+            .addArray(RestArrayId, RestArrayStr, nrOfBits % 8, ramEntries)
+            .addWire("s_truncMemContents", RestArrayId);
+        nrOfMems--;
+      }
+      myTypedWires
+          .addArray(ByteArrayId, ByteArrayStr, 8, ramEntries);
+      for (var mem = 0; mem < nrOfMems; mem++)
+        myTypedWires
+            .addWire(String.format("s_byteMem%dContents", mem), ByteArrayId);
+    } else {
+      myPorts.add(Port.INPUT, "oe", 1, Hdl.oneBit());
+      myTypedWires
+          .addArray(MemArrayId, MemArrayStr, nrOfBits, ramEntries)
+          .addWire("s_memContents", MemArrayId);
+      myWires
+          .addWire("s_we", 1)
+          .addWire("s_oe", 1);
+    }
+    myPorts
+        .add(Port.INPUT, "address", nrOfaddressLines, DualportRamAppearance.getAddrIndex(0, attrs))
+        .add(Port.INPUT, "dataIn", nrOfBits, DualportRamAppearance.getDataInIndex(0, attrs))
+        .add(Port.INPUT, "we", 1, DualportRamAppearance.getWEIndex(0, attrs))
+        .add(Port.OUTPUT, "dataOut", nrOfBits, DualportRamAppearance.getDataOutIndex(0, attrs));
+    if (!async) myPorts.add(Port.CLOCK, HdlPorts.getClockName(1), 1, DualportRamAppearance.getClkIndex(0, attrs));
+  }
+
+  @Override
+  public LineBuffer getModuleFunctionality(Netlist theNetlist, AttributeSet attrs) {
+    final var contents = LineBuffer.getHdlBuffer()
+        .pair("clock", HdlPorts.getClockName(1))
+        .pair("tick", HdlPorts.getTickName(1));
+    final var be = attrs.getValue(DualportRamAttributes.ATTR_ByteEnables);
+    final var byteEnables = be != null && be.equals(DualportRamAttributes.BUS_WITH_BYTEENABLES);
+    if (Hdl.isVhdl()) {
+      contents.empty().addVhdlKeywords().addRemarkBlock("The control signals are defined here");
+      if (byteEnables) {
+        for (var i = 0; i < DualportRamAppearance.getNrBEPorts(attrs); i++) {
+          contents
+              .add("s_byteEnable{{1}} <= s_byteEnableReg({{1}}) {{and}} s_tickDelayLine(2) {{and}} s_oeReg;", i)
+              .add("s_we{{1}}         <= s_byteEnableReg({{1}}) {{and}} s_tickDelayLine(0) {{and}} s_weReg;", i);
+        }
+      } else {
+        contents.add("""
+            s_oe <= s_tickDelayLine(2) {{and}} s_oeReg;
+            s_we <= s_tickDelayLine(0) {{and}} s_weReg;
+            """);
+      }
+      contents
+          .empty()
+          .addRemarkBlock("The input registers are defined here")
+          .add("""
+              inputRegs : {{process}}({{clock}}, {{tick}}, address, dataIn, we, oe) {{is}}
+              {{begin}}
+                 {{if}} (rising_edge({{clock}})) {{then}}
+                    {{if}} ({{tick}} = '1') {{then}}
+                        s_dataInReg  <= dataIn;
+                        s_addressReg <= address;
+                        s_weReg      <= we;
+                        s_oeReg      <= oe;
+              """);
+      if (byteEnables) {
+        for (var i = 0; i < DualportRamAppearance.getNrBEPorts(attrs); i++)
+          contents.add("         s_byteEnableReg({{1}}) <= byteEnable{{1}}};", i);
+      }
+      contents
+          .add("""
+                    {{end}} {{if}};
+                 {{end}} {{if}};
+              {{end}} {{process}} inputRegs;
+              """)
+          .empty()
+          .add("""
+              tickPipeReg : {{process}}({{clock}}) {{is}}
+              {{begin}}
+                 {{if}} (rising_edge({{clock}})) {{then}}
+                     s_tickDelayLine(0)          <= {{tick}};
+                     s_tickDelayLine(2 {{downto}} 1) <= s_tickDelayLine(1 {{downto}} 0);
+                 {{end}} {{if}};
+              {{end}} {{process}} tickPipeReg;
+              """)
+          .empty()
+          .addRemarkBlock("The actual memorie(s) is(are) defined here");
+      if (byteEnables) {
+        final var truncated = (attrs.getValue(Mem.DATA_ATTR).getWidth() % 8) != 0;
+        for (var i = 0; i < DualportRamAppearance.getNrBEPorts(attrs); i++) {
+          contents
+              .add("mem{{1}} : {{process}}({{clock}}, s_we{{1}}, s_dataInReg, s_addressReg) {{is}}", i)
+              .add("{{begin}}")
+              .add("   {{if}} (rising_edge({{clock}})) {{then}}")
+              .add("      {{if}} (s_we{{1}} = '1') {{then}}", i);
+          final var startIndex = i * 8;
+          final var endIndex =
+              (i == (DualportRamAppearance.getNrBEPorts(attrs) - 1))
+                  ? attrs.getValue(Mem.DATA_ATTR).getWidth() - 1
+                  : (i + 1) * 8 - 1;
+          final var memName =
+              (i == (DualportRamAppearance.getNrBEPorts(attrs) - 1) && truncated)
+                  ? "s_truncMemContents"
+                  : String.format("s_byteMem%dContents", i);
+          contents
+              .add("         {{1}}(to_integer(unsigned(s_addressReg))) <= s_dataInReg({{2}} {{downto}} {{3}});", memName, endIndex, startIndex)
+              .add("      {{end}} {{if}};")
+              .add("      s_ramdataOut({{1}} {{downto}} {{2}}) <= {{3}}(to_integer(unsigned(s_addressReg)));", endIndex, startIndex, memName)
+              .add("   {{end}} {{if}};")
+              .add("{{end}} {{process}} mem{{1}};", i)
+              .add("");
+        }
+      } else {
+        contents
+            .add("""
+                mem : {{process}}({{clock}} , s_we, s_dataInReg, s_addressReg) {{is}}
+                {{begin}}
+                   {{if}} (rising_edge({{clock}})) {{then}}
+                      {{if}} (s_we = '1') {{then}}
+                         s_memContents(to_integer(unsigned(s_addressReg))) <= s_dataInReg;
+                      {{end}} {{if}};
+                      s_ramdataOut <= s_memContents(to_integer(unsigned(s_addressReg)));
+                   {{end}} {{if}};
+                {{end}} {{process}} mem;
+                """);
+      }
+      contents.empty().addRemarkBlock("The output register is defined here");
+      if (byteEnables) {
+        for (var i = 0; i < DualportRamAppearance.getNrBEPorts(attrs); i++) {
+          contents
+              .add("res{{1}} : {{process}}({{clock}}, s_byteEnable{{1}}, s_ramdataOut) {{is}}", i)
+              .add("{{begin}}")
+              .add("   {{if}} (rising_edge({{clock}}) {{then}}")
+              .add("      {{if}} (s_byteEnable{{1}} = '1') {{then}}", i);
+          final var startIndex = i * 8;
+          final var endIndex =
+              (i == (DualportRamAppearance.getNrBEPorts(attrs) - 1))
+                  ? attrs.getValue(Mem.DATA_ATTR).getWidth() - 1
+                  : (i + 1) * 8 - 1;
+          contents
+              .add("         dataOut({{1}} {{downto}} {{2}}) <= s_ramdataOut({{1}} {{downto}} {{2}});", endIndex, startIndex)
+              .add("      {{end}} {{if}};")
+              .add("   {{end}} {{if}};")
+              .add("{{end}} {{process}} res{{1}};", i);
+        }
+      } else {
+        contents
+            .add("""
+                res : {{process}}({{clock}}, s_oe, s_ramdataOut) {{is}}
+                {{begin}}
+                   {{if}} (rising_edge({{clock}})) {{then}}
+                      {{if}} (s_oe = '1') {{then}}
+                        dataOut <= s_ramdataOut;
+                      {{end}} {{if}};
+                   {{end}} {{if}};
+                {{end}} {{process}} res;
+                """);
+      }
+    }
+    return contents.empty();
+  }
+
+  @Override
+  public boolean isHdlSupportedTarget(AttributeSet attrs) {
+    if (attrs == null) return false;
+    Object trigger = attrs.getValue(StdAttr.TRIGGER);
+    final var asynch = trigger == null || trigger.equals(StdAttr.TRIG_HIGH) || trigger.equals(StdAttr.TRIG_LOW);
+    final var byteEnabled = DualportRamAppearance.getNrLEPorts(attrs) == 0;
+    final var syncRead = !attrs.containsAttribute(Mem.ASYNC_READ) || !attrs.getValue(Mem.ASYNC_READ);
+    final var clearPin = attrs.getValue(DualportRamAttributes.CLEAR_PIN) == null ? false : attrs.getValue(DualportRamAttributes.CLEAR_PIN);
+    final var readAfterWrite = !attrs.containsAttribute(Mem.READ_ATTR) || attrs.getValue(Mem.READ_ATTR).equals(Mem.READAFTERWRITE);
+    return Hdl.isVhdl() && !asynch && byteEnabled && syncRead && !clearPin && readAfterWrite;
+  }
+}

--- a/src/main/java/com/cburch/logisim/std/memory/MemoryLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/memory/MemoryLibrary.java
@@ -37,6 +37,7 @@ public class MemoryLibrary extends Library {
     new FactoryDescription(ShiftRegister.class, S.getter("shiftRegisterComponent"), "shiftreg.gif"),
     new FactoryDescription(Random.class, S.getter("randomComponent"), "random.gif"),
     new FactoryDescription(Ram.class, S.getter("ramComponent"), "ram.gif"),
+    new FactoryDescription(DualportRam.class, S.getter("dpramComponent"), "ram.gif"),
     new FactoryDescription(Rom.class, S.getter("romComponent"), "rom.gif"),
   };
 

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -574,6 +574,10 @@ tFlipFlopComponent = T Flip-Flop
 #
 ramComponent = RAM
 #
+# memory/DualportRam.java
+#
+dpramComponent = DUALPORT RAM
+#
 # memory/RamAppearance.java
 #
 memAddrTip = Address: location accessed in memory
@@ -599,6 +603,20 @@ ramLETip2 = Line enable for address+2
 ramLETip3 = Line enable for address+3
 ramOETip = Load: if 1, load memory to output
 ramWETip = Store: if 1, store input to memory
+#
+# memory/DualportRamAppearance.java
+#
+memAddr1Tip = Address 1: location 1 accessed in memory
+memAddr2Tip = Address 2: location 2 accessed in memory
+memAddrWriteTip = Address Write: location that is written in memory
+memData1Tip = Data 1: value loaded from address 1
+memData2Tip = Data 2: value loaded from address 2
+dpramInTip = Input: value to be stored at address write
+dpramLETip1 = Line enable for data 1
+dpramLETip2 = Line enable for data 2
+dpramOETip1 = Load 1: if 1, load memory from address 1 to data 1
+dpramOETip2 = Load 2: if 1, load memory from address 2 to data 2
+dpramWETip = Store: if 1, store input to memory at address write
 #
 # memory/RamAttributes.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -574,6 +574,10 @@ tFlipFlopComponent = Biestable T
 #
 ramComponent = RAM
 #
+# memory/DualportRam.java
+#
+dpramComponent = RAM de doble puerto
+#
 # memory/RamAppearance.java
 #
 memAddrTip = Direcci贸n: localizaci贸n de la memoria a la que se quiere acceder
@@ -599,6 +603,20 @@ ramLETip2 = Habilitaci贸n de l铆nea para la direcci贸n 2
 ramLETip3 = Habilitaci贸n de l铆nea para la direcci贸n 3
 ramOETip = Load: si toma el valor 1, mostrar lectura a la salida
 ramWETip = Store: si toma el valor 1, escribir dato de entrada en la memoria
+#
+# memory/DualportRamAppearance.java
+#
+memAddr1Tip = Direcci髇 1: la localizaci髇 1 de memoria que se quiere acceder
+memAddr2Tip = Direcci髇 2: la localizaci髇 2 de memoria que se quiere acceder
+memAddrWriteTip = Direcci髇 de escritura: la localizaci髇 de memoria a donde se va a escribir
+memData1Tip = Dato 1: valor cargado de la localizaci髇 1 de memoria
+memData2Tip = Dato 2: valor cargado de la localizaci髇 2 de memoria
+dpramInTip = Entrada: valor a ser guardado en la direcci髇 de escritura
+dpramLETip1 = Habilitaci髇 de la l韓ea para dato 1
+dpramLETip2 = Habilitaci髇 de la l韓ea para dato 2
+dpramOETip1 = Load 1: si toma el valor 1, se lee el dato en memoria de la direcci髇 1 hacia dato 1
+dpramOETip2 = Load 2: si toma el valor 1, se lee el dato en memoria de la direcci髇 2 hacia dato 2
+dpramWETip = Store: si toma el valor 1, se escribe la entrada hacia la direcci髇 de escritura
 #
 # memory/RamAttributes.java
 #


### PR DESCRIPTION
# Dual port RAM

This pull request:

- [x] Adds a new dual port RAM component.
- [x] Adds new tooltips for its pins.
- [x] Adds tooltips translations for it in spanish.
- [ ] Adds a VHDL generator for it. (W.I.P.)

![image](https://github.com/user-attachments/assets/c8dd84fd-3a61-4711-a8dc-8e8264535a8a)
_(logisim-evolution's appearance)_

![image](https://github.com/user-attachments/assets/3a88f3e4-4b79-4cbf-937e-ed7a864cdedd)
_(classic logisim's appearance)_

## Behavior

![image](https://github.com/user-attachments/assets/dfc9e31b-7cd1-4230-98d1-90dc03580595)

This new RAM component essentially acts like a normal RAM, but has 3 addresses ports:
**Address 1**, which is the address loaded (read) at **Data 1**.
**Address 2**, which is the address loaded (read) at **Data 2**.
**Address Write**, which is the address that **Input** is written to.

Meaning, for example, that to write into the address 0xFA the byte 0xBA, you need to input it into **Address Write** and input 1 into **Write enable** for it to be written (this of course ignoring that we also need the clock input).

To read from an address, you need to input it into either the address 1 pin or the address 2 pin, and then you input 1 into output enable 1 or output enable 2 (both can be enabled at the same time, allowing for a simultaneous read of 2 addresses at the same time).

This makes this RAM component be able to read from 2 different addresses and write into 1 at the same time.

On top of that, it has:
- A write enable pin for **Input** to be written at the address provided in **Address Write**.
- Output enable pins for data 1 and data 2.
- Support for line enables.
- Support for asynchronous read.
- (Of course) support for varied data and address widths, just like the normal RAM.

## Advantages
- Enables the simulation of other more "niche" hardware.
- No more headaches while trying to implement a Register File.
- Allows reading 2 addresses and writing to one in a single clock pulse, without the need to wait for the RAM to complete fetching data.
- Opens the gate to new computing components to be made.

## Disadvantages
The unique disadvantage it has is that it doesn't support line sizes like the normal RAM component, hence it's limited to 3 address ports and 2 outputs.

## Extras
This component can be tested **(if you build with the dualport-ram branch in my fork)** with this .CIRC file inside of the .zip:
[test_dualportram.zip](https://github.com/user-attachments/files/17499237/test_dualportram.zip)
