### PR TITLE
text: skip undo action for unchanged text edits

### DIFF
--- a/src/main/java/com/cburch/logisim/instance/InstanceTextField.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceTextField.java
@@ -31,6 +31,7 @@ import com.cburch.logisim.tools.TextEditable;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics;
+import java.util.Objects;
 
 public class InstanceTextField implements AttributeListener, TextFieldListener, TextEditable {
   private Canvas canvas;
@@ -91,6 +92,8 @@ public class InstanceTextField implements AttributeListener, TextFieldListener, 
 
   @Override
   public Action getCommitAction(Circuit circuit, String oldText, String newText) {
+    if (Objects.equals(oldText, newText)) return null;
+
     final var act = new SetAttributeAction(circuit, S.getter("changeLabelAction"));
     act.set(comp, labelAttr, newText);
     return act;

--- a/src/main/java/com/cburch/logisim/tools/TextEditable.java
+++ b/src/main/java/com/cburch/logisim/tools/TextEditable.java
@@ -14,6 +14,7 @@ import com.cburch.logisim.comp.ComponentUserEvent;
 import com.cburch.logisim.proj.Action;
 
 public interface TextEditable {
+  /** Returns the action for a committed edit, or {@code null} if no action is needed. */
   Action getCommitAction(Circuit circuit, String oldText, String newText);
 
   Caret getTextCaret(ComponentUserEvent event);

--- a/src/test/java/com/cburch/logisim/instance/InstanceTextFieldTest.java
+++ b/src/test/java/com/cburch/logisim/instance/InstanceTextFieldTest.java
@@ -1,0 +1,40 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.instance;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.std.base.Text;
+import com.cburch.logisim.tools.TextEditable;
+import org.junit.jupiter.api.Test;
+
+public class InstanceTextFieldTest {
+
+  @Test
+  public void changedTextCommitCreatesAction() {
+    assertNotNull(newTextEditable().getCommitAction(null, "old", "new"));
+  }
+
+  @Test
+  public void unchangedTextCommitCreatesNoAction() {
+    assertNull(newTextEditable().getCommitAction(null, "same", "same"));
+  }
+
+  private static TextEditable newTextEditable() {
+    final var attrs = Text.FACTORY.createAttributeSet();
+    final var comp = Text.FACTORY.createComponent(Location.create(0, 0, false), attrs);
+    final var editable = (TextEditable) comp.getFeature(TextEditable.class);
+
+    assertNotNull(editable);
+    return editable;
+  }
+}


### PR DESCRIPTION
Summary
- skip creating a text edit action when the committed text is unchanged
- document that TextEditable commit hooks may return no action
- add unit coverage for changed and unchanged text commits

Verification
- ./gradlew.bat compileJava checkstyleMain
- ./gradlew.bat checkstyleTest test --tests com.cburch.logisim.instance.InstanceTextFieldTest

Addresses part of #2097.