### PR TITLE
Circuit instances cannot have a appearance attribute, as this is set by the circuit itself (static attribute)

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
@@ -217,8 +217,7 @@ public class CircuitAttributes extends AbstractAttributeSet {
           NAME_ATTR,
           CIRCUIT_LABEL_ATTR,
           CIRCUIT_LABEL_FACING_ATTR,
-          CIRCUIT_LABEL_FONT_ATTR,
-          APPEARANCE_ATTR);
+          CIRCUIT_LABEL_FONT_ATTR);
 
   private final Circuit source;
   private Instance subcircInstance;


### PR DESCRIPTION
fixes #2052