### PR TITLE
Speedup simulation and fix synchronization bug.

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
@@ -181,7 +181,7 @@ class CircuitWires {
   // derived data
   private Bounds bounds = Bounds.EMPTY_BOUNDS;
 
-  private BundleMap masterBundleMap = null;
+  private volatile BundleMap masterBundleMap = null;
 
   CircuitWires() {}
 
@@ -560,7 +560,8 @@ class CircuitWires {
   // create the new bundle map.
 
   /*synchronized*/ private BundleMap getBundleMap() {
-    if (masterBundleMap != null) return masterBundleMap;
+    final var map = masterBundleMap;
+    if (map != null) return map;
     if (SwingUtilities.isEventDispatchThread()) {
       // AWT event thread.
       final var ret = new BundleMap();

--- a/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
@@ -560,9 +560,9 @@ class CircuitWires {
   // create the new bundle map.
 
   /*synchronized*/ private BundleMap getBundleMap() {
+    if (masterBundleMap != null) return masterBundleMap;
     if (SwingUtilities.isEventDispatchThread()) {
       // AWT event thread.
-      if (masterBundleMap != null) return masterBundleMap;
       final var ret = new BundleMap();
       try {
         computeBundleMap(ret);

--- a/src/main/java/com/cburch/logisim/gui/main/Canvas.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Canvas.java
@@ -1131,7 +1131,6 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
     @Override
     public void propagationCompleted(Simulator.Event e) {
       paintThread.requestRepaint();
-      if (e.didTick()) waitForRepaintDone();
     }
 
     @Override


### PR DESCRIPTION
This is the speedup branch that was tested in the discussion for PR #2129. It contains the commit from PR #1805 and fixes the two synchronization issues that I noted there.

All changes in this PR have already been made in the Holycross version. Since our current main causes problems on some systems, I think we should merge this now and work on the rest of the fixes from the Holycross version as time permits.

To avoid generating merge conflicts, I recommend merging this PR and then closing #1805 as already merged. The commit from #1805 with proper attribution is included here.