### PR TITLE
RegTabCounter now redraws on clear

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/RegTabContent.java
@@ -56,6 +56,7 @@ public class RegTabContent extends JScrollPane
   private boolean showing = false;
   private CircuitState circuitState;
   private final ArrayList<Circuit> circuits = new ArrayList<>();
+  private final ArrayList<Watcher> buildWatchers = new ArrayList<>();
   private final CopyOnWriteArrayList<Watcher> watchers = new CopyOnWriteArrayList<>();
 
   public RegTabContent(Frame frame) {
@@ -124,12 +125,15 @@ public class RegTabContent extends JScrollPane
     gridConstraints.gridx = 1;
     gridConstraints.weightx = 0.3;
     panel.add(hdrValue, gridConstraints);
+    panel.repaint();
   }
 
   private void fill() {
     if (!showing || circuitState == null) return;
     if (circuits.isEmpty()) {
       enumerate();
+      watchers.addAll(buildWatchers);
+      buildWatchers.clear();
     }
     updateWatchers();
     writeValuesToLabels();
@@ -200,7 +204,7 @@ public class RegTabContent extends JScrollPane
       gridConstraints.gridx = 1;
       final var label = new MyLabel("-", 0, false, null);
       panel.add(label, gridConstraints);
-      watchers.add(new Watcher(log, cs, label));
+      buildWatchers.add(new Watcher(log, cs, label));
     }
   }
 


### PR DESCRIPTION
RegTabCounter was leaving register information on the screen after switching to another circuit. This PR adds a repaint of the panel so old information is removed.

It also changes the way watchers are built so they are built in a regular ArrayList and then transferred to the watchers list in a single action. That reduces the number of times the copyOnWriteArrayList copies itself.