### PR TITLE
Fix --test-circuit

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/test/TestBench.java
+++ b/src/main/java/com/cburch/logisim/gui/test/TestBench.java
@@ -19,6 +19,7 @@ import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.proj.ProjectActions;
 import com.cburch.logisim.std.wiring.Pin;
+import com.cburch.logisim.vhdl.base.VhdlSimConstants.State;
 import java.io.File;
 import java.util.Map;
 
@@ -104,9 +105,11 @@ public class TestBench {
     final var vhdlSim = sim.getCircuitState().getProject().getVhdlSimulator();
     vhdlSim.enable();
     sim.setAutoPropagation(true);
-    /* TODO Timeout */
-    while (vhdlSim.isEnabled()) {
-      Thread.yield();
+    if (vhdlSim.getState() == State.STARTING) {
+      /* TODO Timeout */
+      while (!vhdlSim.isRunning()) {
+        Thread.yield();
+      }
     }
 
     return true;


### PR DESCRIPTION
This PR fixes the program freezing whenever the `--test-circuit` command-line option is used, for instance:
```
java -jar logisim-evolution-4.0.0dev-all.jar --test-circuit testbench.circ
```
The problem is in the part at `TestBench.java` that starts the VHDL simulator: it calls `VhdlSimulatorTop.enable` and waits in a loop for the simulator to switch to a state other than `State.DISABLED`. The sequence of states when starting the simulator is:

- starts with `State.ENABLED`,
- if `VhdlSimulatorTop.hasVhdlComponent` returns true, switch to `State.STARTING` and start the simulator process,
- if the process starts sucessfully, switch to `State.RUNNING`,

so the correct way would be to check if the simulator has switched to `State.STARTING` and in this case wait for the state to switch to `State.RUNNING`.
