### PR TITLE
fix(logisim-evolution.desktop): add main category

### DIFF
--- a/support/Flatpak/com.github.reds.LogisimEvolution.desktop
+++ b/support/Flatpak/com.github.reds.LogisimEvolution.desktop
@@ -6,6 +6,6 @@ Exec=LogisimEvolution.sh
 Icon=com.github.reds.LogisimEvolution
 Terminal=false
 Type=Application
-Categories=Electronics
+Categories=Education;Electronics
 MimeType=application/x-logisim-circuit;
 X-Desktop-File-Install-Version=0.24


### PR DESCRIPTION
Add a main category `Education`  in the `logisim-evolution.desktop` (see [Registered Categories](https://specifications.freedesktop.org/menu-spec/latest/category-registry.html)). Otherwise, the software will be classified as "Unknown Category" in the KDE desktop environment.
