### PR TITLE
Added a more human readable pla import format which allows | and spaces at arbitrary positions and || to separate inputs from outputs

### DIFF
--- a/src/main/java/com/cburch/logisim/std/gates/PlaTable.java
+++ b/src/main/java/com/cburch/logisim/std/gates/PlaTable.java
@@ -137,6 +137,127 @@ public class PlaTable {
     return ret.toString();
   }
 
+  private abstract static class Parser {
+    private String Comment(String line) {
+      final var separatorIndex = line.indexOf("#");
+
+      return separatorIndex >= 0 ? line.substring(separatorIndex + 1).trim() : "";
+    }
+
+    protected String InputsOutputs(String line) {
+      final var separatorIndex = line.indexOf("#");
+
+      return  separatorIndex >= 0 ? line.substring(0, separatorIndex).trim() : "";
+    }
+
+    private static char[] ToLogicArray(String line, String errorKey) throws IOException {
+      // java char indices and IO indices are in opposite order i.e. str[0] is IO[n] etc
+      var arr = new StringBuffer(line).reverse().toString().toCharArray();
+
+      for (final char ch : arr) {
+        if (ch != ONE && ch != ZERO && ch != DONTCARE)
+          throw new IOException(S.get(errorKey, line, "" + ch));
+      }
+
+      return arr;
+    }
+
+    public PlaTable parse(PlaTable tt, String line) throws IOException {
+      final var andBits = Inputs(line);
+      final var orBits = Outputs(line);
+      final var isCommentLine = andBits.isEmpty() && orBits.isEmpty();
+
+      if (isCommentLine) {
+        return tt;
+      }
+
+      if (tt == null)
+        tt = new PlaTable(andBits.length(), orBits.length(), "PLA");
+      else if (andBits.length() != tt.inSize)
+        throw new IOException(S.get("plaRowExactInBitError", line, "" +  tt.inSize));
+      else if (orBits.length() != tt.outSize)
+        throw new IOException(S.get("plaRowExactOutBitError", line, "" + tt.outSize));
+
+      final var r = tt.addTableRow();
+
+      r.inBits = ToLogicArray(andBits, "plaInvalidInputBitError");
+      r.outBits = ToLogicArray(orBits, "plaInvalidOutputBitError");
+      r.comment = Comment(line);
+
+      return tt;
+    }
+
+    protected abstract String Inputs(String line);
+
+    protected abstract String Outputs(String line);
+
+    protected abstract boolean CanParse(String line);
+  }
+
+  private static class CompactParser extends Parser {
+    protected String Inputs(String line) {
+      final var io = InputsOutputs(line);
+      final var separatorIndex = io.indexOf(" ");
+
+      return  separatorIndex >= 0 ? io.substring(0, separatorIndex).trim() : "";
+    }
+
+    protected String Outputs(String line) {
+      final var io = InputsOutputs(line);
+      final var separatorIndex = io.indexOf(" ");
+
+      return  separatorIndex >= 0 ? io.substring(separatorIndex + 1).trim() : "";
+    }
+
+    @Override
+    protected boolean CanParse(String line) {
+      final var io = InputsOutputs(line);
+
+      return io.matches("[01]+\\s+[01]+");
+    }
+  }
+
+  private static class FlexibleParser extends Parser {
+    private static String StripSeparators(String line) {
+      return  line.replaceAll("[|\\s]", "").trim();
+    }
+
+    protected String Inputs(String line) {
+      final var io = InputsOutputs(line);
+      final var separatorIndex = io.indexOf("||");
+
+      return  separatorIndex >= 0 ? StripSeparators(io.substring(0, separatorIndex)) : "";
+    }
+
+    protected String Outputs(String line) {
+      final var io = InputsOutputs(line);
+      final var separatorIndex = io.indexOf("||");
+
+      return  separatorIndex >= 0 ? StripSeparators(io.substring(separatorIndex + 1)) : "";
+    }
+
+    protected boolean CanParse(String line) {
+      final var io = InputsOutputs(line);
+
+      return io.contains("||");
+    }
+  }
+
+  private final static Parser[] parsers = new Parser[] {
+      new CompactParser(),
+      new FlexibleParser()
+  };
+
+  private static PlaTable parseOneLine(PlaTable tt, String line) throws IOException {
+    for (final var parser : parsers) {
+      if (parser.CanParse(line)) {
+        return parser.parse(tt, line);
+      }
+    }
+
+    return tt;
+  }
+
   public static PlaTable parse(String str) {
     PlaTable tt = null;
     for (final var line : str.split("\n")) {
@@ -148,41 +269,6 @@ public class PlaTable {
       }
     }
     if (tt == null) tt = new PlaTable(2, 2, "PLA");
-    return tt;
-  }
-
-  private static PlaTable parseOneLine(PlaTable tt, String line) throws IOException {
-    line = line.trim();
-    final var jj = line.indexOf("#");
-    String andBits, orBits, comment = "";
-    if (jj >= 0) {
-      comment = line.substring(jj + 1).trim();
-      line = line.substring(0, jj).trim();
-    }
-    if (line.equals("")) return tt;
-    final var ii = line.indexOf(" ");
-    if (ii <= 0) throw new IOException(S.get("plaRowMissingOutputError", "" + line));
-    andBits = line.substring(0, ii).trim();
-    orBits = line.substring(ii + 1).trim();
-    if (tt == null) tt = new PlaTable(andBits.length(), orBits.length(), "PLA");
-    else if (andBits.length() != tt.inSize)
-      throw new IOException(S.get("plaRowExactInBitError", "" + line, "" +  tt.inSize));
-    else if (orBits.length() != tt.outSize)
-      throw new IOException(S.get("plaRowExactOutBitError", "" + line, "" + tt.outSize));
-    final var r = tt.addTableRow();
-    for (var i = 0; i < andBits.length(); i++) {
-      final var s = andBits.charAt(i);
-      if (s != ONE && s != ZERO && s != DONTCARE)
-        throw new IOException(S.get("plaInvalideInputBitError", "" + line, "" + s));
-      r.inBits[andBits.length() - i - 1] = s;
-    }
-    for (var i = 0; i < orBits.length(); i++) {
-      final var s = orBits.charAt(i);
-      if (s != ONE && s != ZERO)
-        throw new IOException(S.get("plaInvalideOutputBitError", "" + line, "" + s));
-      r.outBits[orBits.length() - i - 1] = s;
-    }
-    r.comment = comment;
     return tt;
   }
 
@@ -457,6 +543,12 @@ public class PlaTable {
         final var f = chooser.getSelectedFile();
         try {
           final var loaded = parse(f);
+          if (loaded.inSize() != newTable.inSize()) {
+            throw new IOException(S.get("plaUnexpectedInputWidth", newTable.inSize(), loaded.inSize()));
+          }
+          if (loaded.outSize() != newTable.outSize()) {
+            throw new IOException(S.get("plaUnexpectedOutputWidth", newTable.outSize(), loaded.outSize()));
+          }
           newTable.copyFrom(loaded);
           reset(false);
         } catch (IOException e) {

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -261,12 +261,14 @@ plaCommentsLabel = comments
 plaInputLabel    = input
 plaOutputLabel   = output
 plaFileIoException = PLA file contained no data.
-plaInvalideInputBitError= PLA row %s contains invalid input bit %s.
-plaInvalideOutputBitError = PLA row %s contains invalid output bit %s.
+plaInvalidInputBitError= PLA row %s contains invalid input bit %s.
+plaInvalidOutputBitError = PLA row %s contains invalid output bit %s.
 plaRowExactOutBitError = PLA row %s must have exactly %s output bits.
 plaRowExactInBitError = PLA row %s must have exactly %s input bits.
 plaRowMissingOutputError = PLA row %s is missing outputs.
 plaTableError = Error in PLA Table
+plaUnexpectedInputWidth = File contains unexpected input width, expected %s but found %s
+plaUnexpectedOutputWidth = File contains unexpected output width, expected %s but found %s
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -261,12 +261,14 @@ plaSaveErrorTitle = Fehler beim Speichern des PLA-Programms
 # ==> plaInputLabel =
 # ==> plaOutputLabel =
 # ==> plaFileIoException =
-# ==> plaInvalideInputBitError =
-# ==> plaInvalideOutputBitError =
+# ==> plaInvalidInputBitError =
+# ==> plaInvalidOutputBitError =
 # ==> plaRowExactOutBitError =
 # ==> plaRowExactInBitError =
 # ==> plaRowMissingOutputError =
 # ==> plaTableError =
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -261,12 +261,14 @@ orGateComponent = OR Πύλη
 # ==> plaInputLabel =
 # ==> plaOutputLabel =
 # ==> plaFileIoException =
-# ==> plaInvalideInputBitError =
-# ==> plaInvalideOutputBitError =
+# ==> plaInvalidInputBitError =
+# ==> plaInvalidOutputBitError =
 # ==> plaRowExactOutBitError =
 # ==> plaRowExactInBitError =
 # ==> plaRowMissingOutputError =
 # ==> plaTableError =
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -261,12 +261,14 @@ plaSaveErrorTitle = Error al guardar el programa PLA
 # ==> plaInputLabel =
 # ==> plaOutputLabel =
 # ==> plaFileIoException =
-# ==> plaInvalideInputBitError =
-# ==> plaInvalideOutputBitError =
+# ==> plaInvalidInputBitError =
+# ==> plaInvalidOutputBitError =
 # ==> plaRowExactOutBitError =
 # ==> plaRowExactInBitError =
 # ==> plaRowMissingOutputError =
 # ==> plaTableError =
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -261,12 +261,14 @@ plaCommentsLabel = Commentaire
 plaInputLabel = entrée
 plaOutputLabel = sortie
 plaFileIoException = PLA le fichier n'a pas de données.
-plaInvalideInputBitError = PLA La ligne %s contiens un bit d'entré invalide %s.
-plaInvalideOutputBitError = PLA La ligne %s contiens un bit de sortie invalide %s.
+plaInvalidInputBitError = PLA La ligne %s contiens un bit d'entré invalide %s.
+plaInvalidOutputBitError = PLA La ligne %s contiens un bit de sortie invalide %s.
 plaRowExactOutBitError = PLA La ligne %s doit avoir exactement %s bits de sortie.
 plaRowExactInBitError = PLA La ligne %s doit avoir exactement %s bits d'entré.
 plaRowMissingOutputError = PLA La ligne %s manque de sorties.
 plaTableError = Erreur dans la table PLA
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -261,12 +261,14 @@ plaSaveErrorTitle = Errore nel salvataggio del programma PLA
 # ==> plaInputLabel =
 # ==> plaOutputLabel =
 # ==> plaFileIoException =
-# ==> plaInvalideInputBitError =
-# ==> plaInvalideOutputBitError =
+# ==> plaInvalidInputBitError =
+# ==> plaInvalidOutputBitError =
 # ==> plaRowExactOutBitError =
 # ==> plaRowExactInBitError =
 # ==> plaRowMissingOutputError =
 # ==> plaTableError =
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -261,12 +261,14 @@ plaSaveErrorTitle = PLAプログラムの保存エラー
 # ==> plaInputLabel =
 # ==> plaOutputLabel =
 # ==> plaFileIoException =
-# ==> plaInvalideInputBitError =
-# ==> plaInvalideOutputBitError =
+# ==> plaInvalidInputBitError =
+# ==> plaInvalidOutputBitError =
 # ==> plaRowExactOutBitError =
 # ==> plaRowExactInBitError =
 # ==> plaRowMissingOutputError =
 # ==> plaTableError =
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -261,12 +261,14 @@ plaCommentsLabel = commentaar
 plaInputLabel = invoer
 plaOutputLabel = uitvoer
 plaFileIoException = PLA file bevat geen data.
-# ==> plaInvalideInputBitError = PLA row %s contains invalid input bit %s.
-# ==> plaInvalideOutputBitError = PLA row %s contains invalid output bit %s.
+# ==> plaInvalidInputBitError = PLA row %s contains invalid input bit %s.
+# ==> plaInvalidOutputBitError = PLA row %s contains invalid output bit %s.
 plaRowExactOutBitError = PLA rij %s moet precies %s uitgansbits hebben.
 plaRowExactInBitError = PLA rij %s moet precies %s ingangsbits hebben.
 plaRowMissingOutputError = PLA rij %s mist uitgangen.
 plaTableError = Fout in PLA Tabel
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -261,12 +261,14 @@ plaSaveErrorTitle = Program do zapisywania błędów PLA
 # ==> plaInputLabel =
 # ==> plaOutputLabel =
 # ==> plaFileIoException =
-# ==> plaInvalideInputBitError =
-# ==> plaInvalideOutputBitError =
+# ==> plaInvalidInputBitError =
+# ==> plaInvalidOutputBitError =
 # ==> plaRowExactOutBitError =
 # ==> plaRowExactInBitError =
 # ==> plaRowMissingOutputError =
 # ==> plaTableError =
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -261,12 +261,14 @@ plaSaveErrorTitle = Erro ao salvar o programa PLA
 # ==> plaInputLabel =
 # ==> plaOutputLabel =
 # ==> plaFileIoException =
-# ==> plaInvalideInputBitError =
-# ==> plaInvalideOutputBitError =
+# ==> plaInvalidInputBitError =
+# ==> plaInvalidOutputBitError =
 # ==> plaRowExactOutBitError =
 # ==> plaRowExactInBitError =
 # ==> plaRowMissingOutputError =
 # ==> plaTableError =
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -261,12 +261,14 @@ plaSaveErrorTitle = Ошибка при сохранении программы
 # ==> plaInputLabel =
 # ==> plaOutputLabel =
 # ==> plaFileIoException =
-# ==> plaInvalideInputBitError =
-# ==> plaInvalideOutputBitError =
+# ==> plaInvalidInputBitError =
+# ==> plaInvalidOutputBitError =
 # ==> plaRowExactOutBitError =
 # ==> plaRowExactInBitError =
 # ==> plaRowMissingOutputError =
 # ==> plaTableError =
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -261,12 +261,14 @@ plaSaveErrorTitle = 保存 PLA 程序时出错
 # ==> plaInputLabel =
 # ==> plaOutputLabel =
 # ==> plaFileIoException =
-# ==> plaInvalideInputBitError =
-# ==> plaInvalideOutputBitError =
+# ==> plaInvalidInputBitError =
+# ==> plaInvalidOutputBitError =
 # ==> plaRowExactOutBitError =
 # ==> plaRowExactInBitError =
 # ==> plaRowMissingOutputError =
 # ==> plaTableError =
+# ==> plaUnexpectedInputWidth =
+# ==> plaUnexpectedOutputWidth =
 #
 # gates/XnorGate.java
 #


### PR DESCRIPTION
This change enables a slightly more flexible input format for PLA's. In the current situation, a PLA import file has to look something like this:

`# Logisim PLA program table`
`10000101 0010001 # Blabla`

This change also allows the following format:
`# Logisim PLA program table`
`# State | Func | Data || Next | Output # Comment`
`    100 |   00 |  101 ||  001 |   0001 # Blaba`

Being able to add column separators makes editing these files more convenient, because of the visual separation of groups of inputs and outputs. Both the current and proposed new format are supported when importing the truth table. Mixed line formats are supported as well (one line in the current format and another in the new format)