### PR TITLE
feat(ui): add quick-search component filtering to toolbox

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
@@ -43,6 +43,7 @@ import javax.swing.JLabel;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
@@ -115,6 +116,17 @@ public class ProjectExplorer extends JTree implements LocaleListener {
     // abbreviated with an ellipsis, even when they fit into the window.
     final ProjectExplorerModel model = (ProjectExplorerModel) getModel();
     model.fireStructureChanged();
+  }
+
+  public void setFilter(String filter) {
+    ((ProjectExplorerModel) getModel()).setFilter(filter);
+    if (filter != null && !filter.trim().isEmpty()) {
+      SwingUtilities.invokeLater(() -> {
+        for (int i = 0; i < getRowCount(); i++) {
+          expandRow(i);
+        }
+      });
+    }
   }
 
   public void setHaloedTool(Tool t) {

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorerModel.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorerModel.java
@@ -30,6 +30,7 @@ class ProjectExplorerModel extends DefaultTreeModel implements ProjectListener {
   private final JTree uiElement;
   private Project proj;
   private final boolean showMouseTools;
+  private String filter = "";
 
   ProjectExplorerModel(Project proj, JTree gui, boolean showMouseTools) {
     super(null);
@@ -105,6 +106,58 @@ class ProjectExplorerModel extends DefaultTreeModel implements ProjectListener {
       setLogisimFile(value.getLogisimFile());
     }
     fireStructureChanged();
+  }
+
+  public void setFilter(String newFilter) {
+    this.filter = (newFilter == null) ? "" : newFilter.trim().toLowerCase();
+    final var root = (Node<?>) getRoot();
+    if (root != null) {
+      fireTreeStructureChanged(this, root.getUserObjectPath(), null, null);
+    } else {
+      fireTreeStructureChanged(this, null, null, null);
+    }
+  }
+
+  private boolean nodeMatchesFilter(Object node) {
+    if (filter.isEmpty()) return true;
+    if (node instanceof ProjectExplorerToolNode toolNode) {
+      final var tool = toolNode.getValue();
+      return tool != null && tool.getDisplayName().toLowerCase().contains(filter);
+    }
+    if (node instanceof ProjectExplorerLibraryNode) {
+      final var libNode = (DefaultMutableTreeNode) node;
+      for (int i = 0; i < libNode.getChildCount(); i++) {
+        if (nodeMatchesFilter(libNode.getChildAt(i))) return true;
+      }
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int getChildCount(Object parent) {
+    if (filter.isEmpty()) return super.getChildCount(parent);
+    int count = 0;
+    final int total = super.getChildCount(parent);
+    for (int i = 0; i < total; i++) {
+      if (nodeMatchesFilter(super.getChild(parent, i))) count++;
+    }
+    return count;
+  }
+
+  @Override
+  public Object getChild(Object parent, int index) {
+    if (filter.isEmpty()) return super.getChild(parent, index);
+    int count = 0;
+    final int total = super.getChildCount(parent);
+    for (int i = 0; i < total; i++) {
+      final var child = super.getChild(parent, i);
+      if (nodeMatchesFilter(child)) {
+        if (count == index) return child;
+        count++;
+      }
+    }
+    return null;
   }
 
   public void updateStructure() {

--- a/src/main/java/com/cburch/logisim/gui/main/Toolbox.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Toolbox.java
@@ -15,23 +15,42 @@ import com.cburch.logisim.gui.menu.MenuListener;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.tools.Tool;
 import java.awt.BorderLayout;
+import javax.swing.BoxLayout;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 class Toolbox extends JPanel {
   private static final long serialVersionUID = 1L;
   private final ProjectExplorer toolbox;
+  private final JTextField searchField;
 
   Toolbox(Project proj, Frame frame, MenuListener menu) {
     super(new BorderLayout());
 
     final var toolbarModel = new ToolboxToolbarModel(frame, menu);
     final var toolbar = new Toolbar(toolbarModel);
-    add(toolbar, BorderLayout.NORTH);
+
+    searchField = new JTextField();
+    searchField.setToolTipText("Filter components...");
+
+    final var northPanel = new JPanel();
+    northPanel.setLayout(new BoxLayout(northPanel, BoxLayout.Y_AXIS));
+    northPanel.add(toolbar);
+    northPanel.add(searchField);
+    add(northPanel, BorderLayout.NORTH);
 
     toolbox = new ProjectExplorer(proj, false);
     toolbox.setListener(new ToolboxManip(proj, toolbox));
     add(new JScrollPane(toolbox), BorderLayout.CENTER);
+
+    searchField.getDocument().addDocumentListener(new DocumentListener() {
+      @Override public void insertUpdate(DocumentEvent e)  { toolbox.setFilter(searchField.getText()); }
+      @Override public void removeUpdate(DocumentEvent e)  { toolbox.setFilter(searchField.getText()); }
+      @Override public void changedUpdate(DocumentEvent e) { toolbox.setFilter(searchField.getText()); }
+    });
 
     toolbarModel.menuEnableChanged(menu);
   }
@@ -44,3 +63,4 @@ class Toolbox extends JPanel {
     toolbox.updateStructure();
   }
 }
+


### PR DESCRIPTION
Hi! 
I've implemented a real-time search field in the Toolbox panel that allows users to quickly filter the component explorer tree. This improves the workflow significantly, especially in large projects with many libraries.

Key Changes:
- Added a JTextField for entering search queries at the top of the Toolbox.
- Implemented case-insensitive filtering for the component tree.
- The view updates dynamically as the user types.
- Tested locally on Windows with JDK 21.