### PR TITLE
Set parent component for the "Edit/specify a components label" input dialog

### DIFF
--- a/src/main/java/com/cburch/logisim/util/AutoLabel.java
+++ b/src/main/java/com/cburch/logisim/util/AutoLabel.java
@@ -229,7 +229,7 @@ public class AutoLabel {
     var newLabel = oldLabel;
     while (!correct) {
       newLabel = (String)
-          OptionPane.showInputDialog(null, S.get("editLabelQuestion") + " " + componentName,
+          OptionPane.showInputDialog(circ.getProject().getFrame(), S.get("editLabelQuestion") + " " + componentName,
               S.get("editLabelDialog"), OptionPane.QUESTION_MESSAGE, null, null, oldLabel);
       if (newLabel != null) {
         if (Circuit.isCorrectLabel(circ.getName(),


### PR DESCRIPTION
The parent component is used to determine the application icon shown in the window decoration and ensures that the dialog window is centered above the application main window.

Thanks, @davidhutchens, for your suggestion how to get the correct parent component.

This fixes issue #1962.