### PR TITLE
chrono: fix timing diagram vector export

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
+++ b/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
@@ -396,7 +396,7 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
 
           g.setClip(l.width + 3, HEADER_HEIGHT, r.width, l.height);
           g.translate(l.width + 3, HEADER_HEIGHT);
-          rightPanel.print(g);
+          rightPanel.paintExportImage(g);
           g.translate(-(l.width + 3), -HEADER_HEIGHT);
         }
 

--- a/src/main/java/com/cburch/logisim/gui/chrono/RightPanel.java
+++ b/src/main/java/com/cburch/logisim/gui/chrono/RightPanel.java
@@ -11,6 +11,7 @@ package com.cburch.logisim.gui.chrono;
 
 import static com.cburch.logisim.gui.Strings.S;
 
+import com.cburch.logisim.gui.generic.TikZWriter;
 import com.cburch.logisim.gui.log.Model;
 import com.cburch.logisim.gui.log.Signal;
 import com.cburch.logisim.prefs.AppPreferences;
@@ -575,9 +576,7 @@ public class RightPanel extends JPanel {
       }
     }
 
-    private void createOffscreen() {
-      buf = (BufferedImage) createImage(width, WAVE_HEIGHT);
-      final var g = buf.createGraphics();
+    private void drawWaveform(Graphics2D g) {
       g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_DEFAULT);
       g.setRenderingHint(
           RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
@@ -591,15 +590,28 @@ public class RightPanel extends JPanel {
       g.fillRect(0, HIGH, width, LOW - HIGH);
       g.setColor(Color.BLACK);
       drawSignal(g, isBold, colors);
+    }
+
+    private void createOffscreen() {
+      buf = (BufferedImage) createImage(width, WAVE_HEIGHT);
+      final var g = buf.createGraphics();
+      drawWaveform(g);
       g.dispose();
     }
 
     public void paintWaveform(Graphics2D g) {
+      final var y = WAVE_HEIGHT * signal.idx;
+      if (g instanceof TikZWriter) {
+        final var gCopy = (Graphics2D) g.create();
+        gCopy.translate(0, y);
+        drawWaveform(gCopy);
+        gCopy.dispose();
+        return;
+      }
       if (buf == null) {
         // TODO: reallocating image each time seems silly
         createOffscreen();
       }
-      final var y = WAVE_HEIGHT * signal.idx;
       g.drawImage(buf, null, 0, y);
     }
 

--- a/src/main/java/com/cburch/logisim/gui/chrono/RightPanel.java
+++ b/src/main/java/com/cburch/logisim/gui/chrono/RightPanel.java
@@ -11,7 +11,6 @@ package com.cburch.logisim.gui.chrono;
 
 import static com.cburch.logisim.gui.Strings.S;
 
-import com.cburch.logisim.gui.generic.TikZWriter;
 import com.cburch.logisim.gui.log.Model;
 import com.cburch.logisim.gui.log.Signal;
 import com.cburch.logisim.prefs.AppPreferences;
@@ -265,12 +264,20 @@ public class RightPanel extends JPanel {
   @Override
   public void paintComponent(Graphics graphics) {
     final var gfx = (Graphics2D) graphics;
+    paintPanel(gfx, getWidth(), getHeight(), false);
+  }
+
+  public void paintExportImage(Graphics2D gfx) {
+    paintPanel(gfx, width, height, true);
+  }
+
+  private void paintPanel(Graphics2D gfx, int paintWidth, int paintHeight, boolean export) {
     /* Anti-aliasing changes from https://github.com/hausen/logisim-evolution */
     gfx.setRenderingHint(
         RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
     gfx.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
     gfx.setColor(Color.WHITE);
-    gfx.fillRect(0, 0, getWidth(), getHeight()); // entire viewport, not just (width, height)
+    gfx.fillRect(0, 0, paintWidth, paintHeight); // entire viewport, not just (width, height)
     gfx.setColor(Color.BLACK);
     if (rows.isEmpty()) {
       final var f = gfx.getFont();
@@ -291,7 +298,10 @@ public class RightPanel extends JPanel {
       gfx.drawString("Oops! Chronogram is too large to display.", 15, 15);
       gfx.drawString("Try zooming out, or reset the simulation.", 15, 29);
     } else {
-      for (final var w : rows) w.paintWaveform(gfx);
+      for (final var w : rows) {
+        if (export) w.paintWaveformDirect(gfx);
+        else w.paintWaveform(gfx);
+      }
       paintCursor(gfx);
     }
   }
@@ -600,19 +610,20 @@ public class RightPanel extends JPanel {
     }
 
     public void paintWaveform(Graphics2D g) {
-      final var y = WAVE_HEIGHT * signal.idx;
-      if (g instanceof TikZWriter) {
-        final var gCopy = (Graphics2D) g.create();
-        gCopy.translate(0, y);
-        drawWaveform(gCopy);
-        gCopy.dispose();
-        return;
-      }
       if (buf == null) {
         // TODO: reallocating image each time seems silly
         createOffscreen();
       }
+      final var y = WAVE_HEIGHT * signal.idx;
       g.drawImage(buf, null, 0, y);
+    }
+
+    public void paintWaveformDirect(Graphics2D g) {
+      final var y = WAVE_HEIGHT * signal.idx;
+      final var gCopy = (Graphics2D) g.create();
+      gCopy.translate(0, y);
+      drawWaveform(gCopy);
+      gCopy.dispose();
     }
 
     public void flush() {

--- a/src/main/java/com/cburch/logisim/gui/main/ExportImage.java
+++ b/src/main/java/com/cburch/logisim/gui/main/ExportImage.java
@@ -295,6 +295,14 @@ public class ExportImage {
     public String getDescription() {
       return desc.toString();
     }
+
+    public String getDefaultExtension() {
+      return extensions[0];
+    }
+
+    public int getType() {
+      return type;
+    }
   }
 
   private static class OptionsPanel extends JPanel implements ChangeListener {

--- a/src/main/java/com/cburch/logisim/gui/menu/PrintHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/PrintHandler.java
@@ -102,20 +102,8 @@ public abstract class PrintHandler implements Printable {
             S.get("exportImageButton"));
     if (returnVal != JFileChooser.APPROVE_OPTION) return;
     var dest = chooser.getSelectedFile();
-    FileFilter ff = null;
-    for (final var filter : filters) {
-      if (filter.accept(dest)) ff = filter;
-    }
-    if (ff == null) ff = chooser.getFileFilter();
-    if (!ff.accept(dest)) {
-      if (ff == filters[0]) dest = new File(dest + ".png");
-      else if (ff == filters[1]) dest = new File(dest + ".gif");
-      else if (ff == filters[2]) dest = new File(dest + ".jpg");
-      else if (ff == filters[3]) dest = new File(dest + ".tex");
-      else if (ff == filters[4]) dest = new File(dest + ".svg");
-      else if (ff == filters[5]) dest = new File(dest + ".json");
-
-    }
+    final var ff = chooseExportFilter(dest, chooser.getFileFilter(), filters);
+    dest = ensureFileExtension(dest, ff);
     setLastExported(dest);
     if (dest.exists()) {
       final var confirm =
@@ -126,14 +114,25 @@ public abstract class PrintHandler implements Printable {
               OptionPane.YES_NO_OPTION);
       if (confirm != OptionPane.YES_OPTION) return;
     }
-    final var fmt =
-            (ff == filters[0] ? ExportImage.FORMAT_PNG
-                    : ff == filters[1] ? ExportImage.FORMAT_GIF
-                    : ff == filters[2] ? ExportImage.FORMAT_JPG
-                    : ff == filters[3] ? ExportImage.FORMAT_TIKZ
-                    : ff == filters[4] ? ExportImage.FORMAT_SVG
-                    : ff == filters[5] ? ExportImage.FORMAT_WAVEDROM : ExportImage.FORMAT_SVG);
-    exportImage(dest, fmt);
+    exportImage(dest, ff.getType());
+  }
+
+  static ImageFileFilter chooseExportFilter(
+      File dest, FileFilter selectedFilter, ImageFileFilter[] filters) {
+    if (selectedFilter instanceof ImageFileFilter imageFileFilter) {
+      return imageFileFilter;
+    }
+    if (dest != null && !dest.isDirectory()) {
+      for (final var filter : filters) {
+        if (filter.accept(dest)) return filter;
+      }
+    }
+    return filters[0];
+  }
+
+  static File ensureFileExtension(File dest, ImageFileFilter filter) {
+    if (dest == null || (!dest.isDirectory() && filter.accept(dest))) return dest;
+    return new File(dest + filter.getDefaultExtension());
   }
 
   public void exportImage(File dest, int fmt) {

--- a/src/test/java/com/cburch/logisim/gui/chrono/RightPanelTest.java
+++ b/src/test/java/com/cburch/logisim/gui/chrono/RightPanelTest.java
@@ -1,0 +1,74 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.chrono;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.gui.generic.TikZWriter;
+import com.cburch.logisim.gui.log.Model;
+import com.cburch.logisim.gui.log.Signal;
+import com.cburch.logisim.gui.log.SignalInfo;
+import java.awt.Color;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.swing.DefaultListSelectionModel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RightPanelTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void vectorExportPaintsWaveformPaths() throws Exception {
+    final var signalInfo = mock(SignalInfo.class);
+    when(signalInfo.getWidth()).thenReturn(1);
+    when(signalInfo.format(any(Value.class))).thenAnswer(inv -> inv.getArgument(0).toString());
+    final var signal = new Signal(0, signalInfo, Value.FALSE, 10, 0, 0);
+    signal.extend(Value.TRUE, 10);
+
+    final var model = mock(Model.class);
+    when(model.getSignalCount()).thenReturn(1);
+    when(model.getSignal(0)).thenReturn(signal);
+    when(model.getStartTime()).thenReturn(0L);
+    when(model.getEndTime()).thenReturn(20L);
+    when(model.getTimeScale()).thenReturn(10L);
+
+    final var chronoPanel = mock(ChronoPanel.class);
+    when(chronoPanel.getModel()).thenReturn(model);
+    when(chronoPanel.rowColors(any(SignalInfo.class), anyBoolean()))
+        .thenReturn(
+            new Color[] {
+              Color.LIGHT_GRAY,
+              Color.GRAY,
+              Color.BLACK,
+              Color.PINK,
+              Color.BLACK,
+              Color.ORANGE,
+              Color.BLACK
+            });
+
+    final var rightPanel = new RightPanel(chronoPanel, new DefaultListSelectionModel());
+    final var writer = new TikZWriter();
+    rightPanel.paintExportImage(writer);
+
+    final var exportFile = tempDir.resolve("timing.svg").toFile();
+    writer.writeSvg(100, 30, exportFile);
+
+    final var svg = Files.readString(exportFile.toPath());
+    assertTrue(svg.contains("stroke=\"#000000\""));
+    assertTrue(svg.contains("V28") || svg.contains("V2"));
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/chrono/RightPanelTest.java
+++ b/src/test/java/com/cburch/logisim/gui/chrono/RightPanelTest.java
@@ -9,30 +9,28 @@
 
 package com.cburch.logisim.gui.chrono;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.cburch.logisim.data.Value;
-import com.cburch.logisim.gui.generic.TikZWriter;
 import com.cburch.logisim.gui.log.Model;
 import com.cburch.logisim.gui.log.Signal;
 import com.cburch.logisim.gui.log.SignalInfo;
 import java.awt.Color;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
 import javax.swing.DefaultListSelectionModel;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 class RightPanelTest {
 
-  @TempDir Path tempDir;
-
   @Test
-  void vectorExportPaintsWaveformPaths() throws Exception {
+  void vectorExportPaintsWaveformsDirectly() {
     final var signalInfo = mock(SignalInfo.class);
     when(signalInfo.getWidth()).thenReturn(1);
     when(signalInfo.format(any(Value.class))).thenAnswer(inv -> inv.getArgument(0).toString());
@@ -61,14 +59,15 @@ class RightPanelTest {
             });
 
     final var rightPanel = new RightPanel(chronoPanel, new DefaultListSelectionModel());
-    final var writer = new TikZWriter();
-    rightPanel.paintExportImage(writer);
+    final var exportGraphics = mock(Graphics2D.class);
+    final var waveformGraphics = mock(Graphics2D.class);
+    final var metricsGraphics = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB).createGraphics();
+    when(exportGraphics.create()).thenReturn(waveformGraphics);
+    when(waveformGraphics.getFontMetrics()).thenReturn(metricsGraphics.getFontMetrics());
 
-    final var exportFile = tempDir.resolve("timing.svg").toFile();
-    writer.writeSvg(100, 30, exportFile);
+    rightPanel.paintExportImage(exportGraphics);
 
-    final var svg = Files.readString(exportFile.toPath());
-    assertTrue(svg.contains("stroke=\"#000000\""));
-    assertTrue(svg.contains("V28") || svg.contains("V2"));
+    verify(waveformGraphics, atLeastOnce()).drawLine(anyInt(), anyInt(), anyInt(), anyInt());
+    metricsGraphics.dispose();
   }
 }

--- a/src/test/java/com/cburch/logisim/gui/menu/PrintHandlerTest.java
+++ b/src/test/java/com/cburch/logisim/gui/menu/PrintHandlerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.menu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.gui.main.ExportImage;
+import com.cburch.logisim.gui.main.ExportImage.ImageFileFilter;
+import com.cburch.logisim.util.StringGetter;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.swing.filechooser.FileFilter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PrintHandlerTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void selectedExportFilterWinsOverExistingFileExtension() {
+    final var filters = imageFilters();
+    final var selectedFilter = filters[3];
+    final var chosenFilter =
+        PrintHandler.chooseExportFilter(new File("timing.svg"), selectedFilter, filters);
+
+    assertEquals(ExportImage.FORMAT_TIKZ, chosenFilter.getType());
+  }
+
+  @Test
+  void fileExtensionSelectsFormatWhenSelectedFilterIsNotAnImageFilter() {
+    final var filters = imageFilters();
+    final var selectedFilter =
+        new FileFilter() {
+          @Override
+          public boolean accept(File f) {
+            return false;
+          }
+
+          @Override
+          public String getDescription() {
+            return "not an image filter";
+          }
+        };
+    final var chosenFilter =
+        PrintHandler.chooseExportFilter(new File("timing.svg"), selectedFilter, filters);
+
+    assertEquals(ExportImage.FORMAT_SVG, chosenFilter.getType());
+  }
+
+  @Test
+  void selectedFilterExtensionIsAppendedWhenFileNameHasDifferentExtension() {
+    final var filters = imageFilters();
+    final var dest = PrintHandler.ensureFileExtension(new File("timing.svg"), filters[3]);
+
+    assertEquals(new File("timing.svg.tex"), dest);
+  }
+
+  @Test
+  void directTikzExportWritesTikzContent() throws Exception {
+    final var dest = tempDir.resolve("timing.tex").toFile();
+    new TestPrintHandler().exportImage(dest, ExportImage.FORMAT_TIKZ);
+
+    final var content = Files.readString(dest.toPath());
+    assertTrue(content.contains("\\begin{tikzpicture}"));
+    assertTrue(content.contains("\\draw"));
+    assertFalse(content.contains("<svg"));
+  }
+
+  @Test
+  void directSvgExportWritesSvgContent() throws Exception {
+    final var dest = tempDir.resolve("timing.svg").toFile();
+    new TestPrintHandler().exportImage(dest, ExportImage.FORMAT_SVG);
+
+    final var content = Files.readString(dest.toPath());
+    assertTrue(content.contains("<svg"));
+    assertTrue(content.contains("<path"));
+    assertFalse(content.contains("\\begin{tikzpicture}"));
+  }
+
+  private static ImageFileFilter[] imageFilters() {
+    return new ImageFileFilter[] {
+      new ImageFileFilter(ExportImage.FORMAT_PNG, getter("PNG"), new String[] {"png"}),
+      new ImageFileFilter(ExportImage.FORMAT_GIF, getter("GIF"), new String[] {"gif"}),
+      new ImageFileFilter(ExportImage.FORMAT_JPG, getter("JPEG"), new String[] {"jpg"}),
+      new ImageFileFilter(ExportImage.FORMAT_TIKZ, getter("TikZ"), new String[] {"tex"}),
+      new ImageFileFilter(ExportImage.FORMAT_SVG, getter("SVG"), new String[] {"svg"}),
+      new ImageFileFilter(ExportImage.FORMAT_WAVEDROM, getter("WaveDrom"), new String[] {"json"})
+    };
+  }
+
+  private static StringGetter getter(String value) {
+    return new StringGetter() {
+      @Override
+      public String toString() {
+        return value;
+      }
+    };
+  }
+
+  private static class TestPrintHandler extends PrintHandler {
+    @Override
+    public int print(Graphics2D g, PageFormat pf, int pageNum, double w, double h) {
+      return Printable.PAGE_EXISTS;
+    }
+
+    @Override
+    public Dimension getExportImageSize() {
+      return new Dimension(20, 20);
+    }
+
+    @Override
+    public void paintExportImage(BufferedImage img, Graphics2D g) {
+      g.drawLine(1, 2, 18, 2);
+    }
+  }
+}


### PR DESCRIPTION
Summary
- render timing diagram waveforms directly for TikZ/SVG export instead of blitting the cached waveform image
- prefer the file filter selected in the timing diagram export dialog, so choosing TikZ is not overridden by a stale `.svg` filename
- add coverage for timing export filter selection and direct TikZ/SVG export output

Fixes #1605
Fixes #1606

Verification
- `./gradlew.bat compileJava checkstyleMain compileTestJava checkstyleTest test --tests com.cburch.logisim.gui.menu.PrintHandlerTest`

Draft note
- I would still like to manually export a timing diagram from the GUI before marking this ready.