### PR TITLE
Fixed double warning message

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/generic/AttrTable.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/AttrTable.java
@@ -225,6 +225,7 @@ public class AttrTable extends JPanel implements LocaleListener {
     int[] currentRowIndexes;
     Component currentEditor;
     boolean multiEditActive = false;
+    boolean stoppedCellEditing = false;
 
     //
     // ActionListener methods
@@ -429,7 +430,12 @@ public class AttrTable extends JPanel implements LocaleListener {
     public boolean stopCellEditing() {
       // Tells the editor to stop editing and accept any partially
       // edited value as the value of the editor.
+      if (stoppedCellEditing) {
+        return false;
+      }
+      stoppedCellEditing = true;
       fireEditingStopped();
+      stoppedCellEditing = false;
       return true;
     }
   }


### PR DESCRIPTION
Fixed https://github.com/logisim-evolution/logisim-evolution/issues/1983
This issue was being caused by the `focusLost` function in `CellEditor`, which contains a call to `stopCellEditing`.

When the `focusLost` function calls `stopCellEditing` and there is an invalid input, `stopCellEditing` throws an error and opens a new window. The new windows causes the `focusLost` function to call again, which leads to the repeat call to `stopCellEditing`, causing a duplicate warning message.

This fix makes it so any call to `stopCellEditing` is only executed if `stopCellEditing` is not currently in progress, preventing duplicate calls.