### PR TITLE
Fixed resizing issue

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/log/Signal.java
+++ b/src/main/java/com/cburch/logisim/gui/log/Signal.java
@@ -92,8 +92,8 @@ public class Signal {
       final var dur2 = new long[c + 1][];
       System.arraycopy(val, 0, val2, 0, c);
       System.arraycopy(dur, 0, dur2, 0, c);
-      val2[c + 1] = new Value[maxSize == 0 || (maxSize - cap) > CHUNK ? CHUNK : (maxSize - cap)];
-      dur2[c + 1] = new long[maxSize == 0 || (maxSize - cap) > CHUNK ? CHUNK : (maxSize - cap)];
+      val2[c] = new Value[maxSize == 0 || (maxSize - cap) > CHUNK ? CHUNK : (maxSize - cap)];
+      dur2[c] = new long[maxSize == 0 || (maxSize - cap) > CHUNK ? CHUNK : (maxSize - cap)];
       val = val2;
       dur = dur2;
       val[curSize / CHUNK][curSize % CHUNK] = v;
@@ -176,7 +176,7 @@ public class Signal {
     if (newMaxSize == maxSize) return;
     if (newMaxSize == 0 || newMaxSize > maxSize) {
       // growing
-      if (firstIndex != 0) retainOnly(0, curSize, newMaxSize); // keeps all data, but shifts it left
+      retainOnly(0, curSize, newMaxSize); // keeps all data, but shifts it left
     } else {
       // shrinking: newMaxSize < maxSize
       if (curSize <= newMaxSize) {


### PR DESCRIPTION
Fixed https://github.com/logisim-evolution/logisim-evolution/issues/2005

This issue was being caused by a problem allocating new blocks in the `Signal` class, which after fixing revealed a second problem with resizing existing blocks.

Issue 1: The updated `val2` and `dur2` arrays were initialized with a length of `c+1`, and a new block was created at the end of the array at position index `c+1`. However arrays are indexed starting from `0`, and `c+1` is outside the bounds of the array. We should instead add this block at `c`.

Issue 2: When resizing to increase the size of an empty array, the `resize` function would not update the capacity of the existing blocks. Leading to the `Signal` class attemping to access outside the bounds of the array when calling the `extend` function. This can be fixed by removing the check for `firstIndex`, though this may create additional work and I think a better solution exists by further modifying the `resize` function. Will continue making changes.