### PR TITLE
Move rsyntaxtextarea back to 3.5.1.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ application {
 dependencies {
   implementation("org.hamcrest:hamcrest:3.0")
   implementation("javax.help:javahelp:2.0.05")
-  implementation("com.fifesoft:rsyntaxtextarea:3.5.2")
+  implementation("com.fifesoft:rsyntaxtextarea:3.5.1")
   implementation("net.sf.nimrod:nimrod-laf:1.2")
   implementation("org.drjekyll:colorpicker:2.0.1")
   implementation("at.swimmesberger:swingx-core:1.6.8")


### PR DESCRIPTION
This restores the older rsyntaxtextarea version so that the build works. I decided to put up a PR to speed up getting the build to work.

First step of #2088.