### PR TITLE
prefs: add default color for text tool

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -55,6 +55,8 @@ class WindowOptions extends OptionsPanel {
   private final JLabel componentColorTitle;
   private final ColorChooserButton componentIconColor;
   private final JLabel componentIconColorTitle;
+  private final ColorChooserButton textToolColor;
+  private final JLabel textToolColorTitle;
   private final JButton gridColorsResetButton;
 
   private final ZoomSlider zoomValue;
@@ -142,6 +144,10 @@ class WindowOptions extends OptionsPanel {
     componentIconColor = new ColorChooserButton(window, AppPreferences.COMPONENT_ICON_COLOR);
     panel.add(componentIconColorTitle);
     panel.add(componentIconColor);
+    textToolColorTitle = new JLabel(S.get("windowTextToolColor"));
+    textToolColor = new ColorChooserButton(window, AppPreferences.TEXT_TOOL_COLOR);
+    panel.add(textToolColorTitle);
+    panel.add(textToolColor);
 
     gridColorsResetButton = new JButton();
     gridColorsResetButton.addActionListener(listener);
@@ -288,6 +294,8 @@ class WindowOptions extends OptionsPanel {
     gridDotColorTitle.setText(S.get("windowGridDotColor"));
     gridZoomedDotColorTitle.setText(S.get("windowGridZoomedDotColor"));
     componentColorTitle.setText(S.get("windowComponentColor"));
+    componentIconColorTitle.setText(S.get("windowComponentIconColor"));
+    textToolColorTitle.setText(S.get("windowTextToolColor"));
     gridColorsResetButton.setText(S.get("windowGridColorsReset"));
     zoomAutoButton.setText(S.get("windowSetAutoScaleFactor"));
   }

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -578,6 +578,7 @@ public class AppPreferences {
   public static final int DEFAULT_COMPONENT_SECONDARY_COLOR = 0x99999999;
   public static final int DEFAULT_COMPONENT_GHOST_COLOR = 0x99999999;
   public static final int DEFAULT_COMPONENT_ICON_COLOR = 0x00000000;
+  public static final int DEFAULT_TEXT_TOOL_COLOR = 0x00000000;
 
   // restores default grid colors
   public static void setDefaultGridColors() {
@@ -607,6 +608,8 @@ public class AppPreferences {
       create(new PrefMonitorInt("componentGhostColor", DEFAULT_COMPONENT_GHOST_COLOR));
   public static final PrefMonitor<Integer> COMPONENT_ICON_COLOR =
       create(new PrefMonitorInt("componentIconColor", DEFAULT_COMPONENT_ICON_COLOR));
+  public static final PrefMonitor<Integer> TEXT_TOOL_COLOR =
+      create(new PrefMonitorInt("textToolColor", DEFAULT_TEXT_TOOL_COLOR));
 
 
   // Layout preferences

--- a/src/main/java/com/cburch/logisim/tools/AddTool.java
+++ b/src/main/java/com/cburch/logisim/tools/AddTool.java
@@ -35,6 +35,7 @@ import com.cburch.logisim.prefs.PrefMonitorKeyStroke;
 import com.cburch.logisim.proj.Action;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.base.BaseLibrary;
+import com.cburch.logisim.std.base.Text;
 import com.cburch.logisim.std.gates.GateKeyboardModifier;
 import com.cburch.logisim.std.wiring.ProbeAttributes;
 import com.cburch.logisim.tools.key.KeyConfigurationEvent;
@@ -100,12 +101,7 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
     this.shouldSnap = base.shouldSnap;
     this.attrs = (AttributeSet) base.attrs.clone();
     attrs.addAttributeListener(new MyAttributeListener());
-    if (this.attrs.containsAttribute(StdAttr.APPEARANCE)) {
-      AppPreferences.DefaultAppearance.addPropertyChangeListener(this);
-    }
-    if (this.attrs.containsAttribute(ProbeAttributes.PROBEAPPEARANCE)) {
-      AppPreferences.NEW_INPUT_OUTPUT_SHAPES.addPropertyChangeListener(this);
-    }
+    configurePreferenceListeners(false);
   }
 
   public AddTool(Class<? extends Library> base, FactoryDescription description) {
@@ -116,12 +112,7 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
     this.attrs = new FactoryAttributes(base, description);
     attrs.addAttributeListener(new MyAttributeListener());
     this.keyHandlerTried = false;
-    if (this.attrs.containsAttribute(StdAttr.APPEARANCE)) {
-      AppPreferences.DefaultAppearance.addPropertyChangeListener(this);
-    }
-    if (this.attrs.containsAttribute(ProbeAttributes.PROBEAPPEARANCE)) {
-      AppPreferences.NEW_INPUT_OUTPUT_SHAPES.addPropertyChangeListener(this);
-    }
+    configurePreferenceListeners(true);
   }
 
   public AddTool(ComponentFactory source) {
@@ -133,12 +124,7 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
     attrs.addAttributeListener(new MyAttributeListener());
     final var value = (Boolean) source.getFeature(ComponentFactory.SHOULD_SNAP, attrs);
     this.shouldSnap = value == null || value;
-    if (this.attrs.containsAttribute(StdAttr.APPEARANCE)) {
-      AppPreferences.DefaultAppearance.addPropertyChangeListener(this);
-    }
-    if (this.attrs.containsAttribute(ProbeAttributes.PROBEAPPEARANCE)) {
-      AppPreferences.NEW_INPUT_OUTPUT_SHAPES.addPropertyChangeListener(this);
-    }
+    configurePreferenceListeners(true);
   }
 
   @Override
@@ -147,6 +133,23 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
       attrs.setValue(StdAttr.APPEARANCE, AppPreferences.getDefaultAppearance());
     } else if (AppPreferences.NEW_INPUT_OUTPUT_SHAPES.isSource(evt)) {
       attrs.setValue(ProbeAttributes.PROBEAPPEARANCE, ProbeAttributes.getDefaultProbeAppearance());
+    } else if (AppPreferences.TEXT_TOOL_COLOR.isSource(evt)) {
+      attrs.setValue(Text.ATTR_COLOR, new Color(AppPreferences.TEXT_TOOL_COLOR.get()));
+    }
+  }
+
+  private void configurePreferenceListeners(boolean applyTextToolColor) {
+    if (this.attrs.containsAttribute(StdAttr.APPEARANCE)) {
+      AppPreferences.DefaultAppearance.addPropertyChangeListener(this);
+    }
+    if (this.attrs.containsAttribute(ProbeAttributes.PROBEAPPEARANCE)) {
+      AppPreferences.NEW_INPUT_OUTPUT_SHAPES.addPropertyChangeListener(this);
+    }
+    if (this.attrs.containsAttribute(Text.ATTR_COLOR)) {
+      AppPreferences.TEXT_TOOL_COLOR.addPropertyChangeListener(this);
+      if (applyTextToolColor) {
+        attrs.setValue(Text.ATTR_COLOR, new Color(AppPreferences.TEXT_TOOL_COLOR.get()));
+      }
     }
   }
 

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -650,6 +650,7 @@ windowToolbarZoomfactor = Zoom factor
 windowCanvasBgColor = Canvas background color:
 windowComponentColor = Component color:
 windowComponentIconColor = Component icon color:
+windowTextToolColor = Text tool default color:
 windowGridBgColor = Grid background color:
 windowGridDotColor = Grid dot color:
 windowGridZoomedDotColor = Grid zoomed dot color:

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -651,6 +651,7 @@ windowToolbarZoomfactor = Zoom-Faktor
 windowCanvasBgColor = Hintergrundfarbe der Leinwand:
 windowComponentColor = Komponentenfarbe:
 windowComponentIconColor = Farbe des Komponentensymbols:
+# ==> windowTextToolColor =
 windowGridBgColor = Hintergrundfarbe des Gitters:
 windowGridDotColor = Farbe der Gitterpunkte:
 windowGridZoomedDotColor = Farbe des Gitterzoompunkts:

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -651,7 +651,7 @@ windowToolbarZoomfactor = Zoom-Faktor
 windowCanvasBgColor = Hintergrundfarbe der Leinwand:
 windowComponentColor = Komponentenfarbe:
 windowComponentIconColor = Farbe des Komponentensymbols:
-# ==> windowTextToolColor =
+windowTextToolColor = Textfarbe:
 windowGridBgColor = Hintergrundfarbe des Gitters:
 windowGridDotColor = Farbe der Gitterpunkte:
 windowGridZoomedDotColor = Farbe des Gitterzoompunkts:

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -649,6 +649,7 @@ windowToolbarLocation = Θέση Εργαλειοθήκης
 # ==> windowCanvasBgColor =
 # ==> windowComponentColor =
 # ==> windowComponentIconColor =
+# ==> windowTextToolColor =
 # ==> windowGridBgColor =
 # ==> windowGridDotColor =
 # ==> windowGridZoomedDotColor =

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -651,6 +651,7 @@ windowToolbarZoomfactor = Factor de zoom
 # ==> windowCanvasBgColor =
 # ==> windowComponentColor =
 # ==> windowComponentIconColor =
+# ==> windowTextToolColor =
 # ==> windowGridBgColor =
 # ==> windowGridDotColor =
 # ==> windowGridZoomedDotColor =

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -650,7 +650,7 @@ windowToolbarZoomfactor = Facteur de zoom
 windowCanvasBgColor = Couleur de fond sans grille :
 windowComponentColor = Couleur des composants :
 windowComponentIconColor = Couleur de l’icône du composant :
-# ==> windowTextToolColor =
+windowTextToolColor = Couleur du texte:
 windowGridBgColor = Couleur de fond si grille :
 windowGridDotColor = Couleur des points d’unité :
 windowGridZoomedDotColor = Couleur des points de sous-unité :

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -650,6 +650,7 @@ windowToolbarZoomfactor = Facteur de zoom
 windowCanvasBgColor = Couleur de fond sans grille :
 windowComponentColor = Couleur des composants :
 windowComponentIconColor = Couleur de l’icône du composant :
+# ==> windowTextToolColor =
 windowGridBgColor = Couleur de fond si grille :
 windowGridDotColor = Couleur des points d’unité :
 windowGridZoomedDotColor = Couleur des points de sous-unité :

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -650,6 +650,7 @@ windowToolbarZoomfactor = Fattore di zoom
 # ==> windowCanvasBgColor =
 # ==> windowComponentColor =
 # ==> windowComponentIconColor =
+# ==> windowTextToolColor =
 # ==> windowGridBgColor =
 # ==> windowGridDotColor =
 # ==> windowGridZoomedDotColor =

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -649,6 +649,7 @@ windowToolbarZoomfactor = ズームファクタ
 # ==> windowCanvasBgColor =
 # ==> windowComponentColor =
 # ==> windowComponentIconColor =
+# ==> windowTextToolColor =
 # ==> windowGridBgColor =
 # ==> windowGridDotColor =
 # ==> windowGridZoomedDotColor =

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -651,6 +651,7 @@ windowToolbarZoomfactor = Uitvergrotingsfactor
 windowCanvasBgColor = Canvas achtergrond kleur:
 windowComponentColor = Component kleur:
 windowComponentIconColor = Component icoon kleur:
+# ==> windowTextToolColor =
 windowGridBgColor = Raster achtergrond kleur:
 windowGridDotColor = Raster punt kleur:
 windowGridZoomedDotColor = Uitvergrote raster punt kleur:

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -651,7 +651,7 @@ windowToolbarZoomfactor = Uitvergrotingsfactor
 windowCanvasBgColor = Canvas achtergrond kleur:
 windowComponentColor = Component kleur:
 windowComponentIconColor = Component icoon kleur:
-# ==> windowTextToolColor =
+windowTextToolColor = Tekstkleur:
 windowGridBgColor = Raster achtergrond kleur:
 windowGridDotColor = Raster punt kleur:
 windowGridZoomedDotColor = Uitvergrote raster punt kleur:

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -651,6 +651,7 @@ windowToolbarZoomfactor = Skalowanie
 windowCanvasBgColor = Płótno edytora:
 windowComponentColor = Kolor komponentu:
 # ==> windowComponentIconColor =
+# ==> windowTextToolColor =
 windowGridBgColor = Tło siatki:
 windowGridDotColor = Punkty siatki:
 windowGridZoomedDotColor = Większe punkty siatki:

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -650,6 +650,7 @@ windowToolbarZoomfactor = Fator Zoom
 # ==> windowCanvasBgColor =
 # ==> windowComponentColor =
 # ==> windowComponentIconColor =
+# ==> windowTextToolColor =
 windowGridBgColor = Cor do fundo da grade
 windowGridDotColor = Cor dos pontos da grade
 windowGridZoomedDotColor = Cor dos pontos da grade no zoom

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -649,6 +649,7 @@ windowToolbarZoomfactor = коэффициент масштабирования
 # ==> windowCanvasBgColor =
 # ==> windowComponentColor =
 # ==> windowComponentIconColor =
+# ==> windowTextToolColor =
 # ==> windowGridBgColor =
 # ==> windowGridDotColor =
 # ==> windowGridZoomedDotColor =

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -649,6 +649,8 @@ windowToolbarReset = 将窗口布局重置为 Logisim 的默认值
 windowToolbarZoomfactor = 缩放系数
 windowCanvasBgColor = 画布背景颜色：
 windowComponentColor = 组件颜色：
+# ==> windowComponentIconColor =
+windowTextToolColor = 文本工具默认颜色：
 windowGridBgColor = 网格背景颜色：
 windowGridDotColor = 栅格点颜色：
 windowGridZoomedDotColor = 栅格缩放点颜色：

--- a/src/test/java/com/cburch/logisim/tools/AddToolTest.java
+++ b/src/test/java/com/cburch/logisim/tools/AddToolTest.java
@@ -1,0 +1,80 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.std.base.Text;
+import java.awt.Color;
+import java.util.Objects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class AddToolTest {
+  private final int originalTextToolColor = AppPreferences.TEXT_TOOL_COLOR.get();
+
+  @AfterEach
+  void restoreTextToolColor() throws InterruptedException {
+    AppPreferences.TEXT_TOOL_COLOR.set(originalTextToolColor);
+    waitForTextToolPreference(originalTextToolColor);
+  }
+
+  @Test
+  void textToolUsesConfiguredDefaultColor() throws InterruptedException {
+    setTextToolPreference(Color.BLUE);
+
+    final var tool = new AddTool(Text.FACTORY);
+
+    assertEquals(Color.BLUE, tool.getAttributeSet().getValue(Text.ATTR_COLOR));
+  }
+
+  @Test
+  void textToolColorFollowsPreferenceChanges() throws InterruptedException {
+    final var tool = new AddTool(Text.FACTORY);
+
+    setTextToolPreference(Color.RED);
+
+    waitForToolColor(tool, Color.RED);
+  }
+
+  @Test
+  void textFactoryDefaultColorStaysBlack() throws InterruptedException {
+    setTextToolPreference(Color.RED);
+
+    assertEquals(Color.BLACK, Text.FACTORY.createAttributeSet().getValue(Text.ATTR_COLOR));
+  }
+
+  private static void setTextToolPreference(Color color) throws InterruptedException {
+    final var rgb = color.getRGB();
+    AppPreferences.TEXT_TOOL_COLOR.set(rgb);
+    waitForTextToolPreference(rgb);
+  }
+
+  private static void waitForTextToolPreference(int rgb) throws InterruptedException {
+    for (var i = 0; i < 100; i++) {
+      if (Objects.equals(AppPreferences.TEXT_TOOL_COLOR.get(), rgb)) {
+        return;
+      }
+      Thread.sleep(10);
+    }
+    assertEquals(rgb, AppPreferences.TEXT_TOOL_COLOR.get());
+  }
+
+  private static void waitForToolColor(AddTool tool, Color color) throws InterruptedException {
+    for (var i = 0; i < 100; i++) {
+      if (color.equals(tool.getAttributeSet().getValue(Text.ATTR_COLOR))) {
+        return;
+      }
+      Thread.sleep(10);
+    }
+    assertEquals(color, tool.getAttributeSet().getValue(Text.ATTR_COLOR));
+  }
+}


### PR DESCRIPTION
Summary
- add an application preference for the Text tool default color and expose it in Window preferences
- apply that preference to newly created Text tools and update existing Text tools when the preference changes
- keep the Text component factory default black so older project files keep their existing appearance
- add unit coverage for configured defaults, preference updates, and factory defaults

Fixes #2329

Verification
- ./gradlew.bat compileJava checkstyleMain compileTestJava checkstyleTest test --tests com.cburch.logisim.tools.AddToolTest
- trans-tool -l "de el en es fr pt ru it nl ja pl zh" -ls "en" -b "src/main/resources/resources/logisim/strings/gui/gui.properties" (reports existing translation issues; no missing entry for the new key)