### PR TITLE
BLIF simulator

### DIFF
--- a/src/main/java/com/cburch/hdl/HdlModel.java
+++ b/src/main/java/com/cburch/hdl/HdlModel.java
@@ -10,7 +10,6 @@
 package com.cburch.hdl;
 
 import com.cburch.logisim.data.BitWidth;
-import com.cburch.logisim.instance.Port;
 
 public interface HdlModel {
   // NOTE: silly members' names are mostly to avoid refactoring of the whole codebase due to record's

--- a/src/main/java/com/cburch/hdl/HdlModel.java
+++ b/src/main/java/com/cburch/hdl/HdlModel.java
@@ -9,7 +9,18 @@
 
 package com.cburch.hdl;
 
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.instance.Port;
+
 public interface HdlModel {
+  // NOTE: silly members' names are mostly to avoid refactoring of the whole codebase due to record's
+  // getters not using Bean naming convention (so i.e. `foo()` instead of `getFoo()`. We may change
+  // that in future, but for now it looks stupid in this file only.
+  public record PortDescription(String getName, String getType, int getWidthInt, BitWidth getWidth) {
+    public PortDescription(String name, String type, int width) {
+      this(name, type, width, BitWidth.create(width));
+    }
+  }
 
   /** Registers a listener for changes to the values. */
   void addHdlModelListener(HdlModelListener l);
@@ -25,6 +36,16 @@ public interface HdlModel {
 
   /** Get the component's name. */
   String getName();
+
+  /**
+   * Get the component's input ports.
+   */
+  PortDescription[] getInputs();
+
+  /**
+   * Get the component's output ports.
+   */
+  PortDescription[] getOutputs();
 
   /** Unregisters a listener for changes to the values. */
   void removeHdlModelListener(HdlModelListener l);

--- a/src/main/java/com/cburch/hdl/HdlModel.java
+++ b/src/main/java/com/cburch/hdl/HdlModel.java
@@ -11,6 +11,13 @@ package com.cburch.hdl;
 
 import com.cburch.logisim.data.BitWidth;
 
+/**
+ * HdlModel is a base interface for objects that contain mutable text representing code
+ *  written in an HDL. Listeners may be attached to appropriately handle updates.
+ * Implementors should typically use HdlContent.
+ * It should not be confused with the other HdlModel, located in
+ *  the logisim.vhdl.base package.
+ */
 public interface HdlModel {
   // NOTE: silly members' names are mostly to avoid refactoring of the whole codebase due to record's
   // getters not using Bean naming convention (so i.e. `foo()` instead of `getFoo()`. We may change

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitAttributes.java
@@ -16,6 +16,9 @@ import java.awt.Font;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * BlifCircuitAttributes is essentially a copy of VhdlEntityAttributes, but for BLIF.
+ */
 public class BlifCircuitAttributes extends AbstractAttributeSet {
 
   private static final List<Attribute<?>> attributes =
@@ -69,23 +72,31 @@ public class BlifCircuitAttributes extends AbstractAttributeSet {
   public <V> void setValue(Attribute<V> attr, V value) {
     if (attr == BlifCircuitComponent.CONTENT_ATTR) {
       final var newContent = (BlifContentComponent) value;
-      if (!content.equals(newContent)) content = newContent;
+      if (!content.equals(newContent)) {
+        content = newContent;
+      }
       fireAttributeValueChanged(attr, value, null);
     }
     if (attr == StdAttr.LABEL && value instanceof String newLabel) {
       final var oldlabel = label;
-      if (label.equals(newLabel)) return;
+      if (label.equals(newLabel)) {
+        return;
+      }
       label = newLabel;
       fireAttributeValueChanged(attr, value, (V) oldlabel);
     }
     if (attr == StdAttr.LABEL_FONT && value instanceof Font newFont) {
-      if (labelFont.equals(newFont)) return;
+      if (labelFont.equals(newFont)) {
+        return;
+      }
       labelFont = newFont;
       fireAttributeValueChanged(attr, value, null);
     }
     if (attr == StdAttr.LABEL_VISIBILITY) {
       final var newVis = (Boolean) value;
-      if (labelVisible.equals(newVis)) return;
+      if (labelVisible.equals(newVis)) {
+        return;
+      }
       labelVisible = newVis;
       fireAttributeValueChanged(attr, value, null);
     }

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitAttributes.java
@@ -12,34 +12,31 @@ package com.cburch.logisim.std.hdl;
 import com.cburch.logisim.data.AbstractAttributeSet;
 import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.instance.StdAttr;
-import com.cburch.logisim.vhdl.base.VhdlSimConstants;
 import java.awt.Font;
 import java.util.Arrays;
 import java.util.List;
 
-public class VhdlEntityAttributes extends AbstractAttributeSet {
+public class BlifCircuitAttributes extends AbstractAttributeSet {
 
   private static final List<Attribute<?>> attributes =
       Arrays.asList(
-          VhdlEntityComponent.CONTENT_ATTR,
+          BlifCircuitComponent.CONTENT_ATTR,
           StdAttr.LABEL,
           StdAttr.LABEL_FONT,
-          StdAttr.LABEL_VISIBILITY,
-          VhdlSimConstants.SIM_NAME_ATTR);
+          StdAttr.LABEL_VISIBILITY);
 
-  private VhdlContentComponent content;
+  private BlifContentComponent content;
   private String label = "";
   private Font labelFont = StdAttr.DEFAULT_LABEL_FONT;
   private Boolean labelVisible = false;
-  private String simName = "";
 
-  VhdlEntityAttributes() {
-    content = VhdlContentComponent.create();
+  BlifCircuitAttributes() {
+    content = BlifContentComponent.create();
   }
 
   @Override
   protected void copyInto(AbstractAttributeSet dest) {
-    final var attr = (VhdlEntityAttributes) dest;
+    final var attr = (BlifCircuitAttributes) dest;
     attr.labelFont = labelFont;
     attr.content = content.clone();
   }
@@ -52,7 +49,7 @@ public class VhdlEntityAttributes extends AbstractAttributeSet {
   @SuppressWarnings("unchecked")
   @Override
   public <V> V getValue(Attribute<V> attr) {
-    if (attr == VhdlEntityComponent.CONTENT_ATTR) {
+    if (attr == BlifCircuitComponent.CONTENT_ATTR) {
       return (V) content;
     }
     if (attr == StdAttr.LABEL) {
@@ -64,17 +61,14 @@ public class VhdlEntityAttributes extends AbstractAttributeSet {
     if (attr == StdAttr.LABEL_VISIBILITY) {
       return (V) labelVisible;
     }
-    if (attr == VhdlSimConstants.SIM_NAME_ATTR) {
-      return (V) simName;
-    }
     return null;
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public <V> void setValue(Attribute<V> attr, V value) {
-    if (attr == VhdlEntityComponent.CONTENT_ATTR) {
-      final var newContent = (VhdlContentComponent) value;
+    if (attr == BlifCircuitComponent.CONTENT_ATTR) {
+      final var newContent = (BlifContentComponent) value;
       if (!content.equals(newContent)) content = newContent;
       fireAttributeValueChanged(attr, value, null);
     }
@@ -95,16 +89,5 @@ public class VhdlEntityAttributes extends AbstractAttributeSet {
       labelVisible = newVis;
       fireAttributeValueChanged(attr, value, null);
     }
-    if (attr == VhdlSimConstants.SIM_NAME_ATTR) {
-      final var name = (String) value;
-      if (value.equals(simName)) return;
-      simName = name;
-      fireAttributeValueChanged(attr, value, null);
-    }
-  }
-
-  @Override
-  public boolean isToSave(Attribute<?> attr) {
-    return attr.isToSave() && attr != VhdlSimConstants.SIM_NAME_ATTR;
   }
 }

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
@@ -78,6 +78,9 @@ public class BlifCircuitComponent extends HdlCircuitComponent<BlifContentCompone
       Value v = state.getPortValue(base + i);
       int width = set[i].getWidthInt();
       for (int j = 0; j < width; j++) {
+        int cellId = pinX[i][j];
+        if (cellId == -1)
+          continue;
         byte b = DenseLogicCircuit.LEV_NONE;
         Value bit = v.get(j);
         if (bit == Value.FALSE)
@@ -86,7 +89,7 @@ public class BlifCircuitComponent extends HdlCircuitComponent<BlifContentCompone
           b = DenseLogicCircuit.LEV_HIGH;
         else if (bit == Value.ERROR)
           b = DenseLogicCircuit.LEV_ERR;
-        id.circuit.setCell(pinX[i][j], b, id.cells, id.auxData);
+        id.circuit.setCell(cellId, b, id.cells, id.auxData);
       }
     }
   }
@@ -94,8 +97,14 @@ public class BlifCircuitComponent extends HdlCircuitComponent<BlifContentCompone
   private void readOutOutputs(int base, HdlModel.PortDescription[] set, int[][] pinO, BlifCircuitState id, InstanceState state) {
     for (int i = 0; i < set.length; i++) {
       Value[] translated = new Value[set[i].getWidthInt()];
-      for (int j = 0; j < translated.length; j++)
-        translated[j] = DenseLogicCircuit.LEV_TO_LS[id.cells[pinO[i][j]]];
+      for (int j = 0; j < translated.length; j++) {
+        int cellId = pinO[i][j];
+        if (cellId == -1) {
+          translated[j] = Value.UNKNOWN;
+        } else {
+          translated[j] = DenseLogicCircuit.LEV_TO_LS[id.cells[cellId]];
+        }
+      }
       state.setPort(base + i, Value.create(translated), 1);
     }
   }

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
@@ -55,6 +55,9 @@ public class BlifCircuitComponent extends HdlCircuitComponent<BlifContentCompone
       id = new BlifCircuitState(content.compiled);
       state.setData(id);
     }
+    // this can somehow get out of sync, so give it a bit
+    if (state.getInstance().getPorts().size() != content.inputs.length + content.outputs.length)
+      return;
 
     // alright, load in inputs
     loadInInputs(0, content.inputs, content.compiledInputPinsX, id, state);

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
@@ -76,7 +76,7 @@ public class BlifCircuitComponent extends HdlCircuitComponent<BlifContentCompone
       int width = set[i].getWidthInt();
       for (int j = 0; j < width; j++) {
         byte b = DenseLogicCircuit.LEV_NONE;
-        Value bit = v.get(i);
+        Value bit = v.get(j);
         if (bit == Value.FALSE)
           b = DenseLogicCircuit.LEV_LOW;
         else if (bit == Value.TRUE)

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
@@ -11,15 +11,15 @@ package com.cburch.logisim.std.hdl;
 
 import static com.cburch.logisim.vhdl.Strings.S;
 
+import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.gui.icons.ArithmeticIcon;
 import com.cburch.logisim.instance.InstanceState;
-import com.cburch.logisim.instance.Port;
 
 /**
  * Represents a BLIF circuit.
  */
-public class BlifCircuitComponent extends GenericInterfaceComponent {
+public class BlifCircuitComponent extends HdlCircuitComponent<BlifContentComponent> {
   /**
    * Unique identifier of the tool, used as reference in project files.
    * Do NOT change as it will prevent project files from loading.
@@ -28,28 +28,19 @@ public class BlifCircuitComponent extends GenericInterfaceComponent {
    */
   public static final String _ID = "BLIFCircuit";
 
+  public static final Attribute<BlifContentComponent> CONTENT_ATTR = new HdlContentAttribute<>(BlifContentComponent::create);
+
   public BlifCircuitComponent() {
-    super(_ID, S.getter("blifComponent"), null, false);
+    super(_ID, S.getter("blifComponent"), null, false, CONTENT_ATTR);
     this.setIcon(new ArithmeticIcon("BLIF"));
+  }
+
+  @Override
+  public AttributeSet createAttributeSet() {
+    return new BlifCircuitAttributes();
   }
 
   @Override
   public void propagate(InstanceState state) {
   }
-
-  @Override
-  protected String getGIAttributesName(AttributeSet attrs) {
-    return "generic";
-  }
-
-  @Override
-  protected Port[] getGIAttributesInputs(AttributeSet attrs) {
-    return new Port[0];
-  }
-
-  @Override
-  protected Port[] getGIAttributesOutputs(AttributeSet attrs) {
-    return new Port[0];
-  }
-
 }

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
@@ -26,12 +26,12 @@ public class BlifCircuitComponent extends HdlCircuitComponent<BlifContentCompone
   /**
    * Unique identifier of the tool, used as reference in project files.
    * Do NOT change as it will prevent project files from loading.
-   *
    * Identifier value must MUST be unique string among all tools.
    */
   public static final String _ID = "BLIFCircuit";
 
-  public static final Attribute<BlifContentComponent> CONTENT_ATTR = new HdlContentAttribute<>(BlifContentComponent::create);
+  public static final Attribute<BlifContentComponent> CONTENT_ATTR =
+      new HdlContentAttribute<>(BlifContentComponent::create);
 
   public BlifCircuitComponent() {
     super(_ID, S.getter("blifComponent"), null, false, CONTENT_ATTR);
@@ -48,53 +48,63 @@ public class BlifCircuitComponent extends HdlCircuitComponent<BlifContentCompone
     // get the circuit, make sure it matches, etc.
     final var content = state.getAttributeValue(contentAttr);
     // can't do anything if it didn't compile...
-    if (content.compiled == null)
+    if (content.compiled == null) {
       return;
+    }
     BlifCircuitState id = (BlifCircuitState) state.getData();
     if (id == null || id.circuit != content.compiled) {
       id = new BlifCircuitState(content.compiled);
       state.setData(id);
     }
     // this can somehow get out of sync, so give it a bit
-    if (state.getInstance().getPorts().size() != content.inputs.length + content.outputs.length)
+    if (state.getInstance().getPorts().size() != content.inputs.length + content.outputs.length) {
       return;
+    }
+
+    int inputsLen = content.inputs.length;
 
     // alright, load in inputs
     loadInInputs(0, content.inputs, content.compiledInputPinsX, id, state);
-    // In a rather 'at the last minute' change, outputs were made outputs and inputs were made inputs.
-    // This is because the propagation model suggested by SimpleGrayCounter suggests that feedback would occur if all pins were bi-directional.
+    // In a rather 'at the last minute' change:
+    // Outputs were made outputs and inputs were made inputs.
+    // This is because the propagation model suggested by SimpleGrayCounter suggests feedback
+    //  would occur if all pins were bi-directional.
     // Still, the support is left in the design in case it is needed.
-    // loadInInputs(content.inputs.length, content.outputs, content.compiledOutputPinsX, id, state);
+    // loadInInputs(inputsLen, content.outputs, content.compiledOutputPinsX, id, state);
 
     id.circuit.simulate(id.cells, id.auxData);
 
     // read out outputs
     // readOutOutputs(0, content.inputs, content.compiledInputPinsO, id, state);
-    readOutOutputs(content.inputs.length, content.outputs, content.compiledOutputPinsO, id, state);
+    readOutOutputs(inputsLen, content.outputs, content.compiledOutputPinsO, id, state);
   }
 
-  private void loadInInputs(int base, HdlModel.PortDescription[] set, int[][] pinX, BlifCircuitState id, InstanceState state) {
+  private void loadInInputs(int base, HdlModel.PortDescription[] set, int[][] pinX,
+      BlifCircuitState id, InstanceState state) {
     for (int i = 0; i < set.length; i++) {
       Value v = state.getPortValue(base + i);
       int width = set[i].getWidthInt();
       for (int j = 0; j < width; j++) {
         int cellId = pinX[i][j];
-        if (cellId == -1)
+        if (cellId == -1) {
           continue;
+        }
         byte b = DenseLogicCircuit.LEV_NONE;
         Value bit = v.get(j);
-        if (bit == Value.FALSE)
+        if (bit == Value.FALSE) {
           b = DenseLogicCircuit.LEV_LOW;
-        else if (bit == Value.TRUE)
+        } else if (bit == Value.TRUE) {
           b = DenseLogicCircuit.LEV_HIGH;
-        else if (bit == Value.ERROR)
+        } else if (bit == Value.ERROR) {
           b = DenseLogicCircuit.LEV_ERR;
+        }
         id.circuit.setCell(cellId, b, id.cells, id.auxData);
       }
     }
   }
 
-  private void readOutOutputs(int base, HdlModel.PortDescription[] set, int[][] pinO, BlifCircuitState id, InstanceState state) {
+  private void readOutOutputs(int base, HdlModel.PortDescription[] set, int[][] pinO,
+      BlifCircuitState id, InstanceState state) {
     for (int i = 0; i < set.length; i++) {
       Value[] translated = new Value[set[i].getWidthInt()];
       for (int j = 0; j < translated.length; j++) {
@@ -109,15 +119,24 @@ public class BlifCircuitComponent extends HdlCircuitComponent<BlifContentCompone
     }
   }
 
+  /**
+   * Contains the BLIF simulation state.
+   */
   public class BlifCircuitState implements InstanceData {
     public final DenseLogicCircuit circuit; 
     public final byte[] cells;
     public final int[] auxData;
 
+    /**
+     * Creates a new BLIF circuit state from the compiled logic.
+     */
     public BlifCircuitState(DenseLogicCircuit circuit) {
       this(circuit, circuit.newCells(), circuit.newAuxData());
     }
 
+    /**
+     * The 'copy constructor' used for cloning.
+     */
     public BlifCircuitState(DenseLogicCircuit circuit, byte[] cells, int[] auxData) {
       this.circuit = circuit;
       this.cells = cells;

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifCircuitComponent.java
@@ -1,0 +1,55 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.hdl;
+
+import static com.cburch.logisim.vhdl.Strings.S;
+
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.gui.icons.ArithmeticIcon;
+import com.cburch.logisim.instance.InstanceState;
+import com.cburch.logisim.instance.Port;
+
+/**
+ * Represents a BLIF circuit.
+ */
+public class BlifCircuitComponent extends GenericInterfaceComponent {
+  /**
+   * Unique identifier of the tool, used as reference in project files.
+   * Do NOT change as it will prevent project files from loading.
+   *
+   * Identifier value must MUST be unique string among all tools.
+   */
+  public static final String _ID = "BLIFCircuit";
+
+  public BlifCircuitComponent() {
+    super(_ID, S.getter("blifComponent"), null, false);
+    this.setIcon(new ArithmeticIcon("BLIF"));
+  }
+
+  @Override
+  public void propagate(InstanceState state) {
+  }
+
+  @Override
+  protected String getGIAttributesName(AttributeSet attrs) {
+    return "generic";
+  }
+
+  @Override
+  protected Port[] getGIAttributesInputs(AttributeSet attrs) {
+    return new Port[0];
+  }
+
+  @Override
+  protected Port[] getGIAttributesOutputs(AttributeSet attrs) {
+    return new Port[0];
+  }
+
+}

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifContentComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifContentComponent.java
@@ -60,6 +60,10 @@ public class BlifContentComponent extends HdlContent {
   protected PortDescription[] inputs;
   protected PortDescription[] outputs;
   protected DenseLogicCircuit compiled;
+  /**
+   * These map the input/output bits to cells.
+   * Some values may be -1 (indicating a bit does not exist for some reason).
+   */
   protected int[][] compiledInputPinsX, compiledInputPinsO, compiledOutputPinsX, compiledOutputPinsO;
   protected String name;
 
@@ -149,8 +153,16 @@ public class BlifContentComponent extends HdlContent {
     for (int i = 0; i < ports.length; i++) {
       PortDescription desc = ports[i];
       int[] result = new int[desc.getWidthInt()];
-      for (int j = 0; j < result.length; j++)
-        result[j] = compiled.symbolTable.get(parser.getPinDLCSymbol(desc, i, output));
+      for (int j = 0; j < result.length; j++) {
+        String symbol = parser.getPinDLCSymbol(desc, j, output);
+        Integer symRes = compiled.symbolTable.get(symbol);
+        if (symRes != null) {
+          result[j] = symRes;
+        } else {
+          // System.out.println("suspicious: " + symbol + " missing");
+          result[j] = -1;
+        }
+      }
       results[i] = result;
     }
     return results;

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifContentComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifContentComponent.java
@@ -13,6 +13,8 @@ import static com.cburch.logisim.vhdl.Strings.S;
 
 import com.cburch.hdl.HdlModel;
 import com.cburch.logisim.gui.generic.OptionPane;
+import com.cburch.logisim.std.hdl.VhdlParser.IllegalVhdlContentException;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,8 +60,8 @@ public class BlifContentComponent extends HdlContent {
   protected StringBuilder content;
   protected PortDescription[] inputs;
   protected PortDescription[] outputs;
+  protected DenseLogicCircuit compiled;
   protected String name;
-  protected String libraries;
 
   protected BlifContentComponent() {
     setContent(TEMPLATE);
@@ -117,7 +119,7 @@ public class BlifContentComponent extends HdlContent {
 
   @Override
   public boolean setContent(String content) {
-    final var parser = new VhdlParser(content);
+    final var parser = new BlifParser(content);
     try {
       parser.parse();
     } catch (Exception ex) {
@@ -127,16 +129,19 @@ public class BlifContentComponent extends HdlContent {
     }
 
     name = parser.getName();
-    libraries = parser.getLibraries();
 
     final var inputsDesc = parser.getInputs();
     final var outputsDesc = parser.getOutputs();
     inputs = inputsDesc.toArray(new PortDescription[0]);
     outputs = outputsDesc.toArray(new PortDescription[0]);
+    compiled = parser.compile();
 
     this.content = new StringBuilder(content);
     fireContentSet();
 
     return true;
+  }
+
+  public void parse() throws IllegalVhdlContentException {
   }
 }

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifContentComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifContentComponent.java
@@ -13,26 +13,21 @@ import static com.cburch.logisim.vhdl.Strings.S;
 
 import com.cburch.hdl.HdlModel;
 import com.cburch.logisim.gui.generic.OptionPane;
-import com.cburch.logisim.util.Softwares;
-import java.awt.Dimension;
-import java.awt.Insets;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
 
-public class VhdlContentComponent extends HdlContent {
+public class BlifContentComponent extends HdlContent {
 
-  public static VhdlContentComponent create() {
-    return new VhdlContentComponent();
+  public static BlifContentComponent create() {
+    return new BlifContentComponent();
   }
 
   private static String loadTemplate() {
-    InputStream input = VhdlContentComponent.class.getResourceAsStream(RESOURCE);
+    InputStream input = BlifContentComponent.class.getResourceAsStream(RESOURCE);
     BufferedReader in = new BufferedReader(new InputStreamReader(input));
 
     StringBuilder tmp = new StringBuilder();
@@ -49,7 +44,7 @@ public class VhdlContentComponent extends HdlContent {
       try {
         if (input != null) input.close();
       } catch (IOException ex) {
-        Logger.getLogger(VhdlContentComponent.class.getName()).log(Level.SEVERE, null, ex);
+        Logger.getLogger(BlifContentComponent.class.getName()).log(Level.SEVERE, null, ex);
       }
     }
 
@@ -65,16 +60,15 @@ public class VhdlContentComponent extends HdlContent {
   protected PortDescription[] outputs;
   protected String name;
   protected String libraries;
-  protected String architecture;
 
-  protected VhdlContentComponent() {
-    this.parseContent(TEMPLATE);
+  protected BlifContentComponent() {
+    setContent(TEMPLATE);
   }
 
   @Override
-  public VhdlContentComponent clone() {
+  public BlifContentComponent clone() {
     try {
-      VhdlContentComponent ret = (VhdlContentComponent) super.clone();
+      BlifContentComponent ret = (BlifContentComponent) super.clone();
       ret.content = new StringBuilder(this.content);
       return ret;
     } catch (CloneNotSupportedException ex) {
@@ -95,12 +89,6 @@ public class VhdlContentComponent extends HdlContent {
         .equals(value.replaceAll("\\r\\n|\\r|\\n", " "));
   }
 
-  public String getArchitecture() {
-    if (architecture == null) return "";
-
-    return architecture;
-  }
-
   @Override
   public String getContent() {
     return content.toString();
@@ -111,18 +99,6 @@ public class VhdlContentComponent extends HdlContent {
     if (inputs == null) return new PortDescription[0];
 
     return inputs;
-  }
-
-  public int getInputsNumber() {
-    if (inputs == null) return 0;
-
-    return inputs.length;
-  }
-
-  public String getLibraries() {
-    if (libraries == null) return "";
-
-    return libraries;
   }
 
   @Override
@@ -139,25 +115,8 @@ public class VhdlContentComponent extends HdlContent {
     return outputs;
   }
 
-  public int getOutputsNumber() {
-    if (outputs == null) return 0;
-
-    return outputs.length;
-  }
-
-  public PortDescription[] getPorts() {
-    if (inputs == null || outputs == null) return new PortDescription[0];
-
-    return concat(inputs, outputs);
-  }
-
-  public int getPortsNumber() {
-    if (inputs == null || outputs == null) return 0;
-
-    return inputs.length + outputs.length;
-  }
-
-  public boolean parseContent(String content) {
+  @Override
+  public boolean setContent(String content) {
     final var parser = new VhdlParser(content);
     try {
       parser.parse();
@@ -169,7 +128,6 @@ public class VhdlContentComponent extends HdlContent {
 
     name = parser.getName();
     libraries = parser.getLibraries();
-    architecture = parser.getArchitecture();
 
     final var inputsDesc = parser.getInputs();
     final var outputsDesc = parser.getOutputs();
@@ -180,42 +138,5 @@ public class VhdlContentComponent extends HdlContent {
     fireContentSet();
 
     return true;
-  }
-
-  @Override
-  public boolean setContent(String content) {
-    final var title = new StringBuilder();
-    final var result = new StringBuilder();
-
-    switch (Softwares.validateVhdl(content, title, result)) {
-      case Softwares.ERROR:
-        final var message = new JTextArea();
-        message.setText(result.toString());
-        message.setEditable(false);
-        message.setLineWrap(false);
-        message.setMargin(new Insets(5, 5, 5, 5));
-
-        final var sp = new JScrollPane(message);
-        sp.setPreferredSize(new Dimension(700, 400));
-
-        OptionPane.showOptionDialog(
-            null,
-            sp,
-            title.toString(),
-            OptionPane.OK_OPTION,
-            OptionPane.ERROR_MESSAGE,
-            null,
-            new String[] {S.get("validationErrorButton")},
-            S.get("validationErrorButton"));
-        return false;
-      case Softwares.ABORT:
-        OptionPane.showMessageDialog(
-            null, result.toString(), title.toString(), OptionPane.INFORMATION_MESSAGE);
-        return false;
-      case Softwares.SUCCESS:
-        return parseContent(content);
-    }
-
-    return false;
   }
 }

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifContentComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifContentComponent.java
@@ -56,7 +56,7 @@ public class BlifContentComponent extends HdlContent {
     return tmp.toString();
   }
 
-  private static final String RESOURCE = "/resources/logisim/hdl/vhdl.templ";
+  private static final String RESOURCE = "/resources/logisim/hdl/blif.templ";
 
   private static final String TEMPLATE = loadTemplate();
 

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifParser.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifParser.java
@@ -80,6 +80,7 @@ public final class BlifParser {
           if (type.equals("BUF")) {
             gates.add(new Gate(DenseLogicCircuit.GATE_BUS, pins.get("A"), pins.get("A"), pins.get("Y")));
           } else if (type.equals("NOT")) {
+            // !(A|A)
             gates.add(new Gate(DenseLogicCircuit.GATE_NOR, pins.get("A"), pins.get("A"), pins.get("Y")));
           } else if (type.equals("AND")) {
             gates.add(new Gate(DenseLogicCircuit.GATE_AND, pins.get("A"), pins.get("B"), pins.get("Y")));

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifParser.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifParser.java
@@ -97,8 +97,9 @@ public final class BlifParser {
         } else if (words[0].equals(".model")) {
           // use this as a name source if possible
           if (words.length > 1) {
-            if (name != null)
+            if (name != null) {
               throw new RuntimeException("many tops (try 'synth -flatten -top " + name + "')");
+            }
             name = words[1];
           }
         } else if (words[0].equals(".names")) {
@@ -180,8 +181,8 @@ public final class BlifParser {
               }
             }
             if (!found) {
-              throw new RuntimeException("unknown gate " + type + "\n" +
-                  "try basing your script on " + RECOMMENDED_LOGIC_LIBRARY_URL);
+              throw new RuntimeException("unknown gate " + type + "\n"
+                + "try basing your script on " + RECOMMENDED_LOGIC_LIBRARY_URL);
             }
           }
         }

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifParser.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifParser.java
@@ -9,6 +9,8 @@
 
 package com.cburch.logisim.std.hdl;
 
+import com.cburch.hdl.HdlModel.PortDescription;
+import com.cburch.logisim.instance.Port;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -16,9 +18,6 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-
-import com.cburch.hdl.HdlModel.PortDescription;
-import com.cburch.logisim.instance.Port;
 
 /**
  * Parses a BLIF file.
@@ -32,14 +31,19 @@ public final class BlifParser {
   private final List<PortDescription> outputs;
   private final List<Gate> gates;
   private final List<Mux> muxes;
-  private final List<DFF> dff;
-  private final List<DFFSR> dffsr;
+  private final List<Dff> dff;
+  private final List<Dffsr> dffsr;
   private final List<Latch> latches;
   private final List<String> pullups;
   private final List<String> pulldowns;
   private final String source;
   private String name;
 
+  /**
+   * Creates the BlifParser with the source.
+   * The parse won't be complete until parse() is called.
+   * And it should only be called once.
+   */
   public BlifParser(String source) {
     this.source = source;
     this.inputs = new ArrayList<>();
@@ -53,16 +57,25 @@ public final class BlifParser {
     this.pulldowns = new ArrayList<>();
   }
 
+  /**
+   * Gets the model name (or null if none).
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Parses the BLIF file.
+   * Call only once.
+   */
   public void parse() {
-    // Determinism is absolutely important here; exact ordering is less important, but should be consistent.
-    // Preserving original order is probably not ideal, as it requires trusting the generator not to reorder things itself.
-    // While Yosys does appear to avoid this, assuming this as a guarantee feels naive and dangerous.
+    // Determinism is absolutely important here.
+    // Exact ordering is less important, but should be consistent.
+    // Preserving original order is probably not ideal:
+    //  it requires trusting the generator not to reorder things itself.
+    // While Yosys does appear to avoid this, assuming this as a guarantee feels dangerous.
     // TreeMap/Map uses String.compare, which does not take locale into account.
-    // This is an intentional choice on my part and should apply to everything in this code that affects port order.
+    // This is an intentional choice and should apply to anything that affects port order.
     var inputSet = new TreeSet<String>();
     var outputSet = new TreeSet<String>();
     for (String s : source.split("\n")) {
@@ -71,11 +84,18 @@ public final class BlifParser {
         // actual command, we may need to listen to it
         String[] words = lineActual.split(" ");
         if (words[0].equals(".inputs")) {
-          for (int i = 1; i < words.length; i++)
+          for (int i = 1; i < words.length; i++) {
             inputSet.add(words[i]);
+          }
         } else if (words[0].equals(".outputs")) {
-          for (int i = 1; i < words.length; i++)
+          for (int i = 1; i < words.length; i++) {
             outputSet.add(words[i]);
+          }
+        } else if (words[0].equals(".model")) {
+          // use this as a name source if possible
+          if (words.length > 1) {
+            name = words[1];
+          }
         } else if (words[0].equals(".names")) {
           // If Yosys is correctly configured, this is only used for constants.
           if (words.length == 2) {
@@ -86,11 +106,11 @@ public final class BlifParser {
             } else if (words[1].equals("$undef")) {
               // constant, we generate this internally
             } else {
-              // There's probably something to be said for the need to translate these exception messages somehow...
-              throw new RuntimeException("unexpected .names (did you pass '-icells -conn' to 'write_blif'?)");
+              // There's probably something to be said about translating these exception messages.
+              throw new RuntimeException("unexpected .names (try '-icells -conn')");
             }
           } else {
-            throw new RuntimeException(".names of unexpected length (did you pass '-icells -conn' to 'write_blif'?)");
+            throw new RuntimeException(".names of unexpected length (try '-icells -conn')");
           }
         } else if (words[0].equals(".conn")) {
           // .conn IN OUT ; enabled with -conn
@@ -106,59 +126,76 @@ public final class BlifParser {
             pins.put(k, v);
           }
 
-          // This list is partially based on https://github.com/YosysHQ/yosys/blob/0c689091e2a0959b1a6173de1bd7bd679b6120b2/examples/cmos/cmos_cells.lib
+          // This list is partially based on yosys examples/cmos/cmos_cells.lib
           // However, this I feel is a more general set of components.
-          // Note that the binary gates are in the simulator core (as DenseLogicCircuit.GATE_TYPE_NAMES).
+          // Note that the binary gates are in DenseLogicCircuit.GATE_TYPE_NAMES
           if (type.equals("BUF")) {
-            gates.add(new Gate(DenseLogicCircuit.GATE_BUS, pins.get("A"), pins.get("A"), pins.get("Y")));
+            String a = pins.get("A");
+            String y = pins.get("Y");
+            gates.add(new Gate(DenseLogicCircuit.GATE_BUS, a, a, y));
           } else if (type.equals("NOT")) {
             // !(A|A)
-            gates.add(new Gate(DenseLogicCircuit.GATE_NOR, pins.get("A"), pins.get("A"), pins.get("Y")));
-          } else if (type.equals("TRIS")) {
-            gates.add(new Gate(DenseLogicCircuit.GATE_TRIS, pins.get("A"), pins.get("B"), pins.get("Y")));
+            String a = pins.get("A");
+            String y = pins.get("Y");
+            gates.add(new Gate(DenseLogicCircuit.GATE_NOR, a, a, y));
           } else if (type.equals("MUX")) {
-            muxes.add(new Mux(pins.get("A"), pins.get("B"), pins.get("S"), pins.get("Y")));
+            String a = pins.get("A");
+            String b = pins.get("B");
+            String select = pins.get("S");
+            String y = pins.get("Y");
+            muxes.add(new Mux(a, b, select, y));
           } else if (type.equals("PULLUP")) {
             pullups.add(pins.get("Y"));
           } else if (type.equals("PULLDOWN")) {
             pulldowns.add(pins.get("Y"));
           } else if (type.equals("DFF")) {
-            dff.add(new DFF(pins.get("C"), pins.get("D"), pins.get("Q")));
+            String c = pins.get("C");
+            String d = pins.get("D");
+            String q = pins.get("Q");
+            dff.add(new Dff(c, d, q));
           } else if (type.equals("DFFSR")) {
-            dffsr.add(new DFFSR(pins.get("C"), pins.get("D"), pins.get("Q"), pins.get("S"), pins.get("R")));
+            String c = pins.get("C");
+            String d = pins.get("D");
+            String q = pins.get("Q");
+            dffsr.add(new Dffsr(c, d, q, pins.get("S"), pins.get("R")));
           } else if (type.equals("DLATCH")) {
-            latches.add(new Latch(pins.get("D"), pins.get("E"), pins.get("Q")));
+            String d = pins.get("D");
+            String e = pins.get("E");
+            String q = pins.get("Q");
+            latches.add(new Latch(d, e, q));
           } else {
             boolean found = false;
-            for (int gateType = 0; gateType < DenseLogicCircuit.GATE_TYPE_NAMES.length; gateType++) {
-              if (type.equals(DenseLogicCircuit.GATE_TYPE_NAMES[gateType])) {
+            String[] gateTypeNames = DenseLogicCircuit.GATE_TYPE_NAMES;
+            for (int gateType = 0; gateType < gateTypeNames.length; gateType++) {
+              if (type.equals(gateTypeNames[gateType])) {
                 // found a binary gate
                 gates.add(new Gate(gateType, pins.get("A"), pins.get("B"), pins.get("Y")));
                 found = true;
                 break;
               }
             }
-            if (!found)
+            if (!found) {
               throw new RuntimeException("Unknown gate: " + type);
+            }
           }
         }
       }
     }
     // A pin can't be both an input and an output according to the layout logic.
-    // Really, we should be checking for this, as it can be used to implement lots of fun fastpathy stuff.
+    // Really, it'd be good to generate pins according to their type (or use).
     // Oh well.
     inputSet.removeIf((s) -> outputSet.contains(s));
     // Now parse inputs and outputs into port descriptions (aka the hard part).
-    parseNamesIntoDescriptions(inputs, inputSet, Port.INPUT);
-    parseNamesIntoDescriptions(outputs, outputSet, Port.OUTPUT);
+    parseNameSet(inputs, inputSet, Port.INPUT);
+    parseNameSet(outputs, outputSet, Port.OUTPUT);
   }
 
   /**
-   * This and getPinBLIFSymbol describe the outer layer of the 'ABI' used for the ports.
+   * This and getPinBlifSymbol describe the outer layer of the 'ABI' used for the ports.
    * The inner layer is the "x."/"i."/"o." prefix set described in compileBidiPin.
    * Of these, only "x." and "o." are relevant externally.
    */
-  private void parseNamesIntoDescriptions(List<PortDescription> ports, SortedSet<String> src, String type) {
+  private void parseNameSet(List<PortDescription> ports, SortedSet<String> src, String type) {
     // See inputSet/outputSet for data structure choice rationale.
     var maxBitNumbers = new TreeMap<String, Integer>();
     while (!src.isEmpty()) {
@@ -172,9 +209,9 @@ public final class BlifParser {
             int num = Integer.parseUnsignedInt(bitIndex);
             String prefix = queue.substring(0, leftIdx);
             Integer existing = maxBitNumbers.get(prefix);
-            if (existing != null)
-              if (existing > num)
-                num = existing;
+            if (existing != null && existing > num) {
+              num = existing;
+            }
             maxBitNumbers.put(prefix, num);
             // handled
             continue;
@@ -188,12 +225,15 @@ public final class BlifParser {
     }
     // All buses are handled in this separate pass, since aggregation needs to happen.
     // This means buses always go after individual signals.
-    // Note the +1 ; the given value is the bit number, so we have to add 1 to it to get the bit count.
+    // Note the +1 ; the given value is the bit number.
+    // So we have to add 1 to it to get the bit count.
     for (Map.Entry<String, Integer> map : maxBitNumbers.entrySet()) {
       int width = map.getValue() + 1;
       if (width == 1) {
-        // So something interesting has happened in this case: we have found a 'bus' of only 1 bit.
-        // The way this 'ABI' works is based on bit width, so we really need to get that [0] back in somehow.
+        // So something interesting has happened in this case:
+        // We have found a 'bus' of only 1 bit.
+        // The way this 'ABI' works is based on bit width.
+        // We really need to get that [0] back in somehow.
         ports.add(new PortDescription(map.getKey() + "[0]", type, 1));
       } else {
         ports.add(new PortDescription(map.getKey(), type, width));
@@ -204,7 +244,7 @@ public final class BlifParser {
   /**
    * Describes the outer 'ABI' (and used by compilePort to compile it).
    */
-  public String getPinBLIFSymbol(PortDescription port, int index) {
+  public String getPinBlifSymbol(PortDescription port, int index) {
     int width = port.getWidthInt();
     if (width == 1) {
       return port.getName();
@@ -214,10 +254,11 @@ public final class BlifParser {
   }
 
   /**
-   * Implements the 'inner ABI' (the input/output line mechanism used to try and prevent self-propagation).
+   * Implements the 'inner ABI'.
+   * Splitting the line into two prevents self-propagation for bi-directional ports.
    */
-  public String getPinDLCSymbol(PortDescription port, int index, boolean output) {
-    return (output ? "o." : "x.") + getPinBLIFSymbol(port, index);
+  public String getPinDlcSymbol(PortDescription port, int index, boolean output) {
+    return (output ? "o." : "x.") + getPinBlifSymbol(port, index);
   }
 
   public List<PortDescription> getInputs() {
@@ -235,8 +276,9 @@ public final class BlifParser {
     DenseLogicCircuitBuilder builder = new DenseLogicCircuitBuilder();
     // The builder's symbol table is used to do all the complicated stuff.
     // x. : External input. The simulator can drive inputs using this.
-    // i. : Internal input; merges external input and internal output, for use by gates inside the circuit.
-    // o. : External output; what this circuit sends to the outside world, unbiased by external input.
+    // i. : Internal input; bus(x, o); for use by gates inside the circuit.
+    // o. : External output; what this circuit sends to the outside world.
+    //      Does not include x or i.
     // The integration layer is expected to write to x. cells and read from o. cells.
     builder.symbolTable.put("i.$false", DenseLogicCircuit.LEV_LOW);
     builder.symbolTable.put("o.$false", DenseLogicCircuit.LEV_LOW);
@@ -245,57 +287,71 @@ public final class BlifParser {
     builder.symbolTable.put("i.$undef", DenseLogicCircuit.LEV_NONE);
     builder.symbolTable.put("o.$undef", DenseLogicCircuit.LEV_NONE);
     // prepare inputs & outputs
-    for (PortDescription pd : inputs)
+    for (PortDescription pd : inputs) {
       compilePort(builder, pd);
-    for (PortDescription pd : outputs)
+    }
+    for (PortDescription pd : outputs) {
       compilePort(builder, pd);
+    }
     // install gates
     for (Gate g : gates) {
-      int aInput = compileGetInput(builder, g.a);
-      int bInput = compileGetInput(builder, g.b);
-      int yOutput = compileGetOutput(builder, g.y);
-      builder.attachGate(g.type, aInput, bInput, yOutput);
+      int a = compileGetInput(builder, g.a);
+      int b = compileGetInput(builder, g.b);
+      int y = compileGetOutput(builder, g.y);
+      builder.attachGate(g.type, a, b, y);
     }
     // install muxes
     for (Mux m : muxes) {
-      // Muxes are interesting, because we don't natively support them (they would be 3-input).
+      // Muxes are interesting.
+      // We don't natively support them (they would be 3-input).
       // But we do have the building blocks to implement them in a better way.
-      // The TRIS and TRISI gates are attached, and a BUS gate is automatically added by the builder.
+      // The TRIS and TRISI gates are attached.
+      // A BUS gate is automatically added by the builder.
       // This creates a 3-gate mux which also handles tri-state inputs.
-      // It would also be possible to create a 3-gate mux with regular logic with some inverted inputs.
+      // It would also be possible to create a regular 3-gate mux:
       // i.e. Y = (B & S) | (A & !S); this would use the ANDNOT gate. Again: no tri-state.
-      int aInput = compileGetInput(builder, m.a);
-      int bInput = compileGetInput(builder, m.b);
-      int sInput = compileGetInput(builder, m.s);
-      int yOutput = compileGetOutput(builder, m.y);
-      builder.attachGate(DenseLogicCircuit.GATE_TRISI, aInput, sInput, yOutput);
-      builder.attachGate(DenseLogicCircuit.GATE_TRIS, bInput, sInput, yOutput);
+      int a = compileGetInput(builder, m.a);
+      int b = compileGetInput(builder, m.b);
+      int s = compileGetInput(builder, m.s);
+      int y = compileGetOutput(builder, m.y);
+      builder.attachGate(DenseLogicCircuit.GATE_TRISI, a, s, y);
+      builder.attachGate(DenseLogicCircuit.GATE_TRIS, b, s, y);
     }
     // install DFFs
-    for (DFF ff : dff)
-      builder.attachBuffer(builder.addDFF(compileGetInput(builder, ff.c), compileGetInput(builder, ff.d)), compileGetOutput(builder, ff.q));
+    for (Dff ff : dff) {
+      int c = compileGetInput(builder, ff.c);
+      int d = compileGetInput(builder, ff.d);
+      int q = compileGetOutput(builder, ff.q);
+      builder.attachBuffer(builder.addDff(c, d), q);
+    }
     // install latches
-    for (Latch l : latches)
-      builder.attachBuffer(builder.addLatch(compileGetInput(builder, l.d), compileGetInput(builder, l.e)), compileGetOutput(builder, l.q));
-    for (DFFSR ff : dffsr) {
+    for (Latch l : latches) {
+      int d = compileGetInput(builder, l.d);
+      int e = compileGetInput(builder, l.e);
+      int q = compileGetOutput(builder, l.q);
+      builder.attachBuffer(builder.addLatch(d, e), q);
+    }
+    for (Dffsr ff : dffsr) {
       int c = compileGetInput(builder, ff.c);
       int d = compileGetInput(builder, ff.d);
       int q = compileGetOutput(builder, ff.q);
       int s = compileGetInput(builder, ff.s);
       int r = compileGetInput(builder, ff.r);
-      builder.attachBuffer(builder.addDFFSR(c, d, s, r), q);
+      builder.attachBuffer(builder.addDffsr(c, d, s, r), q);
     }
     // install pullups/pulldowns
-    for (String s : pullups)
+    for (String s : pullups) {
       builder.setCellPull(compileGetOutput(builder, s), DenseLogicCircuit.LEV_HIGH);
-    for (String s : pulldowns)
+    }
+    for (String s : pulldowns) {
       builder.setCellPull(compileGetOutput(builder, s), DenseLogicCircuit.LEV_LOW);
+    }
     // done!
     return builder.build();
   }
 
   /**
-   * Creates three cells: the external input cell, the internal input cell, and the external output cell.
+   * Creates three cells: external input, internal input, external output.
    * Internal input merges external input and internal output.
    */
   private void compileBidiPin(DenseLogicCircuitBuilder builder, String pin) {
@@ -307,26 +363,33 @@ public final class BlifParser {
     builder.symbolTable.put("o." + pin, externalOutput);
     builder.attachGate(DenseLogicCircuit.GATE_BUS, externalInput, externalOutput, internalInput);
   }
+
   /**
    * Creates bidi pins for a port.
    */
   private void compilePort(DenseLogicCircuitBuilder builder, PortDescription port) {
     int width = port.getWidthInt();
-    for (int i = 0; i < width; i++)
-      compileBidiPin(builder, getPinBLIFSymbol(port, i));
+    for (int i = 0; i < width; i++) {
+      compileBidiPin(builder, getPinBlifSymbol(port, i));
+    }
   }
+
   private int compileGetInput(DenseLogicCircuitBuilder builder, String pin) {
     Integer existing = builder.symbolTable.get("i." + pin);
-    if (existing == null)
+    if (existing == null) {
       existing = compileNewWire(builder, pin);
+    }
     return existing;
   }
+
   private int compileGetOutput(DenseLogicCircuitBuilder builder, String pin) {
     Integer existing = builder.symbolTable.get("o." + pin);
-    if (existing == null)
+    if (existing == null) {
       existing = compileNewWire(builder, pin);
+    }
     return existing;
   }
+
   private int compileNewWire(DenseLogicCircuitBuilder builder, String pin) {
     int res = builder.addCell(false);
     builder.symbolTable.put("i." + pin, res);
@@ -334,18 +397,18 @@ public final class BlifParser {
     return res;
   }
 
-  public record Gate(int type, String a, String b, String y) {
+  private record Gate(int type, String a, String b, String y) {
   }
 
-  public record Mux(String a, String b, String s, String y) {
+  private record Mux(String a, String b, String s, String y) {
   }
 
-  public record DFF(String c, String d, String q) {
+  private record Dff(String c, String d, String q) {
   }
 
-  public record DFFSR(String c, String d, String q, String s, String r) {
+  private record Dffsr(String c, String d, String q, String s, String r) {
   }
 
-  public record Latch(String d, String e, String q) {
+  private record Latch(String d, String e, String q) {
   }
 }

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifParser.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifParser.java
@@ -1,0 +1,201 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.hdl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import com.cburch.hdl.HdlModel.PortDescription;
+import com.cburch.logisim.instance.Port;
+
+/**
+ * Parses a BLIF file.
+ * The BLIF file must contain a single circuit made up of a fixed set of supported subcircuits.
+ * The objective here is to provide a Yosys-compatible target.
+ * This can be compiled with something like: write_blif -icells -buf BUF A Y test1.blif
+ */
+public class BlifParser {
+  private final List<PortDescription> inputs;
+  private final List<PortDescription> outputs;
+  private final List<Gate> gates;
+  private final String source;
+  private String name;
+
+  public BlifParser(String source) {
+    this.source = source;
+    this.inputs = new ArrayList<>();
+    this.outputs = new ArrayList<>();
+    this.gates = new ArrayList<>();
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void parse() {
+    TreeSet<String> inputSet = new TreeSet<>();
+    TreeSet<String> outputSet = new TreeSet<>();
+    for (String s : source.split("\n")) {
+      String lineActual = s.trim();
+      if (lineActual.startsWith(".")) {
+        // actual command, we may need to listen to it
+        String[] words = lineActual.split(" ");
+        if (words[0].equals(".inputs")) {
+          for (int i = 1; i < words.length; i++)
+            inputSet.add(words[i]);
+        } else if (words[0].equals(".outputs")) {
+          for (int i = 1; i < words.length; i++)
+            outputSet.add(words[i]);
+        } else if (words[0].equals(".subckt")) {
+          String type = words[1];
+          HashMap<String, String> pins = new HashMap<>();
+          for (int i = 2; i < words.length; i++) {
+            String assignment = words[i];
+            int eq = assignment.indexOf('=');
+            String k = assignment.substring(0, eq);
+            String v = assignment.substring(eq + 1);
+            pins.put(k, v);
+          }
+
+          if (type.equals("BUF")) {
+            gates.add(new Gate(DenseLogicCircuit.GATE_BUS, pins.get("A"), pins.get("A"), pins.get("Y")));
+          } else if (type.equals("NOT")) {
+            gates.add(new Gate(DenseLogicCircuit.GATE_NOR, pins.get("A"), pins.get("A"), pins.get("Y")));
+          } else if (type.equals("AND")) {
+            gates.add(new Gate(DenseLogicCircuit.GATE_AND, pins.get("A"), pins.get("B"), pins.get("Y")));
+          } else if (type.equals("NAND")) {
+            gates.add(new Gate(DenseLogicCircuit.GATE_NAND, pins.get("A"), pins.get("B"), pins.get("Y")));
+          } else if (type.equals("OR")) {
+            gates.add(new Gate(DenseLogicCircuit.GATE_OR, pins.get("A"), pins.get("B"), pins.get("Y")));
+          } else if (type.equals("NOR")) {
+            gates.add(new Gate(DenseLogicCircuit.GATE_NOR, pins.get("A"), pins.get("B"), pins.get("Y")));
+          } else if (type.equals("XOR")) {
+            gates.add(new Gate(DenseLogicCircuit.GATE_XOR, pins.get("A"), pins.get("B"), pins.get("Y")));
+          } else if (type.equals("NXOR")) {
+            gates.add(new Gate(DenseLogicCircuit.GATE_NXOR, pins.get("A"), pins.get("B"), pins.get("Y")));
+          } else if (type.equals("TRIS")) {
+            // the Yosys cell library doesn't expose this, but I feel it may be useful
+            gates.add(new Gate(DenseLogicCircuit.GATE_TRIS, pins.get("A"), pins.get("B"), pins.get("Y")));
+          } else {
+            throw new RuntimeException("Unknown subcircuit " + type);
+          }
+        }
+      }
+    }
+    // A pin can't be both an input and an output according to the layout logic.
+    // Really, we should be checking for this, as it can be used to implement lots of fun fastpathy stuff.
+    // Oh well.
+    inputSet.removeIf((s) -> outputSet.contains(s));
+    // Now parse inputs and outputs into port descriptions (aka the hard part).
+    parseNamesIntoDescriptions(inputs, inputSet);
+    parseNamesIntoDescriptions(outputs, outputSet);
+  }
+
+  private void parseNamesIntoDescriptions(List<PortDescription> ports, SortedSet<String> src) {
+    // For now, use a very bad implementation just to get things kind of working.
+    while (!src.isEmpty()) {
+      String queue = src.removeFirst();
+      ports.add(new PortDescription(queue, Port.INOUT, 1));
+    }
+  }
+
+  public List<PortDescription> getInputs() {
+    return inputs;
+  }
+
+  public List<PortDescription> getOutputs() {
+    return outputs;
+  }
+
+  /**
+   * Compiles the BLIF into the DenseLogicCircuit format used for simulation.
+   */
+  public DenseLogicCircuit compile() {
+    DenseLogicCircuitBuilder builder = new DenseLogicCircuitBuilder();
+    // The builder's symbol table is used to do all the complicated stuff.
+    // x. : External input. The simulator can drive inputs using this.
+    // i. : Internal input; merges external input and internal output, for use by gates inside the circuit.
+    // o. : External output; what this circuit sends to the outside world, unbiased by external input.
+    // The integration layer is expected to write to x. cells and read from o. cells.
+    builder.symbolTable.put("i.$false", DenseLogicCircuit.LEV_LOW);
+    builder.symbolTable.put("o.$false", DenseLogicCircuit.LEV_LOW);
+    builder.symbolTable.put("i.$true", DenseLogicCircuit.LEV_HIGH);
+    builder.symbolTable.put("o.$true", DenseLogicCircuit.LEV_HIGH);
+    builder.symbolTable.put("i.$undef", DenseLogicCircuit.LEV_NONE);
+    builder.symbolTable.put("o.$undef", DenseLogicCircuit.LEV_NONE);
+    // prepare inputs & outputs
+    for (PortDescription pd : inputs)
+      compilePort(builder, pd);
+    for (PortDescription pd : outputs)
+      compilePort(builder, pd);
+    // install gates
+    for (Gate g : gates) {
+      int aInput = compileGetInput(builder, g.a);
+      int bInput = compileGetInput(builder, g.b);
+      int yOutput = compileGetOutput(builder, g.y);
+      builder.attachGate(g.type, aInput, bInput, yOutput);
+    }
+    // done!
+    return builder.build();
+  }
+
+  /**
+   * Creates three cells: the external input cell, the internal input cell, and the external output cell.
+   * Internal input merges external input and internal output.
+   */
+  private void compileBidiPin(DenseLogicCircuitBuilder builder, String pin) {
+    int externalInput = builder.addCell(true);
+    int internalInput = builder.addCell(false);
+    int externalOutput = builder.addCell(false);
+    builder.symbolTable.put("x." + pin, externalInput);
+    builder.symbolTable.put("i." + pin, internalInput);
+    builder.symbolTable.put("o." + pin, externalOutput);
+    builder.attachGate(DenseLogicCircuit.GATE_BUS, externalInput, externalOutput, internalInput);
+  }
+  /**
+   * Creates bidi pins for a port.
+   */
+  private void compilePort(DenseLogicCircuitBuilder builder, PortDescription port) {
+    int width = port.getWidthInt();
+    if (width == 1) {
+      compileBidiPin(builder, port.getName());
+    } else {
+      for (int i = 0; i < width; i++)
+        compileBidiPin(builder, port.getName() + "[" + i + "]");
+    }
+  }
+  private int compileGetInput(DenseLogicCircuitBuilder builder, String pin) {
+    Integer existing = builder.symbolTable.get("i." + pin);
+    if (existing == null)
+      existing = compileNewWire(builder, pin);
+    return existing;
+  }
+  private int compileGetOutput(DenseLogicCircuitBuilder builder, String pin) {
+    Integer existing = builder.symbolTable.get("o." + pin);
+    if (existing == null)
+      existing = compileNewWire(builder, pin);
+    return existing;
+  }
+  private int compileNewWire(DenseLogicCircuitBuilder builder, String pin) {
+    int res = builder.addCell(false);
+    builder.symbolTable.put("i." + pin, res);
+    builder.symbolTable.put("o." + pin, res);
+    return res;
+  }
+
+  /**
+   * BLIF subcircuit data.
+   */
+  public record Gate(int type, String a, String b, String y) {
+  }
+}

--- a/src/main/java/com/cburch/logisim/std/hdl/BlifParser.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/BlifParser.java
@@ -27,6 +27,9 @@ import java.util.TreeSet;
  * Some effort has been made to support other configurations of Yosys, but icells must be used.
  */
 public final class BlifParser {
+  public static final String RECOMMENDED_LOGIC_LIBRARY_URL =
+      "https://github.com/YosysHQ/yosys/tree/main/examples/cmos";
+
   private final List<PortDescription> inputs;
   private final List<PortDescription> outputs;
   private final List<Gate> gates;
@@ -94,6 +97,8 @@ public final class BlifParser {
         } else if (words[0].equals(".model")) {
           // use this as a name source if possible
           if (words.length > 1) {
+            if (name != null)
+              throw new RuntimeException("many tops (try 'synth -flatten -top " + name + "')");
             name = words[1];
           }
         } else if (words[0].equals(".names")) {
@@ -107,10 +112,10 @@ public final class BlifParser {
               // constant, we generate this internally
             } else {
               // There's probably something to be said about translating these exception messages.
-              throw new RuntimeException("unexpected .names (try '-icells -conn')");
+              throw new RuntimeException("odd .names (try 'write_blif -icells -conn out.blif')");
             }
           } else {
-            throw new RuntimeException(".names of unexpected length (try '-icells -conn')");
+            throw new RuntimeException("odd .names (try 'write_blif -icells -conn out.blif')");
           }
         } else if (words[0].equals(".conn")) {
           // .conn IN OUT ; enabled with -conn
@@ -175,7 +180,8 @@ public final class BlifParser {
               }
             }
             if (!found) {
-              throw new RuntimeException("Unknown gate: " + type);
+              throw new RuntimeException("unknown gate " + type + "\n" +
+                  "try basing your script on " + RECOMMENDED_LOGIC_LIBRARY_URL);
             }
           }
         }

--- a/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuit.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuit.java
@@ -30,17 +30,28 @@ public final class DenseLogicCircuit {
   public static final Value[] LEV_TO_LS = {Value.NIL, Value.FALSE, Value.TRUE, Value.ERROR};
 
   // Gate types
-  // 'Bus merge operator': Joins A and B onto the bus.
+  /**
+   * 'Bus merge operator': Joins A and B onto the bus.
+   */
   public static final int GATE_BUS = 0;
-  // Tri-state: If B is HIGH, then A is forwarded; else NONE
+  /**
+   * Tri-state: If B is HIGH, then A is forwarded; else NONE
+   */
   public static final int GATE_TRIS = 1;
-  public static final int GATE_AND = 2;
-  public static final int GATE_OR = 3;
-  public static final int GATE_XOR = 4;
-  public static final int GATE_NAND = 5;
-  public static final int GATE_NOR = 6;
-  public static final int GATE_NXOR = 7;
-  public static final String[] GATE_TYPE_NAMES = {"BUS", "TRIS", "AND", "OR", "XOR", "NAND", "NOR", "NXOR"};
+  /**
+   * GATE_TRIS with inverted B input.
+   * This was added to simplify 2-input muxes.
+   * Doing this to D-flipflops would break counters.
+   * I'm not strictly sure latches won't break either, so I don't believe too much engineering effort is justified here.
+   */
+  public static final int GATE_TRISI = 2;
+  public static final int GATE_AND = 3;
+  public static final int GATE_OR = 4;
+  public static final int GATE_XOR = 5;
+  public static final int GATE_NAND = 6;
+  public static final int GATE_NOR = 7;
+  public static final int GATE_NXOR = 8;
+  public static final String[] GATE_TYPE_NAMES = {"BUS", "TRIS", "TRISI", "AND", "OR", "XOR", "NAND", "NOR", "NXOR"};
 
   /**
    * D-flipflop[D, C, Q, X]: When cell[C] goes to high, set cell[Q] to cell[D]. Uses seqData[X] to detect this change.
@@ -206,6 +217,10 @@ public final class DenseLogicCircuit {
         break;
       case GATE_TRIS:
         if (vB == LEV_HIGH)
+          vO = vA;
+        break;
+      case GATE_TRISI:
+        if (vB != LEV_HIGH)
           vO = vA;
         break;
       case GATE_AND:

--- a/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuit.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuit.java
@@ -11,6 +11,8 @@ package com.cburch.logisim.std.hdl;
 
 import java.util.Map;
 
+import com.cburch.logisim.data.Value;
+
 /**
  * A stored dense logic circuit.
  * The state of the circuit is made up of byte 'cells'.
@@ -22,6 +24,10 @@ public final class DenseLogicCircuit {
   public static final int LEV_HIGH = 2;
   public static final int LEV_ERR = 3;
   public static final int LEV_COUNT = 4;
+  /**
+   * Translates DenseLogicCircuit levels to Logisim values.
+   */
+  public static final Value[] LEV_TO_LS = {Value.NIL, Value.FALSE, Value.TRUE, Value.ERROR};
 
   // Gate types
   // 'Bus merge operator': Joins A and B onto the bus.
@@ -152,9 +158,12 @@ public final class DenseLogicCircuit {
   }
 
   /**
-   * Marks a cell update in the given auxData.
+   * Updates a cell.
    */
-  public final void markCellUpdate(int cell, int[] auxData) {
+  public final void setCell(int cell, byte value, byte[] cells, int[] auxData) {
+    if (cells[cell] == value)
+      return;
+    cells[cell] = value;
     for (int g : cellUpdateNotifiesGate[cell]) {
       if (auxData[g] == -1) {
         auxData[g] = auxData[gateCount];

--- a/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuit.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuit.java
@@ -40,6 +40,7 @@ public final class DenseLogicCircuit {
   public static final int GATE_NAND = 5;
   public static final int GATE_NOR = 6;
   public static final int GATE_NXOR = 7;
+  public static final String[] GATE_TYPE_NAMES = {"BUS", "TRIS", "AND", "OR", "XOR", "NAND", "NOR", "NXOR"};
 
   /**
    * D-flipflop[D, C, Q, X]: When cell[C] goes to high, set cell[Q] to cell[D]. Uses seqData[X] to detect this change.
@@ -146,14 +147,19 @@ public final class DenseLogicCircuit {
    */
   public final int[] newAuxData() {
     int[] dat = new int[auxDataSize];
-    // setup the initial queue
-    // each gate is followed by next gate
-    for (int i = 0; i < gateCount - 1; i++)
-      dat[i] = i + 1;
-    // last gate ends list
-    dat[gateCount - 1] = -1;
-    // list starts with first gate
-    dat[gateCount] = 0;
+    if (gateCount != 0) {
+      // setup the initial queue
+      // each gate is followed by next gate
+      for (int i = 0; i < gateCount - 1; i++)
+        dat[i] = i + 1;
+      // last gate ends list
+      dat[gateCount - 1] = -1;
+      // list starts with first gate
+      dat[gateCount] = 0;
+    } else {
+      // there are no gates, so the update queue must be empty
+      dat[gateCount] = -1;
+    }
     return dat;
   }
 
@@ -178,11 +184,12 @@ public final class DenseLogicCircuit {
    */
   private final void simulateCombinatorial(byte[] cells, int[] auxData) {
     // Maximum iteration count of the amount of gates multiplied by itself.
-    // This is a pessimistic count, it shouldn't be needed in most cases.
+    // This is a pessimistic count; it shouldn't be needed in most cases.
     // The main problem is A = !A.
     long maxIterationCount = (long) gateCount;
     maxIterationCount *= maxIterationCount;
-    for (long i = 0; i < maxIterationCount; i++) {
+    while (maxIterationCount > 0) {
+      maxIterationCount--;
       int gateToEval = auxData[gateCount];
       if (gateToEval == -1)
         break;

--- a/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuit.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuit.java
@@ -1,0 +1,249 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.hdl;
+
+import java.util.Map;
+
+/**
+ * A stored dense logic circuit.
+ * The state of the circuit is made up of byte 'cells'.
+ */
+public final class DenseLogicCircuit {
+  // Levels. These are intended to be OR'd by GATE_BUS.
+  public static final int LEV_NONE = 0;
+  public static final int LEV_LOW = 1;
+  public static final int LEV_HIGH = 2;
+  public static final int LEV_ERR = 3;
+  public static final int LEV_COUNT = 4;
+
+  // Gate types
+  // 'Bus merge operator': Joins A and B onto the bus.
+  public static final int GATE_BUS = 0;
+  // Tri-state: If B is HIGH, then A is forwarded; else NONE
+  public static final int GATE_TRIS = 1;
+  public static final int GATE_AND = 2;
+  public static final int GATE_OR = 3;
+  public static final int GATE_XOR = 4;
+  public static final int GATE_NAND = 5;
+  public static final int GATE_NOR = 6;
+  public static final int GATE_NXOR = 7;
+  // Pullup/pulldown: Iff A = LEV_NONE then it is set to B.
+  public static final int GATE_PULL = 8;
+
+  /**
+   * D-flipflop[D, C, Q, X]: When cell[C] goes to high, set cell[Q] to cell[D]. Uses seqData[X] to detect this change. 
+   */
+  public static final int SQOP_DFF = 0;
+
+  /**
+   * The amount of cells in the circuit.
+   * Each cell has an update list.
+   * The first LEV_COUNT cells are reserved as constants.
+   */
+  public final int cellCount;
+  /**
+   * The amount of combinatorial gates in the circuit.
+   */
+  public final int gateCount;
+  /**
+   * The size of the update queue section of auxData / start of sequential logic data.
+   */
+  public final int updateQueueSize;
+  /**
+   * The amount of auxillary data (contains the update queue and sequential logic data).
+   */
+  public final int auxDataSize;
+  /**
+   * The amount and types of combinatorial gates.
+   */
+  public final byte[] gateTypes;
+  /**
+   * Combinatorial gate input A.
+   */
+  public final int[] gateCellA;
+  /**
+   * Combinatorial gate input B.
+   */
+  public final int[] gateCellB;
+  /**
+   * Combinatorial gate output cell.
+   */
+  public final int[] gateCellO;
+  /**
+   * Cell updates notify these gates.
+   */
+  public final int[][] cellUpdateNotifiesGate;
+  /**
+   * Sequential script.
+   */
+  public final int[] sequentialScript;
+  /**
+   * "Symbol table" of cells.
+   * Doesn't necessarily cover all cells.
+   */
+  public final Map<String, Integer> symbolTable;
+
+  public DenseLogicCircuit(int[][] cellUpdateNotifiesGate, byte[] gateTypes, int[] gateCellA, int[] gateCellB, int[] gateCellO, int[] seq, int seqDataSize, Map<String, Integer> symbolTable) {
+    this.cellCount = cellUpdateNotifiesGate.length;
+    this.gateCount = gateTypes.length;
+    this.updateQueueSize = gateCount + 1;
+    this.auxDataSize = updateQueueSize + seqDataSize;
+    this.cellUpdateNotifiesGate = cellUpdateNotifiesGate;
+    this.gateTypes = gateTypes;
+    this.gateCellA = gateCellA;
+    this.gateCellB = gateCellB;
+    this.gateCellO = gateCellO;
+    this.sequentialScript = seq;
+    this.symbolTable = symbolTable;
+  }
+
+  /**
+   * Simulates a tick of the dense logic circuit.
+   */
+  public final void simulate(byte[] cells, int[] auxData) {
+    simulateCombinatorial(cells, auxData);
+    simulateSequential(cells, auxData);
+    simulateCombinatorial(cells, auxData);
+  }
+
+  /**
+   * Creates a newly initialized cell array for a new simulation.
+   */
+  public final byte[] newCells() {
+    byte[] dat = new byte[cellCount];
+    for (int i = 0; i < LEV_COUNT; i++)
+      dat[i] = (byte) i;
+    return dat;
+  }
+
+  /**
+   * Creates a newly initialized aux. data array for a new simulation.
+   */
+  public final int[] newAuxData() {
+    int[] dat = new int[auxDataSize];
+    // setup the initial queue
+    // each gate is followed by next gate
+    for (int i = 0; i < gateCount - 1; i++)
+      dat[i] = i + 1;
+    // last gate ends list
+    dat[gateCount - 1] = -1;
+    // list starts with first gate
+    dat[gateCount] = 0;
+    return dat;
+  }
+
+  /**
+   * Marks a cell update in the given auxData.
+   */
+  public final void markCellUpdate(int cell, int[] auxData) {
+    for (int g : cellUpdateNotifiesGate[cell]) {
+      if (auxData[g] == -1) {
+        auxData[g] = auxData[gateCount];
+        auxData[gateCount] = g;
+      }
+    }
+  }
+
+  /**
+   * Simulates the combinatorial part of a tick.
+   * This has to be run twice; once to get data into the sequential components, once to get it out.
+   */
+  private final void simulateCombinatorial(byte[] cells, int[] auxData) {
+    // Maximum iteration count of the amount of gates multiplied by itself.
+    // This is a pessimistic count, it shouldn't be needed in most cases.
+    // The main problem is A = !A.
+    long maxIterationCount = (long) gateCount;
+    maxIterationCount *= maxIterationCount;
+    for (long i = 0; i < maxIterationCount; i++) {
+      int gateToEval = auxData[gateCount];
+      if (gateToEval == -1)
+        break;
+      // update next gate register & clear this gate
+      auxData[gateCount] = auxData[gateToEval];
+      auxData[gateToEval] = -1;
+      // run gate
+      int vA = cells[gateCellA[gateToEval]];
+      int vB = cells[gateCellB[gateToEval]];
+      int vO = LEV_NONE;
+      switch (gateTypes[gateToEval]) {
+      case GATE_BUS:
+        vO = vA | vB;
+        break;
+      case GATE_TRIS:
+        if (vB == LEV_HIGH)
+          vO = vA;
+        break;
+      case GATE_AND:
+        vO = (vA == LEV_HIGH && vB == LEV_HIGH) ? LEV_HIGH : LEV_LOW;
+        break;
+      case GATE_OR:
+        vO = (vA == LEV_HIGH || vB == LEV_HIGH) ? LEV_HIGH : LEV_LOW;
+        break;
+      case GATE_XOR:
+        vO = (vA == LEV_HIGH ^ vB == LEV_HIGH) ? LEV_HIGH : LEV_LOW;
+        break;
+      case GATE_NAND:
+        vO = (vA == LEV_HIGH && vB == LEV_HIGH) ? LEV_LOW : LEV_HIGH;
+        break;
+      case GATE_NOR:
+        vO = (vA == LEV_HIGH || vB == LEV_HIGH) ? LEV_LOW : LEV_HIGH;
+        break;
+      case GATE_NXOR:
+        vO = (vA == LEV_HIGH ^ vB == LEV_HIGH) ? LEV_LOW : LEV_HIGH;
+        break;
+      case GATE_PULL:
+        vO = vA == LEV_NONE ? vB : vA;
+        break;
+      }
+      int outCell = gateCellO[gateToEval];
+      if (vO != cells[outCell]) {
+        cells[outCell] = (byte) vO;
+        // inlined: markCellUpdate
+        for (int g : cellUpdateNotifiesGate[outCell]) {
+          if (auxData[g] == -1) {
+            auxData[g] = auxData[gateCount];
+            auxData[gateCount] = g;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Simulates the sequential part of a tick.
+   */
+  private final void simulateSequential(byte[] cells, int[] auxData) {
+    int ptr = 0;
+    while (ptr < sequentialScript.length) {
+      switch (sequentialScript[ptr++]) {
+      case SQOP_DFF: {
+        int d = sequentialScript[ptr++];
+        int c = sequentialScript[ptr++];
+        int q = sequentialScript[ptr++];
+        // notice the 'relocation' of x to past the update queue
+        int x = updateQueueSize + sequentialScript[ptr++];
+        int xOld = auxData[x];
+        int xNew = cells[c];
+        auxData[x] = xNew;
+        if (xNew == LEV_HIGH && xNew != xOld) {
+          cells[q] = cells[d];
+          // inlined: markCellUpdate
+          for (int g : cellUpdateNotifiesGate[q]) {
+            if (auxData[g] == -1) {
+              auxData[g] = auxData[gateCount];
+              auxData[gateCount] = g;
+            }
+          }
+        }
+      } break;
+      }
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuit.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuit.java
@@ -27,7 +27,7 @@ public final class DenseLogicCircuit {
   /**
    * Translates DenseLogicCircuit levels to Logisim values.
    */
-  public static final Value[] LEV_TO_LS = {Value.NIL, Value.FALSE, Value.TRUE, Value.ERROR};
+  public static final Value[] LEV_TO_LS = {Value.UNKNOWN, Value.FALSE, Value.TRUE, Value.ERROR};
 
   // Gate types
   /**
@@ -51,7 +51,15 @@ public final class DenseLogicCircuit {
   public static final int GATE_NAND = 6;
   public static final int GATE_NOR = 7;
   public static final int GATE_NXOR = 8;
-  public static final String[] GATE_TYPE_NAMES = {"BUS", "TRIS", "TRISI", "AND", "OR", "XOR", "NAND", "NOR", "NXOR"};
+  public static final int GATE_ANDNOT = 9;
+  public static final int GATE_ORNOT = 10;
+  /**
+   * These are used both for debugging and also by BlifParser.
+   */
+  public static final String[] GATE_TYPE_NAMES = {
+      "BUS", "TRIS", "TRISI", "AND",
+      "OR", "XOR", "NAND", "NOR",
+      "NXOR", "ANDNOT", "ORNOT"};
 
   /**
    * D-flipflop[D, C, Q, X]: When cell[C] goes to high, set cell[Q] to cell[D]. Uses seqData[X] to detect this change.
@@ -233,13 +241,19 @@ public final class DenseLogicCircuit {
         vO = (vA == LEV_HIGH ^ vB == LEV_HIGH) ? LEV_HIGH : LEV_LOW;
         break;
       case GATE_NAND:
-        vO = (vA == LEV_HIGH && vB == LEV_HIGH) ? LEV_LOW : LEV_HIGH;
+        vO = (vA == LEV_HIGH && vB == LEV_HIGH) ? LEV_LOW : LEV_HIGH; // inverted output
         break;
       case GATE_NOR:
-        vO = (vA == LEV_HIGH || vB == LEV_HIGH) ? LEV_LOW : LEV_HIGH;
+        vO = (vA == LEV_HIGH || vB == LEV_HIGH) ? LEV_LOW : LEV_HIGH; // inverted output
         break;
       case GATE_NXOR:
-        vO = (vA == LEV_HIGH ^ vB == LEV_HIGH) ? LEV_LOW : LEV_HIGH;
+        vO = (vA == LEV_HIGH ^ vB == LEV_HIGH) ? LEV_LOW : LEV_HIGH; // inverted output
+        break;
+      case GATE_ANDNOT:
+        vO = (vA == LEV_HIGH && vB != LEV_HIGH) ? LEV_HIGH : LEV_LOW;
+        break;
+      case GATE_ORNOT:
+        vO = (vA == LEV_HIGH || vB != LEV_HIGH) ? LEV_HIGH : LEV_LOW;
         break;
       }
       int outCell = gateCellO[gateToEval];

--- a/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuitBuilder.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuitBuilder.java
@@ -214,6 +214,9 @@ public final class DenseLogicCircuitBuilder {
     seqScript.add(c);
     seqScript.add(q);
     seqScript.add(xc);
+    // https://en.wikipedia.org/wiki/Flip-flop_(electronics)#/media/File:Edge_triggered_D_flip_flop_with_set_and_reset.svg
+    // This schematic indicates that the S/R lines are asynchronous and not edge-based.
+    // Therefore, use SQOP_LATCH to directly overwrite the latch contents.
     // S
     seqScript.add(DenseLogicCircuit.SQOP_LATCH);
     seqScript.add(DenseLogicCircuit.LEV_HIGH);

--- a/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuitBuilder.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuitBuilder.java
@@ -1,0 +1,190 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.hdl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.TreeSet;
+
+/**
+ * Builds a dense logic circuit.
+ */
+public final class DenseLogicCircuitBuilder {
+  private ArrayList<GateInfo> gates = new ArrayList<>();
+  private ArrayList<CellInfo> cells = new ArrayList<>();
+  private ArrayList<Integer> seqScript = new ArrayList<>();
+  public final HashMap<String, Integer> symbolTable = new HashMap<>();
+  private int seqDataSize = 0;
+
+  public DenseLogicCircuitBuilder() {
+    // Create constant cells.
+    for (int i = 0; i < DenseLogicCircuit.LEV_COUNT; i++)
+      cells.add(new CellInfo(i, true));
+  }
+
+  /**
+   * Attaches a gate to the system.
+   * If a gate is already attached to the given pin, a bus gate is automatically inserted.
+   */
+  public void attachGate(int gateType, int a, int b, int o) {
+    CellInfo outCellInfo = cells.get(o);
+    GateInfo existingGate = outCellInfo.currentDrivingGate;
+    if (existingGate != null) {
+      // there is already a driving gate!
+      // setup intermediate cells and redirect.
+      CellInfo existingGateOutputCell = addCellInternal(false);
+      existingGate.setOutput(existingGateOutputCell);
+      CellInfo incomingGateOutputCell = addCellInternal(false);
+      addGate(gateType, cells.get(a), cells.get(b)).setOutput(incomingGateOutputCell);
+      // add in the bus gate
+      addGate(DenseLogicCircuit.GATE_BUS, existingGateOutputCell, incomingGateOutputCell).setOutput(outCellInfo);
+    } else {
+      addGate(gateType, cells.get(a), cells.get(b)).setOutput(outCellInfo);
+    }
+  }
+
+  /**
+   * Builds the dense logic circuit.
+   */
+  public DenseLogicCircuit build() {
+    // notification array
+    int[][] cellUpdateNotifiesGate = new int[cells.size()][];
+    for (int i = 0; i < cellUpdateNotifiesGate.length; i++) {
+      CellInfo cell = cells.get(i);
+      int[] notifyArray = new int[cell.notifiesTheseGates.size()];
+      int idx = 0;
+      for (Integer gate : cell.notifiesTheseGates)
+        notifyArray[idx++] = gate;
+      cellUpdateNotifiesGate[i] = notifyArray;
+    }
+    // assemble gates
+    byte[] gateTypes = new byte[gates.size()];
+    int[] gateCellA = new int[gateTypes.length];
+    int[] gateCellB = new int[gateTypes.length];
+    int[] gateCellO = new int[gateTypes.length];
+    for (int i = 0; i < gateTypes.length; i++) {
+      GateInfo gi = gates.get(i);
+      gateTypes[i] = (byte) gi.type;
+      gateCellA[i] = gi.pinA.index;
+      gateCellB[i] = gi.pinB.index;
+      gateCellO[i] = gi.pinOutput.index;
+    }
+    // copy seq script
+    int[] seq = new int[seqScript.size()];
+    for (int i = 0; i < seq.length; i++)
+      seq[i] = seqScript.get(i);
+    // output
+    return new DenseLogicCircuit(cellUpdateNotifiesGate, gateTypes, gateCellA, gateCellB, gateCellO, seq, seqDataSize, Collections.unmodifiableMap(new HashMap<>(symbolTable)));
+  }
+
+  /**
+   * Adds a cell to the system.
+   */
+  private CellInfo addCellInternal(boolean ext) {
+    int idx = cells.size();
+    CellInfo ci = new CellInfo(idx, ext);
+    cells.add(ci);
+    return ci;
+  }
+
+  /**
+   * Adds a cell to the system.
+   */
+  public int addCell(boolean ext) {
+    return addCellInternal(ext).index;
+  }
+
+  /**
+   * Adds a gate to the system.
+   */
+  private GateInfo addGate(int type, CellInfo a, CellInfo b) {
+    int gateIndex = gates.size();
+    GateInfo gi = new GateInfo(gateIndex, type, a, b);
+    gates.add(gi);
+    return gi;
+  }
+
+  /**
+   * Adds a D-flipflop. Returns the Q line cell.
+   */
+  public int addDFF(int d, int c) {
+    int q = addCellInternal(true).index;
+    int x = seqDataSize++;
+    seqScript.add(DenseLogicCircuit.SQOP_DFF);
+    seqScript.add(d);
+    seqScript.add(c);
+    seqScript.add(q);
+    seqScript.add(x);
+    return q;
+  }
+
+  private class CellInfo {
+    /**
+     * Records the index.
+     */
+    final int index;
+
+    /**
+     * Indicates the current driving gate of this cell.
+     * This is used to rewrite gates into GATE_BUS.
+     */
+    GateInfo currentDrivingGate;
+
+    /**
+     * Indicates an external driver. Trying to connect a gate or other driver to these is an error!
+     */
+    boolean externallyDriven;
+
+    /**
+     * These gates are notified by this cell.
+     */
+    TreeSet<Integer> notifiesTheseGates = new TreeSet<>();
+
+    CellInfo(int index, boolean ext) {
+      this.index = index;
+      externallyDriven = ext;
+    }
+  }
+  /**
+   * Contains info about a gate.
+   */
+  private class GateInfo {
+    final int type;
+    CellInfo pinA;
+    CellInfo pinB;
+    CellInfo pinOutput;
+    GateInfo(int index, int t, CellInfo a, CellInfo b) {
+      type = t;
+      pinA = a;
+      a.notifiesTheseGates.add(index);
+      pinB = b;
+      b.notifiesTheseGates.add(index);
+    }
+
+    GateInfo setOutput(CellInfo cell) {
+      // unlink
+      if (pinOutput != null) {
+        pinOutput.currentDrivingGate = null;
+        pinOutput = null;
+      }
+      // link
+      if (cell != null) {
+        if (cell.externallyDriven)
+          throw new RuntimeException("Cannot set driving gate for an externally driven cell!");
+        if (cell.currentDrivingGate != null)
+          throw new RuntimeException("setOutput does not insert bus gates automatically!");
+        cell.currentDrivingGate = this;
+      }
+      pinOutput = cell;
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuitBuilder.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuitBuilder.java
@@ -231,6 +231,19 @@ public final class DenseLogicCircuitBuilder {
     return q;
   }
 
+  /**
+   * Adds a D-latch. Returns the Q line cell.
+   */
+  public int addLatch(int d, int e) {
+    int q = addCellInternal(true).index;
+    seqScript.add(DenseLogicCircuit.SQOP_LATCH);
+    seqScript.add(d);
+    seqScript.add(e);
+    seqScript.add(q);
+    setCellPull(q, DenseLogicCircuit.LEV_LOW);
+    return q;
+  }
+
   private class CellInfo {
     /**
      * Records the index.

--- a/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuitBuilder.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/DenseLogicCircuitBuilder.java
@@ -73,6 +73,13 @@ public final class DenseLogicCircuitBuilder {
   }
 
   /**
+   * Shorthand for attaching a BUS gate as a buffer.
+   */
+  public void attachBuffer(int from, int to) {
+    attachGate(DenseLogicCircuit.GATE_BUS, from, from, to);
+  }
+
+  /**
    * Builds the dense logic circuit.
    */
   public DenseLogicCircuit build() {
@@ -147,7 +154,7 @@ public final class DenseLogicCircuitBuilder {
   /**
    * Adds a D-flipflop. Returns the Q line cell.
    */
-  public int addDFF(int d, int c) {
+  public int addDFF(int c, int d) {
     int q = addCellInternal(true).index;
     int x = seqDataSize++;
     seqScript.add(DenseLogicCircuit.SQOP_DFF);
@@ -155,6 +162,33 @@ public final class DenseLogicCircuitBuilder {
     seqScript.add(c);
     seqScript.add(q);
     seqScript.add(x);
+    setCellPull(q, DenseLogicCircuit.LEV_LOW);
+    return q;
+  }
+
+  /**
+   * Adds a DFFSR flipflop. Returns the Q line cell.
+   */
+  public int addDFFSR(int c, int d, int s, int r) {
+    int q = addCellInternal(true).index;
+    int xc = seqDataSize++;
+    // C
+    seqScript.add(DenseLogicCircuit.SQOP_DFF);
+    seqScript.add(d);
+    seqScript.add(c);
+    seqScript.add(q);
+    seqScript.add(xc);
+    // S
+    seqScript.add(DenseLogicCircuit.SQOP_LATCH);
+    seqScript.add(DenseLogicCircuit.LEV_HIGH);
+    seqScript.add(s);
+    seqScript.add(q);
+    // R
+    seqScript.add(DenseLogicCircuit.SQOP_LATCH);
+    seqScript.add(DenseLogicCircuit.LEV_LOW);
+    seqScript.add(r);
+    seqScript.add(q);
+    setCellPull(q, DenseLogicCircuit.LEV_LOW);
     return q;
   }
 

--- a/src/main/java/com/cburch/logisim/std/hdl/GenericInterfaceComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/GenericInterfaceComponent.java
@@ -1,0 +1,139 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.hdl;
+
+import java.awt.Color;
+import java.util.Arrays;
+
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.data.Bounds;
+import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
+import com.cburch.logisim.instance.Instance;
+import com.cburch.logisim.instance.InstanceFactory;
+import com.cburch.logisim.instance.InstancePainter;
+import com.cburch.logisim.instance.Port;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.util.GraphicsUtil;
+import com.cburch.logisim.util.StringGetter;
+import com.cburch.logisim.util.StringUtil;
+
+/**
+ * Base class.
+ * This base class provides a standard port layout and drawing code for generic logic interfaces (like for VHDL).
+ * It does not assume much about the target; the goal is simply to keep the port layout code in one place.
+ */
+public abstract class GenericInterfaceComponent extends InstanceFactory {
+  public GenericInterfaceComponent(String name,
+      StringGetter displayName,
+      HdlGeneratorFactory generator,
+      boolean requiresGlobalClock) {
+    super(name, displayName, generator, requiresGlobalClock);
+  }
+
+  static final int WIDTH = 140;
+  static final int HEIGHT = 40;
+  static final int PORT_GAP = 10;
+
+  static final int X_PADDING = 5;
+
+  @Override
+  public Bounds getOffsetBounds(AttributeSet attrs) {
+    int nbInputs = getGIAttributesInputs(attrs).length;
+    int nbOutputs = getGIAttributesOutputs(attrs).length;
+    return Bounds.create(0, 0, WIDTH, Math.max(nbInputs, nbOutputs) * PORT_GAP + HEIGHT);
+  }
+
+  @Override
+  public void paintInstance(InstancePainter painter) {
+    AttributeSet attrs = painter.getAttributeSet();
+    final var g = painter.getGraphics();
+    var metric = g.getFontMetrics();
+
+    final var bds = painter.getBounds();
+    final var x0 = bds.getX() + (bds.getWidth() / 2);
+    final var y0 = bds.getY() + metric.getHeight() + 12;
+    g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
+    GraphicsUtil.drawText(
+        g,
+        StringUtil.resizeString(getGIAttributesName(attrs), metric, WIDTH),
+        x0,
+        y0,
+        GraphicsUtil.H_CENTER,
+        GraphicsUtil.V_BOTTOM);
+
+    final var glbLabel = painter.getAttributeValue(StdAttr.LABEL);
+    if (glbLabel != null) {
+      final var font = g.getFont();
+      g.setFont(painter.getAttributeValue(StdAttr.LABEL_FONT));
+      GraphicsUtil.drawCenteredText(
+          g, glbLabel, bds.getX() + bds.getWidth() / 2, bds.getY() - g.getFont().getSize());
+      g.setFont(font);
+    }
+
+    g.setColor(new Color(AppPreferences.COMPONENT_SECONDARY_COLOR.get()));
+    g.setFont(g.getFont().deriveFont((float) 10));
+    metric = g.getFontMetrics();
+
+    final var inputs = getGIAttributesInputs(attrs);
+    final var outputs = getGIAttributesOutputs(attrs);
+
+    for (var i = 0; i < inputs.length; i++)
+      GraphicsUtil.drawText(
+          g,
+          StringUtil.resizeString(inputs[i].getToolTip(), metric, (WIDTH / 2) - X_PADDING),
+          bds.getX() + 5,
+          bds.getY() + HEIGHT - 2 + (i * PORT_GAP),
+          GraphicsUtil.H_LEFT,
+          GraphicsUtil.V_CENTER);
+    for (var i = 0; i < outputs.length; i++)
+      GraphicsUtil.drawText(
+          g,
+          StringUtil.resizeString(outputs[i].getToolTip(), metric, (WIDTH / 2) - X_PADDING),
+          bds.getX() + WIDTH - 5,
+          bds.getY() + HEIGHT - 2 + (i * PORT_GAP),
+          GraphicsUtil.H_RIGHT,
+          GraphicsUtil.V_CENTER);
+
+    g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
+    painter.drawBounds();
+    painter.drawPorts();
+  }
+
+  /**
+   * Get the chip name for the given attributes.
+   */
+  protected abstract String getGIAttributesName(AttributeSet attrs);
+
+  /**
+   * Get the input ports for the given attributes.
+   * The returned value is not to be modified.
+   */
+  protected abstract Port[] getGIAttributesInputs(AttributeSet attrs);
+
+  /**
+   * Get the output ports for the given attributes.
+   * The returned value is not to be modified.
+   */
+  protected abstract Port[] getGIAttributesOutputs(AttributeSet attrs);
+
+  /**
+   * Called by subclasses when something happens which changes anything affecting getGIAttributes* functions.
+   */
+  protected void updatePorts(Instance instance) {
+    Port[] inputs = getGIAttributesInputs(instance.getAttributeSet());
+    Port[] outputs = getGIAttributesOutputs(instance.getAttributeSet());
+    Port[] result = Arrays.copyOf(inputs, inputs.length + outputs.length);
+    System.arraycopy(outputs, 0, result, inputs.length, outputs.length);
+    instance.setPorts(result);
+    instance.recomputeBounds();
+  }
+
+}

--- a/src/main/java/com/cburch/logisim/std/hdl/GenericInterfaceComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/GenericInterfaceComponent.java
@@ -11,8 +11,6 @@ package com.cburch.logisim.std.hdl;
 
 import static com.cburch.logisim.vhdl.Strings.S;
 
-import java.awt.Color;
-
 import com.cburch.hdl.HdlModel.PortDescription;
 import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.data.Bounds;
@@ -26,11 +24,14 @@ import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.util.GraphicsUtil;
 import com.cburch.logisim.util.StringGetter;
 import com.cburch.logisim.util.StringUtil;
+import java.awt.Color;
 
 /**
  * Base class.
- * This base class provides a standard port layout and drawing code for generic logic interfaces (like for VHDL).
- * It does not assume much about the target; the goal is simply to keep the port layout code in one place.
+ * This base class provides a standard port layout
+ *  and drawing code for generic logic interfaces (like for VHDL).
+ * It does not assume much about the target;
+ *  the goal is simply to keep the port layout code in one place.
  */
 public abstract class GenericInterfaceComponent extends InstanceFactory {
   public GenericInterfaceComponent(String name,
@@ -48,8 +49,8 @@ public abstract class GenericInterfaceComponent extends InstanceFactory {
 
   @Override
   public Bounds getOffsetBounds(AttributeSet attrs) {
-    int nbInputs = getGIAttributesInputs(attrs).length;
-    int nbOutputs = getGIAttributesOutputs(attrs).length;
+    int nbInputs = getGiAttributesInputs(attrs).length;
+    int nbOutputs = getGiAttributesOutputs(attrs).length;
     return Bounds.create(0, 0, WIDTH, Math.max(nbInputs, nbOutputs) * PORT_GAP + HEIGHT);
   }
 
@@ -65,7 +66,7 @@ public abstract class GenericInterfaceComponent extends InstanceFactory {
     g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
     GraphicsUtil.drawText(
         g,
-        StringUtil.resizeString(getGIAttributesName(attrs), metric, WIDTH),
+        StringUtil.resizeString(getGiAttributesName(attrs), metric, WIDTH),
         x0,
         y0,
         GraphicsUtil.H_CENTER,
@@ -87,10 +88,10 @@ public abstract class GenericInterfaceComponent extends InstanceFactory {
     g.setFont(g.getFont().deriveFont((float) 10));
     metric = g.getFontMetrics();
 
-    final var inputs = getGIAttributesInputs(attrs);
-    final var outputs = getGIAttributesOutputs(attrs);
+    final var inputs = getGiAttributesInputs(attrs);
+    final var outputs = getGiAttributesOutputs(attrs);
 
-    for (var i = 0; i < inputs.length; i++)
+    for (var i = 0; i < inputs.length; i++) {
       GraphicsUtil.drawText(
           g,
           StringUtil.resizeString(inputs[i].getName(), metric, (WIDTH / 2) - X_PADDING),
@@ -98,7 +99,8 @@ public abstract class GenericInterfaceComponent extends InstanceFactory {
           bds.getY() + HEIGHT - 2 + (i * PORT_GAP),
           GraphicsUtil.H_LEFT,
           GraphicsUtil.V_CENTER);
-    for (var i = 0; i < outputs.length; i++)
+    }
+    for (var i = 0; i < outputs.length; i++) {
       GraphicsUtil.drawText(
           g,
           StringUtil.resizeString(outputs[i].getName(), metric, (WIDTH / 2) - X_PADDING),
@@ -106,6 +108,7 @@ public abstract class GenericInterfaceComponent extends InstanceFactory {
           bds.getY() + HEIGHT - 2 + (i * PORT_GAP),
           GraphicsUtil.H_RIGHT,
           GraphicsUtil.V_CENTER);
+    }
 
     g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
     painter.drawBounds();
@@ -115,26 +118,27 @@ public abstract class GenericInterfaceComponent extends InstanceFactory {
   /**
    * Get the chip name for the given attributes.
    */
-  protected abstract String getGIAttributesName(AttributeSet attrs);
+  protected abstract String getGiAttributesName(AttributeSet attrs);
 
   /**
    * Get the input ports for the given attributes.
    * The returned value is not to be modified.
    */
-  protected abstract PortDescription[] getGIAttributesInputs(AttributeSet attrs);
+  protected abstract PortDescription[] getGiAttributesInputs(AttributeSet attrs);
 
   /**
    * Get the output ports for the given attributes.
    * The returned value is not to be modified.
    */
-  protected abstract PortDescription[] getGIAttributesOutputs(AttributeSet attrs);
+  protected abstract PortDescription[] getGiAttributesOutputs(AttributeSet attrs);
 
   /**
-   * Called by subclasses when something happens which changes anything affecting getGIAttributes* functions.
+   * Called by subclasses when something happens
+   *  which changes anything affecting getGiAttributes* functions.
    */
   protected void updatePorts(Instance instance) {
-    PortDescription[] inputs = getGIAttributesInputs(instance.getAttributeSet());
-    PortDescription[] outputs = getGIAttributesOutputs(instance.getAttributeSet());
+    PortDescription[] inputs = getGiAttributesInputs(instance.getAttributeSet());
+    PortDescription[] outputs = getGiAttributesOutputs(instance.getAttributeSet());
     Port[] result = new Port[inputs.length + outputs.length];
     int resultIndex = 0;
 

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlCircuitComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlCircuitComponent.java
@@ -1,0 +1,90 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.hdl;
+
+import java.util.WeakHashMap;
+
+import com.cburch.hdl.HdlModel;
+import com.cburch.hdl.HdlModelListener;
+import com.cburch.hdl.HdlModel.PortDescription;
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
+import com.cburch.logisim.instance.Instance;
+import com.cburch.logisim.util.StringGetter;
+
+/**
+ * Contains the code that refreshes the component's ports when the contents are changed, among other things.
+ */
+public abstract class HdlCircuitComponent<C extends HdlContent> extends GenericInterfaceComponent {
+  static class HdlCircuitListener implements HdlModelListener {
+
+    final Instance instance;
+
+    HdlCircuitListener(Instance instance) {
+      this.instance = instance;
+    }
+
+    @Override
+    public void contentSet(HdlModel source) {
+      // ((InstanceState)
+      // instance).getProject().getSimulator().getVhdlSimulator().fireInvalidated();
+      instance.fireInvalidated();
+      instance.recomputeBounds();
+    }
+  }
+
+  protected final WeakHashMap<Instance, HdlCircuitListener> contentListeners;
+  protected final Attribute<C> contentAttr;
+
+  public HdlCircuitComponent(String name, StringGetter displayName, HdlGeneratorFactory generator, boolean requiresGlobalClock, Attribute<C> contentAttr) {
+    super(name, displayName, generator, requiresGlobalClock);
+    this.contentListeners = new WeakHashMap<>();
+    this.contentAttr = contentAttr;
+  }
+
+  @Override
+  protected void configureNewInstance(Instance instance) {
+    final var content = instance.getAttributeValue(contentAttr);
+    final var listener = new HdlCircuitListener(instance);
+  
+    contentListeners.put(instance, listener);
+    content.addHdlModelListener(listener);
+  
+    instance.addAttributeListener();
+    updatePorts(instance);
+  }
+
+  @Override
+  protected final String getGIAttributesName(AttributeSet attrs) {
+    final var content = attrs.getValue(contentAttr);
+    return content.getName();
+  }
+
+  @Override
+  protected final PortDescription[] getGIAttributesInputs(AttributeSet attrs) {
+    final var content = attrs.getValue(contentAttr);
+    return content.getInputs();
+  }
+
+  @Override
+  protected final PortDescription[] getGIAttributesOutputs(AttributeSet attrs) {
+    final var content = attrs.getValue(contentAttr);
+    return content.getOutputs();
+  }
+
+  @Override
+  protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
+    if (attr == contentAttr) {
+      updatePorts(instance);
+    }
+  }
+
+}

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlCircuitComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlCircuitComponent.java
@@ -9,19 +9,19 @@
 
 package com.cburch.logisim.std.hdl;
 
-import java.util.WeakHashMap;
-
 import com.cburch.hdl.HdlModel;
-import com.cburch.hdl.HdlModelListener;
 import com.cburch.hdl.HdlModel.PortDescription;
+import com.cburch.hdl.HdlModelListener;
 import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.util.StringGetter;
+import java.util.WeakHashMap;
 
 /**
- * Contains the code that refreshes the component's ports when the contents are changed, among other things.
+ * Contains the code that refreshes the component's ports when contents are changed,
+ *  among other things.
  */
 public abstract class HdlCircuitComponent<C extends HdlContent> extends GenericInterfaceComponent {
   static class HdlCircuitListener implements HdlModelListener {
@@ -34,6 +34,7 @@ public abstract class HdlCircuitComponent<C extends HdlContent> extends GenericI
 
     @Override
     public void contentSet(HdlModel source) {
+      // This was commented in VhdlEntityListener before I moved it here.
       // ((InstanceState)
       // instance).getProject().getSimulator().getVhdlSimulator().fireInvalidated();
       instance.fireInvalidated();
@@ -44,7 +45,12 @@ public abstract class HdlCircuitComponent<C extends HdlContent> extends GenericI
   protected final WeakHashMap<Instance, HdlCircuitListener> contentListeners;
   protected final Attribute<C> contentAttr;
 
-  public HdlCircuitComponent(String name, StringGetter displayName, HdlGeneratorFactory generator, boolean requiresGlobalClock, Attribute<C> contentAttr) {
+  /**
+   * Creates the HdlCircuitComponent.
+   * This includes a lot of stuff.
+   */
+  public HdlCircuitComponent(String name, StringGetter displayName, HdlGeneratorFactory generator,
+      boolean requiresGlobalClock, Attribute<C> contentAttr) {
     super(name, displayName, generator, requiresGlobalClock);
     this.contentListeners = new WeakHashMap<>();
     this.contentAttr = contentAttr;
@@ -63,19 +69,19 @@ public abstract class HdlCircuitComponent<C extends HdlContent> extends GenericI
   }
 
   @Override
-  protected final String getGIAttributesName(AttributeSet attrs) {
+  protected final String getGiAttributesName(AttributeSet attrs) {
     final var content = attrs.getValue(contentAttr);
     return content.getName();
   }
 
   @Override
-  protected final PortDescription[] getGIAttributesInputs(AttributeSet attrs) {
+  protected final PortDescription[] getGiAttributesInputs(AttributeSet attrs) {
     final var content = attrs.getValue(contentAttr);
     return content.getInputs();
   }
 
   @Override
-  protected final PortDescription[] getGIAttributesOutputs(AttributeSet attrs) {
+  protected final PortDescription[] getGiAttributesOutputs(AttributeSet attrs) {
     final var content = attrs.getValue(contentAttr);
     return content.getOutputs();
   }

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlContent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlContent.java
@@ -14,6 +14,9 @@ import com.cburch.hdl.HdlModelListener;
 import com.cburch.logisim.util.EventSourceWeakSupport;
 import java.util.Arrays;
 
+/**
+ * HdlContent is a base class for attribute content that contains a simulatable HDL string.
+ */
 public abstract class HdlContent implements HdlModel, Cloneable {
 
   protected static <T> T[] concat(T[] first, T[] second) {

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlContentAttribute.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlContentAttribute.java
@@ -11,25 +11,31 @@ package com.cburch.logisim.std.hdl;
 
 import static com.cburch.logisim.vhdl.Strings.S;
 
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.gui.main.Frame;
+import com.cburch.logisim.proj.Project;
 import java.awt.Dialog;
 import java.awt.Window;
 import java.util.WeakHashMap;
 import java.util.function.Supplier;
 
-import com.cburch.logisim.data.Attribute;
-import com.cburch.logisim.gui.main.Frame;
-import com.cburch.logisim.proj.Project;
-
 /**
  * Universal code for any textual simulated HDL format.
  */
 public class HdlContentAttribute<C extends HdlContent> extends Attribute<C> {
+  /**
+   * Returns an HdlContentEditor to edit HdlContent.
+   * This is suitable for returning from getCellEditor.
+   */
   public static HdlContentEditor getContentEditor(Window source, HdlContent value, Project proj) {
     synchronized (windowRegistry) {
       HdlContentEditor ret = windowRegistry.get(value);
       if (ret == null) {
-        if (source instanceof Frame frame) ret = new HdlContentEditor(frame, proj, value);
-        else ret = new HdlContentEditor((Dialog) source, proj, value);
+        if (source instanceof Frame frame) {
+          ret = new HdlContentEditor(frame, proj, value);
+        } else {
+          ret = new HdlContentEditor((Dialog) source, proj, value);
+        }
         windowRegistry.put(value, ret);
       }
       return ret;
@@ -55,7 +61,9 @@ public class HdlContentAttribute<C extends HdlContent> extends Attribute<C> {
   @Override
   public C parse(String value) {
     C content = contentFactory.get();
-    if (!content.compare(value)) content.setContent(value);
+    if (!content.compare(value)) {
+      content.setContent(value);
+    }
     return content;
   }
 

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlContentAttribute.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlContentAttribute.java
@@ -1,0 +1,71 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.hdl;
+
+import static com.cburch.logisim.vhdl.Strings.S;
+
+import java.awt.Dialog;
+import java.awt.Window;
+import java.util.WeakHashMap;
+import java.util.function.Supplier;
+
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.gui.main.Frame;
+import com.cburch.logisim.proj.Project;
+
+/**
+ * Universal code for any textual simulated HDL format.
+ */
+public class HdlContentAttribute<C extends HdlContent> extends Attribute<C> {
+  public static HdlContentEditor getContentEditor(Window source, HdlContent value, Project proj) {
+    synchronized (windowRegistry) {
+      HdlContentEditor ret = windowRegistry.get(value);
+      if (ret == null) {
+        if (source instanceof Frame frame) ret = new HdlContentEditor(frame, proj, value);
+        else ret = new HdlContentEditor((Dialog) source, proj, value);
+        windowRegistry.put(value, ret);
+      }
+      return ret;
+    }
+  }
+
+  private static final WeakHashMap<HdlContent, HdlContentEditor> windowRegistry =
+      new WeakHashMap<>();
+
+  private final Supplier<C> contentFactory;
+
+  public HdlContentAttribute(Supplier<C> creator) {
+    super("content", S.getter("vhdlContentAttr"));
+    this.contentFactory = creator;
+  }
+
+  @Override
+  public java.awt.Component getCellEditor(Window source, C value) {
+    final var proj = (source instanceof Frame frame) ? frame.getProject() : null;
+    return getContentEditor(source, value, proj);
+  }
+
+  @Override
+  public C parse(String value) {
+    C content = contentFactory.get();
+    if (!content.compare(value)) content.setContent(value);
+    return content;
+  }
+
+  @Override
+  public String toDisplayString(HdlContent value) {
+    return S.get("vhdlContentValue");
+  }
+
+  @Override
+  public String toStandardString(HdlContent value) {
+    return value.getContent();
+  }
+}

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlLibrary.java
@@ -17,6 +17,10 @@ import com.cburch.logisim.tools.Library;
 import com.cburch.logisim.tools.Tool;
 import java.util.List;
 
+/**
+ * Contains the HDL-IP library.
+ * This library contains components for simulating HDL entities in Logisim. 
+ */
 public class HdlLibrary extends Library {
 
   /**

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlLibrary.java
@@ -28,8 +28,10 @@ public class HdlLibrary extends Library {
   public static final String _ID = "HDL-IP";
 
   private static final FactoryDescription[] DESCRIPTIONS = {
-    new FactoryDescription(
-        VhdlEntityComponent.class, S.getter("vhdlComponent"), new ArithmeticIcon("VHDL")),
+      new FactoryDescription(
+          VhdlEntityComponent.class, S.getter("vhdlComponent"), new ArithmeticIcon("VHDL")),
+      new FactoryDescription(
+          BlifCircuitComponent.class, S.getter("blifComponent"), new ArithmeticIcon("BLIF"))
   };
 
   private List<Tool> tools = null;

--- a/src/main/java/com/cburch/logisim/std/hdl/VhdlContentComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/VhdlContentComponent.java
@@ -25,8 +25,15 @@ import java.util.logging.Logger;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 
+/**
+ * VhdlContentComponent connects the VHDL interface parser with other code.
+ * (The parsed VHDL interface is then used for the ports of a VHDL entity component.)
+ */
 public class VhdlContentComponent extends HdlContent {
 
+  /**
+   * Creates a new VhdlContentComponent.
+   */
   public static VhdlContentComponent create() {
     return new VhdlContentComponent();
   }
@@ -47,7 +54,9 @@ public class VhdlContentComponent extends HdlContent {
       return "";
     } finally {
       try {
-        if (input != null) input.close();
+        if (input != null) {
+          input.close();
+        }
       } catch (IOException ex) {
         Logger.getLogger(VhdlContentComponent.class.getName()).log(Level.SEVERE, null, ex);
       }
@@ -95,8 +104,13 @@ public class VhdlContentComponent extends HdlContent {
         .equals(value.replaceAll("\\r\\n|\\r|\\n", " "));
   }
 
+  /**
+   * Returns the detected VHDL architecture.
+   */
   public String getArchitecture() {
-    if (architecture == null) return "";
+    if (architecture == null) {
+      return "";
+    }
 
     return architecture;
   }
@@ -108,55 +122,43 @@ public class VhdlContentComponent extends HdlContent {
 
   @Override
   public PortDescription[] getInputs() {
-    if (inputs == null) return new PortDescription[0];
-
-    return inputs;
+    return inputs == null ? new PortDescription[0] : inputs;
   }
 
   public int getInputsNumber() {
-    if (inputs == null) return 0;
-
-    return inputs.length;
+    return inputs == null ? 0 : inputs.length;
   }
 
   public String getLibraries() {
-    if (libraries == null) return "";
-
-    return libraries;
+    return libraries == null ? "" : libraries;
   }
 
   @Override
   public String getName() {
-    if (name == null) return "";
-
-    return name;
+    return name == null ? "" : name;
   }
 
   @Override
   public PortDescription[] getOutputs() {
-    if (outputs == null) return new PortDescription[0];
-
-    return outputs;
+    return outputs == null ? new PortDescription[0] : outputs;
   }
 
   public int getOutputsNumber() {
-    if (outputs == null) return 0;
-
-    return outputs.length;
+    return outputs == null ? 0 : outputs.length;
   }
 
   public PortDescription[] getPorts() {
-    if (inputs == null || outputs == null) return new PortDescription[0];
-
-    return concat(inputs, outputs);
+    return (inputs == null || outputs == null) ? new PortDescription[0] : concat(inputs, outputs);
   }
 
   public int getPortsNumber() {
-    if (inputs == null || outputs == null) return 0;
-
-    return inputs.length + outputs.length;
+    return (inputs == null || outputs == null) ? 0 : inputs.length + outputs.length;
   }
 
+  /**
+   * Parses the content.
+   * This is the 'guts' of setContent, after external validation may have been performed.
+   */
   public boolean parseContent(String content) {
     final var parser = new VhdlParser(content);
     try {
@@ -214,8 +216,9 @@ public class VhdlContentComponent extends HdlContent {
         return false;
       case Softwares.SUCCESS:
         return parseContent(content);
+      default:
+        // This is not a change in behaviour, but had to be moved during linting.
+        return false;
     }
-
-    return false;
   }
 }

--- a/src/main/java/com/cburch/logisim/std/hdl/VhdlEntityAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/VhdlEntityAttributes.java
@@ -17,6 +17,10 @@ import java.awt.Font;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * VhdlEntityAttributes is a special attribute set.
+ * This attribute set is unique in setting up and cloning the VhdlContentComponent.
+ */
 public class VhdlEntityAttributes extends AbstractAttributeSet {
 
   private static final List<Attribute<?>> attributes =
@@ -75,29 +79,39 @@ public class VhdlEntityAttributes extends AbstractAttributeSet {
   public <V> void setValue(Attribute<V> attr, V value) {
     if (attr == VhdlEntityComponent.CONTENT_ATTR) {
       final var newContent = (VhdlContentComponent) value;
-      if (!content.equals(newContent)) content = newContent;
+      if (!content.equals(newContent)) {
+        content = newContent;
+      }
       fireAttributeValueChanged(attr, value, null);
     }
     if (attr == StdAttr.LABEL && value instanceof String newLabel) {
       final var oldlabel = label;
-      if (label.equals(newLabel)) return;
+      if (label.equals(newLabel)) {
+        return;
+      }
       label = newLabel;
       fireAttributeValueChanged(attr, value, (V) oldlabel);
     }
     if (attr == StdAttr.LABEL_FONT && value instanceof Font newFont) {
-      if (labelFont.equals(newFont)) return;
+      if (labelFont.equals(newFont)) {
+        return;
+      }
       labelFont = newFont;
       fireAttributeValueChanged(attr, value, null);
     }
     if (attr == StdAttr.LABEL_VISIBILITY) {
       final var newVis = (Boolean) value;
-      if (labelVisible.equals(newVis)) return;
+      if (labelVisible.equals(newVis)) {
+        return;
+      }
       labelVisible = newVis;
       fireAttributeValueChanged(attr, value, null);
     }
     if (attr == VhdlSimConstants.SIM_NAME_ATTR) {
       final var name = (String) value;
-      if (value.equals(simName)) return;
+      if (value.equals(simName)) {
+        return;
+      }
       simName = name;
       fireAttributeValueChanged(attr, value, null);
     }

--- a/src/main/java/com/cburch/logisim/std/hdl/VhdlEntityComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/VhdlEntityComponent.java
@@ -25,35 +25,54 @@ import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Simulated VHDL entity via external tool.
+ */
 public class VhdlEntityComponent extends HdlCircuitComponent<VhdlContentComponent> {
   /**
    * Unique identifier of the tool, used as reference in project files.
    * Do NOT change as it will prevent project files from loading.
-   *
    * Identifier value must MUST be unique string among all tools.
    */
   public static final String _ID = "VHDL Entity";
 
   static final Logger logger = LoggerFactory.getLogger(VhdlEntityComponent.class);
 
-  public static final Attribute<VhdlContentComponent> CONTENT_ATTR = new HdlContentAttribute<>(VhdlContentComponent::create);
+  public static final Attribute<VhdlContentComponent> CONTENT_ATTR =
+      new HdlContentAttribute<>(VhdlContentComponent::create);
 
+  /**
+   * Creates a VhdlEntityComponent.
+   */
   public VhdlEntityComponent() {
     super(_ID, S.getter("vhdlComponent"), new VhdlHdlGeneratorFactory(), true, CONTENT_ATTR);
 
     this.setIcon(new ArithmeticIcon("VHDL"));
   }
 
-  public void setSimName(AttributeSet attrs, String SName) {
-    if (attrs == null) return;
+  /**
+   * During the process of preparing files for the simulator, the name of each simulated component
+   *  must be set. These simulation names are stored in the component attributes.
+   * The given name will be ignored if a label has been set by the user.
+   */
+  public void setSimName(AttributeSet attrs, String simName) {
+    if (attrs == null) {
+      return;
+    }
     final var atrs = (VhdlEntityAttributes) attrs;
-    final var label = (!attrs.getValue(StdAttr.LABEL).equals("")) ? getHDLTopName(attrs) : SName;
-    if (atrs.containsAttribute(VhdlSimConstants.SIM_NAME_ATTR))
+    final var label = (!attrs.getValue(StdAttr.LABEL).equals("")) ? getHDLTopName(attrs) : simName;
+    if (atrs.containsAttribute(VhdlSimConstants.SIM_NAME_ATTR)) {
       atrs.setValue(VhdlSimConstants.SIM_NAME_ATTR, label);
+    }
   }
 
+  /**
+   * Retrieves the simulation name. Can return null in some cases.
+   */
   public String getSimName(AttributeSet attrs) {
-    if (attrs == null) return null;
+    if (attrs == null) {
+      return null;
+    }
     final var atrs = (VhdlEntityAttributes) attrs;
     return atrs.getValue(VhdlSimConstants.SIM_NAME_ATTR);
   }
@@ -118,12 +137,12 @@ public class VhdlEntityComponent extends HdlCircuitComponent<VhdlContentComponen
       vhdlSimulator.send("sync");
 
       /* Get response from tcl server */
-      String server_response;
-      while ((server_response = vhdlSimulator.receive()) != null
-          && server_response.length() > 0
-          && !server_response.equals("sync")) {
+      String serverResponse;
+      while ((serverResponse = vhdlSimulator.receive()) != null
+          && serverResponse.length() > 0
+          && !serverResponse.equals("sync")) {
 
-        final var parameters = server_response.split(":");
+        final var parameters = serverResponse.split(":");
 
         final var busValue = parameters[1];
 
@@ -164,7 +183,8 @@ public class VhdlEntityComponent extends HdlCircuitComponent<VhdlContentComponen
       }
 
       throw new UnsupportedOperationException(
-          "VHDL component simulation is not supported. This could be because there is no Questasim/Modelsim simulation server running.");
+          "VHDL component simulation is not supported."
+          + " This could be because there is no Questasim/Modelsim simulation server running.");
     }
   }
 

--- a/src/main/java/com/cburch/logisim/std/hdl/VhdlEntityComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/VhdlEntityComponent.java
@@ -19,11 +19,9 @@ import com.cburch.logisim.instance.InstanceState;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.vhdl.base.VhdlSimConstants;
 import com.cburch.logisim.vhdl.sim.VhdlSimulatorTop;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/cburch/logisim/std/hdl/VhdlEntityComponent.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/VhdlEntityComponent.java
@@ -15,21 +15,15 @@ import com.cburch.hdl.HdlModel;
 import com.cburch.hdl.HdlModelListener;
 import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.data.AttributeSet;
-import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Value;
 import com.cburch.logisim.gui.icons.ArithmeticIcon;
 import com.cburch.logisim.gui.main.Frame;
 import com.cburch.logisim.instance.Instance;
-import com.cburch.logisim.instance.InstanceFactory;
-import com.cburch.logisim.instance.InstancePainter;
 import com.cburch.logisim.instance.InstanceState;
+import com.cburch.logisim.instance.Port;
 import com.cburch.logisim.instance.StdAttr;
-import com.cburch.logisim.prefs.AppPreferences;
-import com.cburch.logisim.util.GraphicsUtil;
-import com.cburch.logisim.util.StringUtil;
 import com.cburch.logisim.vhdl.base.VhdlSimConstants;
 import com.cburch.logisim.vhdl.sim.VhdlSimulatorTop;
-import java.awt.Color;
 import java.awt.Window;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -38,7 +32,7 @@ import java.util.WeakHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class VhdlEntityComponent extends InstanceFactory {
+public class VhdlEntityComponent extends GenericInterfaceComponent {
   /**
    * Unique identifier of the tool, used as reference in project files.
    * Do NOT change as it will prevent project files from loading.
@@ -97,11 +91,6 @@ public class VhdlEntityComponent extends InstanceFactory {
   static final Logger logger = LoggerFactory.getLogger(VhdlEntityComponent.class);
 
   public static final Attribute<VhdlContentComponent> CONTENT_ATTR = new ContentAttribute();
-  static final int WIDTH = 140;
-  static final int HEIGHT = 40;
-  static final int PORT_GAP = 10;
-
-  static final int X_PADDING = 5;
 
   private final WeakHashMap<Instance, VhdlEntityListener> contentListeners;
 
@@ -159,76 +148,28 @@ public class VhdlEntityComponent extends InstanceFactory {
   }
 
   @Override
-  public Bounds getOffsetBounds(AttributeSet attrs) {
+  protected String getGIAttributesName(AttributeSet attrs) {
     final var content = attrs.getValue(CONTENT_ATTR);
-    final var nbInputs = content.getInputsNumber();
-    final var nbOutputs = content.getOutputsNumber();
+    return content.getName();
+  }
 
-    return Bounds.create(0, 0, WIDTH, Math.max(nbInputs, nbOutputs) * PORT_GAP + HEIGHT);
+  @Override
+  protected Port[] getGIAttributesInputs(AttributeSet attrs) {
+    final var content = attrs.getValue(CONTENT_ATTR);
+    return content.getInputs();
+  }
+
+  @Override
+  protected Port[] getGIAttributesOutputs(AttributeSet attrs) {
+    final var content = attrs.getValue(CONTENT_ATTR);
+    return content.getOutputs();
   }
 
   @Override
   protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
     if (attr == CONTENT_ATTR) {
       updatePorts(instance);
-      instance.recomputeBounds();
     }
-  }
-
-  @Override
-  public void paintInstance(InstancePainter painter) {
-    final var g = painter.getGraphics();
-    final var content = painter.getAttributeValue(CONTENT_ATTR);
-    var metric = g.getFontMetrics();
-
-    final var bds = painter.getBounds();
-    final var x0 = bds.getX() + (bds.getWidth() / 2);
-    final var y0 = bds.getY() + metric.getHeight() + 12;
-    g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
-    GraphicsUtil.drawText(
-        g,
-        StringUtil.resizeString(content.getName(), metric, WIDTH),
-        x0,
-        y0,
-        GraphicsUtil.H_CENTER,
-        GraphicsUtil.V_BOTTOM);
-
-    final var glbLabel = painter.getAttributeValue(StdAttr.LABEL);
-    if (glbLabel != null) {
-      final var font = g.getFont();
-      g.setFont(painter.getAttributeValue(StdAttr.LABEL_FONT));
-      GraphicsUtil.drawCenteredText(
-          g, glbLabel, bds.getX() + bds.getWidth() / 2, bds.getY() - g.getFont().getSize());
-      g.setFont(font);
-    }
-
-    g.setColor(new Color(AppPreferences.COMPONENT_SECONDARY_COLOR.get()));
-    g.setFont(g.getFont().deriveFont((float) 10));
-    metric = g.getFontMetrics();
-
-    final var inputs = content.getInputs();
-    final var outputs = content.getOutputs();
-
-    for (var i = 0; i < inputs.length; i++)
-      GraphicsUtil.drawText(
-          g,
-          StringUtil.resizeString(inputs[i].getToolTip(), metric, (WIDTH / 2) - X_PADDING),
-          bds.getX() + 5,
-          bds.getY() + HEIGHT - 2 + (i * PORT_GAP),
-          GraphicsUtil.H_LEFT,
-          GraphicsUtil.V_CENTER);
-    for (var i = 0; i < outputs.length; i++)
-      GraphicsUtil.drawText(
-          g,
-          StringUtil.resizeString(outputs[i].getToolTip(), metric, (WIDTH / 2) - X_PADDING),
-          bds.getX() + WIDTH - 5,
-          bds.getY() + HEIGHT - 2 + (i * PORT_GAP),
-          GraphicsUtil.H_RIGHT,
-          GraphicsUtil.V_CENTER);
-
-    g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
-    painter.drawBounds();
-    painter.drawPorts();
   }
 
   /**
@@ -342,10 +283,5 @@ public class VhdlEntityComponent extends InstanceFactory {
       logger.error("Could not create vhdl file: {}", e.getMessage());
       e.printStackTrace();
     }
-  }
-
-  void updatePorts(Instance instance) {
-    VhdlContentComponent content = instance.getAttributeValue(CONTENT_ATTR);
-    instance.setPorts(content.getPorts());
   }
 }

--- a/src/main/java/com/cburch/logisim/std/hdl/VhdlHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/VhdlHdlGeneratorFactory.java
@@ -15,9 +15,11 @@ import com.cburch.logisim.fpga.file.FileWriter;
 import com.cburch.logisim.fpga.hdlgenerator.AbstractHdlGeneratorFactory;
 import com.cburch.logisim.fpga.hdlgenerator.Hdl;
 import com.cburch.logisim.instance.Port;
-
 import java.util.ArrayList;
 
+/**
+ * Copies VHDL entities into generated output.
+ */
 public class VhdlHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
 
   public static final String HDL_DIRECTORY = "circuit";
@@ -33,10 +35,12 @@ public class VhdlHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     final var inputs = contents.getInputs();
     final var outputs = contents.getOutputs();
     var portId = 0;
-    for (final var input : inputs)
+    for (final var input : inputs) {
       myPorts.add(Port.INPUT, input.getName(), input.getWidthInt(), portId++);
-    for (final var output : outputs)
+    }
+    for (final var output : outputs) {
       myPorts.add(Port.OUTPUT, output.getName(), output.getWidthInt(), portId++);
+    }
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/hdl/VhdlHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/VhdlHdlGeneratorFactory.java
@@ -34,9 +34,9 @@ public class VhdlHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     final var outputs = contents.getOutputs();
     var portId = 0;
     for (final var input : inputs)
-      myPorts.add(Port.INPUT, input.getToolTip(), input.getFixedBitWidth().getWidth(), portId++);
+      myPorts.add(Port.INPUT, input.getName(), input.getWidthInt(), portId++);
     for (final var output : outputs)
-      myPorts.add(Port.OUTPUT, output.getToolTip(), output.getFixedBitWidth().getWidth(), portId++);
+      myPorts.add(Port.OUTPUT, output.getName(), output.getWidthInt(), portId++);
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/hdl/VhdlParser.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/VhdlParser.java
@@ -11,7 +11,7 @@ package com.cburch.logisim.std.hdl;
 
 import static com.cburch.logisim.vhdl.Strings.S;
 
-import com.cburch.logisim.data.BitWidth;
+import com.cburch.hdl.HdlModel.PortDescription;
 import com.cburch.logisim.instance.Port;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,15 +39,6 @@ public class VhdlParser {
 
     public IllegalVhdlContentException(Throwable cause) {
       super(cause);
-    }
-  }
-
-  // NOTE: silly members' names are mostly to avoid refactoring of the whole codebase due to record's
-  // getters not using Bean naming convention (so i.e. `foo()` instead of `getFoo()`. We may change
-  // that in future, but for now it looks stupid in this file only.
-  public record PortDescription(String getName, String getType, int getWidthInt, BitWidth getWidth) {
-    public PortDescription(String name, String type, int width) {
-      this(name, type, width, BitWidth.create(width));
     }
   }
 

--- a/src/main/java/com/cburch/logisim/std/hdl/VhdlParser.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/VhdlParser.java
@@ -19,8 +19,14 @@ import java.util.Scanner;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
+/**
+ * VhdlParser lightly parses VHDL using regexes to extract critical information.
+ */
 public class VhdlParser {
 
+  /**
+   * This exception is thrown when the VHDL content does not match Logisim's expectations.
+   */
   public static class IllegalVhdlContentException extends Exception {
 
     private static final long serialVersionUID = 1L;
@@ -42,7 +48,8 @@ public class VhdlParser {
     }
   }
 
-  private static final String ENTITY_PATTERN = "\\s*entity\\s+(\\w+)\\s+is\\s+(.*?end)\\s+(\\w+)\\s*;";
+  private static final String ENTITY_PATTERN =
+      "\\s*entity\\s+(\\w+)\\s+is\\s+(.*?end)\\s+(\\w+)\\s*;";
   private static final String ARCH_PATTERN = "\\s*architecture.*";
   private static final String LIBRARY_PATTERN = "\\s*library\\s+\\w+\\s*;";
   private static final String USING_PATTERN = "\\s*use\\s+\\S+\\s*;";
@@ -50,7 +57,8 @@ public class VhdlParser {
   private static final String PORTS_PATTERN = "\\s*port\\s*[(](.*)[)]\\s*;\\s*end";
   private static final String PORT_PATTERN = "\\s*(\\w+)\\s*";
   private static final String LINE_PATTERN = ":\\s*(\\w+)\\s+std_logic";
-  private static final String VECTOR_PATTERN = ":\\s*(\\w+)\\s+std_logic_vector\\s*[(]\\s*(\\d+)\\s+downto\\s+(\\d+)\\s*[)]";
+  private static final String VECTOR_PATTERN =
+      ":\\s*(\\w+)\\s+std_logic_vector\\s*[(]\\s*(\\d+)\\s+downto\\s+(\\d+)\\s*[)]";
 
   private final List<PortDescription> inputs;
   private final List<PortDescription> outputs;
@@ -59,6 +67,9 @@ public class VhdlParser {
   private String libraries;
   private String architecture;
 
+  /**
+   * Creates this VHDL parser with the given source code.
+   */
   public VhdlParser(String source) {
     this.source = source;
     this.inputs = new ArrayList<>();
@@ -69,17 +80,23 @@ public class VhdlParser {
     return architecture;
   }
 
-  private int getEOLIndex(String input, int from) {
+  private int getLineEndIndex(String input, int from) {
     int index;
 
     index = input.indexOf("\n", from);
-    if (index != -1) return index;
+    if (index != -1) {
+      return index;
+    }
 
     index = input.indexOf("\r\n", from);
-    if (index != -1) return index;
+    if (index != -1) {
+      return index;
+    }
 
     index = input.indexOf("\r", from);
-    if (index != -1) return index;
+    if (index != -1) {
+      return index;
+    }
 
     return input.length();
   }
@@ -101,13 +118,22 @@ public class VhdlParser {
   }
 
   private String getType(String type) throws IllegalVhdlContentException {
-    if (type.equals("in")) return Port.INPUT;
-    if (type.equals("out")) return Port.OUTPUT;
-    if (type.equals("inout")) return Port.INOUT;
+    if (type.equals("in")) {
+      return Port.INPUT;
+    }
+    if (type.equals("out")) {
+      return Port.OUTPUT;
+    }
+    if (type.equals("inout")) {
+      return Port.INOUT;
+    }
 
     throw new IllegalVhdlContentException(S.get("invalidTypeException"));
   }
 
+  /**
+   * Parses the VHDL, accumulating information in the fields of this object.
+   */
   public void parse() throws IllegalVhdlContentException {
     final var input = removeComments();
     final var pattern = Pattern.compile(ENTITY_PATTERN, Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
@@ -161,11 +187,14 @@ public class VhdlParser {
 
   private int parseLine(Scanner scanner, StringBuilder type) throws IllegalVhdlContentException {
     if (scanner.findWithinHorizon(Pattern.compile(LINE_PATTERN, Pattern.CASE_INSENSITIVE), 0)
-        == null) throw new IllegalVhdlContentException(S.get("lineDeclarationException"));
+        == null) {
+      throw new IllegalVhdlContentException(S.get("lineDeclarationException"));
+    }
     MatchResult result = scanner.match();
 
-    if (result.groupCount() != 1)
+    if (result.groupCount() != 1) {
       throw new IllegalVhdlContentException(S.get("lineDeclarationException"));
+    }
     type.append(getType(result.group(1).toLowerCase()));
 
     return 1;
@@ -173,29 +202,35 @@ public class VhdlParser {
 
   private void parseMultiplePorts(String line) throws IllegalVhdlContentException {
     final var index = line.indexOf(':');
-    if (index == -1)
+    if (index == -1) {
       throw new IllegalVhdlContentException(S.get("multiplePortsDeclarationException"));
+    }
 
     var local = new Scanner(line.substring(0, index));
     local.useDelimiter(",");
 
     final var names = new ArrayList<String>();
-    while (local.hasNext()) names.add(local.next().trim());
+    while (local.hasNext()) {
+      names.add(local.next().trim());
+    }
 
     local.close();
     local = new Scanner(line);
 
     int width;
     final var type = new StringBuilder();
-    if (line.toLowerCase().contains("std_logic_vector"))
+    if (line.toLowerCase().contains("std_logic_vector")) {
       width = parseVector(local, type);
-    else
+    } else {
       width = parseLine(local, type);
+    }
 
     for (final var name : names) {
-      if (type.toString().equals(Port.INPUT))
+      if (type.toString().equals(Port.INPUT)) {
         inputs.add(new PortDescription(name, type.toString(), width));
-      else outputs.add(new PortDescription(name, type.toString(), width));
+      } else {
+        outputs.add(new PortDescription(name, type.toString(), width));
+      }
     }
 
     local.close();
@@ -213,15 +248,17 @@ public class VhdlParser {
 
     int width;
     final var type = new StringBuilder();
-    if (line.toLowerCase().contains("std_logic_vector"))
+    if (line.toLowerCase().contains("std_logic_vector")) {
       width = parseVector(local, type);
-    else
+    } else {
       width = parseLine(local, type);
+    }
 
-    if (type.toString().equals(Port.INPUT))
+    if (type.toString().equals(Port.INPUT)) {
       inputs.add(new PortDescription(name, type.toString(), width));
-    else
+    } else {
       outputs.add(new PortDescription(name, type.toString(), width));
+    }
 
     local.close();
   }
@@ -229,15 +266,20 @@ public class VhdlParser {
   private void parsePorts(String input) throws IllegalVhdlContentException {
     final var matcher =
         Pattern.compile(PORTS_PATTERN, Pattern.DOTALL | Pattern.CASE_INSENSITIVE).matcher(input);
-    if (!matcher.find() || matcher.groupCount() != 1) return;
+    if (!matcher.find() || matcher.groupCount() != 1) {
+      return;
+    }
     final var ports = matcher.group(1);
 
     final var scanner = new Scanner(ports);
     scanner.useDelimiter(";");
     while (scanner.hasNext()) {
       final var statement = scanner.next();
-      if (statement.contains(",")) parseMultiplePorts(statement.trim());
-      else parsePort(statement.trim());
+      if (statement.contains(",")) {
+        parseMultiplePorts(statement.trim());
+      } else {
+        parsePort(statement.trim());
+      }
     }
 
     scanner.close();
@@ -245,11 +287,14 @@ public class VhdlParser {
 
   private int parseVector(Scanner scanner, StringBuilder type) throws IllegalVhdlContentException {
     if (scanner.findWithinHorizon(Pattern.compile(VECTOR_PATTERN, Pattern.CASE_INSENSITIVE), 0)
-        == null) throw new IllegalVhdlContentException(S.get("vectorDeclarationException"));
+        == null) {
+      throw new IllegalVhdlContentException(S.get("vectorDeclarationException"));
+    }
     final var result = scanner.match();
 
-    if (result.groupCount() != 3)
+    if (result.groupCount() != 3) {
       throw new IllegalVhdlContentException(S.get("vectorDeclarationException"));
+    }
     type.append(getType(result.group(1).toLowerCase()));
 
     return Integer.parseInt(result.group(2)) - Integer.parseInt(result.group(3)) + 1;
@@ -265,7 +310,7 @@ public class VhdlParser {
 
     int from;
     while ((from = input.indexOf("--")) != -1) {
-      int to = getEOLIndex(input.toString(), from);
+      int to = getLineEndIndex(input.toString(), from);
       input.delete(from, to);
     }
 

--- a/src/main/java/com/cburch/logisim/std/tcl/TclGeneric.java
+++ b/src/main/java/com/cburch/logisim/std/tcl/TclGeneric.java
@@ -18,6 +18,7 @@ import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.instance.InstancePainter;
+import com.cburch.logisim.instance.Port;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.std.hdl.VhdlContentComponent;
@@ -174,7 +175,7 @@ public class TclGeneric extends TclComponent {
     for (var i = 0; i < inputs.length; i++)
       GraphicsUtil.drawText(
           g,
-          StringUtil.resizeString(inputs[i].getToolTip(), metric, (WIDTH / 2) - X_PADDING),
+          StringUtil.resizeString(inputs[i].getName(), metric, (WIDTH / 2) - X_PADDING),
           bds.getX() + 5,
           bds.getY() + HEIGHT - 2 + (i * PORT_GAP),
           GraphicsUtil.H_LEFT,
@@ -182,7 +183,7 @@ public class TclGeneric extends TclComponent {
     for (var i = 0; i < outputs.length; i++)
       GraphicsUtil.drawText(
           g,
-          StringUtil.resizeString(outputs[i].getToolTip(), metric, (WIDTH / 2) - X_PADDING),
+          StringUtil.resizeString(outputs[i].getName(), metric, (WIDTH / 2) - X_PADDING),
           bds.getX() + WIDTH - 5,
           bds.getY() + HEIGHT - 2 + (i * PORT_GAP),
           GraphicsUtil.H_RIGHT,
@@ -195,7 +196,39 @@ public class TclGeneric extends TclComponent {
   @Override
   void updatePorts(Instance instance) {
     final var content = instance.getAttributeValue(CONTENT_ATTR);
-    instance.setPorts(content.getPorts());
-    setPorts(content.getPorts());
+    HdlModel.PortDescription[] inputs = content.getInputs();
+    HdlModel.PortDescription[] outputs = content.getOutputs();
+
+    Port[] result = new Port[inputs.length + outputs.length];
+    int resultIndex = 0;
+
+    int i = 0;
+    for (var desc : inputs) {
+      result[resultIndex] =
+          new Port(
+              0,
+              (i * PORT_GAP) + HEIGHT,
+              desc.getType(),
+              desc.getWidth());
+      result[resultIndex].setToolTip(S.getter(desc.getName()));
+      resultIndex++;
+      i++;
+    }
+
+    i = 0;
+    for (var desc : outputs) {
+      result[resultIndex] =
+          new Port(
+              WIDTH,
+              (i * PORT_GAP) + HEIGHT,
+              desc.getType(),
+              desc.getWidth());
+      result[resultIndex].setToolTip(S.getter(desc.getName()));
+      resultIndex++;
+      i++;
+    }
+
+    instance.setPorts(result);
+    setPorts(result);
   }
 }

--- a/src/main/java/com/cburch/logisim/std/tcl/TclGeneric.java
+++ b/src/main/java/com/cburch/logisim/std/tcl/TclGeneric.java
@@ -38,7 +38,6 @@ public class TclGeneric extends TclComponent {
   /**
    * Unique identifier of the tool, used as reference in project files.
    * Do NOT change as it will prevent project files from loading.
-   *
    * Identifier value must MUST be unique string among all tools.
    */
   public static final String _ID = "TclGeneric";
@@ -61,7 +60,9 @@ public class TclGeneric extends TclComponent {
     @Override
     public VhdlContentComponent parse(String value) {
       final var content = VhdlContentComponent.create();
-      if (!content.compare(value)) content.setContent(value);
+      if (!content.compare(value)) {
+        content.setContent(value);
+      }
       return content;
     }
 
@@ -95,6 +96,9 @@ public class TclGeneric extends TclComponent {
 
   private final WeakHashMap<Instance, TclGenericListener> contentListeners;
 
+  /**
+   * Creates a TclGeneric component.
+   */
   public TclGeneric() {
     super(_ID, S.getter("tclGeneric"));
 
@@ -162,7 +166,8 @@ public class TclGeneric extends TclComponent {
     if (glbLabel != null) {
       final var font = g.getFont();
       g.setFont(painter.getAttributeValue(StdAttr.LABEL_FONT));
-      GraphicsUtil.drawCenteredText(g, glbLabel, bds.getX() + bds.getWidth() / 2, bds.getY() - g.getFont().getSize());
+      GraphicsUtil.drawCenteredText(g, glbLabel,
+          bds.getX() + bds.getWidth() / 2, bds.getY() - g.getFont().getSize());
       g.setFont(font);
     }
 
@@ -172,7 +177,7 @@ public class TclGeneric extends TclComponent {
     final var inputs = content.getInputs();
     final var outputs = content.getOutputs();
 
-    for (var i = 0; i < inputs.length; i++)
+    for (var i = 0; i < inputs.length; i++) {
       GraphicsUtil.drawText(
           g,
           StringUtil.resizeString(inputs[i].getName(), metric, (WIDTH / 2) - X_PADDING),
@@ -180,7 +185,8 @@ public class TclGeneric extends TclComponent {
           bds.getY() + HEIGHT - 2 + (i * PORT_GAP),
           GraphicsUtil.H_LEFT,
           GraphicsUtil.V_CENTER);
-    for (var i = 0; i < outputs.length; i++)
+    }
+    for (var i = 0; i < outputs.length; i++) {
       GraphicsUtil.drawText(
           g,
           StringUtil.resizeString(outputs[i].getName(), metric, (WIDTH / 2) - X_PADDING),
@@ -188,6 +194,7 @@ public class TclGeneric extends TclComponent {
           bds.getY() + HEIGHT - 2 + (i * PORT_GAP),
           GraphicsUtil.H_RIGHT,
           GraphicsUtil.V_CENTER);
+    }
 
     painter.drawBounds();
     painter.drawPorts();

--- a/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorVhdlTop.java
+++ b/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorVhdlTop.java
@@ -90,7 +90,7 @@ public class VhdlSimulatorVhdlTop {
             state.getAttributeValue(VhdlEntityComponent.CONTENT_ATTR).getPorts()) {
           VhdlParser.PortDescription nport =
               new VhdlParser.PortDescription(
-                  port.getToolTip(), type[port.getType()], port.getFixedBitWidth().getWidth());
+                  port.getName(), port.getType(), port.getWidthInt());
           myPorts.add(nport);
         }
       }

--- a/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorVhdlTop.java
+++ b/src/main/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorVhdlTop.java
@@ -19,7 +19,6 @@ import com.cburch.logisim.vhdl.base.VhdlEntity;
 import com.cburch.logisim.vhdl.base.VhdlEntityAttributes;
 import com.cburch.logisim.vhdl.base.VhdlParser;
 import com.cburch.logisim.vhdl.base.VhdlSimConstants;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
@@ -52,9 +51,14 @@ public class VhdlSimulatorVhdlTop {
     valid = false;
   }
 
+  /**
+   * If the top file has been invalidated, regenerates the VHDL top file.
+   */
   public void generate(List<Component> comps) {
     /* Do not generate if file is already valid */
-    if (valid) return;
+    if (valid) {
+      return;
+    }
 
     final var lineSeparator = System.getProperty("line.separator");
 

--- a/src/main/resources/resources/logisim/hdl/blif.templ
+++ b/src/main/resources/resources/logisim/hdl/blif.templ
@@ -40,7 +40,7 @@
 # read_verilog example.v
 # read_verilog -lib yosys-cmos/cmos_cells.v
 # check -assert
-# synth -top example
+# synth -flatten -top example
 # dfflibmap -liberty yosys-cmos/cmos_cells.lib
 # abc -liberty yosys-cmos/cmos_cells.lib
 # opt_clean

--- a/src/main/resources/resources/logisim/hdl/blif.templ
+++ b/src/main/resources/resources/logisim/hdl/blif.templ
@@ -1,0 +1,70 @@
+# A subset of BLIF is supported.
+# Only one model is defined.
+# All lines not beginning with '.' (after trimming) are ignored.
+# Custom gates (via truth table) cannot be specified.
+# Instead, a set of predefined subcircuits exist for various gates.
+
+# The value of the .model statement is usually set to the top module name.
+# For that reason, it is used to set a visible label.
+
+.model lightswitch
+.inputs button reset
+.outputs light_out
+
+# These three .names statements are the only .names statements permitted.
+# They are ignored.
+.names $false
+.names $true
+1
+.names $undef
+
+# gates can be placed with .subckt or .gate.
+# An example of a binary gate would be: .subckt OR A=in_a B=in_b Y=output
+# Various gates are supported.
+# However, the definition of new subcircuits is not supported.
+# The expectation is that your BLIF will come from synthesis.
+.subckt NOT A=light Y=light_inv
+.subckt DFFSR C=button D=light_inv Q=light R=reset S=$false
+
+# Buffers may be specified using the BUF gate, similar to NOT above.
+# '.conn' has the same effect.
+.conn light light_out
+
+# ignored
+.end
+
+# The goal of this subset is to be sufficiently compatible with Yosys.
+# You can find an example of the necessary cell files in the 'examples/cmos' directory of Yosys.
+# An example Yosys script:
+
+# read_verilog example.v
+# read_verilog -lib yosys-cmos/cmos_cells.v
+# check -assert
+# synth -top example
+# dfflibmap -liberty yosys-cmos/cmos_cells.lib
+# abc -liberty yosys-cmos/cmos_cells.lib
+# opt_clean
+# write_blif -icells -conn example.blif
+
+# The libraries can be expanded somewhat, also.
+
+# The full list of binary gates:
+# BUS, TRIS, TRISI, AND, OR, XOR, NAND, NOR, NXOR, ANDNOT, ORNOT
+# BUS is essentially two buffers.
+# TRIS is a buffer which only sends A to Y when B is high.
+# TRISI is like TRIS but with the B input inverted.
+# ANDNOT is A & !B ; ORNOT is A | !B.
+# The rest should be self-explanatory.
+# The unary gates are NOT and BUF.
+# Then there are the special gates:
+# MUX A=. B=. S=. Y=. outputs A to Y if S isn't high, outputs B to Y if S is high.
+# DFFSR is a D flip-flop with asynchronous set/reset pins.
+# DFF is like DFFSR but without the S/R pins. Honestly not that much to say here.
+# DLATCH D=. E=. Q. continually sets Q to D while (and only while) E is high. 
+# PULLUP/PULLDOWN are very special; they change the default state of a line if nothing else is driving it.
+# PULLUP/PULLDOWN do not work with lines directly connected to external inputs (inputs outside of the BLIF).
+# They will likely create very hard-to-find internal logic error states if you try.
+
+# Something worth keeping in mind is that the BLIF simulation processes all combinatorial logic
+#  until it settles (or it runs out of time), then flip-flops/'sequential logic', then updates combinatorial logic again.
+# This is important for D-flip-flop consistency across registers larger than 1 bit (i.e. for counters).

--- a/src/main/resources/resources/logisim/strings/hdl/hdl.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = Validate & Save
 #
 hdlSaveDialog = Export VHDL file
 #
+# hdl/BlifCircuitComponent.java
+#
+blifComponent = BLIF Component
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_de.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_de.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = Validieren
 #
 hdlSaveDialog = VHDL-Datei exportieren
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_el.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_el.properties
@@ -28,6 +28,10 @@
 #
 # ==> hdlSaveDialog =
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 # ==> hdlLibrary =

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_es.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_es.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = Validar y guardar
 #
 hdlSaveDialog = Exportar archivo VHDL
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_fr.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_fr.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = Valider et sauvegarder
 #
 hdlSaveDialog = Exporter un fichier VHDL
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_it.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_it.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = Convalida
 #
 hdlSaveDialog = Esporta file VHDL
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_ja.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_ja.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = 検証と保存
 #
 hdlSaveDialog = VHDLファイルのエクスポート
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_nl.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_nl.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = Valideren & Opslaan
 #
 hdlSaveDialog = VHDL-bestand exporteren
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_pl.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_pl.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = Sprawdź i zapisz
 #
 hdlSaveDialog = Eksportuj plik VHDL
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_pt.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_pt.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = Validar
 #
 hdlSaveDialog = Exportar arquivo VHDL
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_ru.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_ru.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = Подтвердить
 #
 hdlSaveDialog = Экспорт файла VHDL
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_zh.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_zh.properties
@@ -28,6 +28,10 @@ validateAndSaveButton = 验证并保存
 #
 hdlSaveDialog = 导出 VHDL 文件
 #
+# hdl/BlifCircuitComponent.java
+#
+# ==> blifComponent =
+#
 # hdl/Hdl.java
 #
 hdlLibrary = HDL-IP


### PR DESCRIPTION
This adds a simulator for .blif files as exported by Yosys with the correct options, intending to support running Verilog modules inside a Logisim project.

It does not support the entire .blif format and doesn't support truth-table gates.

Unlike previous work such as the VHDL simulator (which this is partially derived from), the simulator itself is entirely part of Logisim, and requires no installation or configuration.

The simulator is separate from the Logisim core due to the logic being highly 'dense' (the simulator can't shortcut operations such as addition) and due to an inability to determine how best to patch the additional components seamlessly into the simulation anyway.

The simulator supports a decent set of logic gates, tri-state logic, pullups/pulldowns, D flip-flops, D-latches. See the template for more precise information.

I will admit I expect that the functionality in this PR is unpolished, and I don't understand the codebase well enough to perform that polishing. Still, I believe the ability to use Logisim as an interactive open-source Verilog simulator is useful enough to be adopted regardless.

Example circuits, BLIF files, etc.:
[package.zip](https://github.com/user-attachments/files/19775981/package.zip)

'Representative screenshot':
![image](https://github.com/user-attachments/assets/bc6b2a73-5e90-4265-af1d-695fcd388eed)

Note that someone who can actually test the old VHDL simulator integration (i.e. not me) needs to do so.
In order to not mass copy/paste code I had to do a bit of refactoring and cleanup and I can't be completely and totally sure I got it perfectly correct.