### PR TITLE
vhdl: move appearance property out of instance attributes

### DIFF
--- a/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
@@ -22,6 +22,7 @@ import com.cburch.logisim.comp.Component;
 import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Location;
+import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.std.base.Text;
 import com.cburch.logisim.std.memory.Mem;
 import com.cburch.logisim.std.memory.Ram;
@@ -29,6 +30,7 @@ import com.cburch.logisim.std.memory.RamAttributes;
 import com.cburch.logisim.tools.AddTool;
 import com.cburch.logisim.util.CollectionUtil;
 import com.cburch.logisim.util.StringUtil;
+import com.cburch.logisim.vhdl.base.VhdlEntity;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -101,6 +103,9 @@ public class XmlCircuitReader extends CircuitTransaction {
       defaults = null;
     }
     reader.initAttributeSet(elt, attrs, defaults, isHolyCross, isEvolution);
+    if (source instanceof VhdlEntity vhdl) {
+      initLegacyVhdlAppearance(elt, reader, vhdl);
+    }
 
     // Create component if location known
     if (StringUtil.isNullOrEmpty(locStr)) {
@@ -110,6 +115,23 @@ public class XmlCircuitReader extends CircuitTransaction {
       return source.createComponent(Location.parse(locStr), attrs);
     } catch (NumberFormatException e) {
       throw new XmlReaderException(S.get("compLocInvalidError", source.getName(), locStr));
+    }
+  }
+
+  private static void initLegacyVhdlAppearance(
+      Element elt, XmlReader.ReadContext reader, VhdlEntity vhdl) {
+    for (final var attrElt : XmlIterator.forChildElements(elt, "a")) {
+      if (!StdAttr.APPEARANCE.getName().equals(attrElt.getAttribute("name"))) continue;
+      final var attrValue =
+          attrElt.hasAttribute("val") ? attrElt.getAttribute("val") : attrElt.getTextContent();
+      try {
+        vhdl.getContent().setAppearance(StdAttr.APPEARANCE.parse(attrValue));
+      } catch (NumberFormatException e) {
+        reader.addError(
+            S.get("attrValueInvalidError", attrValue, StdAttr.APPEARANCE.getName()),
+            "vhdl." + vhdl.getName());
+      }
+      return;
     }
   }
 

--- a/src/main/java/com/cburch/logisim/file/XmlReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlReader.java
@@ -466,6 +466,19 @@ class XmlReader {
             final var vhdl = circElt.getTextContent();
             final var contents = VhdlContent.parse(name, vhdl, file);
             if (contents != null) {
+              if (circElt.hasAttribute("appearance")) {
+                try {
+                  contents.setAppearance(
+                      StdAttr.APPEARANCE.parse(circElt.getAttribute("appearance")));
+                } catch (NumberFormatException e) {
+                  addError(
+                      S.get(
+                          "attrValueInvalidError",
+                          circElt.getAttribute("appearance"),
+                          StdAttr.APPEARANCE.getName()),
+                      "vhdl." + name);
+                }
+              }
               file.addVhdlContent(contents);
             }
           }

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -305,6 +305,7 @@ final class XmlWriter {
     vhdl.aboutToSave();
     final var ret = doc.createElement("vhdl");
     ret.setAttribute("name", vhdl.getName());
+    ret.setAttribute("appearance", StdAttr.APPEARANCE.toStandardString(vhdl.getAppearance()));
     ret.setTextContent(vhdl.getContent());
     return ret;
   }

--- a/src/main/java/com/cburch/logisim/gui/main/AttrTableHdlModel.java
+++ b/src/main/java/com/cburch/logisim/gui/main/AttrTableHdlModel.java
@@ -1,0 +1,84 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.main;
+
+import static com.cburch.logisim.gui.Strings.S;
+
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.gui.generic.AttrTableSetException;
+import com.cburch.logisim.gui.generic.AttributeSetTableModel;
+import com.cburch.logisim.proj.Action;
+import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.vhdl.base.HdlModel;
+import com.cburch.logisim.vhdl.base.HdlModelListener;
+import com.cburch.logisim.vhdl.base.VhdlContent;
+
+class AttrTableHdlModel extends AttributeSetTableModel implements HdlModelListener {
+  private final Project proj;
+  private final VhdlContent hdl;
+
+  AttrTableHdlModel(Project proj, VhdlContent hdl) {
+    super(hdl.getStaticAttributes());
+    this.proj = proj;
+    this.hdl = hdl;
+    hdl.addHdlModelListener(this);
+  }
+
+  @Override
+  public void contentSet(HdlModel source) {
+    setAttributeSet(hdl.getStaticAttributes());
+    fireTitleChanged();
+  }
+
+  @Override
+  public void displayChanged(HdlModel source) {
+    fireTitleChanged();
+  }
+
+  @Override
+  public String getTitle() {
+    return S.get("hdlAttrTitle", hdl.getName());
+  }
+
+  @Override
+  public void setValueRequested(final Attribute<Object> attr, Object value)
+      throws AttrTableSetException {
+    proj.doAction(new HdlAttributeAction(hdl, attr, value));
+  }
+
+  private static class HdlAttributeAction extends Action {
+    private final VhdlContent hdl;
+    private final Attribute<Object> attr;
+    private final Object newValue;
+    private Object oldValue;
+
+    HdlAttributeAction(VhdlContent hdl, Attribute<Object> attr, Object newValue) {
+      this.hdl = hdl;
+      this.attr = attr;
+      this.newValue = newValue;
+    }
+
+    @Override
+    public void doIt(Project proj) {
+      oldValue = hdl.getStaticAttributes().getValue(attr);
+      hdl.getStaticAttributes().setValue(attr, newValue);
+    }
+
+    @Override
+    public String getName() {
+      return "VHDL attributes";
+    }
+
+    @Override
+    public void undo(Project proj) {
+      hdl.getStaticAttributes().setValue(attr, oldValue);
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/gui/main/AttrTableSelectionModel.java
+++ b/src/main/java/com/cburch/logisim/gui/main/AttrTableSelectionModel.java
@@ -131,20 +131,28 @@ class AttrTableSelectionModel extends AttributeSetTableModel implements Selectio
   void updateAttributeSet() {
     final var canvas = frame.getCanvas();
     final var circuit = canvas.getCircuit();
+    final var hdl = canvas.getCurrentHdl();
     final var selection = canvas.getSelection();
-    setAttributeSet(
-        circuit != null && selection.isEmpty()
-            ? circuit.getStaticAttributes()
-            : selection.getAttributeSet());
+    if (circuit != null && selection.isEmpty()) {
+      setAttributeSet(circuit.getStaticAttributes());
+    } else if (hdl instanceof VhdlContent vhdlContent) {
+      setAttributeSet(vhdlContent.getStaticAttributes());
+    } else {
+      setAttributeSet(selection.getAttributeSet());
+    }
   }
 
   @Override
   public void setValueRequested(final Attribute<Object> attr, final Object value) throws AttrTableSetException {
     final var selection = frame.getCanvas().getSelection();
     final var circuit = frame.getCanvas().getCircuit();
+    final var hdl = frame.getCanvas().getCurrentHdl();
     if (circuit != null && selection.isEmpty()) {
       final var circuitModel = new AttrTableCircuitModel(project, circuit);
       circuitModel.setValueRequested(attr, value);
+    } else if (hdl instanceof VhdlContent vhdlContent) {
+      final var hdlModel = new AttrTableHdlModel(project, vhdlContent);
+      hdlModel.setValueRequested(attr, value);
     } else {
       final var act = new SetAttributeAction(circuit, S.getter("selectionAttributeAction"));
       AutoLabel labeler = null;

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -873,10 +873,13 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
           if (appearance != null) {
             appearance.setCircuit(project, project.getCircuitState());
           }
+          viewAttributes(project.getTool());
         } else if (event.getData() instanceof HdlModel model) {
           setHdlEditorView(model);
+          viewCircuitAttributes();
+        } else {
+          viewAttributes(project.getTool());
         }
-        viewAttributes(project.getTool());
         buildTitleString();
       } else if (action == ProjectEvent.ACTION_SET_TOOL) {
         if (attrTable == null) {

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -50,6 +50,7 @@ import com.cburch.logisim.util.LocaleListener;
 import com.cburch.logisim.util.LocaleManager;
 import com.cburch.logisim.util.VerticalSplitPane;
 import com.cburch.logisim.vhdl.base.HdlModel;
+import com.cburch.logisim.vhdl.base.VhdlContent;
 import com.cburch.logisim.vhdl.gui.HdlContentView;
 import com.cburch.logisim.vhdl.gui.VhdlSimState;
 import com.cburch.logisim.vhdl.gui.VhdlSimulatorConsole;
@@ -809,6 +810,8 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     final var circ = project.getCurrentCircuit();
     if (circ != null) {
       setAttrTableModel(new AttrTableCircuitModel(project, circ));
+    } else if (project.getCurrentHdl() instanceof VhdlContent hdl) {
+      setAttrTableModel(new AttrTableHdlModel(project, hdl));
     } else {
       setAttrTableModel(null);
     }

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlContent.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlContent.java
@@ -108,6 +108,7 @@ public class VhdlContent extends HdlContent {
       VhdlContent ret = (VhdlContent) super.clone();
       ret.content = new StringBuilder(this.content);
       ret.valid = this.valid;
+      ret.staticAttrs = VhdlEntityAttributes.createBaseAttrs(ret);
       return ret;
     } catch (CloneNotSupportedException ex) {
       return this;

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntity.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntity.java
@@ -329,6 +329,14 @@ public class VhdlEntity extends InstanceFactory implements HdlModelListener {
     icon.setInvalid(!content.isValid());
   }
 
+  @Override
+  public void appearanceChanged(HdlModel source) {
+    for (final var instance : myInstances) {
+      updatePorts(instance);
+      instance.fireInvalidated();
+    }
+  }
+
   private final WeakHashMap<Component, Circuit> circuitsUsingThis = new WeakHashMap<>();
 
   public Collection<Circuit> getCircuitsUsingThis() {

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntityAttributes.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlEntityAttributes.java
@@ -13,7 +13,6 @@ import com.cburch.logisim.data.AbstractAttributeSet;
 import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.data.AttributeOption;
 import com.cburch.logisim.data.AttributeSet;
-import com.cburch.logisim.data.AttributeSets;
 import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.instance.StdAttr;
@@ -26,6 +25,52 @@ import java.util.HashMap;
 import java.util.List;
 
 public class VhdlEntityAttributes extends AbstractAttributeSet {
+  private static class VhdlContentAttributes extends AbstractAttributeSet {
+    private final VhdlContent content;
+
+    private VhdlContentAttributes(VhdlContent content) {
+      this.content = content;
+    }
+
+    @Override
+    protected void copyInto(AbstractAttributeSet dest) {
+      // VHDL content attributes are owned by the VhdlContent object.
+    }
+
+    @Override
+    public List<Attribute<?>> getAttributes() {
+      return STATIC_ATTRIBUTES;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <V> V getValue(Attribute<V> attr) {
+      if (attr == VhdlEntity.nameAttr) return (V) content.getName();
+      if (attr == StdAttr.APPEARANCE) return (V) content.getAppearance();
+      return null;
+    }
+
+    @Override
+    public <V> void setValue(Attribute<V> attr, V value) {
+      if (attr == VhdlEntity.nameAttr && value instanceof String name) {
+        final var oldName = content.getName();
+        if (oldName.equals(name) || !content.setName(name)) return;
+        @SuppressWarnings("unchecked")
+        final var oldValue = (V) oldName;
+        fireAttributeValueChanged(attr, value, oldValue);
+      } else if (attr == StdAttr.APPEARANCE
+          && (value == StdAttr.APPEAR_FPGA
+              || value == StdAttr.APPEAR_CLASSIC
+              || value == StdAttr.APPEAR_EVOLUTION)) {
+        final var oldAppearance = content.getAppearance();
+        if (oldAppearance.equals(value)) return;
+        content.setAppearance((AttributeOption) value);
+        @SuppressWarnings("unchecked")
+        final var oldValue = (V) oldAppearance;
+        fireAttributeValueChanged(attr, value, oldValue);
+      }
+    }
+  }
 
   public static class VhdlGenericAttribute extends Attribute<Integer> {
     final int start;
@@ -79,40 +124,11 @@ public class VhdlEntityAttributes extends AbstractAttributeSet {
       return new VhdlGenericAttribute("vhdl_" + name, disp, Integer.MIN_VALUE, Integer.MAX_VALUE, generic);
   }
 
-  private static final List<Attribute<?>> static_attributes =
-      Arrays.asList(
-          VhdlEntity.nameAttr,
-          StdAttr.LABEL,
-          StdAttr.LABEL_FONT,
-          StdAttr.LABEL_VISIBILITY,
-          StdAttr.FACING,
-          StdAttr.APPEARANCE,
-          VhdlSimConstants.SIM_NAME_ATTR);
+  private static final List<Attribute<?>> STATIC_ATTRIBUTES =
+      Arrays.asList(VhdlEntity.nameAttr, StdAttr.APPEARANCE);
 
   static AttributeSet createBaseAttrs(VhdlContent content) {
-    final var generic = content.getGenerics();
-    final var genericAttr = content.getGenericAttributes();
-    final var attrs = new Attribute<?>[7 + generic.length];
-    final var value = new Object[7 + generic.length];
-    attrs[0] = VhdlEntity.nameAttr;
-    value[0] = content.getName();
-    attrs[1] = StdAttr.LABEL;
-    value[1] = "";
-    attrs[2] = StdAttr.LABEL_FONT;
-    value[2] = StdAttr.DEFAULT_LABEL_FONT;
-    attrs[3] = StdAttr.LABEL_VISIBILITY;
-    value[3] = false;
-    attrs[4] = StdAttr.FACING;
-    value[4] = Direction.EAST;
-    attrs[5] = StdAttr.APPEARANCE;
-    value[5] = StdAttr.APPEAR_EVOLUTION;
-    attrs[6] = VhdlSimConstants.SIM_NAME_ATTR;
-    value[6] = "";
-    for (var i = 0; i < generic.length; i++) {
-      attrs[6 + i] = genericAttr.get(i);
-      value[6 + i] = generic[i].getDefaultValue();
-    }
-    return AttributeSets.fixedSet(attrs, value);
+    return new VhdlContentAttributes(content);
   }
 
   private VhdlContent content;
@@ -158,7 +174,6 @@ public class VhdlEntityAttributes extends AbstractAttributeSet {
     instanceAttrs.add(StdAttr.LABEL_FONT);
     instanceAttrs.add(StdAttr.LABEL_VISIBILITY);
     instanceAttrs.add(StdAttr.FACING);
-    instanceAttrs.add(StdAttr.APPEARANCE);
     instanceAttrs.add(VhdlSimConstants.SIM_NAME_ATTR);
     instanceAttrs.addAll(genericAttrs);
     if (genericValues == null) genericValues = new HashMap<>();

--- a/src/test/java/com/cburch/logisim/file/VhdlAppearanceXmlTest.java
+++ b/src/test/java/com/cburch/logisim/file/VhdlAppearanceXmlTest.java
@@ -1,0 +1,47 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.vhdl.base.VhdlContent;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class VhdlAppearanceXmlTest {
+  @Test
+  void vhdlAppearanceRoundTripsOnVhdlElement() throws Exception {
+    final var loader = new Loader(null);
+    final var file = LogisimFile.createNew(loader, null);
+    final var vhdl = VhdlContent.create("MyVhdl", file);
+
+    vhdl.setAppearance(StdAttr.APPEAR_CLASSIC);
+    file.addVhdlContent(vhdl);
+
+    final var output = new ByteArrayOutputStream();
+    file.write(output, loader);
+
+    final var xml = new String(output.toByteArray(), StandardCharsets.UTF_8);
+    assertTrue(xml.contains("appearance=\"classic\""));
+
+    final var loaded =
+        LogisimFile.load(new ByteArrayInputStream(output.toByteArray()), new Loader(null));
+    final var loadedVhdl = loaded.getVhdlContent("MyVhdl");
+
+    assertEquals(StdAttr.APPEAR_CLASSIC, loadedVhdl.getAppearance());
+    assertEquals(
+        StdAttr.APPEAR_CLASSIC,
+        loadedVhdl.getStaticAttributes().getValue(StdAttr.APPEARANCE));
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/main/AttrTableHdlModelTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/AttrTableHdlModelTest.java
@@ -1,0 +1,48 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.main;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.proj.Action;
+import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.vhdl.base.VhdlContent;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AttrTableHdlModelTest {
+  @Test
+  void hdlAppearanceEditsAreUndoableProjectActions() throws Exception {
+    final var project = mock(Project.class);
+    final var hdl = VhdlContent.create("AttrTableHdlActionTest", null);
+    final var model = new AttrTableHdlModel(project, hdl);
+
+    model.setValueRequested(asObjectAttribute(StdAttr.APPEARANCE), StdAttr.APPEAR_CLASSIC);
+
+    final var actionCaptor = ArgumentCaptor.forClass(Action.class);
+    verify(project).doAction(actionCaptor.capture());
+
+    final var action = actionCaptor.getValue();
+    action.doIt(project);
+    assertSame(StdAttr.APPEAR_CLASSIC, hdl.getAppearance());
+
+    action.undo(project);
+    assertSame(StdAttr.APPEAR_EVOLUTION, hdl.getAppearance());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Attribute<Object> asObjectAttribute(Attribute<?> attr) {
+    return (Attribute<Object>) attr;
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/main/AttrTableSelectionModelTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/AttrTableSelectionModelTest.java
@@ -19,6 +19,7 @@ import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.data.AttributeSets;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.vhdl.base.VhdlContent;
 import org.junit.jupiter.api.Test;
 
 class AttrTableSelectionModelTest {
@@ -50,6 +51,26 @@ class AttrTableSelectionModelTest {
     when(selection.isEmpty()).thenReturn(true);
     model.updateAttributeSet();
     assertSame(circuitAttrs, model.getAttributeSet());
+  }
+
+  @Test
+  void usesHdlAttributesWhenHdlEditorIsCurrent() {
+    final var project = mock(Project.class);
+    final var frame = mock(Frame.class);
+    final var canvas = mock(Canvas.class);
+    final var selection = mock(Selection.class);
+    final var selectionAttrs = attributeSet("selection");
+    final var hdl = VhdlContent.create("AttrTableHdlTest", null);
+
+    when(frame.getCanvas()).thenReturn(canvas);
+    when(canvas.getCircuit()).thenReturn(null);
+    when(canvas.getCurrentHdl()).thenReturn(hdl);
+    when(canvas.getSelection()).thenReturn(selection);
+    when(selection.getAttributeSet()).thenReturn(selectionAttrs);
+
+    final var model = new AttrTableSelectionModel(project, frame);
+
+    assertSame(hdl.getStaticAttributes(), model.getAttributeSet());
   }
 
   private static AttributeSet attributeSet(String label) {

--- a/src/test/java/com/cburch/logisim/vhdl/base/VhdlEntityAttributesTest.java
+++ b/src/test/java/com/cburch/logisim/vhdl/base/VhdlEntityAttributesTest.java
@@ -1,0 +1,55 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.vhdl.base;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.instance.StdAttr;
+import org.junit.jupiter.api.Test;
+
+class VhdlEntityAttributesTest {
+  @Test
+  void appearanceBelongsToVhdlContentAttributesNotInstanceAttributes() {
+    final var content = VhdlContent.create("VhdlEntityTest", null);
+    final var instanceAttrs = new VhdlEntityAttributes(content);
+
+    assertFalse(instanceAttrs.getAttributes().contains(StdAttr.APPEARANCE));
+    assertTrue(content.getStaticAttributes().getAttributes().contains(StdAttr.APPEARANCE));
+
+    content.getStaticAttributes().setValue(StdAttr.APPEARANCE, StdAttr.APPEAR_CLASSIC);
+
+    assertSame(StdAttr.APPEAR_CLASSIC, content.getAppearance());
+    assertSame(StdAttr.APPEAR_CLASSIC, instanceAttrs.getValue(StdAttr.APPEARANCE));
+  }
+
+  @Test
+  void legacyProgrammaticInstanceAppearanceWritesStillUpdateContent() {
+    final var content = VhdlContent.create("VhdlEntityLegacyTest", null);
+    final var instanceAttrs = new VhdlEntityAttributes(content);
+
+    instanceAttrs.setValue(StdAttr.APPEARANCE, StdAttr.APPEAR_CLASSIC);
+
+    assertSame(StdAttr.APPEAR_CLASSIC, content.getAppearance());
+  }
+
+  @Test
+  void clonedVhdlContentAttributesPointToClone() {
+    final var content = VhdlContent.create("VhdlEntityCloneTest", null);
+    content.setAppearance(StdAttr.APPEAR_CLASSIC);
+
+    final var cloned = content.clone();
+    cloned.getStaticAttributes().setValue(StdAttr.APPEARANCE, StdAttr.APPEAR_FPGA);
+
+    assertSame(StdAttr.APPEAR_CLASSIC, content.getAppearance());
+    assertSame(StdAttr.APPEAR_FPGA, cloned.getAppearance());
+  }
+}


### PR DESCRIPTION
Summary
- move the VHDL Appearance property from placed instance attributes to the VHDL entity/content attributes shown in the HDL editor
- refresh existing VHDL instances when the shared appearance changes
- persist VHDL appearance on the <vhdl> element and keep reading legacy component-level appearance values
- add regression coverage for attribute placement, undoable HDL attribute edits, selection-table routing, cloning, and XML round-trip

Verification
- ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.vhdl.base.VhdlEntityAttributesTest --tests com.cburch.logisim.gui.main.AttrTableSelectionModelTest --tests com.cburch.logisim.gui.main.AttrTableHdlModelTest --tests com.cburch.logisim.file.VhdlAppearanceXmlTest checkstyleMain checkstyleTest

Fixes #2599