### PR TITLE
gui: localize assembly viewer

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/menu/AssemblyWindow.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/AssemblyWindow.java
@@ -9,6 +9,8 @@
 
 package com.cburch.logisim.gui.menu;
 
+import static com.cburch.logisim.gui.Strings.S;
+
 import com.cburch.contracts.BaseKeyListenerContract;
 import com.cburch.contracts.BaseWindowListenerContract;
 import com.cburch.logisim.circuit.Circuit;
@@ -60,11 +62,14 @@ public class AssemblyWindow
   private final Preferences prefs;
   private final LFrame windows;
   private final JMenuBar winMenuBar;
+  private final JMenu fileMenu;
+  private final JMenu windowMenu;
   private final JCheckBoxMenuItem ontopItem;
   private final JMenuItem openFileItem;
   private final JMenuItem reloadFileItem;
   private final JMenuItem close;
-  private final JButton refresh = new JButton("Get Registers");
+  private final JButton refresh = new JButton();
+  private final JLabel registerLabel = new JLabel();
   private final JLabel status = new JLabel();
   private final JEditorPane document = new JEditorPane();
 
@@ -81,8 +86,8 @@ public class AssemblyWindow
     curCircuit = proj.getCurrentCircuit();
     curCircuitState = proj.getCircuitState();
     winMenuBar = new JMenuBar();
-    final var windowMenu = new JMenu("Window");
-    final var fileMenu = new JMenu("File");
+    windowMenu = new JMenu();
+    fileMenu = new JMenu();
     final var main = new JPanel(new BorderLayout());
     final var north = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 2));
     /* LinePainter painter = new LinePainter(document); */
@@ -93,15 +98,15 @@ public class AssemblyWindow
     combo.setFocusable(false);
     refresh.addActionListener(this);
     refresh.setFocusable(false);
-    refresh.setToolTipText("Get register list of current displayed circuit.");
 
-    ontopItem = new JCheckBoxMenuItem("Set on top", true);
+    ontopItem = new JCheckBoxMenuItem();
+    ontopItem.setState(true);
     ontopItem.addActionListener(this);
-    openFileItem = new JMenuItem("Open lss file");
+    openFileItem = new JMenuItem();
     openFileItem.addActionListener(this);
-    reloadFileItem = new JMenuItem("Reload lss file");
+    reloadFileItem = new JMenuItem();
     reloadFileItem.addActionListener(this);
-    close = new JMenuItem("Close");
+    close = new JMenuItem();
     close.addActionListener(this);
     winMenuBar.add(fileMenu);
     winMenuBar.add(windowMenu);
@@ -113,7 +118,6 @@ public class AssemblyWindow
     fileMenu.add(close);
 
     windows = new LFrame.Dialog(null);
-    windows.setTitle("Assembly: " + proj.getLogisimFile().getDisplayName());
     windows.setJMenuBar(winMenuBar);
     windows.toFront();
     windows.setAlwaysOnTop(true);
@@ -121,7 +125,7 @@ public class AssemblyWindow
     windows.addWindowListener(this);
     windows.addKeyListener(this);
 
-    north.add(new JLabel("Register: "));
+    north.add(registerLabel);
     north.add(combo);
     north.add(refresh);
 
@@ -141,6 +145,7 @@ public class AssemblyWindow
     windows.setLocation(prefs.getInt("X", 0), prefs.getInt("Y", 0));
     windows.setSize(
         prefs.getInt("W", windows.getSize().width), prefs.getInt("H", windows.getSize().height));
+    localeChanged();
   }
 
   @Override
@@ -160,7 +165,7 @@ public class AssemblyWindow
 
             @Override
             public String getDescription() {
-              return ".lss disassembly file";
+              return S.get("assemblyLssFileFilter");
             }
           };
       fileChooser.setFileFilter(ff);
@@ -173,11 +178,11 @@ public class AssemblyWindow
             status.setText("");
             document.setPage(file.toURI().toURL());
           } else {
-            status.setText("Wrong file selected !");
+            status.setText(S.get("assemblyWrongFileSelected"));
             file = null;
           }
         } catch (Exception ex) {
-          status.setText("Cannot open file !");
+          status.setText(S.get("assemblyCannotOpenFile"));
           file = null;
         }
       }
@@ -188,9 +193,9 @@ public class AssemblyWindow
       if (file != null) {
         try {
           document.setPage(file.toURI().toURL());
-          status.setText("File reloaded.");
+          status.setText(S.get("assemblyFileReloaded"));
         } catch (Exception ex) {
-          status.setText("Cannot open file !");
+          status.setText(S.get("assemblyCannotOpenFile"));
           file = null;
         }
       }
@@ -225,7 +230,7 @@ public class AssemblyWindow
     combo.removeAllItems();
 
     if (entry.isEmpty()) {
-      status.setText("No labeled registers found.");
+      status.setText(S.get("assemblyNoLabeledRegisters"));
       combo.setEnabled(false);
     } else {
       status.setText("");
@@ -249,6 +254,20 @@ public class AssemblyWindow
   public void setVisible(boolean bool) {
     fillCombo();
     windows.setVisible(bool);
+  }
+
+  public void localeChanged() {
+    fileMenu.setText(S.get("fileMenu"));
+    windowMenu.setText(S.get("assemblyWindowMenu"));
+    ontopItem.setText(S.get("assemblySetOnTop"));
+    openFileItem.setText(S.get("assemblyOpenLssFile"));
+    reloadFileItem.setText(S.get("assemblyReloadLssFile"));
+    close.setText(S.get("fileCloseItem"));
+    registerLabel.setText(S.get("assemblyRegisterLabel"));
+    refresh.setText(S.get("assemblyGetRegisters"));
+    refresh.setToolTipText(S.get("assemblyGetRegistersToolTip"));
+    windows.setTitle(
+        S.get("assemblyWindowTitle", proj.getLogisimFile().getDisplayName()));
   }
 
   @Override
@@ -327,7 +346,7 @@ public class AssemblyWindow
             ex.printStackTrace();
           }
         } else {
-          status.setText("Line (" + where + ") not found!");
+          status.setText(S.get("assemblyLineNotFound", where));
         }
       }
     }

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuSimulate.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuSimulate.java
@@ -238,6 +238,9 @@ public class MenuSimulate extends Menu {
     log.setText(S.get("simulateLogItem"));
     test.setText(S.get("simulateTestItem"));
     assemblyWindow.setText(S.get("simulateAssemblyViewer"));
+    if (assWin != null) {
+      assWin.localeChanged();
+    }
   }
 
   private void recreateStateMenu(JMenu menu, List<CircuitStateMenuItem> items, int code) {

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -381,6 +381,23 @@ projectOptionsItem = Options…
 projectRevertAppearanceItem = Revert To Default Appearance
 projectUnloadLibrariesItem = Unload Libraries…
 #
+# menu/AssemblyWindow.java
+#
+assemblyCannotOpenFile = Cannot open file.
+assemblyFileReloaded = File reloaded.
+assemblyGetRegisters = Get Registers
+assemblyGetRegistersToolTip = Get register list of current displayed circuit.
+assemblyLineNotFound = Line (%s) not found!
+assemblyLssFileFilter = .lss disassembly file
+assemblyNoLabeledRegisters = No labeled registers found.
+assemblyOpenLssFile = Open lss file
+assemblyRegisterLabel = Register:
+assemblyReloadLssFile = Reload lss file
+assemblySetOnTop = Set on top
+assemblyWindowMenu = Window
+assemblyWindowTitle = Assembly: %s
+assemblyWrongFileSelected = Wrong file selected.
+#
 # menu/MenuSimulate.java
 #
 simulateAssemblyViewer = Assembly viewer

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -384,20 +384,20 @@ projectUnloadLibrariesItem = Bibliotheken entfernen…
 #
 # menu/AssemblyWindow.java
 #
-# ==> assemblyCannotOpenFile =
-# ==> assemblyFileReloaded =
-# ==> assemblyGetRegisters =
-# ==> assemblyGetRegistersToolTip =
-# ==> assemblyLineNotFound =
-# ==> assemblyLssFileFilter =
-# ==> assemblyNoLabeledRegisters =
-# ==> assemblyOpenLssFile =
-# ==> assemblyRegisterLabel =
-# ==> assemblyReloadLssFile =
-# ==> assemblySetOnTop =
-# ==> assemblyWindowMenu =
-# ==> assemblyWindowTitle =
-# ==> assemblyWrongFileSelected =
+assemblyCannotOpenFile = Kann die Datei nicht öfnen.
+assemblyFileReloaded = Datei neu geladen.
+assemblyGetRegisters = Register abrufen
+assemblyGetRegistersToolTip = Die Registerliste der aktuell angezeigten Schaltung abrufen.
+assemblyLineNotFound = Zeile (%s) nicht gefunden!
+assemblyLssFileFilter = .lss disassembly Datei
+assemblyNoLabeledRegisters = Es wurden keine beschrifteten Register gefunden.
+assemblyOpenLssFile = Öfne eine lss Datei
+assemblyRegisterLabel = Register:
+assemblyReloadLssFile = lss-Datei neu laden
+assemblySetOnTop = Oben platzieren
+assemblyWindowMenu = Fenster
+assemblyWindowTitle = Assembly: %s
+assemblyWrongFileSelected = Falsche Datei ausgewählt.
 #
 # menu/MenuSimulate.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -382,6 +382,23 @@ projectOptionsItem = Optionen…
 projectRevertAppearanceItem = Standart Aussehen wiederherstellen
 projectUnloadLibrariesItem = Bibliotheken entfernen…
 #
+# menu/AssemblyWindow.java
+#
+# ==> assemblyCannotOpenFile =
+# ==> assemblyFileReloaded =
+# ==> assemblyGetRegisters =
+# ==> assemblyGetRegistersToolTip =
+# ==> assemblyLineNotFound =
+# ==> assemblyLssFileFilter =
+# ==> assemblyNoLabeledRegisters =
+# ==> assemblyOpenLssFile =
+# ==> assemblyRegisterLabel =
+# ==> assemblyReloadLssFile =
+# ==> assemblySetOnTop =
+# ==> assemblyWindowMenu =
+# ==> assemblyWindowTitle =
+# ==> assemblyWrongFileSelected =
+#
 # menu/MenuSimulate.java
 #
 simulateAssemblyViewer = Assembly-Betrachter

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -380,6 +380,23 @@ projectOptionsItem = Επιλογές…
 projectRevertAppearanceItem = Επαναφορά στην Προεπιλεγμένη Εμφάνιση
 projectUnloadLibrariesItem = Ελευθέρωση Βιβλιοθηκών…
 #
+# menu/AssemblyWindow.java
+#
+# ==> assemblyCannotOpenFile =
+# ==> assemblyFileReloaded =
+# ==> assemblyGetRegisters =
+# ==> assemblyGetRegistersToolTip =
+# ==> assemblyLineNotFound =
+# ==> assemblyLssFileFilter =
+# ==> assemblyNoLabeledRegisters =
+# ==> assemblyOpenLssFile =
+# ==> assemblyRegisterLabel =
+# ==> assemblyReloadLssFile =
+# ==> assemblySetOnTop =
+# ==> assemblyWindowMenu =
+# ==> assemblyWindowTitle =
+# ==> assemblyWrongFileSelected =
+#
 # menu/MenuSimulate.java
 #
 # ==> simulateAssemblyViewer =

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -382,6 +382,23 @@ projectOptionsItem = Opciones…
 projectRevertAppearanceItem = Volver a la apariencia original
 projectUnloadLibrariesItem = Dejar de usar librerías…
 #
+# menu/AssemblyWindow.java
+#
+# ==> assemblyCannotOpenFile =
+# ==> assemblyFileReloaded =
+# ==> assemblyGetRegisters =
+# ==> assemblyGetRegistersToolTip =
+# ==> assemblyLineNotFound =
+# ==> assemblyLssFileFilter =
+# ==> assemblyNoLabeledRegisters =
+# ==> assemblyOpenLssFile =
+# ==> assemblyRegisterLabel =
+# ==> assemblyReloadLssFile =
+# ==> assemblySetOnTop =
+# ==> assemblyWindowMenu =
+# ==> assemblyWindowTitle =
+# ==> assemblyWrongFileSelected =
+#
 # menu/MenuSimulate.java
 #
 # ==> simulateAssemblyViewer =

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -381,6 +381,23 @@ projectOptionsItem = Options…
 projectRevertAppearanceItem = Revenir à l’apparence par défaut
 projectUnloadLibrariesItem = Enlever les librairies…
 #
+# menu/AssemblyWindow.java
+#
+# ==> assemblyCannotOpenFile =
+# ==> assemblyFileReloaded =
+# ==> assemblyGetRegisters =
+# ==> assemblyGetRegistersToolTip =
+# ==> assemblyLineNotFound =
+# ==> assemblyLssFileFilter =
+# ==> assemblyNoLabeledRegisters =
+# ==> assemblyOpenLssFile =
+# ==> assemblyRegisterLabel =
+# ==> assemblyReloadLssFile =
+# ==> assemblySetOnTop =
+# ==> assemblyWindowMenu =
+# ==> assemblyWindowTitle =
+# ==> assemblyWrongFileSelected =
+#
 # menu/MenuSimulate.java
 #
 simulateAssemblyViewer = Visionneur d’assembly

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -383,20 +383,20 @@ projectUnloadLibrariesItem = Enlever les librairies…
 #
 # menu/AssemblyWindow.java
 #
-# ==> assemblyCannotOpenFile =
-# ==> assemblyFileReloaded =
-# ==> assemblyGetRegisters =
-# ==> assemblyGetRegistersToolTip =
-# ==> assemblyLineNotFound =
-# ==> assemblyLssFileFilter =
-# ==> assemblyNoLabeledRegisters =
-# ==> assemblyOpenLssFile =
-# ==> assemblyRegisterLabel =
-# ==> assemblyReloadLssFile =
-# ==> assemblySetOnTop =
-# ==> assemblyWindowMenu =
-# ==> assemblyWindowTitle =
-# ==> assemblyWrongFileSelected =
+assemblyCannotOpenFile = Impossible d'ouvrir le fichier.
+assemblyFileReloaded = Le fichier a été rechargé.
+assemblyGetRegisters = Obtenir les registres
+assemblyGetRegistersToolTip = Obtenir la liste des registres du circuit actuellement affiché.
+assemblyLineNotFound = Ligne (%s) introuvable!
+assemblyLssFileFilter = fichier de désassemblage .lss
+assemblyNoLabeledRegisters = Aucun registre étiqueté n'a été trouvé.
+assemblyOpenLssFile = Ouvrir un fichier lss
+assemblyRegisterLabel = Registre:
+assemblyReloadLssFile = Recharger le fichier lss
+assemblySetOnTop = Placer au-dessus
+assemblyWindowMenu = Fenêtre
+assemblyWindowTitle = Assemblage : %s
+assemblyWrongFileSelected = Fichier incorrect sélectionné.
 #
 # menu/MenuSimulate.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -381,6 +381,23 @@ projectOptionsItem = Opzioni…
 projectRevertAppearanceItem = Torna All’Aspetto Predefinito
 projectUnloadLibrariesItem = Rimuovi Librerie…
 #
+# menu/AssemblyWindow.java
+#
+# ==> assemblyCannotOpenFile =
+# ==> assemblyFileReloaded =
+# ==> assemblyGetRegisters =
+# ==> assemblyGetRegistersToolTip =
+# ==> assemblyLineNotFound =
+# ==> assemblyLssFileFilter =
+# ==> assemblyNoLabeledRegisters =
+# ==> assemblyOpenLssFile =
+# ==> assemblyRegisterLabel =
+# ==> assemblyReloadLssFile =
+# ==> assemblySetOnTop =
+# ==> assemblyWindowMenu =
+# ==> assemblyWindowTitle =
+# ==> assemblyWrongFileSelected =
+#
 # menu/MenuSimulate.java
 #
 simulateAssemblyViewer =

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -380,6 +380,23 @@ projectOptionsItem = オプション…
 projectRevertAppearanceItem = デフォルトの外観に戻す
 projectUnloadLibrariesItem = ライブラリの取り外し…
 #
+# menu/AssemblyWindow.java
+#
+# ==> assemblyCannotOpenFile =
+# ==> assemblyFileReloaded =
+# ==> assemblyGetRegisters =
+# ==> assemblyGetRegistersToolTip =
+# ==> assemblyLineNotFound =
+# ==> assemblyLssFileFilter =
+# ==> assemblyNoLabeledRegisters =
+# ==> assemblyOpenLssFile =
+# ==> assemblyRegisterLabel =
+# ==> assemblyReloadLssFile =
+# ==> assemblySetOnTop =
+# ==> assemblyWindowMenu =
+# ==> assemblyWindowTitle =
+# ==> assemblyWrongFileSelected =
+#
 # menu/MenuSimulate.java
 #
 # ==> simulateAssemblyViewer =

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -401,7 +401,7 @@ assemblyWrongFileSelected = Er is een verkeerd bestand geselecteerd.
 #
 # menu/MenuSimulate.java
 #
-simulateAssemblyViewer = Assembly-viewer
+simulateAssemblyViewer = Assembler aanzicht
 simulateDownStateMenu = Ga naar de staat
 simulateGenVhdlFilesItem = Herstart VHDL-simulator
 simulateLogItem = Chronogram

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -384,24 +384,24 @@ projectUnloadLibrariesItem = Bibliotheken sluiten…
 #
 # menu/AssemblyWindow.java
 #
-# ==> assemblyCannotOpenFile =
-# ==> assemblyFileReloaded =
-# ==> assemblyGetRegisters =
-# ==> assemblyGetRegistersToolTip =
-# ==> assemblyLineNotFound =
-# ==> assemblyLssFileFilter =
-# ==> assemblyNoLabeledRegisters =
-# ==> assemblyOpenLssFile =
-# ==> assemblyRegisterLabel =
-# ==> assemblyReloadLssFile =
-# ==> assemblySetOnTop =
-# ==> assemblyWindowMenu =
-# ==> assemblyWindowTitle =
-# ==> assemblyWrongFileSelected =
+assemblyCannotOpenFile = Het bestand kan niet worden geopend.
+assemblyFileReloaded = Bestand opnieuw geladen.
+assemblyGetRegisters = Registers opvragen
+assemblyGetRegistersToolTip = Haal de registerlijst op van het momenteel weergegeven circuit.
+assemblyLineNotFound = Regel (%s) niet gevonden!
+assemblyLssFileFilter = .lss-disassemblagebestand
+assemblyNoLabeledRegisters = Er zijn geen registers met labels gevonden.
+assemblyOpenLssFile = Open lss-bestand
+assemblyRegisterLabel = Register:
+assemblyReloadLssFile = Het lss-bestand opnieuw laden
+assemblySetOnTop = Bovenop plaatsen
+assemblyWindowMenu = Venster
+assemblyWindowTitle = Disassemblage: %s
+assemblyWrongFileSelected = Er is een verkeerd bestand geselecteerd.
 #
 # menu/MenuSimulate.java
 #
-# ==> simulateAssemblyViewer =
+simulateAssemblyViewer = Assembly-viewer
 simulateDownStateMenu = Ga naar de staat
 simulateGenVhdlFilesItem = Herstart VHDL-simulator
 simulateLogItem = Chronogram

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -382,6 +382,23 @@ projectOptionsItem = Project Instellingen…
 projectRevertAppearanceItem = Terug naar de standaarduitstraling
 projectUnloadLibrariesItem = Bibliotheken sluiten…
 #
+# menu/AssemblyWindow.java
+#
+# ==> assemblyCannotOpenFile =
+# ==> assemblyFileReloaded =
+# ==> assemblyGetRegisters =
+# ==> assemblyGetRegistersToolTip =
+# ==> assemblyLineNotFound =
+# ==> assemblyLssFileFilter =
+# ==> assemblyNoLabeledRegisters =
+# ==> assemblyOpenLssFile =
+# ==> assemblyRegisterLabel =
+# ==> assemblyReloadLssFile =
+# ==> assemblySetOnTop =
+# ==> assemblyWindowMenu =
+# ==> assemblyWindowTitle =
+# ==> assemblyWrongFileSelected =
+#
 # menu/MenuSimulate.java
 #
 # ==> simulateAssemblyViewer =

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -382,6 +382,23 @@ projectOptionsItem = Opcje…
 projectRevertAppearanceItem = Wróć do domyślnego wyglądu
 projectUnloadLibrariesItem = Usuń biblioteki…
 #
+# menu/AssemblyWindow.java
+#
+# ==> assemblyCannotOpenFile =
+# ==> assemblyFileReloaded =
+# ==> assemblyGetRegisters =
+# ==> assemblyGetRegistersToolTip =
+# ==> assemblyLineNotFound =
+# ==> assemblyLssFileFilter =
+# ==> assemblyNoLabeledRegisters =
+# ==> assemblyOpenLssFile =
+# ==> assemblyRegisterLabel =
+# ==> assemblyReloadLssFile =
+# ==> assemblySetOnTop =
+# ==> assemblyWindowMenu =
+# ==> assemblyWindowTitle =
+# ==> assemblyWrongFileSelected =
+#
 # menu/MenuSimulate.java
 #
 simulateAssemblyViewer = Visionneur d’assembly

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -381,6 +381,23 @@ projectOptionsItem = Opções…
 projectRevertAppearanceItem = Restaurar aparencia padrão
 projectUnloadLibrariesItem = Descarregar bibliotecas
 #
+# menu/AssemblyWindow.java
+#
+# ==> assemblyCannotOpenFile =
+# ==> assemblyFileReloaded =
+# ==> assemblyGetRegisters =
+# ==> assemblyGetRegistersToolTip =
+# ==> assemblyLineNotFound =
+# ==> assemblyLssFileFilter =
+# ==> assemblyNoLabeledRegisters =
+# ==> assemblyOpenLssFile =
+# ==> assemblyRegisterLabel =
+# ==> assemblyReloadLssFile =
+# ==> assemblySetOnTop =
+# ==> assemblyWindowMenu =
+# ==> assemblyWindowTitle =
+# ==> assemblyWrongFileSelected =
+#
 # menu/MenuSimulate.java
 #
 simulateAssemblyViewer = Visionneur d’assembly

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -380,6 +380,23 @@ projectOptionsItem = Параметры…
 projectRevertAppearanceItem = Вернуть внешний вид по умолчанию
 projectUnloadLibrariesItem = Выгрузить библиотеки…
 #
+# menu/AssemblyWindow.java
+#
+# ==> assemblyCannotOpenFile =
+# ==> assemblyFileReloaded =
+# ==> assemblyGetRegisters =
+# ==> assemblyGetRegistersToolTip =
+# ==> assemblyLineNotFound =
+# ==> assemblyLssFileFilter =
+# ==> assemblyNoLabeledRegisters =
+# ==> assemblyOpenLssFile =
+# ==> assemblyRegisterLabel =
+# ==> assemblyReloadLssFile =
+# ==> assemblySetOnTop =
+# ==> assemblyWindowMenu =
+# ==> assemblyWindowTitle =
+# ==> assemblyWrongFileSelected =
+#
 # menu/MenuSimulate.java
 #
 # ==> simulateAssemblyViewer =

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -380,6 +380,23 @@ projectOptionsItem = 选项…
 projectRevertAppearanceItem = 恢复为默认外观
 projectUnloadLibrariesItem = 卸载库…
 #
+# menu/AssemblyWindow.java
+#
+assemblyCannotOpenFile = 无法打开文件。
+assemblyFileReloaded = 文件已重新加载。
+assemblyGetRegisters = 获取寄存器
+assemblyGetRegistersToolTip = 获取当前显示电路的寄存器列表。
+assemblyLineNotFound = 未找到行（%s）！
+assemblyLssFileFilter = .lss 反汇编文件
+assemblyNoLabeledRegisters = 未找到带标签的寄存器。
+assemblyOpenLssFile = 打开 lss 文件
+assemblyRegisterLabel = 寄存器：
+assemblyReloadLssFile = 重新加载 lss 文件
+assemblySetOnTop = 始终置顶
+assemblyWindowMenu = 窗口
+assemblyWindowTitle = 汇编：%s
+assemblyWrongFileSelected = 选择的文件无效。
+#
 # menu/MenuSimulate.java
 #
 simulateAssemblyViewer = 汇编查看器


### PR DESCRIPTION
Summary
- move Assembly Viewer window/menu/button/status text into GUI resource strings
- add English source strings, Simplified Chinese translations, and placeholders for other GUI locales
- refresh an open Assembly Viewer when the application locale changes through the Simulate menu listener

Verification
- ./gradlew.bat compileJava checkstyleMain
- verified all new Assembly Viewer localization keys are present in all 12 gui resource files

Closes #1748
