### PR TITLE
Allow plexer selects to be up to 8 bits.

### DIFF
--- a/src/main/java/com/cburch/logisim/std/plexers/PlexersLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/PlexersLibrary.java
@@ -102,7 +102,7 @@ public class PlexersLibrary extends Library {
           "size", S.getter("gateSizeAttr"), new AttributeOption[] {SIZE_NARROW, SIZE_WIDE});
 
   public static final Attribute<BitWidth> ATTR_SELECT =
-      Attributes.forBitWidth("select", S.getter("plexerSelectBitsAttr"), 1, 5);
+      Attributes.forBitWidth("select", S.getter("plexerSelectBitsAttr"), 1, 8);
   public static final Object DEFAULT_SELECT = BitWidth.create(1);
 
   public static final Attribute<Boolean> ATTR_TRISTATE =


### PR DESCRIPTION
This PR addresses issue #2273 by allowing up to 8 bits for the plexer selector inputs. I don't see any reason to stop at 6 bits as I noted in that issue.