### PR TITLE
Fixing the appearance of NOT gates

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
@@ -291,7 +291,6 @@ public class TikZInfo implements Cloneable {
           }
         }
         if (merged) l.remove();
-        else ((TikZLine) obj).closeIfPossible();
       } else if (obj.getClass() == TikZEllipse.class) {
         //This non-instanceof check must be used so that we DON'T match with classes that extend TikZEllipse.
         final var ovalA = (TikZEllipse) obj;
@@ -535,14 +534,6 @@ public class TikZInfo implements Cloneable {
       if (getEndPoint().equals(l.getStartPoint())) return true;
       if (getStartPoint().equals(l.getStartPoint())) return true;
       return getEndPoint().equals(l.getEndPoint());
-    }
-
-    public void closeIfPossible() {
-      if (points.isEmpty()) return;
-      if (getStartPoint().equals(getEndPoint())) {
-        points.remove(points.size() - 1);
-        close = true;
-      }
     }
 
     private void addPoints(ArrayList<Point> p, int start, int end, boolean atEnd, boolean reverseOrder) {

--- a/src/main/java/com/cburch/logisim/std/gates/PainterShaped.java
+++ b/src/main/java/com/cburch/logisim/std/gates/PainterShaped.java
@@ -149,14 +149,14 @@ public class PainterShaped {
       GraphicsUtil.switchToWidth(g, 2);
       int[] xp = new int[4];
       int[] yp = new int[4];
-      xp[0] = -6;
-      yp[0] = 0;
+      xp[0] = -7;
+      yp[0] = -1;
       xp[1] = -19;
       yp[1] = -6;
       xp[2] = -19;
       yp[2] = 6;
-      xp[3] = -6;
-      yp[3] = 0;
+      xp[3] = -7;
+      yp[3] = 1;
       g.drawPolyline(xp, yp, 4);
       g.drawOval(-6, -3, 6, 6);
     } else {


### PR DESCRIPTION
This PR consists of only two commits, but it corrects some graphical issues that have been bugging me for months. First major point of order: Polylines are not Polygons, and Polygons are not Polylines. Attempting to convert one into the other as an "optimization" step is not a valid action.

The purpose of `TikZLine::closeIfPossible()` was to perform this illegal action on polylines whose start and end points are at the same location. The problem with this "optimization" is that the drawing logic for polylines and polygons differs fundamentally. Turning a polyline into a polygon in this manner causes a sharp angle to be rendered at the newly-merged corner, where previously no sharpening would be applied if the shape were left in its original polyline form.

To compound the problem, this polyline-to-polygon conversion was happening ONLY in the process of exporting a vector image, and _not_ being performed by Java's own graphics systems. This means that the **_only_** purpose that `TikZLine::closeIfPossible()` has ever actually served is to deliberately make the results of vector image export _**fail**_ to match the results of bitmap image rendering. This seems (to me, at least) to be an obvious **non-goal.**

Eradicating the blight upon graphics that was `TikZLine::closeIfPossible()` brings about the following change in the appearance of NOT gates:

![Large_NOTs](https://github.com/user-attachments/assets/6420fd11-0e2c-490c-81d0-6eb32abc047f)

Following that change, a second problem with NOT gates persisted: the rendering of Narrow sized NOT gates. The points of its polyline body were positioned such that the ends of the lines could be seen extending into the circle:

![Small_NOTs_Before](https://github.com/user-attachments/assets/81618a76-4c57-4b10-bde2-ec326aa4a96c)

The solution to _this_ problem was less insidious than the first problem. I simply adjusted the points of the polyline to bring about a more visually-pleasing intersection. This is how they look following my second commit:

![Small_NOTs_After](https://github.com/user-attachments/assets/8d170e45-e417-46e4-ae6c-b9b0eed53627)