### PR TITLE
Fix #2348: Add export data functionality to Timing Diagram

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
+++ b/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
@@ -37,6 +37,7 @@ import java.awt.image.BufferedImage;
 import java.awt.print.PageFormat;
 import java.awt.print.Printable;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -51,6 +52,13 @@ import javax.swing.JViewport;
 import javax.swing.KeyStroke;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.UIManager;
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
+
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+import com.cburch.logisim.util.JFileChoosers;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 public class ChronoPanel extends LogPanel implements Model.Listener {
   private static final long serialVersionUID = 1L;
@@ -104,12 +112,19 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
     gbc.gridx = 1;
     gbl.setConstraints(selButton, gbc);
     toolpanel.add(selButton);
+    // Create button "Export Data"
+    final var exportButton = new JButton("Export Data");
+    exportButton.setFont(exportButton.getFont().deriveFont(10.0f)); 
+    exportButton.addActionListener(e -> exportSimulationData());
+    gbc.gridx = 2; // The column in which this button will be displayed
+    gbl.setConstraints(exportButton, gbc);
+    toolpanel.add(exportButton);
     gbc.insets = insets;
 
     final var filler = Box.createHorizontalGlue();
     gbc.fill = GridBagConstraints.HORIZONTAL;
     gbc.weightx = 1.0;
-    gbc.gridx = 2;
+    gbc.gridx = 3;  
     gbl.setConstraints(filler, gbc);
     toolpanel.add(filler);
     add(toolpanel, BorderLayout.NORTH);
@@ -508,4 +523,94 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
           return Printable.PAGE_EXISTS;
         }
       };
+  
+public void exportSimulationData() {
+    // Create a window for users to navigate throught their computer files (file chooser) 
+    JFileChooser chooser = JFileChoosers.create();
+    chooser.setDialogTitle("Export Simulation Data");
+    chooser.setAcceptAllFileFilterUsed(false); // Restriction to .csv and .txt formats only
+    FileNameExtensionFilter csvFilter = new FileNameExtensionFilter("Comma-Separated Values (*.csv)", "csv");
+    FileNameExtensionFilter txtFilter = new FileNameExtensionFilter("Tab-Separated Text (*.txt)", "txt");
+    chooser.addChoosableFileFilter(csvFilter);
+    chooser.addChoosableFileFilter(txtFilter);
+    chooser.setFileFilter(csvFilter); 
+
+    int returnVal = chooser.showSaveDialog(this);
+    if (returnVal != JFileChooser.APPROVE_OPTION) {
+        return; // When user clicks "Cancel" and does not continue the export process
+    }
+
+    File file = chooser.getSelectedFile();
+    FileNameExtensionFilter selectedFilter = (FileNameExtensionFilter) chooser.getFileFilter();
+    String extension = selectedFilter.getExtensions()[0]; // Either "csv" or "txt"
+    // Set delimiter based on chosen format
+    String delimiter = extension.equals("csv") ? "," : "\t";
+
+    // Automatically adding the correct suffix (".csv" or ".txt") if needed
+    if (!file.getName().toLowerCase().endsWith("." + extension)) {
+        file = new File(file.getAbsolutePath() + "." + extension);
+    }
+
+    try (BufferedWriter writer = new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
+        
+        java.util.List<Signal> signalList = model.getSignals();
+        // There is nothing to export if no signals are selected
+        if (signalList.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "No signals available to export.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
+            return;
+        }
+
+        // UTF-8 BOM for CSV files to be correctly read
+        if (extension.equals("csv")) {
+            writer.write('\ufeff');
+        }
+
+        // Headers
+        writer.write("Time");
+        for (Signal s : signalList) {
+            writer.write(delimiter + s.getName());
+        }
+        writer.newLine();
+
+        // Determine the total number of time steps from the first signal
+        long totalSamples = 0;
+        if (!signalList.isEmpty()) {
+            totalSamples = signalList.get(0).getEndTime(); 
+        }
+        if (totalSamples == 0) {
+            JOptionPane.showMessageDialog(this, "No simulation data recorded yet. Please enable simulation/ticking.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
+            return;
+        }
+
+        // String history for compressing repeated rows so that the result file is not excessively heavy
+        String previousRowString = "";
+        for (long t = 0; t < totalSamples; t++) {
+            StringBuilder currentRowText = new StringBuilder();
+            for (Signal s : signalList) {
+                currentRowText.append(delimiter).append(s.getFormattedValue(t));
+            }
+            
+            String currentRowString = currentRowText.toString();
+
+            // Display this row only if values have changed  
+            if (t == 0 || !currentRowString.equals(previousRowString)) {
+                writer.write(Long.toString(t) + currentRowString);
+                writer.newLine();
+                previousRowString = currentRowString;  // Update history
+            }
+        }
+
+        JOptionPane.showMessageDialog(this, 
+            "Data exported successfully to " + file.getName(), 
+            "Export Successful", 
+            JOptionPane.INFORMATION_MESSAGE);
+
+    } catch (Exception ex) {
+        JOptionPane.showMessageDialog(this, 
+            "Error exporting data: " + ex.getMessage(), 
+            "Export Error", 
+            JOptionPane.ERROR_MESSAGE);
+    }
+}
 }

--- a/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
+++ b/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
@@ -54,7 +54,6 @@ import javax.swing.ScrollPaneConstants;
 import javax.swing.UIManager;
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
-
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import com.cburch.logisim.util.JFileChoosers;
@@ -523,94 +522,93 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
           return Printable.PAGE_EXISTS;
         }
       };
-  
-public void exportSimulationData() {
-  // Create a window for users to navigate throught their computer files (file chooser) 
-  JFileChooser chooser = JFileChoosers.create();
-  chooser.setDialogTitle("Export Simulation Data");
-  chooser.setAcceptAllFileFilterUsed(false); // Restriction to .csv and .txt formats only
-  FileNameExtensionFilter csvFilter = new FileNameExtensionFilter("Comma-Separated Values (*.csv)", "csv");
-  FileNameExtensionFilter txtFilter = new FileNameExtensionFilter("Tab-Separated Text (*.txt)", "txt");
-  chooser.addChoosableFileFilter(csvFilter);
-  chooser.addChoosableFileFilter(txtFilter);
-  chooser.setFileFilter(csvFilter); 
+  public void exportSimulationData() {
+    // Create a window for users to navigate throught their computer files (file chooser) 
+    JFileChooser chooser = JFileChoosers.create();
+    chooser.setDialogTitle("Export Simulation Data");
+    chooser.setAcceptAllFileFilterUsed(false); // Restriction to .csv and .txt formats only
+    FileNameExtensionFilter csvFilter = new FileNameExtensionFilter("Comma-Separated Values (*.csv)", "csv");
+    FileNameExtensionFilter txtFilter = new FileNameExtensionFilter("Tab-Separated Text (*.txt)", "txt");
+    chooser.addChoosableFileFilter(csvFilter);
+    chooser.addChoosableFileFilter(txtFilter);
+    chooser.setFileFilter(csvFilter); 
 
-  int returnVal = chooser.showSaveDialog(this);
-  if (returnVal != JFileChooser.APPROVE_OPTION) {
-    return; // When user clicks "Cancel" and does not continue the export process
-  }
+    int returnVal = chooser.showSaveDialog(this);
+    if (returnVal != JFileChooser.APPROVE_OPTION) {
+      return; // When user clicks "Cancel" and does not continue the export process
+    }
 
-  File file = chooser.getSelectedFile();
-  FileNameExtensionFilter selectedFilter = (FileNameExtensionFilter) chooser.getFileFilter();
-  String extension = selectedFilter.getExtensions()[0]; // Either "csv" or "txt"
-  // Set delimiter based on chosen format
-  String delimiter = extension.equals("csv") ? "," : "\t";
+    File file = chooser.getSelectedFile();
+    FileNameExtensionFilter selectedFilter = (FileNameExtensionFilter) chooser.getFileFilter();
+    String extension = selectedFilter.getExtensions()[0]; // Either "csv" or "txt"
+    // Set delimiter based on chosen format
+    String delimiter = extension.equals("csv") ? "," : "\t";
 
-  // Automatically adding the correct suffix (".csv" or ".txt") if needed
-  if (!file.getName().toLowerCase().endsWith("." + extension)) {
-    file = new File(file.getAbsolutePath() + "." + extension);
-  }
+    // Automatically adding the correct suffix (".csv" or ".txt") if needed
+    if (!file.getName().toLowerCase().endsWith("." + extension)) {
+      file = new File(file.getAbsolutePath() + "." + extension);
+    }
 
-  try (BufferedWriter writer = new BufferedWriter(
-      new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
+    try (BufferedWriter writer = new BufferedWriter(
+        new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
         
-    java.util.List<Signal> signalList = model.getSignals();
-    // There is nothing to export if no signals are selected
-    if (signalList.isEmpty()) {
-      JOptionPane.showMessageDialog(this, "No signals available to export.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
-      return;
-    }
+      java.util.List<Signal> signalList = model.getSignals();
+      // There is nothing to export if no signals are selected
+      if (signalList.isEmpty()) {
+        JOptionPane.showMessageDialog(this, "No signals available to export.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
+        return;
+      }
 
-    // UTF-8 BOM for CSV files to be correctly read
-    if (extension.equals("csv")) {
-      writer.write('\ufeff');
-    }
+      // UTF-8 BOM for CSV files to be correctly read
+      if (extension.equals("csv")) {
+        writer.write('\ufeff');
+      }
 
-    // Headers
-    writer.write("Time");
-    for (Signal s : signalList) {
-      writer.write(delimiter + s.getName());
-    }
-    writer.newLine();
-
-    // Determine the total number of time steps from the first signal
-    long totalSamples = 0;
-    if (!signalList.isEmpty()) {
-      totalSamples = signalList.get(0).getEndTime(); 
-    }
-    if (totalSamples == 0) {
-      JOptionPane.showMessageDialog(this, "No simulation data recorded yet. Please enable simulation/ticking.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
-      return;
-    }
-
-    // String history for compressing repeated rows so that the result file is not excessively heavy
-    String previousRowString = "";
-    for (long t = 0; t < totalSamples; t++) {
-      StringBuilder currentRowText = new StringBuilder();
+      // Headers
+      writer.write("Time");
       for (Signal s : signalList) {
-        currentRowText.append(delimiter).append(s.getFormattedValue(t));
+        writer.write(delimiter + s.getName());
       }
+      writer.newLine();
+
+      // Determine the total number of time steps from the first signal
+      long totalSamples = 0;
+      if (!signalList.isEmpty()) {
+        totalSamples = signalList.get(0).getEndTime(); 
+      }
+      if (totalSamples == 0) {
+        JOptionPane.showMessageDialog(this, "No simulation data recorded yet. Please enable simulation/ticking.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
+        return;
+      }
+
+      // String history for compressing repeated rows so that the result file is not excessively heavy
+      String previousRowString = "";
+      for (long t = 0; t < totalSamples; t++) {
+        StringBuilder currentRowText = new StringBuilder();
+        for (Signal s : signalList) {
+          currentRowText.append(delimiter).append(s.getFormattedValue(t));
+        }
             
-      String currentRowString = currentRowText.toString();
+        String currentRowString = currentRowText.toString();
 
-      // Display this row only if values have changed  
-      if (t == 0 || !currentRowString.equals(previousRowString)) {
-        writer.write(Long.toString(t) + currentRowString);
-        writer.newLine();
-        previousRowString = currentRowString;  // Update history
+        // Display this row only if values have changed  
+        if (t == 0 || !currentRowString.equals(previousRowString)) {
+          writer.write(Long.toString(t) + currentRowString);
+          writer.newLine();
+          previousRowString = currentRowString;  // Update history
+        }
       }
+
+      JOptionPane.showMessageDialog(this, 
+          "Data exported successfully to " + file.getName(), 
+          "Export Successful", 
+          JOptionPane.INFORMATION_MESSAGE);
+
+    } catch (Exception ex) {
+      JOptionPane.showMessageDialog(this, 
+          "Error exporting data: " + ex.getMessage(), 
+          "Export Error", 
+          JOptionPane.ERROR_MESSAGE);
     }
-
-    JOptionPane.showMessageDialog(this, 
-      "Data exported successfully to " + file.getName(), 
-      "Export Successful", 
-      JOptionPane.INFORMATION_MESSAGE);
-
-  } catch (Exception ex) {
-    JOptionPane.showMessageDialog(this, 
-      "Error exporting data: " + ex.getMessage(), 
-      "Export Error", 
-      JOptionPane.ERROR_MESSAGE);
   }
-}
 }

--- a/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
+++ b/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
@@ -73,6 +73,8 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
   private JSplitPane splitPane;
   private JButton selButton;
 
+  private JButton exportButton;
+
   // listeners
 
   public ChronoPanel(LogFrame logFrame) {
@@ -112,7 +114,7 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
     gbl.setConstraints(selButton, gbc);
     toolpanel.add(selButton);
     // Create button "Export Data"
-    final var exportButton = new JButton("Export Data");
+    exportButton = new JButton(S.get("ButtonExportData"));
     exportButton.setFont(exportButton.getFont().deriveFont(10.0f)); 
     exportButton.addActionListener(e -> exportSimulationData());
     gbc.gridx = 2; // The column in which this button will be displayed
@@ -205,6 +207,7 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
   @Override
   public void localeChanged() {
     selButton.setText(S.get("addRemoveSignals"));
+    exportButton.setText(S.get("ButtonExportData"));
   }
   public LeftPanel getLeftPanel() {
     return leftPanel;
@@ -525,10 +528,10 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
   public void exportSimulationData() {
     // Create a window for users to navigate throught their computer files (file chooser) 
     JFileChooser chooser = JFileChoosers.create();
-    chooser.setDialogTitle("Export Simulation Data");
     chooser.setAcceptAllFileFilterUsed(false); // Restriction to .csv and .txt formats only
-    FileNameExtensionFilter csvFilter = new FileNameExtensionFilter("Comma-Separated Values (*.csv)", "csv");
-    FileNameExtensionFilter txtFilter = new FileNameExtensionFilter("Tab-Separated Text (*.txt)", "txt");
+    chooser.setDialogTitle(S.get("exportDialogTitle"));
+    FileNameExtensionFilter csvFilter = new FileNameExtensionFilter(S.get("exportFilterCsv"), "csv");
+    FileNameExtensionFilter txtFilter = new FileNameExtensionFilter(S.get("exportFilterTxt"), "txt");
     chooser.addChoosableFileFilter(csvFilter);
     chooser.addChoosableFileFilter(txtFilter);
     chooser.setFileFilter(csvFilter); 
@@ -555,7 +558,7 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
       java.util.List<Signal> signalList = model.getSignals();
       // There is nothing to export if no signals are selected
       if (signalList.isEmpty()) {
-        JOptionPane.showMessageDialog(this, "No signals available to export.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
+        JOptionPane.showMessageDialog(this, S.get("exportNoSignals"), S.get("exportInfoTitle"), JOptionPane.INFORMATION_MESSAGE);
         return;
       }
 
@@ -577,7 +580,7 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
         totalSamples = signalList.get(0).getEndTime(); 
       }
       if (totalSamples == 0) {
-        JOptionPane.showMessageDialog(this, "No simulation data recorded yet. Please enable simulation/ticking.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
+        JOptionPane.showMessageDialog(this, S.get("exportNoData"), S.get("exportInfoTitle"), JOptionPane.INFORMATION_MESSAGE);
         return;
       }
 
@@ -600,14 +603,14 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
       }
 
       JOptionPane.showMessageDialog(this, 
-          "Data exported successfully to " + file.getName(), 
-          "Export Successful", 
+          S.get("exportSuccessMessage", file.getName()),
+          S.get("exportSuccessTitle"),
           JOptionPane.INFORMATION_MESSAGE);
 
     } catch (Exception ex) {
       JOptionPane.showMessageDialog(this, 
-          "Error exporting data: " + ex.getMessage(), 
-          "Export Error", 
+          S.get("exportErrorMessage", ex.getMessage()),
+          S.get("exportErrorTitle"),
           JOptionPane.ERROR_MESSAGE);
     }
   }

--- a/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
+++ b/src/main/java/com/cburch/logisim/gui/chrono/ChronoPanel.java
@@ -525,92 +525,92 @@ public class ChronoPanel extends LogPanel implements Model.Listener {
       };
   
 public void exportSimulationData() {
-    // Create a window for users to navigate throught their computer files (file chooser) 
-    JFileChooser chooser = JFileChoosers.create();
-    chooser.setDialogTitle("Export Simulation Data");
-    chooser.setAcceptAllFileFilterUsed(false); // Restriction to .csv and .txt formats only
-    FileNameExtensionFilter csvFilter = new FileNameExtensionFilter("Comma-Separated Values (*.csv)", "csv");
-    FileNameExtensionFilter txtFilter = new FileNameExtensionFilter("Tab-Separated Text (*.txt)", "txt");
-    chooser.addChoosableFileFilter(csvFilter);
-    chooser.addChoosableFileFilter(txtFilter);
-    chooser.setFileFilter(csvFilter); 
+  // Create a window for users to navigate throught their computer files (file chooser) 
+  JFileChooser chooser = JFileChoosers.create();
+  chooser.setDialogTitle("Export Simulation Data");
+  chooser.setAcceptAllFileFilterUsed(false); // Restriction to .csv and .txt formats only
+  FileNameExtensionFilter csvFilter = new FileNameExtensionFilter("Comma-Separated Values (*.csv)", "csv");
+  FileNameExtensionFilter txtFilter = new FileNameExtensionFilter("Tab-Separated Text (*.txt)", "txt");
+  chooser.addChoosableFileFilter(csvFilter);
+  chooser.addChoosableFileFilter(txtFilter);
+  chooser.setFileFilter(csvFilter); 
 
-    int returnVal = chooser.showSaveDialog(this);
-    if (returnVal != JFileChooser.APPROVE_OPTION) {
-        return; // When user clicks "Cancel" and does not continue the export process
-    }
+  int returnVal = chooser.showSaveDialog(this);
+  if (returnVal != JFileChooser.APPROVE_OPTION) {
+    return; // When user clicks "Cancel" and does not continue the export process
+  }
 
-    File file = chooser.getSelectedFile();
-    FileNameExtensionFilter selectedFilter = (FileNameExtensionFilter) chooser.getFileFilter();
-    String extension = selectedFilter.getExtensions()[0]; // Either "csv" or "txt"
-    // Set delimiter based on chosen format
-    String delimiter = extension.equals("csv") ? "," : "\t";
+  File file = chooser.getSelectedFile();
+  FileNameExtensionFilter selectedFilter = (FileNameExtensionFilter) chooser.getFileFilter();
+  String extension = selectedFilter.getExtensions()[0]; // Either "csv" or "txt"
+  // Set delimiter based on chosen format
+  String delimiter = extension.equals("csv") ? "," : "\t";
 
-    // Automatically adding the correct suffix (".csv" or ".txt") if needed
-    if (!file.getName().toLowerCase().endsWith("." + extension)) {
-        file = new File(file.getAbsolutePath() + "." + extension);
-    }
+  // Automatically adding the correct suffix (".csv" or ".txt") if needed
+  if (!file.getName().toLowerCase().endsWith("." + extension)) {
+    file = new File(file.getAbsolutePath() + "." + extension);
+  }
 
-    try (BufferedWriter writer = new BufferedWriter(
-            new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
+  try (BufferedWriter writer = new BufferedWriter(
+      new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
         
-        java.util.List<Signal> signalList = model.getSignals();
-        // There is nothing to export if no signals are selected
-        if (signalList.isEmpty()) {
-            JOptionPane.showMessageDialog(this, "No signals available to export.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
-            return;
-        }
-
-        // UTF-8 BOM for CSV files to be correctly read
-        if (extension.equals("csv")) {
-            writer.write('\ufeff');
-        }
-
-        // Headers
-        writer.write("Time");
-        for (Signal s : signalList) {
-            writer.write(delimiter + s.getName());
-        }
-        writer.newLine();
-
-        // Determine the total number of time steps from the first signal
-        long totalSamples = 0;
-        if (!signalList.isEmpty()) {
-            totalSamples = signalList.get(0).getEndTime(); 
-        }
-        if (totalSamples == 0) {
-            JOptionPane.showMessageDialog(this, "No simulation data recorded yet. Please enable simulation/ticking.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
-            return;
-        }
-
-        // String history for compressing repeated rows so that the result file is not excessively heavy
-        String previousRowString = "";
-        for (long t = 0; t < totalSamples; t++) {
-            StringBuilder currentRowText = new StringBuilder();
-            for (Signal s : signalList) {
-                currentRowText.append(delimiter).append(s.getFormattedValue(t));
-            }
-            
-            String currentRowString = currentRowText.toString();
-
-            // Display this row only if values have changed  
-            if (t == 0 || !currentRowString.equals(previousRowString)) {
-                writer.write(Long.toString(t) + currentRowString);
-                writer.newLine();
-                previousRowString = currentRowString;  // Update history
-            }
-        }
-
-        JOptionPane.showMessageDialog(this, 
-            "Data exported successfully to " + file.getName(), 
-            "Export Successful", 
-            JOptionPane.INFORMATION_MESSAGE);
-
-    } catch (Exception ex) {
-        JOptionPane.showMessageDialog(this, 
-            "Error exporting data: " + ex.getMessage(), 
-            "Export Error", 
-            JOptionPane.ERROR_MESSAGE);
+    java.util.List<Signal> signalList = model.getSignals();
+    // There is nothing to export if no signals are selected
+    if (signalList.isEmpty()) {
+      JOptionPane.showMessageDialog(this, "No signals available to export.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
+      return;
     }
+
+    // UTF-8 BOM for CSV files to be correctly read
+    if (extension.equals("csv")) {
+      writer.write('\ufeff');
+    }
+
+    // Headers
+    writer.write("Time");
+    for (Signal s : signalList) {
+      writer.write(delimiter + s.getName());
+    }
+    writer.newLine();
+
+    // Determine the total number of time steps from the first signal
+    long totalSamples = 0;
+    if (!signalList.isEmpty()) {
+      totalSamples = signalList.get(0).getEndTime(); 
+    }
+    if (totalSamples == 0) {
+      JOptionPane.showMessageDialog(this, "No simulation data recorded yet. Please enable simulation/ticking.", "Export Info", JOptionPane.INFORMATION_MESSAGE);
+      return;
+    }
+
+    // String history for compressing repeated rows so that the result file is not excessively heavy
+    String previousRowString = "";
+    for (long t = 0; t < totalSamples; t++) {
+      StringBuilder currentRowText = new StringBuilder();
+      for (Signal s : signalList) {
+        currentRowText.append(delimiter).append(s.getFormattedValue(t));
+      }
+            
+      String currentRowString = currentRowText.toString();
+
+      // Display this row only if values have changed  
+      if (t == 0 || !currentRowString.equals(previousRowString)) {
+        writer.write(Long.toString(t) + currentRowString);
+        writer.newLine();
+        previousRowString = currentRowString;  // Update history
+      }
+    }
+
+    JOptionPane.showMessageDialog(this, 
+      "Data exported successfully to " + file.getName(), 
+      "Export Successful", 
+      JOptionPane.INFORMATION_MESSAGE);
+
+  } catch (Exception ex) {
+    JOptionPane.showMessageDialog(this, 
+      "Error exporting data: " + ex.getMessage(), 
+      "Export Error", 
+      JOptionPane.ERROR_MESSAGE);
+  }
 }
 }

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -30,6 +30,19 @@ showStateDialogTitle = State for %s
 ButtonExport = Export…
 ButtonLoad = Load file
 ChronoTitle = Timing diagram
+
+ButtonExportData = Export Data
+exportDialogTitle = Export Simulation Data
+exportFilterCsv = Comma-Separated Values (*.csv)
+exportFilterTxt = Tab-Separated Text (*.txt)
+exportNoSignals = No signals available to export.
+exportInfoTitle = Export Info
+exportNoData = No simulation data recorded yet. Please enable simulation/ticking.
+exportSuccessMessage = Data exported successfully to %s
+exportSuccessTitle = Export Successful
+exportErrorMessage = Error exporting data: %s
+exportErrorTitle = Export Error
+
 ChronoHelp = Displays signal values in real time.
 ChronoPrintTitle = Timing diagram: %s of %s
 ButtonExportAsImage = Export as image


### PR DESCRIPTION
This PR resolves issue #2348 by introducing a feature that allows users to export recorded simulation data directly from the Timing Diagram (ChronoPanel) into external files. It supports both CSV and TXT formats, enabling users to easily analyze their circuit's behavior using external tools like Excel.

I added an "Export Data" button to the tool panel that triggers a JFileChooser. It restricts user selection strictly to .csv and .txt extensions and automatically appends the correct suffix if needed.
The export utilizes UTF-8 encoding. For CSV files, a Byte Order Mark (BOM) (\ufeff) is explicitly injected to ensure proper rendering of headers and values when opened directly in Microsoft Excel.
In extensive simulations, writing data for every single micro-step creates massive, excessively heavy and redundant files. To keep the output lightweight, the algorithm monitors state changes and thus a new row is written only when a signal value actually transitions. Consequently, we avoid having duplicated rows. 
There are also safety checks to handle cases, such as when no signals are currently tracked or when no simulation ticks have been recorded yet.

Since this feature introduces a UI-driven file export action, I have tested it manually within the application environment: 

- Verified that the "Export Data" button scales correctly in the ChronoPanel toolbar and integrates smoothly with the existing layout.

- Tested selecting both CSV and TXT options in the file chooser. Confirmed that file extensions are appended automatically if not typed by the user.

- Confirmed that appropriate warning dialogs pop up when attempting to export with an empty signal list or when no simulation ticks have occurred yet.

- Verified the output files in external editors. The row deduplication logic correctly compresses consecutive identical states, and the CSV file opens in Excel with proper column separation thanks to the UTF-8 BOM encoding.
