### PR TITLE
Fixing the appearance of arrow-style Pins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   * Fixed TTY appearance bug while changing various zoom levels.
   * Added Metal graphics acceleration
   * Added option to hide/show toolbar
+  * Corrected appearance of NOT gates in TikZ/SVG image export
+  * Corrected disjoint corners in arrow-style Pins
 
 * v3.9.0 (2024-08-15)
   * Updated Java requirement to Java 21.

--- a/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
@@ -914,11 +914,11 @@ public class TikZInfo implements Cloneable {
         final var width = strokeWidth * BASIC_STROKE_WIDTH;
         contents.append(rounded(width)).append("pt, ").append(color);
         if (filled && alpha != 1.0) contents.append(", fill opacity=").append(rounded(alpha));
-        contents.append(" ] ");
+        contents.append("]");
         contents.append(getPoint(start));
         contents.append("rectangle");
         contents.append(getPoint(end));
-        contents.append(";");
+        contents.setCharAt(contents.length() - 1, ';');
       } else {
         /* TODO : change to tikz command as pgfpicture causes sometimes troubles */
         contents.append("\\begin{pgfpicture}\n");

--- a/src/main/java/com/cburch/logisim/gui/generic/TikZWriter.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/TikZWriter.java
@@ -341,6 +341,11 @@ public class TikZWriter extends Graphics2D {
   }
 
   @Override
+  public void drawRect(int x, int y, int width, int height) {
+    MyInfo.addRectangle(x, y, x + width, y + height, false, false);
+  }
+
+  @Override
   public void clearRect(int x, int y, int width, int height) {
     MyInfo.addRectangle(x, y, x + width, y + height, true, true);
   }

--- a/src/main/java/com/cburch/logisim/std/wiring/Pin.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Pin.java
@@ -1004,11 +1004,11 @@ public class Pin extends InstanceFactory {
         GraphicsUtil.switchToWidth(g, 2);
       }
       g.setColor(col);
-      g.drawLine(-15, -rheight / 2, -5, 0);
-      g.drawLine(-15, rheight / 2, -5, 0);
-      g.drawLine(-rwidth, -rheight / 2, -rwidth, rheight / 2);
-      g.drawLine(-rwidth, -rheight / 2, -15, -rheight / 2);
-      g.drawLine(-rwidth, rheight / 2, -15, rheight / 2);
+      int[] xPoints = new int[] {-rwidth, -15, -5, -15, -rwidth};
+      int yBottom = rheight / 2;
+      int yTop = -yBottom;
+      int[] yPoints = new int[] {yTop, yTop, 0, yBottom, yBottom};
+      g.drawPolygon(xPoints, yPoints, 5);
       drawNewStyleValue(painter, rwidth, rheight, false, isGhost);
       g2.rotate(-rotation);
       g2.translate(-xpos, -ypos);
@@ -1068,11 +1068,11 @@ public class Pin extends InstanceFactory {
         GraphicsUtil.switchToWidth(g, 2);
       }
       g.setColor(col);
-      g.drawLine(10 - rwidth, -rheight / 2, -rwidth, 0);
-      g.drawLine(10 - rwidth, rheight / 2, -rwidth, 0);
-      g.drawLine(-5, -rheight / 2, -5, rheight / 2);
-      g.drawLine(-5, -rheight / 2, 10 - rwidth, -rheight / 2);
-      g.drawLine(-5, rheight / 2, 10 - rwidth, rheight / 2);
+      int[] xPoints = new int[] {-5, 10 - rwidth, -rwidth, 10 - rwidth, -5};
+      int yTop = rheight / 2;
+      int yBottom = -yTop;
+      int[] yPoints = new int[] {yTop, yTop, 0, yBottom, yBottom};
+      g.drawPolygon(xPoints, yPoints, 5);
       drawNewStyleValue(painter, rwidth, rheight, true, isGhost);
       g2.rotate(-rotation);
       g2.translate(-xpos, -ypos);


### PR DESCRIPTION
Two changes in this PR. First up: correcting the disjoint corners at the transition between the rectangular body of arrow-style pins and their pointed arrow end. The culprit behind this visual issue was pretty easy to find: all five sides of this pointed shape were being drawn individually, instead of as a connected polygon. Here's a before-and-after comparison:

![Pointy_Pins_Before_After](https://github.com/user-attachments/assets/76313806-02ec-4c32-a905-0d8a78d39a50)

The second bug I addressed in this PR wasn't visual, but rather technical. In my experiments with vector output files, I noticed something funny happening with rectangular-shaped "input" pins. Even though the drawing code in `Pin::drawInputShape()` was calling `drawRect()`, the vector output files were _not_ outputting actual rectangles. Instead, the vector output contained four individual edges laid out sequentially in each place where an unfilled rectangle should have been specified.

This problem was a little strange to diagnose. Here's what I think was happening:
- `drawRect()` was being called, but `TikZWriter` actually **_didn't have_** a `drawRect()` method defined.
- `TikZWriter` extends `java.awt.Graphics2D`, which inherits a `drawRect()` method from `java.awt.Graphics`.
- I think `java.awt.Graphics::drawRect()` actually delegates its drawing work to four sequential calls to `drawLine()`.
- Those calls to `drawLine()` were going _back_ to `TikZWriter::drawLine()`.

I solved this problem by adding in a definition for `TikZWriter::drawRect()`.