### PR TITLE
FixQ synthesizing Port I/O single pin  #2070

### DIFF
--- a/src/main/java/com/cburch/logisim/std/io/PortHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/PortHdlGeneratorFactory.java
@@ -77,25 +77,37 @@ public class PortHdlGeneratorFactory extends InlinedHdlGeneratorFactory {
       // simple case first, we have a single output enable
       if (portType == PortIo.INOUTSE || nrOfPins == 1) {
         if (Hdl.isVhdl()) {
+          final var netEnable = Hdl.getNetName(componentInfo, 0, true, nets);
           if (nrOfPins == 1) {
-            contents
-                .addVhdlKeywords()
-                .add(
-                    "{{1}}({{2}}) <= {{3}} {{when}} {{4}} = '1' {{else}} ({{others}} => 'Z');",
-                    LOCAL_INOUT_BUBBLE_BUS_NAME,
-                    startIndex,
-                    Hdl.getNetName(componentInfo, 1, true, nets),
-                    Hdl.getNetName(componentInfo, 0, true, nets));
+            final var netData = Hdl.getNetName(componentInfo, 1, true, nets);
+            
+            // skip OPEN assignment if any pin is unconnected 
+            if (!netData.equals("OPEN") && !netEnable.equals("OPEN")) {
+              contents
+                  .addVhdlKeywords()
+                  //'Z' instead of (others => 'Z') for 1-bit signals
+                  .add(
+                      "{{1}}({{2}}) <= {{3}} {{when}} {{4}} = '1' {{else}} 'Z';",
+                      LOCAL_INOUT_BUBBLE_BUS_NAME,
+                      startIndex,
+                      netData,
+                      netEnable);
+            }
           } else {
-            contents
-                .addVhdlKeywords()
-                .add(
-                    "{{1}}({{2}} {{downto}} {{3}}) <= {{4}} {{when}} {{5}} = '1' {{else}} ({{others}} => 'Z');",
-                    LOCAL_INOUT_BUBBLE_BUS_NAME,
-                    endIndex,
-                    startIndex,
-                    Hdl.getBusName(componentInfo, 1, nets),
-                    Hdl.getNetName(componentInfo, 0, true, nets));
+            final var busData = Hdl.getBusName(componentInfo, 1, nets);
+            
+            // skip OPEN assignment if any pin is unconnected 
+            if (!busData.equals("OPEN") && !netEnable.equals("OPEN")) {
+              contents
+                  .addVhdlKeywords()
+                  .add(
+                      "{{1}}({{2}} {{downto}} {{3}}) <= {{4}} {{when}} {{5}} = '1' {{else}} ({{others}} => 'Z');",
+                      LOCAL_INOUT_BUBBLE_BUS_NAME,
+                      endIndex,
+                      startIndex,
+                      busData,
+                      netEnable);
+            }
           }
         } else {
           if (nrOfPins == 1) {


### PR DESCRIPTION
This PR fixes the invalid VHDL code generated by the Port I/O component when pins are left unconnected, as reported in the related issue. Changes made in PortHdlGeneratorFactory.java. To be more specific :
1)I added the condition !netData.equals("OPEN") && !netEnable.equals("OPEN") to skip generating the VHDL assignment entirely if the data or enable pins are left unconnected.
2) For 1-bit signals, replaced the syntactically incorrect (others => 'Z') with a simple 'Z'.
Resolves issue #2070 