### PR TITLE
cli: include bit widths in tty table headers

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
+++ b/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
@@ -205,7 +205,7 @@ public class TtyInterface {
   }
 
   static String formatTestVectorHeader(String pinName, int width) {
-    return String.format("%s[%d]", pinName, width);
+    return width == 1 ? pinName : String.format("%s[%d]", pinName, width);
   }
 
   private static String formatTestVectorHeader(String pinName, Instance pin) {

--- a/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
+++ b/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
@@ -204,6 +204,14 @@ public class TtyInterface {
     }
   }
 
+  static String formatTestVectorHeader(String pinName, int width) {
+    return String.format("%s[%d]", pinName, width);
+  }
+
+  private static String formatTestVectorHeader(String pinName, Instance pin) {
+    return formatTestVectorHeader(pinName, pin.getAttributeValue(StdAttr.WIDTH).getWidth());
+  }
+
   private static void ensureLineTerminated() {
     if (!lastIsNewline) {
       lastIsNewline = true;
@@ -399,7 +407,7 @@ public class TtyInterface {
       final var pin = entry.getKey();
       final var pinName = entry.getValue();
       if (Pin.FACTORY.isInputPin(pin)) {
-        headers.add(pinName);
+        headers.add(formatTestVectorHeader(pinName, pin));
         pinList.add(pin);
       }
     }
@@ -408,7 +416,7 @@ public class TtyInterface {
       final var pin = entry.getKey();
       final var pinName = entry.getValue();
       if (!Pin.FACTORY.isInputPin(pin)) {
-        headers.add(pinName);
+        headers.add(formatTestVectorHeader(pinName, pin));
         pinList.add(pin);
       }
     }

--- a/src/test/java/com/cburch/logisim/gui/start/TtyInterfaceTest.java
+++ b/src/test/java/com/cburch/logisim/gui/start/TtyInterfaceTest.java
@@ -24,7 +24,7 @@ public class TtyInterfaceTest {
 
   @Test
   public void testVectorHeaderIncludesBitWidth() {
-    assertEquals("a[1]", TtyInterface.formatTestVectorHeader("a", 1));
+    assertEquals("a", TtyInterface.formatTestVectorHeader("a", 1));
     assertEquals("x[4]", TtyInterface.formatTestVectorHeader("x", 4));
   }
 

--- a/src/test/java/com/cburch/logisim/gui/start/TtyInterfaceTest.java
+++ b/src/test/java/com/cburch/logisim/gui/start/TtyInterfaceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.start;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cburch.logisim.data.TestVector;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TtyInterfaceTest {
+
+  @TempDir File tempDir;
+
+  @Test
+  public void testVectorHeaderIncludesBitWidth() {
+    assertEquals("a[1]", TtyInterface.formatTestVectorHeader("a", 1));
+    assertEquals("x[4]", TtyInterface.formatTestVectorHeader("x", 4));
+  }
+
+  @Test
+  public void testVectorHeaderCanBeParsedByTestVector() throws IOException {
+    File testFile = new File(tempDir, "tty-table-output.txt");
+    try (FileWriter writer = new FileWriter(testFile)) {
+      writer.write(
+          TtyInterface.formatTestVectorHeader("a", 2)
+              + " "
+              + TtyInterface.formatTestVectorHeader("x", 4)
+              + "\n");
+      writer.write("00 0001\n");
+      writer.write("11 1000\n");
+    }
+
+    TestVector vector = new TestVector(testFile);
+
+    assertEquals("a", vector.columnName[0]);
+    assertEquals(2, vector.columnWidth[0].getWidth());
+    assertEquals("x", vector.columnName[1]);
+    assertEquals(4, vector.columnWidth[1].getWidth());
+    assertEquals(2, vector.data.size());
+  }
+}


### PR DESCRIPTION
## Summary

- Include pin bit widths in `-tty table` headers, for example `a[2] x[4]`.
- Add a focused regression test that verifies the generated header format can be parsed by `TestVector`.

## Why

`TestVector` headers require explicit bit widths, but `-tty table` previously printed only pin names. That made the generated table output unusable as a TestVector without manual editing.

Fixes #2570.

## Validation

- `./gradlew.bat test --tests com.cburch.logisim.gui.start.TtyInterfaceTest --tests com.cburch.logisim.data.TestVectorTest`
- `./gradlew.bat checkstyleMain checkstyleTest`
- `git diff --check`
