### PR TITLE
Improved Rounded Rectangles in TikZ image export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
   * Added option to hide/show toolbar
   * Corrected appearance of NOT gates in TikZ/SVG image export
   * Corrected disjoint corners in arrow-style Pins
+  * Improved output of rectangles with rounded corners in TikZ image export
 
 * v3.9.0 (2024-08-15)
   * Updated Java requirement to Java 21.

--- a/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
@@ -185,15 +185,28 @@ public class TikZInfo implements Cloneable {
     contents.add(new TikZBezier(s, filled));
   }
 
-  public void addRectangle(int x, int y, int width, int height, boolean filled, boolean backcolor) {
-    TikZRectangle obj = new TikZRectangle(x, y, width, height, filled);
+  public void addRectangle(int x1, int y1, int x2, int y2, boolean filled, boolean backcolor) {
+    TikZRectangle obj = new TikZRectangle(x1, y1, x2, y2, filled);
     if (backcolor) obj.setBackColor();
     contents.add(obj);
   }
 
-  public void addRoundedRectangle(
-      int x, int y, int width, int height, int arcWidth, int arcHeight, boolean filled) {
-    contents.add(new TikZRectangle(x, y, width, height, arcWidth, arcHeight, filled));
+  public void addRoundedRectangle(int x1, int y1, int x2, int y2, int arcWidth, int arcHeight, boolean filled) {
+    int width = Math.abs(x1 - x2);
+    int height = Math.abs(y1 - y2);
+    int xDiameter = Math.max(0, Math.min(arcWidth, width));
+    int yDiameter = Math.max(0, Math.min(arcHeight, height));
+    //The previous two lines implement a just-in-case data normalization.
+    //The SVG standard asserts this behavior, so I've replicated it here.
+    if ((xDiameter == 0) || (yDiameter == 0)) {
+      addRectangle(x1, y1, x2, y2, filled, false);
+      return;
+    }
+    if ((xDiameter == width) && (yDiameter == height)) {
+      addEllipse(x1, y1, width, height, filled);
+      return;
+    }
+    contents.add(new TikZRectangle(x1, y1, x2, y2, xDiameter, yDiameter, filled));
   }
 
   public void addEllipse(int x, int y, int width, int height, boolean filled) {


### PR DESCRIPTION
The first thing I noticed, and tried to correct, was the lack of what I call "arc-length normalization" in Logisim's vector export code. In basic terms, you want to constrain the x-radius and y-radius of the curvature of the corners of rectangles to specific maximums: The x-radius should be no greater than half the width of the rectangle, and the y-radius should be no greater than half the height of the rectangle.

Now, the SVG standard actually demands this behavior explicitly, so if you exported an SVG from Logisim that contained rectangles with rounded corners, the results coming out of Logisim could contain some larger-than-correct radii, but standards-compliant SVG renderers would notice the problem, and correct it without even telling you. However, no such auto-correction exists in TikZ land, which meant that before I made any of the changes in this PR, Logisim would output the following in its TikZ export:

![Rectangle_Progress_001](https://github.com/user-attachments/assets/c66af5d7-59ad-4e84-8a41-27d42d068bd1)

Take careful note of the hitch in the curvature on the left side of this Probe object. It turns out that the graphical height of this Probe is `18`, but the y-radius of the corner curvature is being specified as `10`, when it _should_ have been constrained to a maximum of `9`. The curved corners end up overlapping each other, causing the path to hitch where the curves were _supposed_ to line up. The first commit in this PR added in arc-length normalization to correct that, and following that commit, I got this result:

![Rectangle_Progress_002](https://github.com/user-attachments/assets/3a7fd70f-fffc-418e-bad5-db68d1d72139)

While things had definitely changed now, I could tell that something was still off. To figure out why this still didn't look exactly right, I manually reduced the y-radius to make it noticeably different from the x-radius. To my horror, this is what came out:

![Rectangle_Progress_003](https://github.com/user-attachments/assets/158e8cbb-6743-4fc3-9945-57e01d364a47)

So it turns out that `\\pgfsetcornersarced` combined with `\\pgfpathrectanglecorners` ends up rendering in an _**extremely**_ idiotic manner. The graphically acceptable behavior would be to take the arc at one of the corners and mirror it horizontally and vertically to produce an arc that could fit in the other corners. What PGF is doing instead is _rotating_ the arc in increments of 90°, which is _bananas_ level of wrong. PGF's behavior is causing the x-radius and the y-radius to _swap roles_ on every other corner of the rectangle, resulting in the lopsided abomination you see above.

I don't know for certain how deeply anyone here previously understood how bad this behavior is. There was only one comment previously present in this portion of the code, and I found it to be quite fitting: `/* TODO : change to tikz command as pgfpicture causes sometimes troubles */`

I'm reminded of good old Uncle Bob, who warned that "TODO comments are useful, but I never _**check them in**_, because that's the point at which they become _don't-do_ comments."

I decided I'd do the work of stripping out all the PGF junk that previously blighted the `TikZRectangle` class, and remake `TikZRectangle::getTikZCommand` in a more sensible, TikZ-only manner. Following the second commit in this PR, we get the following graphical result:

![Rectangle_Progress_004](https://github.com/user-attachments/assets/93d29f2a-3548-43d6-8654-814bf3b25497)