### PR TITLE
gui: show circuit attributes for empty selection

### DIFF
--- a/src/main/java/com/cburch/draw/gui/AttrTableDrawManager.java
+++ b/src/main/java/com/cburch/draw/gui/AttrTableDrawManager.java
@@ -10,26 +10,43 @@
 package com.cburch.draw.gui;
 
 import com.cburch.draw.canvas.Canvas;
+import com.cburch.draw.canvas.SelectionEvent;
+import com.cburch.draw.canvas.SelectionListener;
 import com.cburch.draw.tools.AbstractTool;
 import com.cburch.draw.tools.DrawingAttributeSet;
 import com.cburch.draw.tools.SelectTool;
 import com.cburch.logisim.gui.generic.AttrTable;
+import com.cburch.logisim.gui.generic.AttrTableModel;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.function.Supplier;
 
-public class AttrTableDrawManager implements PropertyChangeListener {
+public class AttrTableDrawManager implements PropertyChangeListener, SelectionListener {
   private final Canvas canvas;
   private final AttrTable table;
+  private final Supplier<AttrTableModel> emptySelectionModel;
   private final AttrTableSelectionModel selectionModel;
   private final AttrTableToolModel toolModel;
 
   public AttrTableDrawManager(Canvas canvas, AttrTable table, DrawingAttributeSet attrs) {
+    this(canvas, table, attrs, null);
+  }
+
+  public AttrTableDrawManager(
+      Canvas canvas,
+      AttrTable table,
+      DrawingAttributeSet attrs,
+      Supplier<AttrTableModel> emptySelectionModel) {
     this.canvas = canvas;
     this.table = table;
+    this.emptySelectionModel = emptySelectionModel;
     this.selectionModel = new AttrTableSelectionModel(canvas);
     this.toolModel = new AttrTableToolModel(attrs, null);
 
     canvas.addPropertyChangeListener(Canvas.TOOL_PROPERTY, this);
+    if (emptySelectionModel != null) {
+      canvas.getSelection().addSelectionListener(this);
+    }
     updateToolAttributes();
   }
 
@@ -48,10 +65,25 @@ public class AttrTableDrawManager implements PropertyChangeListener {
     }
   }
 
+  @Override
+  public void selectionChanged(SelectionEvent e) {
+    if (emptySelectionModel != null && canvas.getTool() instanceof SelectTool) {
+      updateSelectionAttributes();
+    }
+  }
+
+  private void updateSelectionAttributes() {
+    if (emptySelectionModel != null && canvas.getSelection().isEmpty()) {
+      table.setAttrTableModel(emptySelectionModel.get());
+    } else {
+      table.setAttrTableModel(selectionModel);
+    }
+  }
+
   private void updateToolAttributes() {
     final var tool = canvas.getTool();
     if (tool instanceof SelectTool) {
-      table.setAttrTableModel(selectionModel);
+      updateSelectionAttributes();
     } else if (tool instanceof AbstractTool absTool) {
       toolModel.setTool(absTool);
       table.setAttrTableModel(toolModel);

--- a/src/main/java/com/cburch/draw/gui/AttrTableSelectionModel.java
+++ b/src/main/java/com/cburch/draw/gui/AttrTableSelectionModel.java
@@ -66,6 +66,7 @@ class AttrTableSelectionModel extends AttributeSetTableModel implements Selectio
   //
   @Override
   public void selectionChanged(SelectionEvent e) {
+    attributeListChanged(null);
     fireTitleChanged();
   }
 

--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceView.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceView.java
@@ -20,6 +20,7 @@ import com.cburch.logisim.gui.generic.AttrTable;
 import com.cburch.logisim.gui.generic.BasicZoomModel;
 import com.cburch.logisim.gui.generic.CanvasPane;
 import com.cburch.logisim.gui.generic.ZoomModel;
+import com.cburch.logisim.gui.main.AttrTableCircuitModel;
 import com.cburch.logisim.gui.menu.EditHandler;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Project;
@@ -79,7 +80,12 @@ public class AppearanceView {
   public AttrTableDrawManager getAttrTableDrawManager(AttrTable table) {
     var ret = attrTableManager;
     if (ret == null) {
-      ret = new AttrTableDrawManager(canvas, table, attrs);
+      ret =
+          new AttrTableDrawManager(
+              canvas,
+              table,
+              attrs,
+              () -> new AttrTableCircuitModel(canvas.getProject(), canvas.getCircuit()));
       attrTableManager = ret;
     }
     return ret;

--- a/src/main/java/com/cburch/logisim/gui/main/AttrTableSelectionModel.java
+++ b/src/main/java/com/cburch/logisim/gui/main/AttrTableSelectionModel.java
@@ -40,6 +40,7 @@ class AttrTableSelectionModel extends AttributeSetTableModel implements Selectio
     super(frame.getCanvas().getSelection().getAttributeSet());
     this.project = project;
     this.frame = frame;
+    updateAttributeSet();
     frame.getCanvas().getSelection().addListener(this);
   }
 
@@ -120,14 +121,21 @@ class AttrTableSelectionModel extends AttributeSetTableModel implements Selectio
   // Selection.Listener methods
   @Override
   public void selectionChanged(final Event event) {
+    updateAttributeSet();
     fireTitleChanged();
     if (!frame.getEditorView().equals(Frame.EDIT_APPEARANCE)) {
-      if (frame.getCanvas().getSelection().isEmpty()) {
-        frame.viewCircuitAttributes();
-      } else {
-        frame.setAttrTableModel(this);
-      }
+      frame.setAttrTableModel(this);
     }
+  }
+
+  void updateAttributeSet() {
+    final var canvas = frame.getCanvas();
+    final var circuit = canvas.getCircuit();
+    final var selection = canvas.getSelection();
+    setAttributeSet(
+        circuit != null && selection.isEmpty()
+            ? circuit.getStaticAttributes()
+            : selection.getAttributeSet());
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/main/AttrTableSelectionModel.java
+++ b/src/main/java/com/cburch/logisim/gui/main/AttrTableSelectionModel.java
@@ -122,7 +122,11 @@ class AttrTableSelectionModel extends AttributeSetTableModel implements Selectio
   public void selectionChanged(final Event event) {
     fireTitleChanged();
     if (!frame.getEditorView().equals(Frame.EDIT_APPEARANCE)) {
-      frame.setAttrTableModel(this);
+      if (frame.getCanvas().getSelection().isEmpty()) {
+        frame.viewCircuitAttributes();
+      } else {
+        frame.setAttrTableModel(this);
+      }
     }
   }
 

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -798,11 +798,8 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     if (newAttrs == null) {
       viewCircuitAttributes();
     } else if (newAttrs instanceof SelectionAttributes) {
-      if (layoutCanvas.getSelection().isEmpty()) {
-        viewCircuitAttributes();
-      } else {
-        setAttrTableModel(attrTableSelectionModel);
-      }
+      attrTableSelectionModel.updateAttributeSet();
+      setAttrTableModel(attrTableSelectionModel);
     } else {
       setAttrTableModel(new AttrTableToolModel(project, newTool));
     }

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -796,16 +796,24 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
       if (!force && !same && !(oldModel instanceof AttrTableCircuitModel)) return;
     }
     if (newAttrs == null) {
-      final var circ = project.getCurrentCircuit();
-      if (circ != null) {
-        setAttrTableModel(new AttrTableCircuitModel(project, circ));
-      } else if (force) {
-        setAttrTableModel(null);
-      }
+      viewCircuitAttributes();
     } else if (newAttrs instanceof SelectionAttributes) {
-      setAttrTableModel(attrTableSelectionModel);
+      if (layoutCanvas.getSelection().isEmpty()) {
+        viewCircuitAttributes();
+      } else {
+        setAttrTableModel(attrTableSelectionModel);
+      }
     } else {
       setAttrTableModel(new AttrTableToolModel(project, newTool));
+    }
+  }
+
+  void viewCircuitAttributes() {
+    final var circ = project.getCurrentCircuit();
+    if (circ != null) {
+      setAttrTableModel(new AttrTableCircuitModel(project, circ));
+    } else {
+      setAttrTableModel(null);
     }
   }
 

--- a/src/test/java/com/cburch/draw/gui/AttrTableDrawManagerTest.java
+++ b/src/test/java/com/cburch/draw/gui/AttrTableDrawManagerTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.cburch.draw.canvas.Canvas;
 import com.cburch.draw.shapes.Rectangle;
 import com.cburch.draw.tools.DrawingAttributeSet;
+import com.cburch.draw.tools.RectangleTool;
 import com.cburch.draw.tools.SelectTool;
 import com.cburch.logisim.gui.generic.AttrTable;
 import com.cburch.logisim.gui.generic.AttrTableModel;
@@ -29,9 +30,10 @@ class AttrTableDrawManagerTest {
   void selectToolUsesFallbackModelOnlyForEmptySelections() {
     final var canvas = new Canvas();
     final var table = new AttrTable(null);
+    final var drawingAttrs = new DrawingAttributeSet();
     final var emptySelectionModel = new TestAttrTableModel();
 
-    new AttrTableDrawManager(canvas, table, new DrawingAttributeSet(), () -> emptySelectionModel);
+    new AttrTableDrawManager(canvas, table, drawingAttrs, () -> emptySelectionModel);
     canvas.setTool(new SelectTool());
     assertSame(emptySelectionModel, table.getAttrTableModel());
 
@@ -41,6 +43,31 @@ class AttrTableDrawManagerTest {
 
     canvas.getSelection().clearSelected();
     assertSame(emptySelectionModel, table.getAttrTableModel());
+  }
+
+  @Test
+  void drawingToolAttributesAreIndependentFromSelectionFallback() {
+    final var canvas = new Canvas();
+    final var table = new AttrTable(null);
+    final var drawingAttrs = new DrawingAttributeSet();
+    final var rectangleTool = new RectangleTool(drawingAttrs);
+    final var emptySelectionModel = new TestAttrTableModel();
+
+    new AttrTableDrawManager(canvas, table, drawingAttrs, () -> emptySelectionModel);
+
+    canvas.setTool(rectangleTool);
+    final var toolModel = assertInstanceOf(AttrTableToolModel.class, table.getAttrTableModel());
+    assertTrue(toolModel.getRowCount() > 1);
+
+    canvas.getSelection().setSelected(rectangleTool.createShape(0, 0, 10, 10), true);
+    assertSame(toolModel, table.getAttrTableModel());
+
+    canvas.setTool(new SelectTool());
+    assertSame(emptySelectionModel, table.getAttrTableModel());
+
+    canvas.getSelection().setSelected(rectangleTool.createShape(0, 0, 10, 10), true);
+    final var selectionModel = assertInstanceOf(AttrTableSelectionModel.class, table.getAttrTableModel());
+    assertTrue(selectionModel.getRowCount() > 1);
   }
 
   private static final class TestAttrTableModel implements AttrTableModel {

--- a/src/test/java/com/cburch/draw/gui/AttrTableDrawManagerTest.java
+++ b/src/test/java/com/cburch/draw/gui/AttrTableDrawManagerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.draw.gui;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.cburch.draw.canvas.Canvas;
+import com.cburch.draw.shapes.Rectangle;
+import com.cburch.draw.tools.DrawingAttributeSet;
+import com.cburch.draw.tools.SelectTool;
+import com.cburch.logisim.gui.generic.AttrTable;
+import com.cburch.logisim.gui.generic.AttrTableModel;
+import com.cburch.logisim.gui.generic.AttrTableModelListener;
+import com.cburch.logisim.gui.generic.AttrTableModelRow;
+import org.junit.jupiter.api.Test;
+
+class AttrTableDrawManagerTest {
+
+  @Test
+  void selectToolUsesFallbackModelOnlyForEmptySelections() {
+    final var canvas = new Canvas();
+    final var table = new AttrTable(null);
+    final var emptySelectionModel = new TestAttrTableModel();
+
+    new AttrTableDrawManager(canvas, table, new DrawingAttributeSet(), () -> emptySelectionModel);
+    canvas.setTool(new SelectTool());
+    assertSame(emptySelectionModel, table.getAttrTableModel());
+
+    canvas.getSelection().setSelected(new Rectangle(0, 0, 10, 10), true);
+    assertInstanceOf(AttrTableSelectionModel.class, table.getAttrTableModel());
+
+    canvas.getSelection().clearSelected();
+    assertSame(emptySelectionModel, table.getAttrTableModel());
+  }
+
+  private static final class TestAttrTableModel implements AttrTableModel {
+    @Override
+    public void addAttrTableModelListener(AttrTableModelListener listener) {}
+
+    @Override
+    public AttrTableModelRow getRow(int rowIndex) {
+      return null;
+    }
+
+    @Override
+    public int getRowCount() {
+      return 0;
+    }
+
+    @Override
+    public String getTitle() {
+      return null;
+    }
+
+    @Override
+    public void removeAttrTableModelListener(AttrTableModelListener listener) {}
+  }
+}

--- a/src/test/java/com/cburch/draw/gui/AttrTableDrawManagerTest.java
+++ b/src/test/java/com/cburch/draw/gui/AttrTableDrawManagerTest.java
@@ -11,6 +11,7 @@ package com.cburch.draw.gui;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cburch.draw.canvas.Canvas;
 import com.cburch.draw.shapes.Rectangle;
@@ -35,7 +36,8 @@ class AttrTableDrawManagerTest {
     assertSame(emptySelectionModel, table.getAttrTableModel());
 
     canvas.getSelection().setSelected(new Rectangle(0, 0, 10, 10), true);
-    assertInstanceOf(AttrTableSelectionModel.class, table.getAttrTableModel());
+    final var selectionModel = assertInstanceOf(AttrTableSelectionModel.class, table.getAttrTableModel());
+    assertTrue(selectionModel.getRowCount() > 1);
 
     canvas.getSelection().clearSelected();
     assertSame(emptySelectionModel, table.getAttrTableModel());

--- a/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
+++ b/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
@@ -9,8 +9,9 @@
 
 package com.cburch.logisim.gui.appear;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -56,6 +57,7 @@ class AppearanceViewTest {
     final var canvas = view.getCanvas();
     canvas.getSelection().setSelected(new Rectangle(0, 0, 10, 10), true);
     assertFalse(table.getAttrTableModel() instanceof AttrTableCircuitModel);
+    assertTrue(table.getAttrTableModel().getRowCount() > 1);
 
     canvas.getSelection().clearSelected();
     assertInstanceOf(AttrTableCircuitModel.class, table.getAttrTableModel());

--- a/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
+++ b/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
@@ -1,0 +1,67 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.appear;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.draw.model.Drawing;
+import com.cburch.draw.shapes.Rectangle;
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.circuit.appear.CircuitAppearance;
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.data.AttributeSets;
+import com.cburch.logisim.file.LogisimFile;
+import com.cburch.logisim.gui.generic.AttrTable;
+import com.cburch.logisim.gui.main.AttrTableCircuitModel;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.proj.Project;
+import org.junit.jupiter.api.Test;
+
+class AppearanceViewTest {
+
+  @Test
+  void emptyAppearanceSelectionShowsCircuitAttributes() {
+    final var project = mock(Project.class);
+    final var circuitState = mock(CircuitState.class);
+    final var circuit = mock(Circuit.class);
+    final var appearance = mock(CircuitAppearance.class);
+    final var logisimFile = mock(LogisimFile.class);
+    final var view = new AppearanceView();
+    final var table = new AttrTable(null);
+
+    when(project.getLogisimFile()).thenReturn(logisimFile);
+    when(logisimFile.contains(circuit)).thenReturn(true);
+    when(circuitState.getCircuit()).thenReturn(circuit);
+    when(circuit.getAppearance()).thenReturn(appearance);
+    when(circuit.getName()).thenReturn("main");
+    when(circuit.getStaticAttributes()).thenReturn(attributeSet("circuit"));
+    when(appearance.getCustomAppearanceDrawing()).thenReturn(new Drawing());
+
+    view.setCircuit(project, circuitState);
+    view.getAttrTableDrawManager(table).attributesSelected();
+    assertInstanceOf(AttrTableCircuitModel.class, table.getAttrTableModel());
+
+    final var canvas = view.getCanvas();
+    canvas.getSelection().setSelected(new Rectangle(0, 0, 10, 10), true);
+    assertFalse(table.getAttrTableModel() instanceof AttrTableCircuitModel);
+
+    canvas.getSelection().clearSelected();
+    assertInstanceOf(AttrTableCircuitModel.class, table.getAttrTableModel());
+  }
+
+  private static AttributeSet attributeSet(String label) {
+    return AttributeSets.fixedSet(new Attribute<?>[] {StdAttr.LABEL}, new Object[] {label});
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
+++ b/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.when;
 
 import com.cburch.draw.model.Drawing;
 import com.cburch.draw.shapes.Rectangle;
+import com.cburch.draw.tools.DrawingAttributeSet;
+import com.cburch.draw.tools.RectangleTool;
 import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.CircuitState;
 import com.cburch.logisim.circuit.appear.CircuitAppearance;
@@ -34,23 +36,9 @@ class AppearanceViewTest {
 
   @Test
   void emptyAppearanceSelectionShowsCircuitAttributes() {
-    final var project = mock(Project.class);
-    final var circuitState = mock(CircuitState.class);
-    final var circuit = mock(Circuit.class);
-    final var appearance = mock(CircuitAppearance.class);
-    final var logisimFile = mock(LogisimFile.class);
-    final var view = new AppearanceView();
+    final var view = newAppearanceView();
     final var table = new AttrTable(null);
 
-    when(project.getLogisimFile()).thenReturn(logisimFile);
-    when(logisimFile.contains(circuit)).thenReturn(true);
-    when(circuitState.getCircuit()).thenReturn(circuit);
-    when(circuit.getAppearance()).thenReturn(appearance);
-    when(circuit.getName()).thenReturn("main");
-    when(circuit.getStaticAttributes()).thenReturn(attributeSet("circuit"));
-    when(appearance.getCustomAppearanceDrawing()).thenReturn(new Drawing());
-
-    view.setCircuit(project, circuitState);
     view.getAttrTableDrawManager(table).attributesSelected();
     assertInstanceOf(AttrTableCircuitModel.class, table.getAttrTableModel());
 
@@ -61,6 +49,42 @@ class AppearanceViewTest {
 
     canvas.getSelection().clearSelected();
     assertInstanceOf(AttrTableCircuitModel.class, table.getAttrTableModel());
+  }
+
+  @Test
+  void createdAppearanceObjectShowsDrawingAttributes() {
+    final var view = newAppearanceView();
+    final var canvas = (AppearanceCanvas) view.getCanvas();
+    final var table = new AttrTable(null);
+    final var rectangleTool = new RectangleTool(new DrawingAttributeSet());
+
+    view.getAttrTableDrawManager(table).attributesSelected();
+    canvas.setTool(rectangleTool);
+    assertTrue(table.getAttrTableModel().getRowCount() > 1);
+
+    canvas.toolGestureComplete(rectangleTool, rectangleTool.createShape(0, 0, 10, 10));
+    assertFalse(table.getAttrTableModel() instanceof AttrTableCircuitModel);
+    assertTrue(table.getAttrTableModel().getRowCount() > 1);
+  }
+
+  private static AppearanceView newAppearanceView() {
+    final var project = mock(Project.class);
+    final var circuitState = mock(CircuitState.class);
+    final var circuit = mock(Circuit.class);
+    final var appearance = mock(CircuitAppearance.class);
+    final var logisimFile = mock(LogisimFile.class);
+    final var view = new AppearanceView();
+
+    when(project.getLogisimFile()).thenReturn(logisimFile);
+    when(logisimFile.contains(circuit)).thenReturn(true);
+    when(circuitState.getCircuit()).thenReturn(circuit);
+    when(circuit.getAppearance()).thenReturn(appearance);
+    when(circuit.getName()).thenReturn("main");
+    when(circuit.getStaticAttributes()).thenReturn(attributeSet("circuit"));
+    when(appearance.getCustomAppearanceDrawing()).thenReturn(new Drawing());
+
+    view.setCircuit(project, circuitState);
+    return view;
   }
 
   private static AttributeSet attributeSet(String label) {

--- a/src/test/java/com/cburch/logisim/gui/main/AttrTableSelectionModelTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/AttrTableSelectionModelTest.java
@@ -1,0 +1,58 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.main;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.data.AttributeSets;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.proj.Project;
+import org.junit.jupiter.api.Test;
+
+class AttrTableSelectionModelTest {
+
+  @Test
+  void updatesAttributeSetWhenSelectionChangesBetweenEmptyAndSelected() {
+    final var project = mock(Project.class);
+    final var frame = mock(Frame.class);
+    final var canvas = mock(Canvas.class);
+    final var selection = mock(Selection.class);
+    final var circuit = mock(Circuit.class);
+    final var circuitAttrs = attributeSet("circuit");
+    final var selectionAttrs = attributeSet("selection");
+
+    when(frame.getCanvas()).thenReturn(canvas);
+    when(canvas.getCircuit()).thenReturn(circuit);
+    when(canvas.getSelection()).thenReturn(selection);
+    when(circuit.getStaticAttributes()).thenReturn(circuitAttrs);
+    when(selection.getAttributeSet()).thenReturn(selectionAttrs);
+
+    when(selection.isEmpty()).thenReturn(true);
+    final var model = new AttrTableSelectionModel(project, frame);
+    assertSame(circuitAttrs, model.getAttributeSet());
+
+    when(selection.isEmpty()).thenReturn(false);
+    model.updateAttributeSet();
+    assertSame(selectionAttrs, model.getAttributeSet());
+
+    when(selection.isEmpty()).thenReturn(true);
+    model.updateAttributeSet();
+    assertSame(circuitAttrs, model.getAttributeSet());
+  }
+
+  private static AttributeSet attributeSet(String label) {
+    return AttributeSets.fixedSet(new Attribute<?>[] {StdAttr.LABEL}, new Object[] {label});
+  }
+}


### PR DESCRIPTION
Summary
- show the current circuit attributes when the selection becomes empty in the layout editor
- avoid using the selection attribute model for an empty selection, so the Properties pane title and rows stay consistent
- share the circuit-attribute display path used when switching tools/circuits

Verification
- ./gradlew.bat compileJava checkstyleMain
- ./gradlew.bat compileTestJava

Addresses #2371.