### PR TITLE
Allow DIP switch minimum width of 1

### DIFF
--- a/src/main/java/com/cburch/logisim/std/io/DipSwitch.java
+++ b/src/main/java/com/cburch/logisim/std/io/DipSwitch.java
@@ -120,7 +120,8 @@ public class DipSwitch extends InstanceFactory {
   }
 
   public static final int MAX_SWITCH = 32;
-  public static final int MIN_SWITCH = 2;
+  // MODIFIED: Changed minimum width from 2 to 1 to allow single DIP switch
+  public static final int MIN_SWITCH = 1;
 
   public static final Attribute<BitWidth> ATTR_SIZE =
       Attributes.forBitWidth("number", S.getter("nrOfSwitch"), MIN_SWITCH, MAX_SWITCH);


### PR DESCRIPTION
This change modifies the DIP switch component to allow a minimum width of 1 instead of 2.

Summary of changes:
- Updated MIN_SWITCH in src/main/java/com/cburch/logisim/std/io/DipSwitch.java from 2 to 1.
- Added an inline comment explaining the change.
- Verified rendering, bounds, port positioning, and validation logic all work for width=1.
- Successfully built and ran the application to confirm no regressions.

Enables creation of single DIP switches for simple on/off controls and single-bit teaching examples.

Fixes #2198
