### PR TITLE
Improve simulation performance

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/Propagator.java
+++ b/src/main/java/com/cburch/logisim/circuit/Propagator.java
@@ -17,6 +17,7 @@ import com.cburch.logisim.data.Location;
 import com.cburch.logisim.data.Value;
 import com.cburch.logisim.file.Options;
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.PriorityQueue;
@@ -382,7 +383,7 @@ public class Propagator {
     clock = toProcess.peek().time;
 
     // propagate all values for this clock tick
-    final var visited = new HashMap<CircuitState, HashSet<ComponentPoint>>();
+    final var visited = new HashMap<CircuitState, ArrayList<ComponentPoint>>();
     while (true) {
       final var data = toProcess.peek();
       if (data == null || data.time != clock) break;
@@ -392,9 +393,11 @@ public class Propagator {
       // if it's already handled for this clock tick, continue
       var handled = visited.get(state);
       if (handled != null) {
-        if (!handled.add(new ComponentPoint(data.cause, data.loc))) continue;
+        var comp = new ComponentPoint(data.cause, data.loc);
+        if (!handled.contains(comp)) handled.add(comp);
+        else continue;
       } else {
-        handled = new HashSet<>();
+        handled = new ArrayList<>();
         visited.put(state, handled);
         handled.add(new ComponentPoint(data.cause, data.loc));
       }
@@ -415,7 +418,7 @@ public class Propagator {
 
       // if the value at point has changed, propagate it
       if (!newVal.equals(oldVal)) {
-        state.markPointAsDirty(data.loc);
+        state.markPointAsDirtyFromPropagator(data.loc);
       }
     }
 

--- a/src/main/java/com/cburch/logisim/data/Location.java
+++ b/src/main/java/com/cburch/logisim/data/Location.java
@@ -9,7 +9,6 @@
 
 package com.cburch.logisim.data;
 
-import com.cburch.logisim.util.Cache;
 import java.util.Comparator;
 import java.util.List;
 
@@ -22,15 +21,12 @@ public class Location implements Comparable<Location> {
     // we round to half-grid base
     final var xRounded = hasToSnap ? Math.round(x / 5) * 5 : x;
     final var yRounded = hasToSnap ? Math.round(y / 5) * 5 : y;
-    final var hashCode = 31 * xRounded + yRounded;
-    final var ret = cache.get(hashCode);
-    if (ret != null) {
-      final var loc = (Location) ret;
-      if (loc.x == xRounded && loc.y == yRounded) return loc;
-    }
-    final var loc = new Location(hashCode, xRounded, yRounded, hasToSnap);
-    cache.put(hashCode, loc);
-    return loc;
+    // minimize hash collisions
+    int hashCode = (int)Short.MAX_VALUE * xRounded + yRounded;
+    // randomize order for better hashing
+    hashCode ^= hashCode >> 14;
+    hashCode ^= hashCode << 11;
+    return new Location(hashCode, xRounded, yRounded, hasToSnap);
   }
 
   public static Location parse(String value) {
@@ -57,7 +53,6 @@ public class Location implements Comparable<Location> {
     return Location.create(x, y, true);
   }
 
-  private static final Cache cache = new Cache();
   private final int hashCode;
   private final int x;
   private final int y;

--- a/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
@@ -22,7 +22,6 @@ import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.memory.Register;
 import com.cburch.logisim.util.AlphanumComparator;
-import com.cburch.logisim.util.CollectionUtil;
 import com.cburch.logisim.util.LocaleListener;
 
 import java.awt.Color;
@@ -150,11 +149,9 @@ public class RegTabContent extends JScrollPane implements LocaleListener, Simula
       return cs.getValue(loc);
     }
 
-    if (CollectionUtil.isNotEmpty(cs.getSubStates())) {
-      for (final var cst : cs.getSubStates()) {
-        final var ret = findVal(cst, cn, loc);
-        if (ret != null) return ret;
-      }
+    for (final var cst : cs.getSubStates()) {
+      final var ret = findVal(cst, cn, loc);
+      if (ret != null) return ret;
     }
     return null;
   }

--- a/src/main/java/com/cburch/logisim/gui/main/Canvas.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Canvas.java
@@ -997,7 +997,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
       Attribute<?> attr = e.getAttribute();
       if (attr == Options.ATTR_GATE_UNDEFINED) {
         final var circState = getCircuitState();
-        circState.markComponentsDirty(getCircuit().getNonWires());
+        circState.markAllComponentsDirty();
         // TODO actually, we'd want to mark all components in
         // subcircuits as dirty as well
       }


### PR DESCRIPTION
In this patch I have gone through the hot path of the logic simulation. Before this patch, more than 95% of the time was just spent on wires. With this patch, the time for wire propagation is down to ~70%. In total this speeds up the simulation by a factor of 2 or more. There is probably another 50% speed increase possible just by rearranging things in `CircuitWires.propagate`, but I'm finished with this.

I have also improved performance in related areas of the code and done some minor cleanup of iterators and concurrency.