### PR TITLE
docs(zh): fix incorrect translation

### DIFF
--- a/src/main/resources/doc/zh/html/guide/gui/gui-attrcomp.html
+++ b/src/main/resources/doc/zh/html/guide/gui/gui-attrcomp.html
@@ -46,7 +46,7 @@
    </p>
    <p>
     <!-- With some tools, the tool's icon reflects some of the attributes' values. One example of this is the Pin tool, whose icon faces the same way as its Facing attribute says. -->
-    对于某些工具，工具的图标反映了某些属性的值。 其中一个例子是“固定”工具，其图标的朝向与其“Facing”属性所示的方向相同。
+    对于某些工具，工具的图标反映了某些属性的值。 其中一个例子是“引脚”工具，其图标的朝向与其“Facing”属性所示的方向相同。
    </p>
    <p>
     <!-- The tools in the toolbar each have a separate attribute set from the corresponding tools in the explorer pane. Thus, even though we changed the toolbar's AND tool to create narrow AND gates, the AND tool in the Gates library will still create wide AND gates unless you change its attributes too. -->

--- a/src/main/resources/doc/zh/html/guide/gui/gui-explore.html
+++ b/src/main/resources/doc/zh/html/guide/gui/gui-explore.html
@@ -178,7 +178,7 @@
     <b class="menu">
      | Load Library |
     </b>
-    或通过 &lt; b class="tkeybd"&gt;左键单击
+    或通过 <b class="tkeybd"> 左键单击
     项目资源管理器的根文件夹。 您可以看到 Logisim-evolution 具有三类库。
    </p>
    <ul>


### PR DESCRIPTION
Fixes #2526

### Changes Made
This PR contains two minor fixes for the zh-CN HTML guide:

* **`gui-attrcomp.html`**: Fixed the incorrect translation of the "Pin" component (changed "固定" to "引脚").
* **`gui-explore.html`**: Fixed broken/escaped HTML tags (`&lt;`/`&gt;` back to `<`/`>`) so the `<b class="tkeybd">` style renders correctly.