### PR TITLE
Do multiple ticks per simulator iteration

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/log/LogFrame.java
+++ b/src/main/java/com/cburch/logisim/gui/log/LogFrame.java
@@ -93,7 +93,7 @@ public class LogFrame extends LFrame.SubWindowWithSimulation {
 
     @Override
     public void propagationInProgress(Simulator.Event e) {
-      curModel.propagationCompleted(false, true, false); // treat as a single-step
+      curModel.propagationCompleted(0, true, false); // treat as a single-step
     }
 
     @Override

--- a/src/main/java/com/cburch/logisim/gui/log/Model.java
+++ b/src/main/java/com/cburch/logisim/gui/log/Model.java
@@ -581,7 +581,7 @@ public class Model implements CircuitListener, SignalInfo.Listener {
     fireSignalsExtended(null); // changed, not extended, but works fine for now
   }
 
-  public void propagationCompleted(boolean ticked, boolean stepped, boolean propagated) {
+  public void propagationCompleted(int ticked, boolean stepped, boolean propagated) {
     if (!stepped && !propagated) {
       // No signals have changed. This was a nudge that resulted in no signal
       // changes, or a tick in single-step mode that hasn't yet propagated

--- a/src/main/java/com/cburch/logisim/gui/main/TickCounter.java
+++ b/src/main/java/com/cburch/logisim/gui/main/TickCounter.java
@@ -111,9 +111,9 @@ public class TickCounter implements Simulator.Listener {
 
   @Override
   public void propagationCompleted(Simulator.Event e) {
-    if (e.didTick()) {
+    if (e.didTick() > 0) {
       simulator = e.getSource();
-      tickCount++;
+      tickCount += e.didTick();
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuSimulate.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuSimulate.java
@@ -302,7 +302,7 @@ public class MenuSimulate extends Menu {
       if (currentSim != null) {
         currentSim.addSimulatorListener(myListener);
       }
-      myListener.simulatorStateChanged(new Simulator.Event(sim, false, false, false));
+      myListener.simulatorStateChanged(new Simulator.Event(sim, 0, false, false));
     }
 
     clearItems(downStateItems);


### PR DESCRIPTION
This patch makes the simulator do multiple ticks in one iteration. That brings a speedup anywhere from 50% (complex circuit) to 1000% (less complex circuit).