### PR TITLE
Fix TestThread to work with subcircuits.

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/test/TestThread.java
+++ b/src/main/java/com/cburch/logisim/gui/test/TestThread.java
@@ -38,7 +38,7 @@ public class TestThread extends UniquelyNamedThread implements CircuitListener {
 
     this.project = model.getProject();
     this.circuit = model.getCircuit();
-    this.circuitState = CircuitState.createRootState(this.project, this.circuit, this);
+    this.circuitState = this.project.getCircuitState().cloneAsNewRootState(this);
     this.vector = model.getVector();
     this.evaluator = new TestVectorEvaluator(circuitState, vector);
     model.getCircuit().addCircuitListener(this);


### PR DESCRIPTION
This PR should fix issue #2499.

The problem was that the simulation tree was being built by propagation while evaluating the test vector, but that also triggered a notification on adding the substate, which TestThread catches and cancels the evaluation. Using clone to build the root circuitState builds the whole tree in advance.