### PR TITLE
Fix build workflow to actually build for Dependabot changes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,12 @@ jobs:
       with:
         filters: |
           src:
-            - 'src/**/*.flex'
             - 'src/**/*.java'
             - 'src/**/*.properties'
             - '*.gradle*'
             - 'gradle.properties'
+            - 'gradle/**/*.properties'
+            - 'build.gradle.kts'
 
     - name: "WILL BUILD STEP BE RUN?"
       run: |


### PR DESCRIPTION
This PR adds change build workflow tests for files Dependabot updates.

It also removes the test for the *.flex file since flex was removed.