### PR TITLE
Add QueueOfQueues and allow user choice of simulation queue.

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/prefs/ExperimentalOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/ExperimentalOptions.java
@@ -23,21 +23,23 @@ class ExperimentalOptions extends OptionsPanel {
   private static final long serialVersionUID = 1L;
   private final JLabel accelRestart = new JLabel();
   private final PrefOptionList accel;
+  private final JLabel simRestart = new JLabel();
+  private final PrefOptionList simQueue;
 
   public ExperimentalOptions(PreferencesFrame window) {
     super(window);
 
-    accel =
-        new PrefOptionList(
-            AppPreferences.GRAPHICS_ACCELERATION,
-            S.getter("accelLabel"),
-            new PrefOption[] {
-              new PrefOption(AppPreferences.ACCEL_DEFAULT, S.getter("accelDefault")),
-              new PrefOption(AppPreferences.ACCEL_NONE, S.getter("accelNone")),
-              new PrefOption(AppPreferences.ACCEL_OPENGL, S.getter("accelOpenGL")),
-              new PrefOption(AppPreferences.ACCEL_D3D, S.getter("accelD3D")),
-              new PrefOption(AppPreferences.ACCEL_METAL, S.getter("accelMetal")),
-            });
+    accel = new PrefOptionList(
+        AppPreferences.GRAPHICS_ACCELERATION,
+        S.getter("accelLabel"),
+        new PrefOption[]{
+            new PrefOption(AppPreferences.ACCEL_DEFAULT, S.getter("accelDefault")),
+            new PrefOption(AppPreferences.ACCEL_NONE, S.getter("accelNone")),
+            new PrefOption(AppPreferences.ACCEL_OPENGL, S.getter("accelOpenGL")),
+            new PrefOption(AppPreferences.ACCEL_D3D, S.getter("accelD3D")),
+            new PrefOption(AppPreferences.ACCEL_METAL, S.getter("accelMetal")),
+        }
+    );
 
     final var accelPanel = new JPanel(new BorderLayout());
     accelPanel.add(accel.getJLabel(), BorderLayout.LINE_START);
@@ -50,6 +52,28 @@ class ExperimentalOptions extends OptionsPanel {
     setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
     add(Box.createGlue());
     add(accelPanel2);
+
+    simQueue = new PrefOptionList(
+        AppPreferences.SIMULATION_QUEUE,
+        S.getter("simQueueLabel"),
+        new PrefOption[]{
+            new PrefOption(AppPreferences.SIM_QUEUE_DEFAULT, S.getter("simQueueDefault")),
+            new PrefOption(AppPreferences.SIM_QUEUE_PRIORITY, S.getter("simQueuePriority")),
+            new PrefOption(AppPreferences.SIM_QUEUE_SPLAY, S.getter("simQueueSplay")),
+            new PrefOption(AppPreferences.SIM_QUEUE_LINKED, S.getter("simQueueLinked")),
+            new PrefOption(AppPreferences.SIM_QUEUE_LIST_OF_QUEUES, S.getter("simQueueListOfQueues")),
+            new PrefOption(AppPreferences.SIM_QUEUE_TREE_OF_QUEUES, S.getter("simQueueTreeOfQueues"))
+        }
+    );
+    final var simPanel = new JPanel(new BorderLayout());
+    simPanel.add(simQueue.getJLabel(), BorderLayout.LINE_START);
+    simPanel.add(simQueue.getJComboBox(), BorderLayout.CENTER);
+    simPanel.add(simRestart, BorderLayout.PAGE_END);
+    simRestart.setFont(simRestart.getFont().deriveFont(Font.ITALIC));
+    final var simPanel2 = new JPanel();
+    simPanel2.add(simPanel);
+
+    add(simPanel2);
     add(Box.createGlue());
   }
 
@@ -67,5 +91,6 @@ class ExperimentalOptions extends OptionsPanel {
   public void localeChanged() {
     accel.localeChanged();
     accelRestart.setText(S.get("accelRestartLabel"));
+    simRestart.setText(S.get("simRestartLabel"));
   }
 }

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -788,6 +788,20 @@ public class AppPreferences {
               "graphicsAcceleration",
               new String[] {ACCEL_DEFAULT, ACCEL_NONE, ACCEL_OPENGL, ACCEL_D3D, ACCEL_METAL},
               ACCEL_DEFAULT));
+
+  public static final String SIM_QUEUE_DEFAULT = "default";
+  public static final String SIM_QUEUE_PRIORITY = "priority";
+  public static final String SIM_QUEUE_SPLAY = "splay";
+  public static final String SIM_QUEUE_LINKED = "linked";
+  public static final String SIM_QUEUE_LIST_OF_QUEUES = "listOfQueues";
+  public static final String SIM_QUEUE_TREE_OF_QUEUES = "treeOfQueues";
+  public static final PrefMonitor<String> SIMULATION_QUEUE =
+      create(
+          new PrefMonitorStringOpts("simQueue",
+              new String[] {SIM_QUEUE_DEFAULT, SIM_QUEUE_PRIORITY, SIM_QUEUE_SPLAY,
+                            SIM_QUEUE_LINKED, SIM_QUEUE_LIST_OF_QUEUES, SIM_QUEUE_TREE_OF_QUEUES},
+              SIM_QUEUE_DEFAULT)
+      );
   public static final PrefMonitor<Boolean> AntiAliassing =
       create(new PrefMonitorBoolean("AntiAliassing", true));
 

--- a/src/main/java/com/cburch/logisim/util/LinkedQueue.java
+++ b/src/main/java/com/cburch/logisim/util/LinkedQueue.java
@@ -10,8 +10,8 @@
 package com.cburch.logisim.util;
 
 /**
- * A simple linked-list priority queue implementation, using keys of type long,
- * and values that extend type QNode. This supports (approximately) a
+ * A simple linked-list priority queue implementation, using
+ * values that extend type QNode. This supports (approximately) a
  * subset of the java.util.PriorityQueue API, but only enough to support
  * Propagator.
  * Objects in the queue must be subclasses of QNode.
@@ -31,7 +31,7 @@ public class LinkedQueue<T extends QNode> implements QNodeQueue<T> {
 
     // Find node p that should precede t.
     QNode p = tail;
-    while (p != null && t.key < p.key) {
+    while (p != null && t.compareTo(p) < 0) {
       p = p.left;
     }
 

--- a/src/main/java/com/cburch/logisim/util/QNode.java
+++ b/src/main/java/com/cburch/logisim/util/QNode.java
@@ -9,11 +9,22 @@
 
 package com.cburch.logisim.util;
 
-public class QNode {
-  final long key;
+public class QNode implements Comparable<QNode> {
+  public final int timeKey, serialNumber;
   QNode left, right;
 
-  public QNode(long key) {
-    this.key = key;
+  public QNode(int timeKey, int serialNumber) {
+    this.timeKey = timeKey;
+    this.serialNumber = serialNumber;
   }
+
+  @Override
+  public int compareTo(QNode other) {
+    // Yes, these subtractions may overflow. This is intentional, as it
+    // avoids potential wraparound problems as the counters increment.
+    int ret = timeKey - other.timeKey;
+    if (ret == 0) ret = serialNumber - other.serialNumber;
+    return ret;
+  }
+
 }

--- a/src/main/java/com/cburch/logisim/util/QueueOfQueues.java
+++ b/src/main/java/com/cburch/logisim/util/QueueOfQueues.java
@@ -1,0 +1,284 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.util;
+
+import com.cburch.logisim.prefs.AppPreferences;
+
+import java.util.Comparator;
+import java.util.TreeMap;
+
+/**
+ * A linked-list priority queue of queues implementation, using values that extend type QNode.
+ * This supports (approximately) a subset of the java.util.PriorityQueue API, but only enough
+ * to support Propagator. Objects in the queue must be subclasses of QNode.
+ */
+public class QueueOfQueues<T extends QNode> implements QNodeQueue<T> {
+  /*
+   * There are two keys for priority in QNode: timeKey and serialNumber. This implementation
+   * uses a sorted linked list map or a treeMap for the timeKey, chosen at time of construction.
+   * In either case, the first timeKey is held outside the list because that makes all peek and
+   * remove operations (except the one that empties the queue for this timeKey) work in constant
+   * time. Furthermore, usually much more than 2/3 of the adds also hit on the first timeKey
+   * since many components have a delay of 1, giving them a constant time lookup as well.
+   * The linked list is searched from current time forward since even after the first entry the
+   * desired timeKey is biased toward the beginning. The result is that the average number of
+   * iterations of the lookup loop is often less than one per lookup. Each TimeNode contains the
+   * head and tail of a linked queue of all QNodes with identical timeKey. Since the serial
+   * numbers actually arrive here in order, a regular (non-priority) queue works. We don't even
+   * look at the serialNumber.
+   *
+   * Invariants of the class:
+   * 1. firstTimeNode is null if and only if size == 0.
+   * 2. If a TimeNode is being used (firstTimeNode or in timeNodeMap), the TimeNode's queue is not empty.
+   */
+  private TimeNode firstTimeNode = null; // the smallest TimeNode
+  private int size = 0; // The total number of T objects held in all TimeNodes
+  private final TimeNodeMap timeNodeMap; // holds all TimeNodes but the smallest
+  private TimeNode unusedTimeNodes = null; // Linked list holding currently unused TimeNodes
+
+  public QueueOfQueues(String queueType) {
+    timeNodeMap = AppPreferences.SIM_QUEUE_LIST_OF_QUEUES.equals(queueType) ? new LinkedNodeMap() : new TreeNodeMap();
+  }
+
+  @Override
+  public boolean add(T node) {
+    findTimeNode(node.timeKey).add(node);
+    size++;
+    return true;
+  }
+
+  @Override
+  public void clear() {
+    firstTimeNode = null;
+    timeNodeMap.clear();
+    size = 0;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return size == 0;
+  }
+
+  @Override
+  public T peek() {
+    return firstTimeNode == null ?  null : firstTimeNode.peek();
+  }
+
+  @Override
+  public T remove() {
+    if (firstTimeNode == null) return null;
+    T ret = firstTimeNode.remove();
+    size--;
+    if (firstTimeNode.isEmpty()) {
+      final var oldFirst = firstTimeNode;
+      firstTimeNode = timeNodeMap.removeFirst(); // This will be null if there are no more.
+      recycleTimeNode(oldFirst);
+    }
+    return ret;
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  /**
+   * @return The TimeNode with the given timeKey, creating it if necessary.
+   */
+  TimeNode findTimeNode(int timeKey) {
+    if (firstTimeNode == null) {
+      firstTimeNode = getNewTimeNode(timeKey);
+      return firstTimeNode;
+    }
+    if (firstTimeNode.timeKey == timeKey) {
+      return firstTimeNode;
+    }
+    if (timeKey - firstTimeNode.timeKey < 0) {
+      final var oldFirst = firstTimeNode;
+      firstTimeNode = getNewTimeNode(timeKey);
+      timeNodeMap.addFirst(oldFirst);
+      return firstTimeNode;
+    }
+    return timeNodeMap.addIfNeeded(timeKey);
+  }
+
+  /**
+   * @return a TimeNode with its timeKey set, taken from unusedTimeNodes if there is one.
+   */
+  private TimeNode getNewTimeNode(int timeKey) {
+    if (unusedTimeNodes == null) {
+      return new TimeNode(timeKey);
+    }
+    final var node = unusedTimeNodes;
+    unusedTimeNodes = unusedTimeNodes.next;
+    node.timeKey = timeKey;
+    node.next = null;
+    return node;
+  }
+
+  /**
+   * Places the node on the unusedTimeNodes list and clears its queue.
+   */
+  private void recycleTimeNode(TimeNode node) {
+    node.head = node.tail = null;
+    node.next = unusedTimeNodes;
+    unusedTimeNodes = node;
+  }
+
+  private class TimeNode {
+    public int timeKey; // the simulation time these events should be processed
+    public TimeNode next; // Link to next TimeNode if TimeNode is in a list
+    private T head, tail; // The linked queue of T for this timeKey
+
+    TimeNode(int timeKey) {
+      this.timeKey = timeKey;
+    }
+
+    /**
+     * Add node to the linked queue for this TimeNode
+     */
+    void add(T node) {
+      if (head == null) {
+        head = tail = node;
+      } else {
+        tail.right = node;
+        tail = node;
+      }
+    }
+
+    /**
+     * @return the first value in the linked queue for this TimeNode
+     */
+    T peek() {
+      return head == null ? null : head;
+    }
+
+    /**
+     * @return the first value in the linked queue for this TimeNode while removing it from the queue.
+     */
+    T remove() {
+      if (head == null) return null;
+      T ret = head;
+      @SuppressWarnings("unchecked")
+      T next = (T) head.right;
+      head = next;
+      return ret;
+    }
+
+    /**
+     * @return if the linked queue for this TimeNode is empty.
+     */
+    boolean isEmpty() {
+      return head == null;
+    }
+  }
+
+  private abstract class TimeNodeMap {
+    /**
+     * Adds the node as the first node of the map.
+     *
+     * @Precondition: node.key is smaller than any current node in the map.
+     */
+    public abstract void addFirst(TimeNode node);
+
+    /**
+     * @return the node in the map with the given timeKey, creating one if none was there.
+     */
+    public abstract TimeNode addIfNeeded(int timeKey);
+
+    /**
+     * Clear the map.
+     */
+    public abstract void clear();
+
+    /**
+     * @return the first TimeNode in the map and also removes it.
+     */
+    public abstract TimeNode removeFirst();
+  }
+
+  private class TreeNodeMap extends TimeNodeMap {
+    private final TreeMap<Integer, TimeNode> treeMap = new TreeMap<>((Comparator<Integer>) (ls, rs) -> ls - rs);
+
+    @Override
+    public void addFirst(TimeNode node) {
+      treeMap.put(node.timeKey, node);
+    }
+
+    @Override
+    public TimeNode addIfNeeded(int timeKey) {
+      return treeMap.computeIfAbsent(timeKey, QueueOfQueues.this::getNewTimeNode);
+    }
+
+    @Override
+    public void clear() {
+      treeMap.clear();
+    }
+
+    @Override
+    public TimeNode removeFirst() {
+      if (treeMap.isEmpty()) return null;
+      final var entry = treeMap.firstEntry();
+      treeMap.remove(entry.getKey());
+      return entry.getValue();
+    }
+  }
+
+  private class LinkedNodeMap extends TimeNodeMap {
+    TimeNode head = null;
+
+    @Override
+    public void addFirst(TimeNode node) {
+      node.next = head;
+      head = node;
+    }
+
+    @Override
+    public TimeNode addIfNeeded(int timeKey) {
+      if (head == null) {
+        head = getNewTimeNode(timeKey);
+        return head;
+      }
+      var node = head;
+      TimeNode previous = null;
+      while (node != null && (node.timeKey - timeKey < 0)) {
+        previous = node;
+        node = node.next;
+      }
+      if (node != null && node.timeKey == timeKey) {
+        return node;
+      }
+      final var newNode = getNewTimeNode(timeKey);
+      newNode.next = node;
+      if (previous == null) {
+        head = newNode;
+      } else {
+        previous.next = newNode;
+      }
+      return newNode;
+    }
+
+    @Override
+    public void clear() {
+      head = null;
+    }
+
+    @Override
+    public TimeNode removeFirst() {
+      if (head == null) {
+        return null;
+      }
+      final var oldHead = head;
+      head = head.next;
+      oldHead.next = null;
+      return oldHead;
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/util/SplayQueue.java
+++ b/src/main/java/com/cburch/logisim/util/SplayQueue.java
@@ -14,7 +14,7 @@
 package com.cburch.logisim.util;
 
 /**
- * A simple splay tree implementation, using keys of type long, and values that
+ * A simple splay tree implementation, using values that
  * extend type QNode. This supports (approximately) a subset of the
  * java.util.PriorityQueue API, but only enough to support Propagator.
  * Objects in the queue must be subclasses of QNode.
@@ -29,8 +29,8 @@ public class SplayQueue<T extends QNode> implements QNodeQueue<T> {
       size++;
       return true;
     }
-    root = splay(root, t.key);
-    long cmp = t.key - root.key;
+    root = splay(root, t);
+    long cmp = t.compareTo(root);
 
     if (cmp < 0) {
       // New node t displaces root, which moves down right.
@@ -69,15 +69,15 @@ public class SplayQueue<T extends QNode> implements QNodeQueue<T> {
    * splay(t, k) rebalances the tree rooted at node t around key k, by moving a
    * node close to k (or an exact match, if it exists) up to the root.
    */
-  private static QNode splay(QNode t, long k) {
+  private static QNode splay(QNode t, QNode k) {
     if (t == null) return null;
 
-    long cmp1 = k - t.key;
+    long cmp1 = k.compareTo(t);
     if (cmp1 < 0) {
       if (t.left == null) {
         return t; // can't go any further left
       }
-      long cmp2 = k - t.left.key;
+      long cmp2 = k.compareTo(t.left);
       if (cmp2 < 0) {
         t.left.left = splay(t.left.left, k);
         t = rotateRight(t);
@@ -93,7 +93,7 @@ public class SplayQueue<T extends QNode> implements QNodeQueue<T> {
       if (t.right == null) {
         return t; // can't go any further right
       }
-      long cmp2 = k - t.right.key;
+      long cmp2 = k.compareTo(t.right);
       if (cmp2 < 0) {
         t.right.left  = splay(t.right.left, k);
         if (t.right.left != null) {

--- a/src/main/resources/doc/en/html/guide/prefs/pref-exp.html
+++ b/src/main/resources/doc/en/html/guide/prefs/pref-exp.html
@@ -26,6 +26,43 @@
         <li>
           <b>Graphics acceleration:</b> One Logisim user observed that adding <tt>-Dsun.java2d.d3d=True</tt> to the command line seemed to improve Logisim's graphics performance by telling it to use hardware graphics acceleration. This drop-down box attempts to configure Logisim to set this up; reports about whether this drop-down box has any effect on performance would be welcome. It won't have any effect until Logisim is restarted.
         </li>
+        <li>
+          <b>Simulation Event Queue:</b>
+          The Simulation Event Queue is a priority queue of events to be processed by the simulator.
+          The choice of queue implementation has an impact on the efficiency, and speed, of the simulation.
+          The most efficient for one project may not be the most efficient for another.
+          We are currently providing 5 choices. We ask for feedback about which works better for you.
+          You can make comments in the Simulation Queue discussion at
+          https://github.com/logisim-evolution/logisim-evolution/discussions.
+          A change won't have any effect until the project is closed and opened again. The choices are:
+          <ul>
+            <li>
+              <b>Java Priority Queue:</b> This is currently the default.
+              A solid choice that deals reasonably with extreme situations, but not especially fast.
+            </li>
+            <li>
+              <b>Splay Tree  Priority Queue:</b>
+              This can be faster, but for some projects it may have an unbalanced tree and
+              since it is recursive it may even fail on a stack overflow.
+            </li>
+            <li>
+              <b>Linked Priority Queue:</b> A linked queue that searches from the back for insertion.
+              Fast for some projects, but it has poor worst case performance.
+            </li>
+            <li>
+              <b>Sorted Linked List of Queues:</b> Can be quite fast.
+              This implementation uses a sorted list of time nodes, each of which has a standard linked queue
+              to hold all events targeting that time.
+            </li>
+            <li>
+              <b>Sorted Tree of Queues:</b> Can also be quite fast.
+              It uses a Sorted Tree for the time nodes.
+              It works better than the Linked List of Queues on projects with a large number of different delays.
+              However, it has more overhead on simpler projects.
+              Even very large projects may be slower than with the Linked List of Queues.
+            </li>
+          </ul>
+        </li>
       </ul>
       <p>
         <b>Next:</b> <a href="pref-cmdline.html">Command line options</a>.

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -529,6 +529,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = Restart Logisim for changes to take effect.
 experimentHelp = Enable features that haven't yet been thoroughly tested
 experimentTitle = Experimental
+simQueueLabel = Simulation Event Queue:
+simQueueDefault = Use default
+simQueueLinked = Linked Priority Queue
+simQueuePriority = Java Priority Queue
+simQueueListOfQueues = Sorted Linked List of Queues
+simQueueTreeOfQueues = Sorted Tree of Queues
+simQueueSplay = Splay Tree Priority Queue
+simRestartLabel = Close and reopen project for changes to take effect.
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -528,6 +528,15 @@ accelOpenGL = OpenGL
 accelRestartLabel = Logisim-evolution muß zur Aktivierung der Änderungen neu gestartet werden.
 experimentHelp = Funktionen aktivieren, die noch nicht ausgiebig getestet worden sind
 experimentTitle = Experimentell
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueOfQueues =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -527,6 +527,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = Επανεκινήστε το Logisim προκειμένου να εφαρμοστούν οι αλλαγές.
 experimentHelp = Ενεργοποίηση χαρακτηριστικών που δεν έχουν ακόμα ελεγχθεί ενδελεχώς
 experimentTitle = Πειραματικό
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -527,6 +527,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = Reinicia Logisim para que se apliquen los cambios.
 experimentHelp = Activa funciones que no han sido acabadas
 experimentTitle = Experimental
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -528,6 +528,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = Redémarrer Logisim pour activer les changements.
 experimentHelp = Activer les options qui n'ont pas encore été bien testées
 experimentTitle = Expérimental
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -527,6 +527,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = Riavvia Logisim per rendere effettivi i cambiamenti.
 experimentHelp = Abilita caratteristiche non ancora testate a fondo
 experimentTitle = Sperimentale
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -527,6 +527,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = 変更が有効になるようにLogisimを再起動します。
 experimentHelp = まだ十分にテストされていない機能を有効にする
 experimentTitle = 実験
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -529,6 +529,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = Start Logisim opnieuw op om de wijzigingen van kracht te laten worden.
 experimentHelp = Functies die nog niet grondig getest zijn, inschakelen
 experimentTitle = Experimenteel
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -527,6 +527,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = Aby wprowadzić zmiany uruchom aplikację ponownie.
 experimentHelp = Włącz funkcje, które nie zostały jeszcze dokładnie przetestowane.
 experimentTitle = Eksperymentalne
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -527,6 +527,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = Reinicie o Logisim para que as alterações tenham efeito.
 experimentHelp = Habilitar características que ainda não foram extensivamente testadas
 experimentTitle = Experimental
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -528,6 +528,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = Перезагрузите Logisim, чтобы изменения вступили в силу.
 experimentHelp = Включить возможности, которые еще не были тщательно протестированы
 experimentTitle = Экспериментальные
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -528,6 +528,14 @@ accelOpenGL = OpenGL
 accelRestartLabel = 需重启 Logisim 以使更改生效。
 experimentHelp = 启用尚未彻底测试的功能
 experimentTitle = 实验性
+# => simQueueLabel =
+# => simQueueDefault =
+# => simQueueLinked =
+# => simQueuePriority =
+# => simQueueListOfQueues =
+# => simQueueTreeOfQueues =
+# => simQueueSplay =
+# => simRestartLabel =
 #
 # prefs/IntlOptions.java
 #


### PR DESCRIPTION
This PR gives the user a choice of five simulation queues as discussed in issue #2182. The choice is made from the Experimental Tab in preferences. It applies to all projects loaded after the setting is made.

The English version of the documentation for the Experimental Tab is modified to describe the choices. I cannot modify the documentation in other languages.

This PR does not change the default simulation queue which remains the Java PriorityQueue.