### PR TITLE
Clarify automatic library import directory

### DIFF
--- a/docs/automatic_library_import.md
+++ b/docs/automatic_library_import.md
@@ -1,14 +1,17 @@
-﻿# Automatically Importing Logisim Libraries
+# Automatically Importing Logisim Libraries
 
 Logisim Evolution supports loading custom libraries at startup, contained in Logisim `.circ` files.
 
-To do this, create a directory named `logisim-defaults` in either:
+To do this, create a directory named `logisim-defaults` in the program directory used to start Logisim Evolution:
 
-- The same directory as the `.jar` file which is executing Logisim
+- For an installed application, this is the application directory. On a default Windows install, that may be
+  `C:\Program Files\logisim-evolution\app\logisim-defaults`.
+- For a standalone `.jar`, place `logisim-defaults` in the same directory as the `.jar` file that starts Logisim Evolution.
   ![Where the logisim-defaults folder goes, if executing from a JAR file.](img/logisim-defaults-jar.png)
-- Inside `/build/classes/java/`, if running from Gradle. ![Where the logisim-defaults folder goes, if running from Gradle.](img/logisim-defaults-build.png)
+- For a Gradle run, place `logisim-defaults` inside `/build/classes/java/`.
+  ![Where the logisim-defaults folder goes, if running from Gradle.](img/logisim-defaults-build.png)
 
-Inside the `logisim-defaults`folder should be any `.circ` files which you would like to load automatically at startup.
+Inside the `logisim-defaults` folder should be any `.circ` files which you would like to load automatically at startup.
 **Every circuit must have a unique name, and must not be called
 "main"**. This is to avoid conflicts caused by loading libraries with the same name.
 


### PR DESCRIPTION
## Summary

Clarifies where the `logisim-defaults` directory should be placed for automatic library imports.

The docs now distinguish between:

- installed application layouts
- standalone JAR execution
- Gradle runs

It also fixes a small spacing typo in the `logisim-defaults` folder sentence.

Related to #2368.

## Tests

Not run; documentation-only change.

## Notes

No screenshots or code behavior were changed.