### PR TITLE
Fix bug in CircuitState copyFrom with subcircuits.

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitState.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitState.java
@@ -251,7 +251,7 @@ public class CircuitState implements InstanceData {
       // possibility of deadlock (though that shouldn't happen either since no
       // other threads have references to this yet).
       for (final var oldSub : src.substates) {
-        final var newSub = CircuitState.createRootState(src.proj, oldSub.circuit);
+        final var newSub = new CircuitState(src.proj, oldSub.circuit, this.base);
         newSub.copyFrom(oldSub);
         newSub.parentState = this;
         this.substates.add(newSub);


### PR DESCRIPTION
This PR fixes issue #2264. I made a mistake in one line of code while backporting from @kevinawalsh's Holycross fork.