### PR TITLE
Fix Divider bugs.

### DIFF
--- a/src/main/java/com/cburch/logisim/std/arith/Divider.java
+++ b/src/main/java/com/cburch/logisim/std/arith/Divider.java
@@ -47,34 +47,26 @@ public class Divider extends InstanceFactory {
     if (!hasUpper) upper = Value.createKnown(width, 0);
     if (a.isFullyDefined() && b.isFullyDefined() && upper.isFullyDefined()) {
       if (w <= 32) {
-        long bb = b.toSignExtendedLongValue();
-        long num;
-        if (hasUpper) {
-          long low = a.toLongValue();
-          long upp = (upper.toSignExtendedLongValue() << w);
-          num = (upp) | low;
-        } else {
-          num = a.toSignExtendedLongValue();
-        }
-        long den = bb == 0 ? 1 : bb;
-
-        long res, rem;
         if (unsigned) {
-          res = Long.divideUnsigned(num, den);
-          rem = Long.remainderUnsigned(num, den);
+          long bb = b.toLongValue();
+          long den = bb == 0 ? 1 : bb;
+          long num = hasUpper ? (upper.toLongValue() << w) | a.toLongValue() : a.toLongValue();
+          long res = Long.divideUnsigned(num, den);
+          long rem = Long.remainderUnsigned(num, den);
+          return new Value[] {Value.createKnown(width, res), Value.createKnown(width, rem)};
         } else {
-          res = num / den;
-          rem = num % den;
+          long bb = b.toSignExtendedLongValue();
+          long den = bb == 0 ? 1 : bb;
+          long num = hasUpper ? (upper.toSignExtendedLongValue() << w) | a.toLongValue() : a.toSignExtendedLongValue();
+          long res = num / den;
+          long rem = num % den;
+          return new Value[] {Value.createKnown(width, res), Value.createKnown(width, rem)};
         }
-
-        return new Value[] {Value.createKnown(width, res), Value.createKnown(width, rem)};
       }
-      BigInteger uu = upper.toBigInteger(unsigned);
-      BigInteger aa = a.toBigInteger(unsigned);
       BigInteger bb = b.toBigInteger(unsigned);
-
-      BigInteger num = uu.shiftLeft(w).or(aa);
-      BigInteger den = bb.equals(BigInteger.ZERO) ? BigInteger.valueOf(1) : bb;
+      BigInteger den = bb.equals(BigInteger.ZERO) ? BigInteger.ONE : bb;
+      BigInteger num = hasUpper ? upper.toBigInteger(unsigned).shiftLeft(w).or(a.toBigInteger(true))
+          : a.toBigInteger(unsigned);
 
       BigInteger[] res = num.divideAndRemainder(den);
       long result = res[0].longValue();


### PR DESCRIPTION
This PR is my solution to issue #2505.

It fixes the original issue by handling the unsigned and signed versions separately for width <= 32. The optimization change sign-extended both the signed and unsigned values causing the reported problem.

This PR also fixes the problem I noted in the BigInteger portion. There, the code sign-extended the lower half of the numerator if its high-order bit was 1 (since BitInteger was told it was 2s complement) when doing a signed divide. This occurred within BigInteger as it resized the value to `or` in the upper half. The fix is to tell BigInteger that the lower half of the numerator is always unsigned when there is an upper half. It still treats that input as 2s complement if there is no upper part. Of course, for unsigned divide, it treats all inputs as unsigned.

Note that the variable `unsigned` is a boolean that is true if doing an unsigned divide and false if doing a 2s-complement divide. The parameter to `toBigInteger` tells it whether to treat the value as unsigned or 2s complement, with `true` meaning unsigned and `false` meaning 2s complement.

I organized the code for the three parts so they all follow the same basic logic pattern. Thus it is easy to see how they work and how they differ.

I spent the last day or so finding various ways to test this. Since there were at least 2 bugs in this method, I wanted to reduce the possibility that I was adding another. I haven't found a fault or noticed a failure. The code looks right to me.