### PR TITLE
Regression: PLA tables cant load rows with `x` aka DONT_CARE in any bit

### DIFF
--- a/src/main/java/com/cburch/logisim/std/gates/PlaTable.java
+++ b/src/main/java/com/cburch/logisim/std/gates/PlaTable.java
@@ -213,7 +213,7 @@ public class PlaTable {
     protected boolean canParse(String line) {
       final var io = inputsOutputs(line);
 
-      return io.matches("[01]+\\s+[01]+");
+      return io.matches("[01x]+\\s+[01]+");
     }
   }
 


### PR DESCRIPTION
see #2339