### PR TITLE
Fix issue with rsyntaxtextarea

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ application {
 dependencies {
   implementation("org.hamcrest:hamcrest:3.0")
   implementation("javax.help:javahelp:2.0.05")
-  implementation("com.fifesoft:rsyntaxtextarea:3.5.1")
+  implementation("com.fifesoft:rsyntaxtextarea:3.5.2")
   implementation("net.sf.nimrod:nimrod-laf:1.2")
   implementation("org.drjekyll:colorpicker:2.0.1")
   implementation("at.swimmesberger:swingx-core:1.6.8")

--- a/src/main/jflex/com/cburch/logisim/vhdl/syntax/VhdlSyntax.jflex
+++ b/src/main/jflex/com/cburch/logisim/vhdl/syntax/VhdlSyntax.jflex
@@ -166,6 +166,9 @@ import org.fife.ui.rsyntaxtextarea.TokenImpl;
 		return zzCurrentPos>=s.offset+s.count;
 	}
 
+	public final int yystate() {
+		return zzLexicalState;
+	}
 
 	/**
 	 * Resets the scanner to read from a new input stream.
@@ -505,4 +508,3 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
 	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
 }
-

--- a/src/main/jflex/com/cburch/logisim/vhdl/syntax/VhdlSyntax.jflex
+++ b/src/main/jflex/com/cburch/logisim/vhdl/syntax/VhdlSyntax.jflex
@@ -17,7 +17,6 @@
  * This is free software released under GNU GPLv3 license
  */
 
-
 /*
  * Generated on 2/20/16 10:40 PM
  */
@@ -30,7 +29,6 @@ import javax.swing.text.Segment;
 import org.fife.ui.rsyntaxtextarea.AbstractJFlexTokenMaker;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
-
 
 /**
  * VHDL Syntax Highlighting for RSyntaxTextArea.
@@ -45,210 +43,195 @@ import org.fife.ui.rsyntaxtextarea.TokenImpl;
 %ignorecase
 %type org.fife.ui.rsyntaxtextarea.Token
 
-
 %{
+  /**
+   * Constructor.  This must be here because JFlex does not generate a
+   * no-parameter constructor.
+   */
+  public VhdlSyntax() {
+  }
 
+  /**
+   * Adds the token specified to the current linked list of tokens.
+   *
+   * @param tokenType The token's type.
+   * @see #addToken(int, int, int)
+   */
+  private void addHyperlinkToken(int start, int end, int tokenType) {
+    int so = start + offsetShift;
+    addToken(zzBuffer, start,end, tokenType, so, true);
+  }
 
-	/**
-	 * Constructor.  This must be here because JFlex does not generate a
-	 * no-parameter constructor.
-	 */
-	public VhdlSyntax() {
-	}
+  /**
+   * Adds the token specified to the current linked list of tokens.
+   *
+   * @param tokenType The token's type.
+   */
+  private void addToken(int tokenType) {
+    addToken(zzStartRead, zzMarkedPos-1, tokenType);
+  }
 
+  /**
+   * Adds the token specified to the current linked list of tokens.
+   *
+   * @param tokenType The token's type.
+   * @see #addHyperlinkToken(int, int, int)
+   */
+  private void addToken(int start, int end, int tokenType) {
+    int so = start + offsetShift;
+    addToken(zzBuffer, start,end, tokenType, so, false);
+  }
 
-	/**
-	 * Adds the token specified to the current linked list of tokens.
-	 *
-	 * @param tokenType The token's type.
-	 * @see #addToken(int, int, int)
-	 */
-	private void addHyperlinkToken(int start, int end, int tokenType) {
-		int so = start + offsetShift;
-		addToken(zzBuffer, start,end, tokenType, so, true);
-	}
+  /**
+   * Adds the token specified to the current linked list of tokens.
+   *
+   * @param array The character array.
+   * @param start The starting offset in the array.
+   * @param end The ending offset in the array.
+   * @param tokenType The token's type.
+   * @param startOffset The offset in the document at which this token
+   *        occurs.
+   * @param hyperlink Whether this token is a hyperlink.
+   */
+  public void addToken(char[] array, int start, int end, int tokenType,
+            int startOffset, boolean hyperlink) {
+    super.addToken(array, start,end, tokenType, startOffset, hyperlink);
+    zzStartRead = zzMarkedPos;
+  }
 
+  /**
+   * {@inheritDoc}
+   */
+  public String[] getLineCommentStartAndEnd(int languageIndex) {
+    return new String[] { "--", null };
+  }
 
-	/**
-	 * Adds the token specified to the current linked list of tokens.
-	 *
-	 * @param tokenType The token's type.
-	 */
-	private void addToken(int tokenType) {
-		addToken(zzStartRead, zzMarkedPos-1, tokenType);
-	}
+  /**
+   * Returns the first token in the linked list of tokens generated
+   * from <code>text</code>.  This method must be implemented by
+   * subclasses so they can correctly implement syntax highlighting.
+   *
+   * @param text The text from which to get tokens.
+   * @param initialTokenType The token type we should start with.
+   * @param startOffset The offset into the document at which
+   *        <code>text</code> starts.
+   * @return The first <code>Token</code> in a linked list representing
+   *         the syntax highlighted text.
+   */
+  public Token getTokenList(Segment text, int initialTokenType, int startOffset) {
+    resetTokenList();
+    this.offsetShift = -text.offset + startOffset;
 
+    // Start off in the proper state.
+    int state = Token.NULL;
+    switch (initialTokenType) {
+      /* No multi-line comments */
+      /* No documentation comments */
+      default:
+        state = Token.NULL;
+    }
 
-	/**
-	 * Adds the token specified to the current linked list of tokens.
-	 *
-	 * @param tokenType The token's type.
-	 * @see #addHyperlinkToken(int, int, int)
-	 */
-	private void addToken(int start, int end, int tokenType) {
-		int so = start + offsetShift;
-		addToken(zzBuffer, start,end, tokenType, so, false);
-	}
+    s = text;
+    try {
+      yyreset(zzReader);
+      yybegin(state);
+      return yylex();
+    } catch (IOException ioe) {
+      ioe.printStackTrace();
+      return new TokenImpl();
+    }
+  }
 
+  /**
+   * Refills the input buffer.
+   *
+   * @return      <code>true</code> if EOF was reached, otherwise
+   *              <code>false</code>.
+   */
+  private boolean zzRefill() {
+    return zzCurrentPos>=s.offset+s.count;
+  }
 
-	/**
-	 * Adds the token specified to the current linked list of tokens.
-	 *
-	 * @param array The character array.
-	 * @param start The starting offset in the array.
-	 * @param end The ending offset in the array.
-	 * @param tokenType The token's type.
-	 * @param startOffset The offset in the document at which this token
-	 *        occurs.
-	 * @param hyperlink Whether this token is a hyperlink.
-	 */
-	public void addToken(char[] array, int start, int end, int tokenType,
-						int startOffset, boolean hyperlink) {
-		super.addToken(array, start,end, tokenType, startOffset, hyperlink);
-		zzStartRead = zzMarkedPos;
-	}
+  public final int yystate() {
+    return zzLexicalState;
+  }
 
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public String[] getLineCommentStartAndEnd(int languageIndex) {
-		return new String[] { "--", null };
-	}
-
-
-	/**
-	 * Returns the first token in the linked list of tokens generated
-	 * from <code>text</code>.  This method must be implemented by
-	 * subclasses so they can correctly implement syntax highlighting.
-	 *
-	 * @param text The text from which to get tokens.
-	 * @param initialTokenType The token type we should start with.
-	 * @param startOffset The offset into the document at which
-	 *        <code>text</code> starts.
-	 * @return The first <code>Token</code> in a linked list representing
-	 *         the syntax highlighted text.
-	 */
-	public Token getTokenList(Segment text, int initialTokenType, int startOffset) {
-
-		resetTokenList();
-		this.offsetShift = -text.offset + startOffset;
-
-		// Start off in the proper state.
-		int state = Token.NULL;
-		switch (initialTokenType) {
-			/* No multi-line comments */
-			/* No documentation comments */
-			default:
-				state = Token.NULL;
-		}
-
-		s = text;
-		try {
-			yyreset(zzReader);
-			yybegin(state);
-			return yylex();
-		} catch (IOException ioe) {
-			ioe.printStackTrace();
-			return new TokenImpl();
-		}
-
-	}
-
-
-	/**
-	 * Refills the input buffer.
-	 *
-	 * @return      <code>true</code> if EOF was reached, otherwise
-	 *              <code>false</code>.
-	 */
-	private boolean zzRefill() {
-		return zzCurrentPos>=s.offset+s.count;
-	}
-
-	public final int yystate() {
-		return zzLexicalState;
-	}
-
-	/**
-	 * Resets the scanner to read from a new input stream.
-	 * Does not close the old reader.
-	 *
-	 * All internal variables are reset, the old input stream
-	 * <b>cannot</b> be reused (internal buffer is discarded and lost).
-	 * Lexical state is set to <tt>YY_INITIAL</tt>.
-	 *
-	 * @param reader   the new input stream
-	 */
-	public final void yyreset(Reader reader) {
-		// 's' has been updated.
-		zzBuffer = s.array;
-		/*
-		 * We replaced the line below with the two below it because zzRefill
-		 * no longer "refills" the buffer (since the way we do it, it's always
-		 * "full" the first time through, since it points to the segment's
-		 * array).  So, we assign zzEndRead here.
-		 */
-		//zzStartRead = zzEndRead = s.offset;
-		zzStartRead = s.offset;
-		zzEndRead = zzStartRead + s.count - 1;
-		zzCurrentPos = zzMarkedPos = zzPushbackPos = s.offset;
-		zzLexicalState = YYINITIAL;
-		zzReader = reader;
-		zzAtBOL  = true;
-		zzAtEOF  = false;
-	}
-
+  /**
+   * Resets the scanner to read from a new input stream.
+   * Does not close the old reader.
+   *
+   * All internal variables are reset, the old input stream
+   * <b>cannot</b> be reused (internal buffer is discarded and lost).
+   * Lexical state is set to <tt>YY_INITIAL</tt>.
+   *
+   * @param reader   the new input stream
+   */
+  public final void yyreset(Reader reader) {
+    // 's' has been updated.
+    zzBuffer = s.array;
+    /*
+     * We replaced the line below with the two below it because zzRefill
+     * no longer "refills" the buffer (since the way we do it, it's always
+     * "full" the first time through, since it points to the segment's
+     * array).  So, we assign zzEndRead here.
+     */
+    //zzStartRead = zzEndRead = s.offset;
+    zzStartRead = s.offset;
+    zzEndRead = zzStartRead + s.count - 1;
+    zzCurrentPos = zzMarkedPos = zzPushbackPos = s.offset;
+    zzLexicalState = YYINITIAL;
+    zzReader = reader;
+    zzAtBOL = true;
+    zzAtEOF = false;
+  }
 
 %}
 
-Letter							= [A-Za-z]
-LetterOrUnderscore				= ({Letter}|"_")
-NonzeroDigit						= [1-9]
-Digit							= ("0"|{NonzeroDigit})
-HexDigit							= ({Digit}|[A-Fa-f])
-OctalDigit						= ([0-7])
-AnyCharacterButApostropheOrBackSlash	= ([^\\'])
-AnyCharacterButDoubleQuoteOrBackSlash	= ([^\\\"\n])
-EscapedSourceCharacter				= ("u"{HexDigit}{HexDigit}{HexDigit}{HexDigit})
-Escape							= ("\\"(([btnfr\"'\\])|([0123]{OctalDigit}?{OctalDigit}?)|({OctalDigit}{OctalDigit}?)|{EscapedSourceCharacter}))
-NonSeparator						= ([^\t\f\r\n\ \(\)\{\}\[\]\;\,\.\=\>\<\!\~\?\:\+\-\*\/\&\|\^\%\"\']|"#"|"\\")
-IdentifierStart					= ({LetterOrUnderscore}|"$")
-IdentifierPart						= ({IdentifierStart}|{Digit}|("\\"{EscapedSourceCharacter}))
+Letter = [A-Za-z]
+LetterOrUnderscore = ({Letter}|"_")
+NonzeroDigit = [1-9]
+Digit = ("0"|{NonzeroDigit})
+HexDigit = ({Digit}|[A-Fa-f])
+OctalDigit = ([0-7])
+AnyCharacterButApostropheOrBackSlash = ([^\\'])
+AnyCharacterButDoubleQuoteOrBackSlash = ([^\\\"\n])
+EscapedSourceCharacter = ("u"{HexDigit}{HexDigit}{HexDigit}{HexDigit})
+Escape = ("\\"(([btnfr\"'\\])|([0123]{OctalDigit}?{OctalDigit}?)|({OctalDigit}{OctalDigit}?)|{EscapedSourceCharacter}))
+NonSeparator = ([^\t\f\r\n\ \(\)\{\}\[\]\;\,\.\=\>\<\!\~\?\:\+\-\*\/\&\|\^\%\"\']|"#"|"\\")
+IdentifierStart = ({LetterOrUnderscore}|"$")
+IdentifierPart = ({IdentifierStart}|{Digit}|("\\"{EscapedSourceCharacter}))
 
-LineTerminator				= (\n)
-WhiteSpace				= ([ \t\f]+)
+LineTerminator = (\n)
+WhiteSpace = ([ \t\f]+)
 
-CharLiteral	= ([\']({AnyCharacterButApostropheOrBackSlash}|{Escape})[\'])
-UnclosedCharLiteral			= ([\'][^\'\n]*)
-ErrorCharLiteral			= ({UnclosedCharLiteral}[\'])
-StringLiteral				= ([\"]({AnyCharacterButDoubleQuoteOrBackSlash}|{Escape})*[\"])
-UnclosedStringLiteral		= ([\"]([\\].|[^\\\"])*[^\"]?)
-ErrorStringLiteral			= ({UnclosedStringLiteral}[\"])
+CharLiteral = ([\']({AnyCharacterButApostropheOrBackSlash}|{Escape})[\'])
+UnclosedCharLiteral = ([\'][^\'\n]*)
+ErrorCharLiteral = ({UnclosedCharLiteral}[\'])
+StringLiteral = ([\"]({AnyCharacterButDoubleQuoteOrBackSlash}|{Escape})*[\"])
+UnclosedStringLiteral = ([\"]([\\].|[^\\\"])*[^\"]?)
+ErrorStringLiteral = ({UnclosedStringLiteral}[\"])
 
 /* No multi-line comments */
 /* No documentation comments */
-LineCommentBegin			= "--"
+LineCommentBegin = "--"
 
-IntegerLiteral			= ({Digit}+)
-HexLiteral			= (0x{HexDigit}+)
-FloatLiteral			= (({Digit}+)("."{Digit}+)?(e[+-]?{Digit}+)? | ({Digit}+)?("."{Digit}+)(e[+-]?{Digit}+)?)
-ErrorNumberFormat			= (({IntegerLiteral}|{HexLiteral}|{FloatLiteral}){NonSeparator}+)
+IntegerLiteral = ({Digit}+)
+HexLiteral = (0x{HexDigit}+)
+FloatLiteral = (({Digit}+)("."{Digit}+)?(e[+-]?{Digit}+)? | ({Digit}+)?("."{Digit}+)(e[+-]?{Digit}+)?)
+ErrorNumberFormat = (({IntegerLiteral}|{HexLiteral}|{FloatLiteral}){NonSeparator}+)
 
+Separator = ([\(\)\{\}\[\]])
+Separator2 = ([\;,.])
 
-Separator					= ([\(\)\{\}\[\]])
-Separator2				= ([\;,.])
+Identifier = ({IdentifierStart}{IdentifierPart}*)
 
-Identifier				= ({IdentifierStart}{IdentifierPart}*)
-
-URLGenDelim				= ([:\/\?#\[\]@])
-URLSubDelim				= ([\!\$&'\(\)\*\+,;=])
-URLUnreserved			= ({LetterOrUnderscore}|{Digit}|[\-\.\~])
-URLCharacter			= ({URLGenDelim}|{URLSubDelim}|{URLUnreserved}|[%])
-URLCharacters			= ({URLCharacter}*)
-URLEndCharacter			= ([\/\$]|{Letter}|{Digit})
-URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
-
+URLGenDelim = ([:\/\?#\[\]@])
+URLSubDelim = ([\!\$&'\(\)\*\+,;=])
+URLUnreserved = ({LetterOrUnderscore}|{Digit}|[\-\.\~])
+URLCharacter = ({URLGenDelim}|{URLSubDelim}|{URLUnreserved}|[%])
+URLCharacters = ({URLCharacter}*)
+URLEndCharacter = ([\/\$]|{Letter}|{Digit})
+URL = (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 
 /* No string state */
 /* No char state */
@@ -259,239 +242,233 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 %%
 
 <YYINITIAL> {
+  /* Keywords */
+  "abs" |
+  "access" |
+  "after" |
+  "alias" |
+  "all" |
+  "and" |
+  "architecture" |
+  "array" |
+  "assert" |
+  "attribute" |
+  "begin" |
+  "block" |
+  "body" |
+  "buffer" |
+  "bus" |
+  "case" |
+  "component" |
+  "configuration" |
+  "constant" |
+  "disconnect" |
+  "downto" |
+  "else" |
+  "elsif" |
+  "end" |
+  "entity" |
+  "exit" |
+  "file" |
+  "for" |
+  "function" |
+  "generate" |
+  "generic" |
+  "group" |
+  "guarded" |
+  "if" |
+  "impure" |
+  "in" |
+  "inertial" |
+  "inout" |
+  "is" |
+  "label" |
+  "library" |
+  "linkage" |
+  "literal" |
+  "loop" |
+  "map" |
+  "mod" |
+  "nand" |
+  "new" |
+  "next" |
+  "nor" |
+  "not" |
+  "null" |
+  "of" |
+  "on" |
+  "open" |
+  "or" |
+  "others" |
+  "out" |
+  "package" |
+  "port" |
+  "postponed" |
+  "procedure" |
+  "process" |
+  "pure" |
+  "range" |
+  "record" |
+  "register" |
+  "reject" |
+  "rem" |
+  "report" |
+  "return" |
+  "rol" |
+  "ror" |
+  "select" |
+  "severity" |
+  "shared" |
+  "signal" |
+  "sla" |
+  "sll" |
+  "sra" |
+  "srl" |
+  "subtype" |
+  "then" |
+  "to" |
+  "transport" |
+  "type" |
+  "unaffected" |
+  "units" |
+  "until" |
+  "use" |
+  "variable" |
+  "wait" |
+  "when" |
+  "while" |
+  "with" |
+  "xnor" |
+  "xor" { addToken(Token.RESERVED_WORD); }
 
-	/* Keywords */
-	"abs" |
-"access" |
-"after" |
-"alias" |
-"all" |
-"and" |
-"architecture" |
-"array" |
-"assert" |
-"attribute" |
-"begin" |
-"block" |
-"body" |
-"buffer" |
-"bus" |
-"case" |
-"component" |
-"configuration" |
-"constant" |
-"disconnect" |
-"downto" |
-"else" |
-"elsif" |
-"end" |
-"entity" |
-"exit" |
-"file" |
-"for" |
-"function" |
-"generate" |
-"generic" |
-"group" |
-"guarded" |
-"if" |
-"impure" |
-"in" |
-"inertial" |
-"inout" |
-"is" |
-"label" |
-"library" |
-"linkage" |
-"literal" |
-"loop" |
-"map" |
-"mod" |
-"nand" |
-"new" |
-"next" |
-"nor" |
-"not" |
-"null" |
-"of" |
-"on" |
-"open" |
-"or" |
-"others" |
-"out" |
-"package" |
-"port" |
-"postponed" |
-"procedure" |
-"process" |
-"pure" |
-"range" |
-"record" |
-"register" |
-"reject" |
-"rem" |
-"report" |
-"return" |
-"rol" |
-"ror" |
-"select" |
-"severity" |
-"shared" |
-"signal" |
-"sla" |
-"sll" |
-"sra" |
-"srl" |
-"subtype" |
-"then" |
-"to" |
-"transport" |
-"type" |
-"unaffected" |
-"units" |
-"until" |
-"use" |
-"variable" |
-"wait" |
-"when" |
-"while" |
-"with" |
-"xnor" |
-"xor"		{ addToken(Token.RESERVED_WORD); }
+  /* Keywords 2 (just an optional set of keywords colored differently) */
+  "'ACTIVE" |
+  "'ASCENDING" |
+  "'ASCENDING" |
+  "'ASCENDING" |
+  "'BASE" |
+  "'DELAYED" |
+  "'DRIVING" |
+  "'DRIVING_VALUE" |
+  "'EVENT" |
+  "'HIGH" |
+  "'HIGH" |
+  "'HIGH" |
+  "'IMAGE" |
+  "'INSTANCE_NAME" |
+  "'LAST_ACTIVE" |
+  "'LAST_EVENT" |
+  "'LAST_VALUE" |
+  "'LEFT" |
+  "'LEFT" |
+  "'LEFT" |
+  "'LEFTOF" |
+  "'LENGTH" |
+  "'LENGTH" |
+  "'LOW" |
+  "'LOW" |
+  "'LOW" |
+  "'PATH_NAME" |
+  "'POS" |
+  "'PRED" |
+  "'QUIET" |
+  "'QUIET" |
+  "'RANGE" |
+  "'RANGE" |
+  "'REVERSE_RANGE" |
+  "'REVERSE_RANGE" |
+  "'RIGHT" |
+  "'RIGHT" |
+  "'RIGHT" |
+  "'RIGHTOF" |
+  "'SIMPLE_NAME" |
+  "'STABLE" |
+  "'STABLE" |
+  "'SUCC" |
+  "'TRANSACTION" |
+  "'VAL" |
+  "'VALUE" { addToken(Token.RESERVED_WORD_2); }
 
-	/* Keywords 2 (just an optional set of keywords colored differently) */
-	"'ACTIVE" |
-"'ASCENDING" |
-"'ASCENDING" |
-"'ASCENDING" |
-"'BASE" |
-"'DELAYED" |
-"'DRIVING" |
-"'DRIVING_VALUE" |
-"'EVENT" |
-"'HIGH" |
-"'HIGH" |
-"'HIGH" |
-"'IMAGE" |
-"'INSTANCE_NAME" |
-"'LAST_ACTIVE" |
-"'LAST_EVENT" |
-"'LAST_VALUE" |
-"'LEFT" |
-"'LEFT" |
-"'LEFT" |
-"'LEFTOF" |
-"'LENGTH" |
-"'LENGTH" |
-"'LOW" |
-"'LOW" |
-"'LOW" |
-"'PATH_NAME" |
-"'POS" |
-"'PRED" |
-"'QUIET" |
-"'QUIET" |
-"'RANGE" |
-"'RANGE" |
-"'REVERSE_RANGE" |
-"'REVERSE_RANGE" |
-"'RIGHT" |
-"'RIGHT" |
-"'RIGHT" |
-"'RIGHTOF" |
-"'SIMPLE_NAME" |
-"'STABLE" |
-"'STABLE" |
-"'SUCC" |
-"'TRANSACTION" |
-"'VAL" |
-"'VALUE"		{ addToken(Token.RESERVED_WORD_2); }
+  /* Data types */
+  "bit" |
+  "bit_vector" |
+  "boolean" |
+  "integer" |
+  "natural" |
+  "positive" |
+  "std_logic" |
+  "std_logic_unsigned" |
+  "std_logic_vector" |
+  "std_logis_signed" { addToken(Token.DATA_TYPE); }
 
-	/* Data types */
-	"bit" |
-"bit_vector" |
-"boolean" |
-"integer" |
-"natural" |
-"positive" |
-"std_logic" |
-"std_logic_unsigned" |
-"std_logic_vector" |
-"std_logis_signed"		{ addToken(Token.DATA_TYPE); }
+  /* Functions */
+  "'-'" |
+  "'0'" |
+  "'1'" |
+  "'H'" |
+  "'L'" |
+  "'U'" |
+  "'W'" |
+  "'X'" |
+  "'Z'" |
+  "false" |
+  "true" { addToken(Token.FUNCTION); }
 
-	/* Functions */
-	"'-'" |
-"'0'" |
-"'1'" |
-"'H'" |
-"'L'" |
-"'U'" |
-"'W'" |
-"'X'" |
-"'Z'" |
-"false" |
-"true"		{ addToken(Token.FUNCTION); }
+  {LineTerminator} { addNullToken(); return firstToken; }
+  {Identifier} { addToken(Token.IDENTIFIER); }
+  {WhiteSpace} { addToken(Token.WHITESPACE); }
 
+   /* String/Character literals. */
+  {CharLiteral} { addToken(Token.LITERAL_CHAR); }
+  {UnclosedCharLiteral} { addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
+  {ErrorCharLiteral} { addToken(Token.ERROR_CHAR); }
+  {StringLiteral} { addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
+  {UnclosedStringLiteral} { addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
+  {ErrorStringLiteral} { addToken(Token.ERROR_STRING_DOUBLE); }
 
+  /* Comment literals. */
+  /* No multi-line comments */
+  /* No documentation comments */
+  {LineCommentBegin} { start = zzMarkedPos-2; yybegin(EOL_COMMENT); }
 
-	{LineTerminator}				{ addNullToken(); return firstToken; }
+  /* Separators. */
+  {Separator} { addToken(Token.SEPARATOR); }
+  {Separator2} { addToken(Token.IDENTIFIER); }
 
-	{Identifier}					{ addToken(Token.IDENTIFIER); }
+  /* Operators. */
+  "&" |
+  "(" |
+  ")" |
+  "*" |
+  "**" |
+  "+" |
+  "-" |
+  "." |
+  "/" |
+  "/=" |
+  ":" |
+  ":=" |
+  ";" |
+  "<" |
+  "<=" |
+  "=" |
+  "=>" |
+  ">" |
+  ">=" { addToken(Token.OPERATOR); }
 
-	{WhiteSpace}					{ addToken(Token.WHITESPACE); }
+   /* Numbers */
+  {IntegerLiteral} { addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
+  {HexLiteral} { addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
+  {FloatLiteral} { addToken(Token.LITERAL_NUMBER_FLOAT); }
+  {ErrorNumberFormat} { addToken(Token.ERROR_NUMBER_FORMAT); }
 
-	/* String/Character literals. */
-	{CharLiteral}				{ addToken(Token.LITERAL_CHAR); }
-{UnclosedCharLiteral}		{ addToken(Token.ERROR_CHAR); addNullToken(); return firstToken; }
-{ErrorCharLiteral}			{ addToken(Token.ERROR_CHAR); }
-	{StringLiteral}				{ addToken(Token.LITERAL_STRING_DOUBLE_QUOTE); }
-{UnclosedStringLiteral}		{ addToken(Token.ERROR_STRING_DOUBLE); addNullToken(); return firstToken; }
-{ErrorStringLiteral}			{ addToken(Token.ERROR_STRING_DOUBLE); }
+  /* Ended with a line not in a string or comment. */
+  <<EOF>> { addNullToken(); return firstToken; }
 
-	/* Comment literals. */
-	/* No multi-line comments */
-	/* No documentation comments */
-	{LineCommentBegin}			{ start = zzMarkedPos-2; yybegin(EOL_COMMENT); }
-
-	/* Separators. */
-	{Separator}					{ addToken(Token.SEPARATOR); }
-	{Separator2}					{ addToken(Token.IDENTIFIER); }
-
-	/* Operators. */
-	"&" |
-"(" |
-")" |
-"*" |
-"**" |
-"+" |
-"-" |
-"." |
-"/" |
-"/=" |
-":" |
-":=" |
-";" |
-"<" |
-"<=" |
-"=" |
-"=>" |
-">" |
-">="		{ addToken(Token.OPERATOR); }
-
-	/* Numbers */
-	{IntegerLiteral}				{ addToken(Token.LITERAL_NUMBER_DECIMAL_INT); }
-	{HexLiteral}					{ addToken(Token.LITERAL_NUMBER_HEXADECIMAL); }
-	{FloatLiteral}					{ addToken(Token.LITERAL_NUMBER_FLOAT); }
-	{ErrorNumberFormat}			{ addToken(Token.ERROR_NUMBER_FORMAT); }
-
-	/* Ended with a line not in a string or comment. */
-	<<EOF>>						{ addNullToken(); return firstToken; }
-
-	/* Catch any other (unhandled) characters. */
-	.							{ addToken(Token.IDENTIFIER); }
+  /* Catch any other (unhandled) characters. */
+  . { addToken(Token.IDENTIFIER); }
 
 }
-
 
 /* No char state */
 
@@ -502,9 +479,9 @@ URL						= (((https?|f(tp|ile))"://"|"www.")({URLCharacters}{URLEndCharacter})?)
 /* No documentation comment state */
 
 <EOL_COMMENT> {
-	[^hwf\n]+				{}
-	{URL}					{ int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
-	[hwf]					{}
-	\n						{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
-	<<EOF>>					{ addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+  [^hwf\n]+ {}
+  {URL} { int temp=zzStartRead; addToken(start,zzStartRead-1, Token.COMMENT_EOL); addHyperlinkToken(temp,zzMarkedPos-1, Token.COMMENT_EOL); start = zzMarkedPos; }
+  [hwf] {}
+  \n { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
+  <<EOF>> { addToken(start,zzStartRead-1, Token.COMMENT_EOL); addNullToken(); return firstToken; }
 }


### PR DESCRIPTION
I checked the examples from [rsyntaxtextarea](https://github.com/bobbylight/RSyntaxTextArea) and learned that all them implement yystate() to return zzLexicalState. So I added that method definition to our VhdlSyntax.flex file. That works with the upgraded rsyntaxtextarea version. The first commit for this PR adds that method and upgrades rsyntaxtextarea.

I also noticed that VhdlSyntax.flex was never reformatted to match our style guidelines. It isn't a .java file, after all. So the second commit in this PR is just reformatting it for consistency with the rest of our code. That commit should make no functional changes.

This PR should complete #2088.
