### PR TITLE
fix #1297: display CJK character in panel correctly

### DIFF
--- a/src/main/java/com/cburch/logisim/Main.java
+++ b/src/main/java/com/cburch/logisim/Main.java
@@ -59,6 +59,13 @@ public class Main {
           UIManager.put(
               "ToolTip.font",
             new FontUIResource("SansSerif", Font.BOLD, AppPreferences.getScaled(12)));
+          UIManager.put(
+              "Tree.font",
+            new FontUIResource("SansSerif", Font.BOLD, AppPreferences.getScaled(12)));
+          // don't need this
+          // UIManager.put(
+          //     "Label.font",
+          //   new FontUIResource("SansSerif", Font.BOLD, AppPreferences.getScaled(12)));
         }
       }
     } catch (ClassNotFoundException


### PR DESCRIPTION
I encounter the bug described in #1297, then I build it from source and reproduce it.

With the help of Deepseek, I fix this bug (maybe)

It works well in my Arch Linux and my termux(with termux-x11 and setting Environment Variable).

This commit include a commented line because without this it is still working. (but I don't test if it has any other uses)
