### PR TITLE
circuit: preserve component state when moving

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitState.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitState.java
@@ -129,7 +129,7 @@ public class CircuitState implements InstanceData {
         if (map == null) return;
         for (final var comp : map.getRemovals()) {
           final var compState = componentData.remove(comp);
-          if (compState != null) continue;
+          if (compState == null) continue;
           Class<?> compFactory = comp.getFactory().getClass();
           var found = false;
           for (final var repl : map.getReplacementsFor(comp)) {

--- a/src/test/java/com/cburch/logisim/circuit/CircuitStateTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/CircuitStateTest.java
@@ -1,0 +1,87 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.circuit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.file.Loader;
+import com.cburch.logisim.file.LogisimFile;
+import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.memory.Ram;
+import com.cburch.logisim.std.wiring.Pin;
+import org.junit.jupiter.api.Test;
+
+class CircuitStateTest {
+
+  private static final class Fixture {
+    private final Circuit circuit;
+    private final CircuitState state;
+
+    private Fixture() {
+      final var file = LogisimFile.createNew(new Loader(null), null);
+      final var project = new Project(file);
+      circuit = file.getMainCircuit();
+      circuit.setProject(project);
+      project.setCurrentCircuit(circuit);
+      state = project.getCircuitState();
+    }
+  }
+
+  @Test
+  void replacementWithSameFactoryKeepsComponentState() {
+    final var fixture = new Fixture();
+    final var ramFactory = new Ram();
+    final var ram = ramFactory.createComponent(Location.create(100, 100, true), ramFactory.createAttributeSet());
+    add(fixture.circuit, ram);
+
+    final var contents = ramFactory.getContents(fixture.state.getInstanceState(ram));
+    contents.set(3, 0x5a);
+    final var ramState = fixture.state.getData(ram);
+
+    final var movedRam = ramFactory.createComponent(Location.create(140, 100, true), ram.getAttributeSet());
+    replace(fixture.circuit, ram, movedRam);
+
+    assertNull(fixture.state.getData(ram));
+    assertSame(ramState, fixture.state.getData(movedRam));
+    assertEquals(0x5a, ramFactory.getContents(fixture.state.getInstanceState(movedRam)).get(3));
+  }
+
+  @Test
+  void replacementWithDifferentFactoryDropsComponentState() {
+    final var fixture = new Fixture();
+    final var ramFactory = new Ram();
+    final var ram = ramFactory.createComponent(Location.create(100, 100, true), ramFactory.createAttributeSet());
+    add(fixture.circuit, ram);
+
+    ramFactory.getContents(fixture.state.getInstanceState(ram)).set(3, 0x5a);
+    final var pin = Pin.FACTORY.createComponent(Location.create(140, 100, true), Pin.FACTORY.createAttributeSet());
+
+    replace(fixture.circuit, ram, pin);
+
+    assertNull(fixture.state.getData(ram));
+    assertNull(fixture.state.getData(pin));
+  }
+
+  private static void add(Circuit circuit, Component component) {
+    final var mutation = new CircuitMutation(circuit);
+    mutation.add(component);
+    mutation.execute();
+  }
+
+  private static void replace(Circuit circuit, Component oldComponent, Component newComponent) {
+    final var mutation = new CircuitMutation(circuit);
+    mutation.replace(oldComponent, newComponent);
+    mutation.execute();
+  }
+}


### PR DESCRIPTION
Summary
- preserve existing component data when a replacement uses the same component factory, restoring state transfer for moved RAM and other stateful components
- keep state dropped when a component is replaced by a different factory
- add coverage for same-factory and different-factory replacement state handling

Fixes #2175

Verification
- ./gradlew.bat test --tests com.cburch.logisim.circuit.CircuitStateTest
- ./gradlew.bat compileJava checkstyleMain
- ./gradlew.bat checkstyleTest compileTestJava