### PR TITLE
draw: notify selection listeners after model removal

### DIFF
--- a/src/main/java/com/cburch/draw/canvas/Selection.java
+++ b/src/main/java/com/cburch/draw/canvas/Selection.java
@@ -114,11 +114,19 @@ public class Selection {
       case CanvasModelEvent.ACTION_REMOVED:
         final var affected = event.getAffected();
         if (affected != null) {
-          selected.removeAll(affected);
-          suppressed.keySet().removeAll(affected);
+          final var removed = new ArrayList<CanvasObject>();
+          for (final var shape : affected) {
+            if (selected.remove(shape)) {
+              removed.add(shape);
+            }
+            suppressed.remove(shape);
+          }
           final var handle = selectedHandle;
           if (handle != null && affected.contains(handle.getObject())) {
             setHandleSelected(null);
+          }
+          if (!removed.isEmpty()) {
+            fireChanged(SelectionEvent.ACTION_REMOVED, removed);
           }
         }
         break;

--- a/src/test/java/com/cburch/draw/canvas/SelectionTest.java
+++ b/src/test/java/com/cburch/draw/canvas/SelectionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.draw.canvas;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.draw.model.Drawing;
+import com.cburch.draw.shapes.Rectangle;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SelectionTest {
+
+  @Test
+  void modelRemovalOfSelectedObjectNotifiesSelectionListeners() {
+    final var canvas = new Canvas();
+    final var drawing = new Drawing();
+    final var selected = new Rectangle(0, 0, 10, 10);
+    final var unselected = new Rectangle(20, 20, 10, 10);
+    drawing.addObjects(0, List.of(selected, unselected));
+    canvas.setModel(drawing, null);
+
+    final var events = new ArrayList<SelectionEvent>();
+    canvas.getSelection().addSelectionListener(new SelectionListener() {
+      @Override
+      public void selectionChanged(SelectionEvent e) {
+        events.add(e);
+      }
+    });
+    canvas.getSelection().setSelected(selected, true);
+    events.clear();
+
+    drawing.removeObjects(List.of(selected, unselected));
+
+    assertTrue(canvas.getSelection().isEmpty());
+    assertEquals(1, events.size());
+    assertEquals(SelectionEvent.ACTION_REMOVED, events.get(0).getAction());
+    assertEquals(List.of(selected), List.copyOf(events.get(0).getAffected()));
+  }
+
+  @Test
+  void modelRemovalOfUnselectedObjectDoesNotNotifySelectionListeners() {
+    final var canvas = new Canvas();
+    final var drawing = new Drawing();
+    final var selected = new Rectangle(0, 0, 10, 10);
+    final var unselected = new Rectangle(20, 20, 10, 10);
+    drawing.addObjects(0, List.of(selected, unselected));
+    canvas.setModel(drawing, null);
+
+    final var events = new ArrayList<SelectionEvent>();
+    canvas.getSelection().addSelectionListener(new SelectionListener() {
+      @Override
+      public void selectionChanged(SelectionEvent e) {
+        events.add(e);
+      }
+    });
+    canvas.getSelection().setSelected(selected, true);
+    events.clear();
+
+    drawing.removeObjects(List.of(unselected));
+
+    assertFalse(canvas.getSelection().isEmpty());
+    assertTrue(canvas.getSelection().isSelected(selected));
+    assertTrue(events.isEmpty());
+  }
+}


### PR DESCRIPTION
Fixes #2598.

## Summary
- notify selection listeners when selected drawing objects are removed by a model change
- keep the notification at the `Selection` abstraction instead of only fixing the Delete key path
- add regression tests for selected-object removal and unselected-object removal

## Verification
- `./gradlew.bat compileJava compileTestJava test --tests com.cburch.draw.canvas.SelectionTest --tests com.cburch.logisim.gui.appear.AppearanceViewTest --tests com.cburch.draw.gui.AttrTableDrawManagerTest checkstyleMain checkstyleTest`