### PR TITLE
Improve user experience for Add Circuit and Add VHDL Entity dialogs

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/menu/ProjectCircuitActions.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/ProjectCircuitActions.java
@@ -141,12 +141,23 @@ public class ProjectCircuitActions {
   }
 
   public static void doAddVhdl(Project proj) {
-    final var name = promptForVhdlName(proj.getFrame(), proj.getLogisimFile(), "");
-    if (name != null) {
+    String initialValue = "";
+    while (true) {
+      final var name = promptForNewName(proj.getFrame(), proj.getLogisimFile(), initialValue, true);
+      if (name == null) break;
+
+      if (VhdlContent.labelVHDLInvalidNotify(name, proj.getLogisimFile())) {
+        initialValue = name;
+        continue;
+      }
+
       final var content = VhdlContent.create(name, proj.getLogisimFile());
       if (content != null) {
         proj.doAction(LogisimFileActions.addVhdl(content));
         proj.setCurrentHdlModel(content);
+        break;
+      } else {
+        initialValue = name;
       }
     }
   }


### PR DESCRIPTION
Hi everyone,

I'm a freshman who just started learning digital logic circuits recently. While using Logisim-evolution, I found something frustrating when adding circuits or VHDL entities:

When I enter an invalid name, an error dialog pops up. After I close it, the input dialog just disappears completely. I have to go back to the menu, click "Add Circuit" (or "Add VHDL Entity") again, and retype everything from scratch. This gets really annoying, especially when I only made a small typo or mistake.

I modified the `doAddCircuit()` and `doAddVhdl()` methods to add retry logic. Now after a validation error, the input dialog automatically reopens with the invalid name pre-filled. Users can simply fix the mistake instead of retyping everything. The dialog keeps retrying until a valid name is entered or the user clicks Cancel.

I've tested this with various invalid inputs and confirmed it works as expected.

Thank you for this amazing project! I hope you like this improvement.