### PR TITLE
Fix Quit followed by Cancel on the Mac.

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/start/MacOsAdapter.java
+++ b/src/main/java/com/cburch/logisim/gui/start/MacOsAdapter.java
@@ -40,8 +40,8 @@ class MacOsAdapter {
       try {
         dt.setQuitHandler(
             (e, response) -> {
-              ProjectActions.doQuit();
-              response.performQuit();
+              ProjectActions.doQuit(); // calls System.exit() if quit is not cancelled
+              response.cancelQuit(); // if we get here the quit was cancelled.
             });
       } catch (Exception ignored) {
         // can fail, but just ignore it.


### PR DESCRIPTION
In checking memory changes, I was creating new projects, adding memory components and then I would just quit and discard. But one time I wanted to try something else and hit cancel rather than discard after quit. Rather than take me back to the project, the program simply quit.

So this PR fixes a long time bug on the Mac where it quits rather than cancels the quit.