### PR TITLE
Minor fix to flipflop documentation.

### DIFF
--- a/src/main/resources/doc/de/html/libs/mem/flipflops.html
+++ b/src/main/resources/doc/de/html/libs/mem/flipflops.html
@@ -147,7 +147,7 @@ continues to appear on the output. The clock triggers are enabled when this
 input is 1 or undefined.</dd>
 
 <dt>South edge, west end (input, bit width 1)</dt>
-<dd>Asynchronous set: When 1 or undefined, this input has no effect.
+<dd>Asynchronous set: When 0 or undefined, this input has no effect.
 When 1, the flip-flop's value is pinned to 1. This occurs asynchronously
 - that is, without regard to the current clock input value. As long as
 this input is 1, the other inputs have no effect, except for the

--- a/src/main/resources/doc/en/html/libs/mem/flipflops.html
+++ b/src/main/resources/doc/en/html/libs/mem/flipflops.html
@@ -378,7 +378,7 @@
           South edge, west end or Nort edge (input, bit width 1)
         </dt>
         <dd>
-          Asynchronous set: When 1 or undefined, this input has no effect. When 1, the flip-flop's value is pinned to 1. This occurs asynchronously - that is, without regard to the current clock input value. As long as this input is 1, the other inputs have no effect, except for the asynchronous reset input, which has priority.
+          Asynchronous set: When 0 or undefined, this input has no effect. When 1, the flip-flop's value is pinned to 1. This occurs asynchronously - that is, without regard to the current clock input value. As long as this input is 1, the other inputs have no effect, except for the asynchronous reset input, which has priority.
         </dd>
       </dl>
       <h2>

--- a/src/main/resources/doc/zh/html/libs/mem/flipflops.html
+++ b/src/main/resources/doc/zh/html/libs/mem/flipflops.html
@@ -537,8 +537,8 @@
      南边、西边或北边（输入，位宽1）
     </dt>
     <dd>
-     <!-- Asynchronous set: When 1 or undefined, this input has no effect. When 1, the flip-flop's value is pinned to 1. This occurs asynchronously - that is, without regard to the current clock input value. As long as this input is 1, the other inputs have no effect, except for the asynchronous reset input, which has priority. -->
-     异步设置：当为1或未定义时，该输入无效。 当为 1 时，触发器的值固定为 1。这是异步发生的，即不考虑当前时钟输入值。 只要该输入为 1，除异步复位输入具有优先级外，其他输入均无效。
+     <!-- Asynchronous set: When 0 or undefined, this input has no effect. When 1, the flip-flop's value is pinned to 1. This occurs asynchronously - that is, without regard to the current clock input value. As long as this input is 1, the other inputs have no effect, except for the asynchronous reset input, which has priority. -->
+     异步设置：当为0或未定义时，该输入无效。 当为 1 时，触发器的值固定为 1。这是异步发生的，即不考虑当前时钟输入值。 只要该输入为 1，除异步复位输入具有优先级外，其他输入均无效。
     </dd>
    </dl>
    <h2>


### PR DESCRIPTION
"Asynchronous set: When 1 or undefined, this input has no effect." -> "Asynchronous set: When 0 or undefined, this input has no effect."

I took the risk of changing the Chinese version as well, despite not speaking Chinese, as it showed up when searching for the string with grep and it seemed a safe enough change to make to the translation based on Google translate ("0" changed to "1").