### PR TITLE
wiring: set owner for pin input dialogs

### DIFF
--- a/src/main/java/com/cburch/logisim/std/wiring/Pin.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Pin.java
@@ -48,6 +48,7 @@ import com.cburch.logisim.util.LocaleListener;
 
 import java.awt.Color;
 import java.awt.Font;
+import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GridBagConstraints;
@@ -75,6 +76,11 @@ public class Pin extends InstanceFactory {
    */
   public static final String _ID = "Pin";
 
+  private static Frame getOwnerFrame(InstanceState state) {
+    final var project = state.getProject();
+    return project == null ? null : project.getFrame();
+  }
+
   @SuppressWarnings("serial")
   private static class EditDecimal extends JDialog implements BaseKeyListenerContract, LocaleListener {
 
@@ -97,7 +103,7 @@ public class Pin extends InstanceFactory {
     }
 
     public EditDecimal(InstanceState state) {
-      super();
+      super(getOwnerFrame(state));
       this.state = state;
       radix = state.getAttributeValue(RadixOption.ATTRIBUTE);
       pinState = getState(state);
@@ -250,7 +256,7 @@ public class Pin extends InstanceFactory {
     }
 
     public EditFloat(InstanceState state) {
-      super();
+      super(getOwnerFrame(state));
       this.state = state;
       pinState = getState(state);
       final var value = pinState.intendedValue;


### PR DESCRIPTION
## Summary

- Set the project frame as the owner for the pin decimal input dialog.
- Apply the same owner handling to the pin float input dialog, which used the same ownerless `JDialog` pattern.

## Why

In #2372, the pin decimal input dialog can be initially laid out incorrectly on Windows with an external monitor / DPI setup. The maintainer noted that the generic Java icon indicates the dialog has no parent window, similar to #1962 and the fix in #2330.

This change gives the pin input dialogs the project frame as their owner, so Swing can associate them with the correct application window and graphics configuration.

## Notes

I cannot reproduce the Windows-specific DPI behavior locally, so this PR focuses on the ownerless-dialog issue identified in the discussion. The fix is intentionally small and mirrors the parent-window approach used by #2330.

Addresses #2372.

## Validation

- `./gradlew.bat compileJava checkstyleMain`
- `git diff --check`
