### PR TITLE
Make the VGA component able to render 2048x2048 pixels.

### DIFF
--- a/src/main/java/com/cburch/logisim/std/io/Video.java
+++ b/src/main/java/com/cburch/logisim/std/io/Video.java
@@ -85,7 +85,7 @@ class Video extends ManagedComponent implements ToolTipMaker, AttributeListener 
     COLOR_GRAY4
   };
 
-  static final Integer[] SIZE_OPTIONS = {2, 4, 8, 16, 32, 64, 128, 256};
+  static final Integer[] SIZE_OPTIONS = {2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048};
 
   public static final Attribute<String> BLINK_OPTION =
       Attributes.forOption("cursor", S.getter("rgbVideoCursor"), BLINK_OPTIONS);


### PR DESCRIPTION
Hi,

I’d like to increase the bit‑width of the VGA component’s X and Y inputs so it can render 640×480—and optionally higher—resolutions. This change simply involves adding the new values to the SIZE_OPTIONS array in Video.java.

I previously requested a related change in issue #2278; this pull request addresses that under #2283.

Thank you,
Elías A.
@elijaxapps (YouTube)