### PR TITLE
Add coloring to bus wires

### DIFF
--- a/src/main/java/com/cburch/logisim/data/Value.java
+++ b/src/main/java/com/cburch/logisim/data/Value.java
@@ -200,6 +200,9 @@ public class Value {
   public static Color widthErrorHighlightColor = new Color(AppPreferences.WIDTH_ERROR_HIGHLIGHT_COLOR.get());
   public static Color widthErrorCaptionBgcolor = new Color(AppPreferences.WIDTH_ERROR_BACKGROUND_COLOR.get());
   public static Color clockFrequencyColor = new Color(AppPreferences.CLOCK_FREQUENCY_COLOR.get());
+  public static Color[] multiColors = new Color[] { new Color(14, 14, 16), new Color(124, 75, 39),
+      new Color(167, 41, 32), new Color(246, 120, 40), new Color(246, 182, 0), new Color(97, 153, 59),
+      new Color(0, 124, 176), new Color(118, 104, 154), new Color(122, 136, 142), new Color(215, 160, 166) };
 
   private static final Cache cache = new Cache();
 
@@ -341,11 +344,14 @@ public class Value {
     } else if (width == 0) {
       return nilColor;
     } else if (width == 1) {
-      if (this == UNKNOWN) return unknownColor;
-      else if (this == TRUE) return trueColor;
-      else return falseColor;
+      if (this == UNKNOWN)
+        return unknownColor;
+      else if (this == TRUE)
+        return trueColor;
+      else
+        return falseColor;
     } else {
-      return multiColor;
+      return multiColors[(int) (this.value % multiColors.length)];
     }
   }
 


### PR DESCRIPTION
Colors are choosen according to IEC 62

IMHO it looks way better than standard black for everything which makes everything a bit hard to look through.

![grafik](https://github.com/user-attachments/assets/477028b3-778a-4db2-9e40-6c7e47ed645e)


Current questions are:
 - [ ] is this something that you would like to see?
 - [ ] should this be configurable in the GUI (default black / IEC Colors / custom colors)
 - [ ] Can this be merged as a first draft and the rest made later™