### PR TITLE
Fix gradle deprecation warning on task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -195,7 +195,7 @@ java {
   }
 }
 
-task<Jar>("sourcesJar") {
+tasks.register<Jar>("sourcesJar") {
   group = "build"
   description = "Creates a JAR archive with project sources."
   dependsOn.add("classes")


### PR DESCRIPTION
This PR fixes the following deprecation warning:

```
w: file:///[...]/logisim-evolution/build.gradle.kts:198:1: 'task(String, noinline type.() -> Unit): type' is deprecated. Use tasks.register instead
```