### PR TITLE
chrono: fix timing diagram GIF export

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/main/ExportImage.java
+++ b/src/main/java/com/cburch/logisim/gui/main/ExportImage.java
@@ -17,7 +17,6 @@ import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.gui.generic.TikZWriter;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Project;
-import com.cburch.logisim.util.GifEncoder;
 import com.cburch.logisim.util.StringGetter;
 import com.cburch.logisim.util.UniquelyNamedThread;
 import java.awt.Color;
@@ -244,7 +243,7 @@ public class ExportImage {
       }
       try {
         switch (filter.type) {
-          case FORMAT_GIF -> GifEncoder.toFile(img, where, monitor);
+          case FORMAT_GIF -> ImageIO.write(img, "GIF", where);
           case FORMAT_PNG -> ImageIO.write(img, "PNG", where);
           case FORMAT_JPG -> ImageIO.write(img, "JPEG", where);
           case FORMAT_TIKZ -> ((TikZWriter) g).writeFile(where);

--- a/src/main/java/com/cburch/logisim/gui/menu/PrintHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/PrintHandler.java
@@ -15,7 +15,6 @@ import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.gui.generic.TikZWriter;
 import com.cburch.logisim.gui.main.ExportImage;
 import com.cburch.logisim.gui.main.ExportImage.ImageFileFilter;
-import com.cburch.logisim.util.GifEncoder;
 import com.cburch.logisim.util.JFileChoosers;
 import java.awt.Color;
 import java.awt.Component;
@@ -167,7 +166,7 @@ public abstract class PrintHandler implements Printable {
 
       try {
         switch (fmt) {
-          case ExportImage.FORMAT_GIF -> GifEncoder.toFile(img, dest, null);
+          case ExportImage.FORMAT_GIF -> ImageIO.write(img, "GIF", dest);
           case ExportImage.FORMAT_PNG -> ImageIO.write(img, "PNG", dest);
           case ExportImage.FORMAT_JPG -> ImageIO.write(img, "JPEG", dest);
           case ExportImage.FORMAT_TIKZ -> ((TikZWriter) g2d).writeFile(dest);

--- a/src/test/java/com/cburch/logisim/gui/menu/PrintHandlerTest.java
+++ b/src/test/java/com/cburch/logisim/gui/menu/PrintHandlerTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.cburch.logisim.gui.main.ExportImage;
 import com.cburch.logisim.gui.main.ExportImage.ImageFileFilter;
 import com.cburch.logisim.util.StringGetter;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
@@ -24,6 +25,7 @@ import java.awt.print.Printable;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import javax.imageio.ImageIO;
 import javax.swing.filechooser.FileFilter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -93,6 +95,16 @@ class PrintHandlerTest {
     assertFalse(content.contains("\\begin{tikzpicture}"));
   }
 
+  @Test
+  void directGifExportWritesImagesWithMoreThan256Colors() throws Exception {
+    final var dest = tempDir.resolve("timing.gif").toFile();
+    new ManyColorPrintHandler().exportImage(dest, ExportImage.FORMAT_GIF);
+
+    assertTrue(dest.isFile());
+    assertTrue(dest.length() > 0);
+    assertEquals(20, ImageIO.read(dest).getWidth());
+  }
+
   private static ImageFileFilter[] imageFilters() {
     return new ImageFileFilter[] {
       new ImageFileFilter(ExportImage.FORMAT_PNG, getter("PNG"), new String[] {"png"}),
@@ -127,6 +139,18 @@ class PrintHandlerTest {
     @Override
     public void paintExportImage(BufferedImage img, Graphics2D g) {
       g.drawLine(1, 2, 18, 2);
+    }
+  }
+
+  private static class ManyColorPrintHandler extends TestPrintHandler {
+    @Override
+    public void paintExportImage(BufferedImage img, Graphics2D g) {
+      for (var y = 0; y < img.getHeight(); y++) {
+        for (var x = 0; x < img.getWidth(); x++) {
+          g.setColor(new Color((x * 13) & 0xFF, (y * 13) & 0xFF, (x * y) & 0xFF));
+          g.fillRect(x, y, 1, 1);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Summary
- write GIF exports through ImageIO instead of the legacy GifEncoder
- apply the change to both PrintHandler image export and regular project image export
- add regression coverage for GIF export of images with more than 256 colors

Root cause
The old GifEncoder rejects images with more than 256 distinct RGB colors. Timing diagrams can exceed that limit because of text, grid/timeline rendering, and anti-aliased drawing, so GIF export reported an error while PNG export worked.

Verification
- .\gradlew.bat compileJava checkstyleMain compileTestJava test --tests com.cburch.logisim.gui.menu.PrintHandlerTest
- .\gradlew.bat checkstyleTest

Fixes #1604