### PR TITLE
fix import VHDL entity from menu Project

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/menu/ProjectCircuitActions.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/ProjectCircuitActions.java
@@ -150,7 +150,7 @@ public class ProjectCircuitActions {
     if (vhdl == null) return;
 
     final var content = VhdlContent.parse(null, vhdl, proj.getLogisimFile());
-    if (content != null) return;
+    if (content == null) return;
     if (VhdlContent.labelVHDLInvalidNotify(content.getName(), proj.getLogisimFile())) return;
 
     proj.doAction(LogisimFileActions.addVhdl(content));


### PR DESCRIPTION
This PR is a fix to Import a VHDL entity from a file. It was not working as expected.

To reproduce the issue, go to the menu `Project -> Import VHDL Entity...` and select a valid VHDL file. Nothing will happen, and the entity won't be imported.

Interestingly, this issue was introduced in an old PR #772 and appears to have gone unnoticed until now. This seems like an important feature for anyone working with VHDL in Logisim, so restoring this functionality is essential.