### PR TITLE
Update reset and step methods for nonSimThreadEvents.

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/Propagator.java
+++ b/src/main/java/com/cburch/logisim/circuit/Propagator.java
@@ -209,9 +209,13 @@ public class Propagator {
     return iters > 0;
   }
 
+  /** Must be called by the simulation thread */
   void reset() {
     halfClockCycles = 0;
     toProcess.clear();
+    synchronized (nonSimThreadEvents) {
+      nonSimThreadEvents.clear();
+    }
     root.reset();
     isOscillating = false;
   }
@@ -273,6 +277,7 @@ public class Propagator {
 
   /** Must be called from simulation thread */
   boolean step(PropagationPoints changedPoints) {
+    moveNonSimThreadEvents();
     oscPoints.clear();
     root.processDirtyPoints();
     root.processDirtyComponents();


### PR DESCRIPTION
I missed a couple of things in PR #2357.

The nonSimThreadEvents ArrayList should be cleared in the reset() method.

The step() method should also check if any events have been put in nonSimThreadEvents.

Those omissions are fixed in this PR.