### PR TITLE
Add FlatLaf macOS look & feels

### DIFF
--- a/src/main/java/com/cburch/logisim/Main.java
+++ b/src/main/java/com/cburch/logisim/Main.java
@@ -17,6 +17,8 @@ import com.formdev.flatlaf.FlatDarculaLaf;
 import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatIntelliJLaf;
 import com.formdev.flatlaf.FlatLightLaf;
+import com.formdev.flatlaf.themes.FlatMacDarkLaf;
+import com.formdev.flatlaf.themes.FlatMacLightLaf;
 import java.awt.Font;
 import java.awt.GraphicsEnvironment;
 import java.io.PrintWriter;
@@ -37,8 +39,10 @@ public class Main {
       if (!GraphicsEnvironment.isHeadless()) {
         FlatLightLaf.installLafInfo();
         FlatDarkLaf.installLafInfo();
-        FlatDarculaLaf.installLafInfo();
         FlatIntelliJLaf.installLafInfo();
+        FlatDarculaLaf.installLafInfo();
+        FlatMacLightLaf.installLafInfo();
+        FlatMacDarkLaf.installLafInfo();
 
         UIManager.setLookAndFeel(AppPreferences.LookAndFeel.get());
         UIManager.put(

--- a/src/main/resources/doc/fr/html/guide/prefs/pref-window.html
+++ b/src/main/resources/doc/fr/html/guide/prefs/pref-window.html
@@ -59,17 +59,18 @@
         <li>
           <p>
             <b>Aspect de l'interface:</b> Permets de sélectionner un certain nombre d'aspects de l'interface à expérimenter selon vos goûts.<br>
-			Metal
-			<br>Nimbus
-			<br>CDE/Motif
-      <br>GTK+
-			<br>Windows
-			<br>Windows classique
-			<br>FlatLaf Light
-			<br>FlatLaf Dark
-      <br>FlatLaf IntelliJ
-			<br>FlatLaf Darcula
-      <br>
+			      Metal<br>
+            Nimbus<br>
+            CDE/Motif<br>
+            GTK+<br>
+            Windows<br>
+            Windows classique<br>
+            FlatLaf Light<br>
+            FlatLaf Dark<br>
+            FlatLaf IntelliJ<br>
+            FlatLaf Darcula<br>
+            FlatLaf macOS Light<br>
+            FlatLaf macOS Dark<br>
             <b>Nécessite de relancer le programme</b>
           </p>
         </li>

--- a/src/main/resources/doc/fr/html/guide/prefs/pref-window.html
+++ b/src/main/resources/doc/fr/html/guide/prefs/pref-window.html
@@ -62,11 +62,14 @@
 			Metal
 			<br>Nimbus
 			<br>CDE/Motif
+      <br>GTK+
 			<br>Windows
 			<br>Windows classique
-			<br>Flatlf Light
+			<br>FlatLaf Light
 			<br>FlatLaf Dark
-			<br>FlatLaf Dracula<br>
+      <br>FlatLaf IntelliJ
+			<br>FlatLaf Darcula
+      <br>
             <b>Nécessite de relancer le programme</b>
           </p>
         </li>


### PR DESCRIPTION
[FlatLaf](https://www.formdev.com/flatlaf/) offers since version 3.0 FlatLaf macOS Light and FlatLaf macOS Dark as part of their [core themes](https://www.formdev.com/flatlaf/themes/). This PR adds support for these themes to Logisim-evolution.