### PR TITLE
Fix SonarQube failure.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
   java
   application
   id("com.gradleup.shadow") version "9.0.2"
-  id("org.sonarqube") version "6.3.0.5676"
+  id("org.sonarqube") version "6.3.1.5724"
 }
 
 repositories {


### PR DESCRIPTION
The version of SonarQube that dependabot gave does not exist in the repository. This updates it.