### PR TITLE
Fix bug where Project->Analyze Circuits could not be run on circuits with text labels

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/Analyze.java
+++ b/src/main/java/com/cburch/logisim/circuit/Analyze.java
@@ -24,6 +24,7 @@ import com.cburch.logisim.data.Value;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.base.Text;
 import com.cburch.logisim.std.wiring.Pin;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -341,6 +342,7 @@ public class Analyze {
         }
       } else if (comp.getFactory() instanceof Pin) { // pins are handled elsewhere
       } else if (comp.getFactory() instanceof SplitterFactory) { // splitters are handled elsewhere
+      } else if (comp.getFactory() instanceof Text) { // can safely ignore
       } else {
         throw new AnalyzeException.CannotHandle(comp.getFactory().getDisplayName());
       }


### PR DESCRIPTION
Previously, if a circuit had a text label in it, using Project->Analyze Circuit would throw an `AnalyzeException.CannotHandle` in the `Analyze.propagateComponents` function and display "Computing truth table instead of expression due to Label" in a popup.

This fix will skip past any `Text` components when propagating components into an `ExpressionMap` as they should not effect the outcome and will normally just make it error.

**Initial bug:**
Use Analyze Circuit from the project menu: 
<img width="328" height="589" alt="image" src="https://github.com/user-attachments/assets/d3e6e24e-23c9-4f1f-9f94-c98190867a2a" />
<img width="669" height="313" alt="image" src="https://github.com/user-attachments/assets/e11cb9a1-ed91-4491-adbc-3fb8fa195702" />

**With fix:**
<img width="1041" height="675" alt="image" src="https://github.com/user-attachments/assets/f2e46a10-192e-403f-8707-3de03a22a905" />

