### PR TITLE
appearance: fix custom appearance drag selection

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/appear/CircuitCustomAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/CircuitCustomAppearance.java
@@ -77,7 +77,15 @@ public class CircuitCustomAppearance extends Drawing {
 
   @Override
   public Collection<CanvasObject> getObjectsIn(Bounds bds) {
-    return parent.getObjectsIn(bds);
+    List<CanvasObject> ret = null;
+    for (final var shape : getObjectsFromBottom()) {
+      if (bds.contains(shape.getBounds())) {
+        if (ret == null) ret = new ArrayList<>();
+        ret.add(shape);
+      }
+    }
+
+    return (ret == null) ? Collections.emptyList() : ret;
   }
 
   @Override

--- a/src/test/java/com/cburch/logisim/circuit/appear/CircuitCustomAppearanceTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/appear/CircuitCustomAppearanceTest.java
@@ -1,0 +1,40 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.circuit.appear;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.draw.shapes.Rectangle;
+import com.cburch.logisim.data.Bounds;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CircuitCustomAppearanceTest {
+
+  @Test
+  void getObjectsInUsesCustomObjectsEvenWhenParentShowsDefaultAppearance() {
+    final var parent = mock(CircuitAppearance.class);
+    final var customShape = new Rectangle(10, 10, 20, 20);
+    final var defaultShape = new Rectangle(100, 100, 20, 20);
+    final var query = Bounds.create(0, 0, 40, 40);
+    final var model = new CircuitCustomAppearance(parent);
+
+    when(parent.getCustomObjectsFromBottom()).thenReturn(List.of(customShape));
+    when(parent.getObjectsIn(query)).thenReturn(List.of(defaultShape));
+
+    final var result = model.getObjectsIn(query);
+
+    assertEquals(1, result.size());
+    assertSame(customShape, result.iterator().next());
+  }
+}


### PR DESCRIPTION
Summary
- make the subcircuit appearance editor query the custom appearance model for box-selection hits
- avoid selecting default/generated appearance objects while editing a non-Custom circuit appearance
- add regression coverage for the custom drawing model used by drag selection

Root cause
When a circuit's Appearance attribute was Classic/FPGA/Evolution, `CircuitAppearance.getObjectsFromBottom()` returned generated default appearance objects. The appearance editor uses `CircuitCustomAppearance` as its editable model, but its `getObjectsIn(...)` method delegated to `parent.getObjectsIn(...)`. That meant drag-selection could collect generated/default objects instead of the editable custom objects, producing the ghost selection behavior described in #2413.

Verification
- `./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.circuit.appear.CircuitCustomAppearanceTest --tests com.cburch.logisim.gui.appear.AppearanceViewTest --tests com.cburch.logisim.circuit.appear.DynamicElementTest`
- `./gradlew.bat checkstyleMain checkstyleTest`

Closes #2413