### PR TITLE
appearance: resolve nested Probe dynamic state

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/appear/DynamicElement.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DynamicElement.java
@@ -28,6 +28,7 @@ import com.cburch.logisim.data.Attributes;
 import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Location;
 import com.cburch.logisim.instance.InstanceComponent;
+import com.cburch.logisim.instance.InstanceState;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.util.GraphicsUtil;
 import com.cburch.logisim.util.UnmodifiableList;
@@ -232,6 +233,24 @@ public abstract class DynamicElement extends AbstractCanvasObject {
       obj = state.getData(path.elt[i]);
     }
     return obj;
+  }
+
+  protected InstanceState getInstanceState(CircuitState state) {
+    final var leafState = getLeafCircuitState(state);
+    return leafState == null ? null : leafState.getInstanceState(path.leaf());
+  }
+
+  private CircuitState getLeafCircuitState(CircuitState state) {
+    for (var i = 0; i < path.elt.length - 1; i++) {
+      final var obj = state.getData(path.elt[i]);
+      if (obj == null) return null;
+      if (!(obj instanceof CircuitState)) {
+        throw new IllegalStateException(
+            "Expecting CircuitState for path[" + i + "] " + path.elt[i] + "  but got: " + obj);
+      }
+      state = (CircuitState) obj;
+    }
+    return state;
   }
 
   protected InstanceComponent getComponent(CircuitState state) {

--- a/src/main/java/com/cburch/logisim/std/wiring/ProbeShape.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/ProbeShape.java
@@ -95,7 +95,8 @@ public class ProbeShape extends DynamicElement {
     int w = bounds.getWidth();
     int h = bounds.getHeight();
     if (state != null) {
-      Value val = Probe.getValue(state.getInstanceState(path.leaf()));
+      final var probeState = getInstanceState(state);
+      Value val = probeState == null ? Value.NIL : Probe.getValue(probeState);
       if (val == null)
         val = Value.NIL;
       RadixOption radix = path.leaf().getAttributeSet().getValue(RadixOption.ATTRIBUTE);

--- a/src/test/java/com/cburch/logisim/circuit/appear/DynamicElementTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/appear/DynamicElementTest.java
@@ -1,0 +1,110 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.circuit.appear;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.data.Bounds;
+import com.cburch.logisim.instance.InstanceComponent;
+import com.cburch.logisim.instance.InstanceState;
+import java.awt.Graphics;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+@ExtendWith(MockitoExtension.class)
+class DynamicElementTest {
+
+  @Test
+  void getInstanceStateUsesCurrentStateForSingleElementPath() {
+    final var state = mock(CircuitState.class);
+    final var leaf = mock(InstanceComponent.class);
+    final var expected = mock(InstanceState.class);
+    final var element = new TestDynamicElement(new DynamicElement.Path(new InstanceComponent[] {leaf}));
+
+    when(state.getInstanceState(leaf)).thenReturn(expected);
+
+    assertSame(expected, element.resolveInstanceState(state));
+  }
+
+  @Test
+  void getInstanceStateTraversesNestedCircuitStatePath() {
+    final var outerState = mock(CircuitState.class);
+    final var innerState = mock(CircuitState.class);
+    final var subcircuit = mock(InstanceComponent.class);
+    final var leaf = mock(InstanceComponent.class);
+    final var expected = mock(InstanceState.class);
+    final var element =
+        new TestDynamicElement(new DynamicElement.Path(new InstanceComponent[] {subcircuit, leaf}));
+
+    when(outerState.getData(subcircuit)).thenReturn(innerState);
+    when(innerState.getInstanceState(leaf)).thenReturn(expected);
+
+    assertSame(expected, element.resolveInstanceState(outerState));
+  }
+
+  @Test
+  void getInstanceStateReturnsNullWhenNestedStateIsUnavailable() {
+    final var outerState = mock(CircuitState.class);
+    final var subcircuit = mock(InstanceComponent.class);
+    final var leaf = mock(InstanceComponent.class);
+    final var element =
+        new TestDynamicElement(new DynamicElement.Path(new InstanceComponent[] {subcircuit, leaf}));
+
+    when(outerState.getData(subcircuit)).thenReturn(null);
+
+    assertNull(element.resolveInstanceState(outerState));
+  }
+
+  @Test
+  void getInstanceStateRejectsUnexpectedIntermediateData() {
+    final var outerState = mock(CircuitState.class);
+    final var subcircuit = mock(InstanceComponent.class);
+    final var leaf = mock(InstanceComponent.class);
+    final var element =
+        new TestDynamicElement(new DynamicElement.Path(new InstanceComponent[] {subcircuit, leaf}));
+
+    when(outerState.getData(subcircuit)).thenReturn(new Object());
+
+    assertThrows(IllegalStateException.class, () -> element.resolveInstanceState(outerState));
+  }
+
+  private static class TestDynamicElement extends DynamicElement {
+    TestDynamicElement(DynamicElement.Path path) {
+      super(path, Bounds.create(0, 0, 1, 1));
+    }
+
+    InstanceState resolveInstanceState(CircuitState state) {
+      return getInstanceState(state);
+    }
+
+    @Override
+    public String getDisplayName() {
+      return "test dynamic element";
+    }
+
+    @Override
+    public void paintDynamic(Graphics g, CircuitState state) {
+      // Not used in these tests.
+    }
+
+    @Override
+    public Element toSvgElement(Document document) {
+      return document.createElement("test-dynamic-element");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- resolve dynamic element instance state through nested subcircuit paths
- use that path-aware lookup for Probe dynamic elements, so nested probes show their live value instead of NIL (`_`)
- add unit coverage for single-level, nested, unavailable, and invalid dynamic element paths

## Verification

- `./gradlew.bat compileJava checkstyleMain`
- `./gradlew.bat checkstyleTest`
- `./gradlew.bat compileJava checkstyleMain compileTestJava test --tests com.cburch.logisim.circuit.appear.DynamicElementTest`

Manual A/B check using the same test circuit:

- v4.1.0 displays `_` for a Probe dynamic element selected from a nested `Leaf` circuit
- this branch displays `0`/`1` and follows the input value

Full `./gradlew.bat test` was also attempted locally, but existing `HexFileTest` cases fail on this Windows environment because the external `xxd` command is not installed.

Refs #2383.