### PR TITLE
Use Java's PriorityQueue for simulation event queue.

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/Propagator.java
+++ b/src/main/java/com/cburch/logisim/circuit/Propagator.java
@@ -127,7 +127,7 @@ public class Propagator {
    * others. It is trivial to switch between the implementations, just change the
    * object to a new one of: SplayQueue, LinkedQueue, or PriorityEventQueue.
    */
-  private final QNodeQueue<SimulatorEvent> toProcess = new SplayQueue<>();
+  private final QNodeQueue<SimulatorEvent> toProcess = new PriorityEventQueue<>();
 
   private int clock = 0;
   private boolean isOscillating = false;


### PR DESCRIPTION
This PR changes the default simulation event queue to be Java's PriorityQueue.

It fixes issue #2182.
