### PR TITLE
soc/rv32im: add mscratch CSR support, refactor some util methods

### DIFF
--- a/src/main/java/com/cburch/logisim/soc/rv32im/RV32imState.java
+++ b/src/main/java/com/cburch/logisim/soc/rv32im/RV32imState.java
@@ -55,10 +55,10 @@ public class RV32imState implements SocUpSimulationStateListener, SocProcessorIn
 
   private static final Integer[] implementedSprs = {
       0xF11, 0xF12, 0xF13, 0xF14, 0x300, 0x301, 0x304, 0x305,
-      0x341, 0x342, 0x343, 0x344, 0x7B0, 0x7B1, 0x7A0, 0x7A1, 0x7A2, 0x7A4};
+      0x340, 0x341, 0x342, 0x343, 0x344, 0x7B0, 0x7B1, 0x7A0, 0x7A1, 0x7A2, 0x7A4};
   public static final String[] implementedSprNames = {
       "MVENDORID", "MARCHID", "MIMPID", "MHARTID", "MSTATUS", "MISA", "MIE", "MTVEC",
-      "MEPC", "MCAUSE", "MTVAL", "MIP", "DCSR", "DPC", "TSELECT", "TDATA1", "TDATA2",
+      "MSCRATCH", "MEPC", "MCAUSE", "MTVAL", "MIP", "DCSR", "DPC", "TSELECT", "TDATA1", "TDATA2",
       "TINFO" };
 
   public class ProcessorState extends JPanel
@@ -649,44 +649,26 @@ public class RV32imState implements SocUpSimulationStateListener, SocProcessorIn
     }
     return 0;
   }
-  
+
   public static boolean isSprImplemented(int index) {
-    var contained = false;
-    for (var i = 0; i < implementedSprs.length; i++) {
-      if (implementedSprs[i].equals(index)) {
-        contained = true;
-      }
-    }
-    return contained;
+    return getSprArrayIndex(index) != -1;
   }
     
   public static int getSprArrayIndex(int index) {
-    if (isSprImplemented(index)) {
-      for (var i = 0; i < implementedSprs.length; i++) {
-        if (implementedSprs[i].equals(index)) {
-          return i;
-        }
-      }
-    }
-    return -1;
+    return Arrays.asList(implementedSprs).indexOf(index);
   }
     
   public static int getSprArrayIndex(String name) {
-    var index = -1;
-    for (var i = 0; i < implementedSprNames.length; i++) {
-      if (implementedSprNames[i].equals(name.toUpperCase())) {
-        index = i;
-      }
-    }
-    return index;
+    return Arrays.asList(implementedSprNames).indexOf(name.toUpperCase());
   }
       
   public static String getSprName(int index) {
-    return isSprImplemented(index)
-          ? implementedSprNames[getSprArrayIndex(index)].toLowerCase()
+    int sprIndex = getSprArrayIndex(index);
+    return sprIndex != -1
+          ? implementedSprNames[sprIndex].toLowerCase()
           : String.format("0x%03X", index);
   }
-    
+
   public static int getSprValue(int index) {
     return (index < 0 || index >= implementedSprs.length) 
           ? -1


### PR DESCRIPTION
After #2465 is landed, the RV32IM processor is now able to handle interrupts. However, the `mscratch` CSR is also very useful (e.g. for context switching when interrupts happen) but not enabled.

This PR adds this CSR, as well as refactors some helper functions for more readability. The changes are tested by a real program that uses `mscratch`.