### PR TITLE
Rewrite RegTabContent.java to remove gui activity from the simulation thread.

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
@@ -61,7 +61,6 @@ public class RegTabContent extends JScrollPane
     setViewportView(panel);
     proj = frame.getProject();
     getVerticalScrollBar().setUnitIncrement(16);
-    proj.getSimulator().addSimulatorListener(this);
 
     c.fill = GridBagConstraints.HORIZONTAL;
     c.anchor = GridBagConstraints.FIRST_LINE_START;
@@ -74,9 +73,11 @@ public class RegTabContent extends JScrollPane
       public void componentShown(ComponentEvent e) {
         showing = true;
         fill();
+        proj.getSimulator().addSimulatorListener(RegTabContent.this);
       }
       public void componentHidden(ComponentEvent e) {
         showing = false;
+        proj.getSimulator().removeSimulatorListener(RegTabContent.this);
       }
     });
 

--- a/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
@@ -47,7 +47,7 @@ import javax.swing.JScrollPane;
 public class RegTabContent extends JScrollPane
     implements LocaleListener, Simulator.Listener, ProjectListener, CircuitListener {
   private final JPanel panel = new JPanel(new GridBagLayout());
-  private final GridBagConstraints c = new GridBagConstraints();
+  private final GridBagConstraints gridConstraints = new GridBagConstraints();
   private final Project proj;
   private final MyLabel hdrName = new MyLabel("", Font.ITALIC | Font.BOLD, false, Color.LIGHT_GRAY);
   private final MyLabel hdrValue = new MyLabel("", Font.BOLD, false, Color.LIGHT_GRAY);
@@ -62,9 +62,9 @@ public class RegTabContent extends JScrollPane
     proj = frame.getProject();
     getVerticalScrollBar().setUnitIncrement(16);
 
-    c.fill = GridBagConstraints.HORIZONTAL;
-    c.anchor = GridBagConstraints.FIRST_LINE_START;
-    c.ipady = 2;
+    gridConstraints.fill = GridBagConstraints.HORIZONTAL;
+    gridConstraints.anchor = GridBagConstraints.FIRST_LINE_START;
+    gridConstraints.ipady = 2;
 
     localeChanged();
     LocaleManager.addLocaleListener(this);
@@ -75,6 +75,7 @@ public class RegTabContent extends JScrollPane
         fill();
         proj.getSimulator().addSimulatorListener(RegTabContent.this);
       }
+
       public void componentHidden(ComponentEvent e) {
         showing = false;
         proj.getSimulator().removeSimulatorListener(RegTabContent.this);
@@ -106,45 +107,42 @@ public class RegTabContent extends JScrollPane
   }
 
   void clear() {
-    if (circuits.isEmpty())
-      return;
-    for (Circuit circ : circuits)
+    if (circuits.isEmpty()) return;
+    for (Circuit circ : circuits) {
       circ.removeCircuitListener(this);
+    }
     circuits.clear();
     synchronized (watchers) {
       watchers.clear();
     }
     panel.removeAll();
-    c.weighty = 0;
-    c.gridy = 0;
-    c.gridx = 0;
-    c.weightx = 0.7;
-    panel.add(hdrName, c);
-    c.gridx = 1;
-    c.weightx = 0.3;
-    panel.add(hdrValue, c);
+    gridConstraints.weighty = 0;
+    gridConstraints.gridy = 0;
+    gridConstraints.gridx = 0;
+    gridConstraints.weightx = 0.7;
+    panel.add(hdrName, gridConstraints);
+    gridConstraints.gridx = 1;
+    gridConstraints.weightx = 0.3;
+    panel.add(hdrValue, gridConstraints);
   }
 
   public void fill() {
-    if (!showing || circuitState == null)
-      return;
-    if (circuits.isEmpty())
-      enumerate();
+    if (!showing || circuitState == null) return;
+    if (circuits.isEmpty()) enumerate();
     updateWatchers();
     writeLabels();
   }
 
   public void updateWatchers() {
     synchronized (watchers) {
-      for (Watcher w : watchers) {
-        w.update();
+      for (Watcher watcher : watchers) {
+        watcher.update();
       }
     }
   }
 
   public void writeLabels() {
-    if (!showing || circuitState == null)
-      return;
+    if (!showing || circuitState == null) return;
     synchronized (watchers) {
       for (final var watcher : watchers) {
         watcher.writeToLabel();
@@ -153,15 +151,14 @@ public class RegTabContent extends JScrollPane
   }
 
   private void enumerate() {
-    if (circuitState == null)
-      return;
+    if (circuitState == null) return;
     Circuit circ = circuitState.getCircuit();
     enumerate(null, circ, circuitState);
-    c.weighty = 1;
-    c.gridy++;
-    c.gridx = 0;
-    c.weightx = 1;
-    panel.add(new MyLabel("", 0, false, null), c); // padding at bottom
+    gridConstraints.weighty = 1;
+    gridConstraints.gridy++;
+    gridConstraints.gridx = 0;
+    gridConstraints.weightx = 1;
+    panel.add(new MyLabel("", 0, false, null), gridConstraints); // padding at bottom
     panel.validate();
   }
 
@@ -179,35 +176,33 @@ public class RegTabContent extends JScrollPane
 
     for (Component comp : circ.getNonWires()) {
       AttributeSet as = comp.getAttributeSet();
-      if (!as.containsAttribute(Register.ATTR_SHOW_IN_TAB))
-        continue;
-      if (!as.getValue(Register.ATTR_SHOW_IN_TAB))
-        continue;
+      if (!as.containsAttribute(Register.ATTR_SHOW_IN_TAB)) continue;
+      if (!as.getValue(Register.ATTR_SHOW_IN_TAB)) continue;
       LoggableContract log = (LoggableContract) comp.getFeature(LoggableContract.class);
-      if (log == null)
-        continue;
+      if (log == null) continue;
       String name = log.getLogName(null);
-      if (name == null)
+      if (name == null) {
         name = comp.getFactory().getName() + comp.getLocation();
+      }
       names.put(comp, name);
     }
-    if (names.isEmpty())
-      return;
+    if (names.isEmpty()) return;
     Object[] comps = names.keySet().toArray();
     Arrays.sort(comps, new CompareByNameLocEtc(names));
-    for (Object o : comps) {
-      Component comp = (Component) o;
+    for (Object obj : comps) {
+      Component comp = (Component) obj;
       String name = names.get(comp);
-      if (prefix != null)
+      if (prefix != null) {
         name = prefix + "/" + name;
+      }
       LoggableContract log = (LoggableContract) comp.getFeature(LoggableContract.class);
       Value val = log.getLogValue(cs, null);
-      c.gridy++;
-      c.gridx = 0;
-      panel.add(new MyLabel(name, Font.ITALIC, true, null), c);
-      c.gridx = 1;
+      gridConstraints.gridy++;
+      gridConstraints.gridx = 0;
+      panel.add(new MyLabel(name, Font.ITALIC, true, null), gridConstraints);
+      gridConstraints.gridx = 1;
       MyLabel v = new MyLabel("-", 0, false, null);
-      panel.add(v, c);
+      panel.add(v, gridConstraints);
       synchronized (watchers) {
         watchers.add(new Watcher(log, cs, v));
       }
@@ -228,8 +223,9 @@ public class RegTabContent extends JScrollPane
     void update() {
       Value newVal = log.getLogValue(cs, null);
       if (val == null && newVal == null
-          || (val != null && newVal != null && val.equals(newVal)))
+          || (val != null && newVal != null && val.equals(newVal))) {
         return;
+      }
       val = newVal;
     }
 
@@ -242,23 +238,23 @@ public class RegTabContent extends JScrollPane
     HashMap<Component, String> names = new HashMap<>();
 
     for (Component comp : circ.getNonWires()) {
-      if (!(comp.getFactory() instanceof SubcircuitFactory))
-        continue;
+      if (!(comp.getFactory() instanceof SubcircuitFactory)) continue;
       SubcircuitFactory factory = (SubcircuitFactory) comp.getFactory();
       String name = comp.getAttributeSet().getValue(StdAttr.LABEL);
-      if (name == null || name.equals(""))
+      if (name == null || name.equals("")) {
         name = factory.getSubcircuit().getName() + comp.getLocation();
+      }
       names.put(comp, name);
     }
-    if (names.isEmpty())
-      return;
+    if (names.isEmpty()) return;
     Object[] comps = names.keySet().toArray();
     Arrays.sort(comps, new CompareByNameLocEtc(names));
-    for (Object o : comps) {
-      Component comp = (Component) o;
+    for (Object obj : comps) {
+      Component comp = (Component) obj;
       String name = names.get(comp);
-      if (prefix != null)
+      if (prefix != null) {
         name = prefix + "/" + name;
+      }
       SubcircuitFactory factory = (SubcircuitFactory) comp.getFactory();
       CircuitState substate = factory.getSubstate(cs, comp);
       enumerate(name, factory.getSubcircuit(), substate);
@@ -290,36 +286,39 @@ public class RegTabContent extends JScrollPane
     CompareByNameLocEtc(HashMap<Component, String> names) {
       this.names = names;
     }
-    public int compare(Object a, Object b) {
-      String aName = names.get((Component) a);
-      String bName = names.get((Component) b);
-      int d = aName.compareToIgnoreCase(bName);
-      if (d == 0)
-        d = ((Component) a).getLocation().compareTo(((Component) b).getLocation());
-      if (d == 0)
-        d = a.hashCode() - b.hashCode(); // last resort, for stability
-      return d;
+    public int compare(Object left, Object right) {
+      String aName = names.get((Component) left);
+      String bName = names.get((Component) right);
+      int diff = aName.compareToIgnoreCase(bName);
+      if (diff == 0) {
+        diff = ((Component) left).getLocation().compareTo(((Component) right).getLocation());
+      }
+      if (diff == 0) {
+        diff = left.hashCode() - right.hashCode(); // last resort, for stability
+      }
+      return diff;
     }
   }
 
   private static class MyLabel extends JLabel {
-    private MyLabel(String text, int style, boolean small, Color bg) {
+    private MyLabel(String text, int style, boolean small, Color bgColor) {
       super(text);
-      if (bg != null) {
+      if (bgColor != null) {
         setOpaque(true);
-        setBackground(bg);
-        setBorder(BorderFactory.createMatteBorder(0, 4, 0, 4, bg));
+        setBackground(bgColor);
+        setBorder(BorderFactory.createMatteBorder(0, 4, 0, 4, bgColor));
       } else {
         setBorder(BorderFactory.createEmptyBorder(0, 4, 0, 4));
       }
-      if (style == 0 && !small)
-        return;
-      Font f = getFont();
-      if (style != 0)
-        f = f.deriveFont(style);
-      if (small)
-        f = f.deriveFont(f.getSize2D() - 2);
-      setFont(f);
+      if (style == 0 && !small) return;
+      Font font = getFont();
+      if (style != 0) {
+        font = font.deriveFont(style);
+      }
+      if (small) {
+        font = font.deriveFont(font.getSize2D() - 2);
+      }
+      setFont(font);
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
@@ -108,7 +108,7 @@ public class RegTabContent extends JScrollPane
 
   void clear() {
     if (circuits.isEmpty()) return;
-    for (Circuit circ : circuits) {
+    for (final var circ : circuits) {
       circ.removeCircuitListener(this);
     }
     circuits.clear();
@@ -128,14 +128,16 @@ public class RegTabContent extends JScrollPane
 
   public void fill() {
     if (!showing || circuitState == null) return;
-    if (circuits.isEmpty()) enumerate();
+    if (circuits.isEmpty()) {
+      enumerate();
+    }
     updateWatchers();
     writeLabels();
   }
 
   public void updateWatchers() {
     synchronized (watchers) {
-      for (Watcher watcher : watchers) {
+      for (final var watcher : watchers) {
         watcher.update();
       }
     }
@@ -174,37 +176,36 @@ public class RegTabContent extends JScrollPane
   private void enumerateLoggables(String prefix, Circuit circ, CircuitState cs) {
     HashMap<Component, String> names = new HashMap<>();
 
-    for (Component comp : circ.getNonWires()) {
+    for (final var comp : circ.getNonWires()) {
       AttributeSet as = comp.getAttributeSet();
       if (!as.containsAttribute(Register.ATTR_SHOW_IN_TAB)) continue;
       if (!as.getValue(Register.ATTR_SHOW_IN_TAB)) continue;
-      LoggableContract log = (LoggableContract) comp.getFeature(LoggableContract.class);
+      final var log = (LoggableContract) comp.getFeature(LoggableContract.class);
       if (log == null) continue;
-      String name = log.getLogName(null);
+      var name = log.getLogName(null);
       if (name == null) {
         name = comp.getFactory().getName() + comp.getLocation();
       }
       names.put(comp, name);
     }
     if (names.isEmpty()) return;
-    Object[] comps = names.keySet().toArray();
+    final var comps = names.keySet().toArray();
     Arrays.sort(comps, new CompareByNameLocEtc(names));
-    for (Object obj : comps) {
-      Component comp = (Component) obj;
-      String name = names.get(comp);
+    for (final var obj : comps) {
+      final var comp = (Component) obj;
+      var name = names.get(comp);
       if (prefix != null) {
         name = prefix + "/" + name;
       }
-      LoggableContract log = (LoggableContract) comp.getFeature(LoggableContract.class);
-      Value val = log.getLogValue(cs, null);
+      final var log = (LoggableContract) comp.getFeature(LoggableContract.class);
       gridConstraints.gridy++;
       gridConstraints.gridx = 0;
       panel.add(new MyLabel(name, Font.ITALIC, true, null), gridConstraints);
       gridConstraints.gridx = 1;
-      MyLabel v = new MyLabel("-", 0, false, null);
-      panel.add(v, gridConstraints);
+      final var label = new MyLabel("-", 0, false, null);
+      panel.add(label, gridConstraints);
       synchronized (watchers) {
-        watchers.add(new Watcher(log, cs, v));
+        watchers.add(new Watcher(log, cs, label));
       }
     }
   }
@@ -220,8 +221,9 @@ public class RegTabContent extends JScrollPane
       this.label = label;
       update();
     }
+
     void update() {
-      Value newVal = log.getLogValue(cs, null);
+      final var newVal = log.getLogValue(cs, null);
       if (val == null && newVal == null
           || (val != null && newVal != null && val.equals(newVal))) {
         return;
@@ -237,26 +239,26 @@ public class RegTabContent extends JScrollPane
   private void enumerateSubcircuits(String prefix, Circuit circ, CircuitState cs) {
     HashMap<Component, String> names = new HashMap<>();
 
-    for (Component comp : circ.getNonWires()) {
+    for (final var comp : circ.getNonWires()) {
       if (!(comp.getFactory() instanceof SubcircuitFactory)) continue;
-      SubcircuitFactory factory = (SubcircuitFactory) comp.getFactory();
-      String name = comp.getAttributeSet().getValue(StdAttr.LABEL);
+      final var factory = (SubcircuitFactory) comp.getFactory();
+      var name = comp.getAttributeSet().getValue(StdAttr.LABEL);
       if (name == null || name.equals("")) {
         name = factory.getSubcircuit().getName() + comp.getLocation();
       }
       names.put(comp, name);
     }
     if (names.isEmpty()) return;
-    Object[] comps = names.keySet().toArray();
+    final var comps = names.keySet().toArray();
     Arrays.sort(comps, new CompareByNameLocEtc(names));
-    for (Object obj : comps) {
+    for (final var obj : comps) {
       Component comp = (Component) obj;
-      String name = names.get(comp);
+      var name = names.get(comp);
       if (prefix != null) {
         name = prefix + "/" + name;
       }
-      SubcircuitFactory factory = (SubcircuitFactory) comp.getFactory();
-      CircuitState substate = factory.getSubstate(cs, comp);
+      final var factory = (SubcircuitFactory) comp.getFactory();
+      final var substate = factory.getSubstate(cs, comp);
       enumerate(name, factory.getSubcircuit(), substate);
     }
   }
@@ -287,16 +289,16 @@ public class RegTabContent extends JScrollPane
       this.names = names;
     }
     public int compare(Object left, Object right) {
-      String aName = names.get((Component) left);
-      String bName = names.get((Component) right);
-      int diff = aName.compareToIgnoreCase(bName);
-      if (diff == 0) {
-        diff = ((Component) left).getLocation().compareTo(((Component) right).getLocation());
+      final var leftName = names.get((Component) left);
+      final var rightName = names.get((Component) right);
+      int ret = leftName.compareToIgnoreCase(rightName);
+      if (ret == 0) {
+        ret = ((Component) left).getLocation().compareTo(((Component) right).getLocation());
       }
-      if (diff == 0) {
-        diff = left.hashCode() - right.hashCode(); // last resort, for stability
+      if (ret == 0) {
+        ret = left.hashCode() - right.hashCode(); // last resort, for stability
       }
-      return diff;
+      return ret;
     }
   }
 

--- a/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
@@ -123,13 +123,26 @@ public class RegTabContent extends JScrollPane
     panel.add(hdrValue, c);
   }
 
-  private void fill() {
+  public void fill() {
     if (!showing || circuitState == null)
       return;
     if (circuits.isEmpty())
       enumerate();
+    updateWatchers();
+    writeLabels();
+  }
+
+  public void updateWatchers() {
     for (Watcher w : watchers)
       w.update();
+  }
+
+  public void writeLabels() {
+    if (!showing || circuitState == null)
+      return;
+    for (final var watcher : watchers) {
+      watcher.writeToLabel();
+    }
   }
 
   private void enumerate() {
@@ -209,6 +222,9 @@ public class RegTabContent extends JScrollPane
           || (val != null && newVal != null && val.equals(newVal)))
         return;
       val = newVal;
+    }
+
+    void writeToLabel() {
       label.setText(val == null ? "-" : val.toHexString());
     }
   }
@@ -248,12 +264,12 @@ public class RegTabContent extends JScrollPane
 
   @Override
   public void simulatorReset(Simulator.Event e) {
-    fill();
+    updateWatchers();
   }
 
   @Override
   public void propagationCompleted(Simulator.Event e) {
-    fill();
+    updateWatchers();
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
@@ -46,15 +46,15 @@ import javax.swing.JScrollPane;
 
 public class RegTabContent extends JScrollPane
     implements LocaleListener, Simulator.Listener, ProjectListener, CircuitListener {
-  private JPanel panel = new JPanel(new GridBagLayout());
-  private GridBagConstraints c = new GridBagConstraints();
-  private Project proj;
-  private MyLabel hdrName = new MyLabel("", Font.ITALIC | Font.BOLD, false, Color.LIGHT_GRAY);
-  private MyLabel hdrValue = new MyLabel("", Font.BOLD, false, Color.LIGHT_GRAY);
+  private final JPanel panel = new JPanel(new GridBagLayout());
+  private final GridBagConstraints c = new GridBagConstraints();
+  private final Project proj;
+  private final MyLabel hdrName = new MyLabel("", Font.ITALIC | Font.BOLD, false, Color.LIGHT_GRAY);
+  private final MyLabel hdrValue = new MyLabel("", Font.BOLD, false, Color.LIGHT_GRAY);
   private boolean showing = false;
   private CircuitState circuitState;
-  private ArrayList<Circuit> circuits = new ArrayList<>();
-  private ArrayList<Watcher> watchers = new ArrayList<>();
+  private final ArrayList<Circuit> circuits = new ArrayList<>();
+  private final ArrayList<Watcher> watchers = new ArrayList<>();
 
   public RegTabContent(Frame frame) {
     super();
@@ -111,7 +111,9 @@ public class RegTabContent extends JScrollPane
     for (Circuit circ : circuits)
       circ.removeCircuitListener(this);
     circuits.clear();
-    watchers.clear();
+    synchronized (watchers) {
+      watchers.clear();
+    }
     panel.removeAll();
     c.weighty = 0;
     c.gridy = 0;
@@ -133,15 +135,20 @@ public class RegTabContent extends JScrollPane
   }
 
   public void updateWatchers() {
-    for (Watcher w : watchers)
-      w.update();
+    synchronized (watchers) {
+      for (Watcher w : watchers) {
+        w.update();
+      }
+    }
   }
 
   public void writeLabels() {
     if (!showing || circuitState == null)
       return;
-    for (final var watcher : watchers) {
-      watcher.writeToLabel();
+    synchronized (watchers) {
+      for (final var watcher : watchers) {
+        watcher.writeToLabel();
+      }
     }
   }
 
@@ -201,7 +208,9 @@ public class RegTabContent extends JScrollPane
       c.gridx = 1;
       MyLabel v = new MyLabel("-", 0, false, null);
       panel.add(v, c);
-      watchers.add(new Watcher(log, cs, v));
+      synchronized (watchers) {
+        watchers.add(new Watcher(log, cs, v));
+      }
     }
   }
 

--- a/src/main/java/com/cburch/logisim/gui/main/Canvas.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Canvas.java
@@ -480,7 +480,9 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
 
   @Override
   public void paintComponent(final Graphics g) {
-    getProject().getFrame().regTabContent.writeLabels();
+    // Also update register values showing in the state registers tab
+    getProject().getFrame().getRegTabContent().writeValuesToLabels();
+
     if (AppPreferences.AntiAliassing.getBoolean()) {
       final var g2 = (Graphics2D) g;
       g2.setRenderingHint(

--- a/src/main/java/com/cburch/logisim/gui/main/Canvas.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Canvas.java
@@ -480,6 +480,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
 
   @Override
   public void paintComponent(final Graphics g) {
+    getProject().getFrame().regTabContent.writeLabels();
     if (AppPreferences.AntiAliassing.getBoolean()) {
       final var g2 = (Graphics2D) g;
       g2.setRenderingHint(

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -112,7 +112,7 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
   // for the Appearance view
   private AppearanceView appearance;
   private Double lastFraction = AppPreferences.WINDOW_RIGHT_SPLIT.get();
-  public final RegTabContent regTabContent;
+  private final RegTabContent regTabContent;
 
   public Frame(Project project) {
     super(project);
@@ -225,6 +225,10 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
 
     LocaleManager.addLocaleListener(this);
     toolbox.updateStructure();
+  }
+
+  public RegTabContent getRegTabContent() {
+    return regTabContent;
   }
 
   /**

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -112,6 +112,7 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
   // for the Appearance view
   private AppearanceView appearance;
   private Double lastFraction = AppPreferences.WINDOW_RIGHT_SPLIT.get();
+  public final RegTabContent regTabContent;
 
   public Frame(Project project) {
     super(project);
@@ -152,7 +153,8 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     bottomTab = new JTabbedPane();
     bottomTab.setFont(AppPreferences.getScaledFont(new Font("Dialog", Font.BOLD, 9)));
     bottomTab.add(attrTable = new AttrTable(this));
-    bottomTab.add(new RegTabContent(this));
+    regTabContent = new RegTabContent(this);
+    bottomTab.add(regTabContent);
 
     zoom = new ZoomControl(layoutZoomModel, layoutCanvas);
 

--- a/src/main/java/com/cburch/logisim/gui/main/TickCounter.java
+++ b/src/main/java/com/cburch/logisim/gui/main/TickCounter.java
@@ -18,10 +18,6 @@ import java.text.DecimalFormat;
 
 public class TickCounter implements Simulator.Listener {
   private final DecimalFormat [] formatterWithDigits = new DecimalFormat[4];
-  private final long [] hertzValue = {1, 1000, 1000000};
-  private final double [] hertzMinValue = {0.0, 999.5, 999500.0};
-  private final String [] hertzKey = {"tickRateHz", "tickRateKHz", "tickRateMHz"};
-  private final int HZ = 0, KHZ = 1, MHZ = 2; // index constants for hertz arrays
   private long fullTickCount = 0;
   private long startTime;
   private long tickTime;
@@ -30,6 +26,10 @@ public class TickCounter implements Simulator.Listener {
   private double requestedClockFrequency;
   private long processedTickCount = 0;
   static final int NANOSECONDS_PER_SECONDS = 1_000_000_000;
+  static final long [] hertzValue = {1, 1000, 1000000};
+  static final double [] hertzMinValue = {0.0, 999.5, 999500.0};
+  static final String [] hertzKey = {"tickRateHz", "tickRateKHz", "tickRateMHz"};
+  static final int HZ = 0, KHZ = 1, MHZ = 2; // index constants for hertz arrays
 
   public TickCounter() {
     String pattern = ".";

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -110,6 +110,11 @@ FPGA_Supported = FPGA supported
 attributeChangeInvalidTitle = Value Invalid
 attributeDialogTitle = Select Value
 #
+# generic/RegTabContent.java
+#
+registerTabNameTitle = Name
+registerTabValueTitle = Value
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = Toggle whether grid is shown

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -296,6 +296,7 @@ statsUniqueCountColumn = Unique
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+tickRateMHz = %s MHz
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -110,6 +110,11 @@ FPGA_Supported = FPGA-Unterstützung
 attributeChangeInvalidTitle = Ungültiger Wert
 attributeDialogTitle = Wert auswählen
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = Gitternetz umschalten
@@ -650,7 +655,7 @@ hotkeyWindowClose = Fenster schließen
 hotkeyWindowMinimize = Fenster minimieren
 hotkeyFileExport = Datei exportieren
 hotkeyFilePrint = Design drucken
-hotkeyErrMeta = Der Shortcut muss die %s Taste enthalten. 
+hotkeyErrMeta = Der Shortcut muss die %s Taste enthalten.
 hotkeyErrConflict = Überschneidung mit: %s.
 hotkeyDirNorth = Norden
 hotkeyDirSouth = Süden
@@ -665,7 +670,7 @@ hotkeyAutoLabelToggle = Label-Sichtbarkeit umschalten
 hotkeyAutoLabelView = Label anzeigen
 hotkeyAutoLabelHide = Label ausblenden
 hotkeyAutoLabelSelfNumberedStop = keine automatische Nummerierung
-hotkeyAddToolRotate = Beim Positionieren rotieren 
+hotkeyAddToolRotate = Beim Positionieren rotieren
 hotkeyGateModifierSizeSmall = Schmale Gattergröße
 hotkeyGateModifierSizeMedium = Mittlere Gattergröße
 hotkeyGateModifierSizeWide = Breite Gattergröße

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -296,6 +296,7 @@ statsUniqueCountColumn = Eindeutig
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -109,6 +109,11 @@ attributeChangeInvalidError = Αμετάβλητη ιδιότητα λόγω μ�
 attributeChangeInvalidTitle = Άκυρη Τιμή
 attributeDialogTitle = Επιλογή Τιμής
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = Εναλλαγή εμφάνισης πλέγματος

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -295,6 +295,7 @@ statsUniqueCountColumn = Μοναδικό
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -109,6 +109,11 @@ attributeChangeInvalidError = Atributo no modificado porque los cambios no son v
 attributeChangeInvalidTitle = Valor no válido
 attributeDialogTitle = Seleccionar valor
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = Activar o desactivar cuadrícula

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -295,6 +295,7 @@ statsUniqueCountColumn = Único
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -110,6 +110,11 @@ FPGA_Supported = FPGA supporté
 attributeChangeInvalidTitle = Valeur non valide
 attributeDialogTitle = Sélectionner une valeur
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = Changer l'affichage de la grille

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -296,6 +296,7 @@ statsUniqueCountColumn = Unique
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -295,6 +295,7 @@ statsUniqueCountColumn = Unico
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -109,6 +109,11 @@ attributeChangeInvalidError = Attributo non cambiato per richiesta non valida
 attributeChangeInvalidTitle = Valore non valido
 attributeDialogTitle = Seleziona Valore
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = Attiva se la griglia è mostrata

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -109,6 +109,11 @@ attributeChangeInvalidError = リクエストが無効なので、属性を変�
 attributeChangeInvalidTitle = 値が無効
 attributeDialogTitle = 選択値
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = グリッドを表示するかどうかを切り替える

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -295,6 +295,7 @@ statsUniqueCountColumn = ユニーク
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -296,6 +296,7 @@ statsUniqueCountColumn = Uniek
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -110,6 +110,11 @@ FPGA_Supported = FPGA ondersteuning
 attributeChangeInvalidTitle = Waarde Ongeldig
 attributeDialogTitle = Selecteer waarde
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = Schakel weergave raster aan / uit
@@ -368,7 +373,7 @@ projectUnloadLibrariesItem = Bibliotheken sluiten…
 #
 # menu/MenuSimulate.java
 #
-# ==> simulateAssemblyViewer = 
+# ==> simulateAssemblyViewer =
 simulateDownStateMenu = Ga naar de staat
 simulateGenVhdlFilesItem = Herstart VHDL-simulator
 simulateLogItem = Chronogram

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -295,6 +295,7 @@ statsUniqueCountColumn = Unikalne
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -109,6 +109,11 @@ FPGA_Supported = Wsparcie dla FPGA
 attributeChangeInvalidTitle = Wartość niepoprawna
 attributeDialogTitle = Wybierz wartość
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = Przełącza rysowanie siatki

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -109,6 +109,11 @@ FPGA_Supported = FPGA Suportado
 attributeChangeInvalidTitle = Valor inválido
 attributeDialogTitle = Selecionar valor
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = Alternar a grade em uso

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -295,6 +295,7 @@ statsUniqueCountColumn = Exclusiva
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -110,6 +110,11 @@ attributeChangeInvalidError = Атрибут не изменён, так как 
 attributeChangeInvalidTitle = Значение неверно
 attributeDialogTitle = Выбор значения
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = Переключить отображение сетки

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -296,6 +296,7 @@ statsUniqueCountColumn = Уникальных
 #
 tickRateHz = %s Гц
 tickRateKHz = %s кГц
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -109,6 +109,11 @@ FPGA_Supported = 是否支持 FPGA：
 attributeChangeInvalidTitle = 数值无效
 attributeDialogTitle = 选择数值
 #
+# generic/RegTabContent.java
+#
+# ==> registerTabNameTitle =
+# ==> registerTabValueTitle =
+#
 # generic/ZoomControl.java
 #
 zoomShowGrid = 切换是否显示网格

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -295,6 +295,7 @@ statsUniqueCountColumn = 唯一
 #
 tickRateHz = %s Hz
 tickRateKHz = %s kHz
+# ==> tickRateMHz =
 #
 # main/ToolAttributeAction.java
 #


### PR DESCRIPTION
This PR addresses issue #2181. It is a rewrite of RegTabContent to remove the gui activities from the simulation thread. This PR also includes translated commits from the Holycross fork by @kevinawalsh. We thank him for that work.

It speeds up the simulation of simple designs to over 1 MHz on my Macbook Pro M2 Max. A single clock runs at about 2.8 MHz. A simple 64-bit register with feedback to increment on each clock tick runs at 1.3 MHz. A simple CPU design runs at over 12 kHz.

I added the MHz range to the displayed clock speed in TickCounter.

The MHz designation was added to the language specific properties. It also adds language strings for the header titles for the State panel that RegTabContent uses to show the values of registers.