### PR TITLE
Fix issue 2224

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -212,7 +212,7 @@ tasks.register<Jar>("sourcesJar") {
 
 
 /**
- * Helper method that simplifies runining external commands using ProcessBuilder().
+ * Helper method that simplifies running external commands using ProcessBuilder().
  * Will throw GradleException on command failure (non-zero return code).
  *
  * params: List of strings which signifies the external program file to be invoked and its arguments (if any).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,6 +162,10 @@ extra.apply {
       "--input", packageInputDir,
       "--main-class", "com.cburch.logisim.Main",
       "--main-jar", shadowJarFilename,
+      // The following list of modules to be added by `jpackage` was obtained using
+      // `jdeps --print-module-deps --ignore-missing-deps build/libs/logisim-evolution-4.0.0dev-all.jar`.
+      // TODO: Run `jdeps` as part of a suitable gradle task instead of manually maintaining it.
+      "--add-modules", "java.base,java.compiler,java.desktop,java.naming,java.prefs,java.scripting,java.sql",
       "--copyright", copyrights,
       "--description", "Digital logic design tool and simulator",
       "--vendor", "${project.name} developers",


### PR DESCRIPTION
This is a quick fix for issue #2224. It passes the required modules explicitly to the `jpackage` call as described in [this comment](https://github.com/logisim-evolution/logisim-evolution/issues/2224#issuecomment-2847169412).

@davidhutchens: Do you have a suggestion, where to integrate the `jdeps` call into the `gradle` build flow?

This PR needs also testing on other platforms than Windows. Feedback welcome!