### PR TITLE
Add appearance option for subcircuits

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
@@ -217,7 +217,8 @@ public class CircuitAttributes extends AbstractAttributeSet {
           NAME_ATTR,
           CIRCUIT_LABEL_ATTR,
           CIRCUIT_LABEL_FACING_ATTR,
-          CIRCUIT_LABEL_FONT_ATTR);
+          CIRCUIT_LABEL_FONT_ATTR,
+          APPEARANCE_ATTR);
 
   private final Circuit source;
   private Instance subcircInstance;


### PR DESCRIPTION
The appearance attribute wasn't being exposed for subcircuits. Just needed to add APPEARANCE_ATTR to the list so it gets included like the other circuit attributes.

Fixes #2370