### PR TITLE
memory: fix wide Random HDL output

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/Random.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Random.java
@@ -77,13 +77,13 @@ public class Random extends InstanceFactory {
 
     private long initSeed;
     private long curSeed;
-    private int value;
+    private long value;
     private long resetValue;
     private Value oldReset;
 
     public StateData(Object seed) {
       resetValue = this.initSeed = this.curSeed = getRandomSeed(seed);
-      this.value = (int) this.initSeed;
+      this.value = this.initSeed;
       oldReset = Value.UNKNOWN;
     }
 
@@ -97,7 +97,7 @@ public class Random extends InstanceFactory {
     public void reset(Object seed) {
       this.initSeed = resetValue;
       this.curSeed = resetValue;
-      this.value = (int) resetValue;
+      this.value = resetValue;
     }
 
     private long getRandomSeed(Object seed) {
@@ -118,7 +118,7 @@ public class Random extends InstanceFactory {
       long v = curSeed;
       v = (v * MULTIPLIER + ADDEND) & MASK;
       curSeed = v;
-      value = (int) (v >> 12);
+      value = v >> 12;
     }
   }
 
@@ -238,7 +238,7 @@ public class Random extends InstanceFactory {
     GraphicsUtil.switchToWidth(g, 1);
   }
 
-  private void drawData(InstancePainter painter, int xpos, int ypos, int nrOfBits, int value) {
+  private void drawData(InstancePainter painter, int xpos, int ypos, int nrOfBits, long value) {
     final var g = painter.getGraphics();
     GraphicsUtil.switchToWidth(g, 2);
     g.drawRect(xpos, ypos, 80, 20);
@@ -261,7 +261,7 @@ public class Random extends InstanceFactory {
     String a;
     String b = null;
     if (painter.getShowState()) {
-      int val = state == null ? 0 : state.value;
+      long val = state == null ? 0 : state.value;
       final var str = StringUtil.toHexString(width, val);
       if (str.length() <= 4) {
         a = str;

--- a/src/main/java/com/cburch/logisim/std/memory/RandomHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RandomHdlGeneratorFactory.java
@@ -168,9 +168,10 @@ public class RandomHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
           makeOutput : {{process}}({{GlobalClock}}, s_reset, s_initSeed) {{is}}
           {{begin}}
              {{if}} (rising_edge({{GlobalClock}})) {{then}}
-                {{if}} (s_reset = '1') {{then}} s_outputReg <= s_initSeed( ({{nrOfBits}}-1) {{downto}} 0 );
+                {{if}} (s_reset = '1') {{then}}
+                   s_outputReg <= std_logic_vector(resize(unsigned(s_initSeed), {{nrOfBits}}));
                 {{elsif}} ({{ClockEnable}} = '1' {{and}} enable = '1') {{then}}
-                   s_outputReg <= s_currentSeed(({{nrOfBits}}+11) {{downto}} 12);
+                   s_outputReg <= std_logic_vector(resize(unsigned(s_currentSeed(47 {{downto}} 12)), {{nrOfBits}}));
                 {{end}} {{if}};
              {{end}} {{if}};
           {{end}} {{process}} makeOutput;
@@ -219,8 +220,8 @@ public class RandomHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
 
           always @(posedge {{GlobalClock}})
           begin
-             if (s_reset) s_outputReg <= s_initSeed[({{nrOfBits}}-1):0];
-             else if ({{ClockEnable}}&enable) s_outputReg <= s_currentSeed[({{nrOfBits}}+11):12];
+             if (s_reset) s_outputReg <= s_initSeed;
+             else if ({{ClockEnable}}&enable) s_outputReg <= s_currentSeed[47:12];
           end
           """);
     }

--- a/src/test/java/com/cburch/logisim/std/memory/RandomHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/RandomHdlGeneratorFactoryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.memory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.prefs.AppPreferences;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class RandomHdlGeneratorFactoryTest {
+
+  private final String originalHdlType = AppPreferences.HdlType.get();
+
+  @AfterEach
+  void restoreHdlType() {
+    AppPreferences.HdlType.set(originalHdlType);
+  }
+
+  @Test
+  void vhdlOutputAssignmentDoesNotSliceBeyondRandomState() {
+    final var hdl = functionality(HdlGeneratorFactory.VHDL);
+
+    assertTrue(hdl.contains("resize(unsigned(s_initSeed), nrOfBits)"));
+    assertTrue(hdl.contains("resize(unsigned(s_currentSeed(47"));
+    assertTrue(hdl.contains("12)), nrOfBits)"));
+    assertFalse(hdl.contains("nrOfBits+11"));
+    assertFalse(hdl.contains("s_initSeed( (nrOfBits-1)"));
+  }
+
+  @Test
+  void verilogOutputAssignmentDoesNotSliceBeyondRandomState() {
+    final var hdl = functionality(HdlGeneratorFactory.VERILOG);
+
+    assertTrue(hdl.contains("s_outputReg <= s_initSeed;"));
+    assertTrue(hdl.contains("s_outputReg <= s_currentSeed[47:12];"));
+    assertFalse(hdl.contains("nrOfBits+11"));
+    assertFalse(hdl.contains("s_initSeed[("));
+  }
+
+  private static String functionality(String hdlType) {
+    AppPreferences.HdlType.set(hdlType);
+    final var attrs = new Random().createAttributeSet();
+    attrs.setValue(StdAttr.WIDTH, BitWidth.create(64));
+    return String.join(
+        "\n", new RandomHdlGeneratorFactory().getModuleFunctionality(null, attrs).get());
+  }
+}


### PR DESCRIPTION
Summary
- keep the Random component's runtime value as a long so widths above 32 bits are not truncated through int
- make VHDL resize the existing 48-bit seed and 36-bit shifted random value instead of slicing past the available state bits
- make Verilog assign the fixed RNG state vectors to the parameterized output register, relying on HDL sizing for truncation or zero-extension
- add regression coverage for VHDL and Verilog generator output

Notes
- This keeps the existing 48-bit RNG algorithm. It does not introduce a new 64-bit random algorithm; wider outputs are sized from the existing state instead of producing invalid HDL slices.

Verification
- .\gradlew.bat compileJava checkstyleMain compileTestJava test --tests com.cburch.logisim.std.memory.RandomHdlGeneratorFactoryTest checkstyleTest

Fixes #2529