### PR TITLE
prefs: update string option values synchronously

### DIFF
--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorStringOpts.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorStringOpts.java
@@ -22,6 +22,13 @@ class PrefMonitorStringOpts extends AbstractPrefMonitor<String> {
 
   private final String dflt;
 
+  private String choose(String newValue) {
+    for (final var s : opts) {
+      if (isSame(s, newValue)) return s;
+    }
+    return dflt;
+  }
+
   /**
    * Constructor for the PrefMonitorStringOpts class.
    * Initializes and sets preferences for string options.
@@ -60,15 +67,8 @@ class PrefMonitorStringOpts extends AbstractPrefMonitor<String> {
     if (prop.equals(name)) {
       final var oldValue = value;
       final var newValue = prefs.get(name, dflt);
-      if (!isSame(oldValue, newValue)) {
-        String chosen = null;
-        for (final var s : opts) {
-          if (isSame(s, newValue)) {
-            chosen = s;
-            break;
-          }
-        }
-        if (chosen == null) chosen = dflt;
+      final var chosen = choose(newValue);
+      if (!isSame(oldValue, chosen)) {
         value = chosen;
         AppPreferences.firePropertyChange(name, oldValue, chosen);
       }
@@ -83,9 +83,12 @@ class PrefMonitorStringOpts extends AbstractPrefMonitor<String> {
    * @param newValue The new value for the preference.
    */
   public void set(String newValue) {
-    final var oldValue = value;
-    if (!isSame(oldValue, newValue)) {
-      AppPreferences.getPrefs().put(getIdentifier(), newValue);
+    final var chosen = choose(newValue);
+    if (!isSame(value, chosen)) {
+      value = chosen;
+      AppPreferences.getPrefs().put(getIdentifier(), chosen);
+    } else if (!isSame(newValue, chosen)) {
+      AppPreferences.getPrefs().put(getIdentifier(), chosen);
     }
   }
 }

--- a/src/test/java/com/cburch/logisim/prefs/PrefMonitorStringOptsTest.java
+++ b/src/test/java/com/cburch/logisim/prefs/PrefMonitorStringOptsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.prefs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class PrefMonitorStringOptsTest {
+
+  private String preferenceName;
+
+  @AfterEach
+  void removeTestPreference() {
+    if (preferenceName != null) {
+      AppPreferences.getPrefs().remove(preferenceName);
+    }
+  }
+
+  @Test
+  void setUpdatesInMemoryValueSynchronously() {
+    preferenceName = "testStringOption-" + System.nanoTime();
+    final var monitor = new PrefMonitorStringOpts(preferenceName, new String[] {"first", "second"}, "first");
+
+    monitor.set("second");
+
+    assertEquals("second", monitor.get());
+  }
+}


### PR DESCRIPTION
Summary
- make `PrefMonitorStringOpts.set(...)` update its in-memory value synchronously
- reuse the same option-selection logic for direct sets and preference change events
- add regression coverage for immediate `set(...)`/`get()` behavior

Context
This is a follow-up to #2592. The Random HDL test switches `AppPreferences.HdlType` and immediately generates HDL. Because `HdlType` is backed by `PrefMonitorStringOpts`, a delayed preference change event could leave `get()` returning the previous HDL type right after `set(...)`. The original #2592 PR was merged before this follow-up commit entered `main`, so this PR carries that small fix separately.

Verification
- `./gradlew.bat compileJava checkstyleMain compileTestJava test --tests com.cburch.logisim.std.memory.RandomHdlGeneratorFactoryTest --tests com.cburch.logisim.prefs.PrefMonitorStringOptsTest checkstyleTest`
- `git diff --check origin/main...HEAD`
