### PR TITLE
Fix ttl simulation failure.

### DIFF
--- a/src/main/java/com/cburch/logisim/std/ttl/ClockState.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/ClockState.java
@@ -59,14 +59,12 @@ class ClockState implements Cloneable {
    * @return true if the clock was triggered, false otherwise
    */
   public boolean updateClock(Value newClock, int which, Object trigger) {
+    if (newClock == null || newClock == Value.NIL) return false;
     if (lastClock.getWidth() <= which) {
       lastClock = lastClock.extendWidth(which + 1, Value.FALSE);
     }
-
     final var oldClock = lastClock.get(which);
-
     lastClock = lastClock.set(which, newClock);
-
     return isTriggered(oldClock, newClock, trigger);
   }
 


### PR DESCRIPTION
While discussing TTL 74165 with @maehne in PR #2244 I noticed a strange behavior. If I started with a new circuit, dropped a ttl74165 on it, then dropped an input pin on the circuit, and then dragged a wire from the input pin, the wire drew in blue.

I decided to look into that. It happens with any TTL that contains a clock trigger. It turns out that the TTL was trying to get the value of the clock input and determine if it had triggered with a rising edge. Unfortunately, since the clock has no wire attached, the read of the port returned Value.NIL. It then used this value to try to set a bit in another value (to remember it as the previous value) resulting in an exception being thrown.

Strangely, the alert that the simulation had failed seems to appear occasionally but not always. I'm still not sure why it doesn't always happen. Perhaps there is a catch block that catches it sometimes.

This PR adds a check in the method that determines if a trigger has occurred to ensure it does not fail on Value.NIL.