### PR TITLE
memory: fix RAM address logging in timing diagrams

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/DualRam.java
+++ b/src/main/java/com/cburch/logisim/std/memory/DualRam.java
@@ -49,11 +49,13 @@ public class DualRam extends Mem {
       var label = state.getAttributeValue(StdAttr.LABEL);
       if (label.equals(""))
         label = null;
-      if (option instanceof Long) {
-        final var disp = S.get("dualRamComponent");
-
-        final var loc = state.getInstance().getLocation();
-        return (label == null) ? disp + loc + "[" + option + "]" : label + "[" + option + "]";
+      if (option instanceof Number) {
+        if (label == null) {
+          final var disp = S.get("dualRamComponent");
+          final var loc = state.getInstance().getLocation();
+          return disp + loc + "[" + option + "]";
+        }
+        return label + "[" + option + "]";
       } else {
         return label;
       }
@@ -85,9 +87,9 @@ public class DualRam extends Mem {
 
     @Override
     public Value getLogValue(InstanceState state, Object option) {
-      if (option instanceof Long addr) {
+      if (option instanceof Number addr) {
         final var memState = (MemState) state.getData();
-        return Value.createKnown(BitWidth.create(memState.getDataBits()), memState.getContents().get(addr));
+        return Value.createKnown(BitWidth.create(memState.getDataBits()), memState.getContents().get(addr.longValue()));
       } else {
         return Value.NIL;
       }

--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -49,10 +49,13 @@ public class Ram extends Mem {
       if (label.equals("")) {
         label = null;
       }
-      if (option instanceof Long) {
-        final var disp = S.get("ramComponent");
-        final var loc = state.getInstance().getLocation();
-        return (label == null) ? disp + loc + "[" + option + "]" : label + "[" + option + "]";
+      if (option instanceof Number) {
+        if (label == null) {
+          final var disp = S.get("ramComponent");
+          final var loc = state.getInstance().getLocation();
+          return disp + loc + "[" + option + "]";
+        }
+        return label + "[" + option + "]";
       } else {
         return label;
       }
@@ -84,9 +87,9 @@ public class Ram extends Mem {
 
     @Override
     public Value getLogValue(InstanceState state, Object option) {
-      if (option instanceof Long addr) {
+      if (option instanceof Number addr) {
         final var memState = (MemState) state.getData();
-        return Value.createKnown(BitWidth.create(memState.getDataBits()), memState.getContents().get(addr));
+        return Value.createKnown(BitWidth.create(memState.getDataBits()), memState.getContents().get(addr.longValue()));
       } else {
         return Value.NIL;
       }

--- a/src/test/java/com/cburch/logisim/std/memory/RamLoggerTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/RamLoggerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.instance.Instance;
+import com.cburch.logisim.instance.InstanceData;
+import com.cburch.logisim.instance.InstanceLogger;
+import com.cburch.logisim.instance.InstanceState;
+import com.cburch.logisim.instance.StdAttr;
+import org.junit.jupiter.api.Test;
+
+class RamLoggerTest {
+
+  @Test
+  void ramAddressLogOptionsReadMemoryValues() {
+    final var contents = memoryContents();
+    final var logger = new Ram.Logger();
+    final var state = memoryState(new RamState(null, contents, listener()));
+
+    assertAddressOptionReadsValue(logger, state);
+  }
+
+  @Test
+  void dualRamAddressLogOptionsReadMemoryValues() {
+    final var contents = memoryContents();
+    final var logger = new DualRam.Logger();
+    final var state = memoryState(new DualRamState(null, contents, listener()));
+
+    assertAddressOptionReadsValue(logger, state);
+  }
+
+  private static void assertAddressOptionReadsValue(InstanceLogger logger, InstanceState state) {
+    final var option = logger.getLogOptions(state)[3];
+
+    assertEquals("Memory[3]", logger.getLogName(state, option));
+    assertEquals(Value.createKnown(BitWidth.create(8), 0x5a), logger.getLogValue(state, option));
+  }
+
+  private static MemContents memoryContents() {
+    final var contents = MemContents.create(4, 8, false);
+    contents.set(3, 0x5a);
+    return contents;
+  }
+
+  private static InstanceState memoryState(InstanceData memoryState) {
+    final var state = mock(InstanceState.class);
+    when(state.getAttributeValue(StdAttr.LABEL)).thenReturn("Memory");
+    when(state.getAttributeValue(Mem.ADDR_ATTR)).thenReturn(BitWidth.create(4));
+    when(state.getAttributeValue(Mem.DATA_ATTR)).thenReturn(BitWidth.create(8));
+    when(state.getData()).thenReturn(memoryState);
+    return state;
+  }
+
+  private static Mem.MemListener listener() {
+    return new Mem.MemListener(mock(Instance.class));
+  }
+}


### PR DESCRIPTION
Summary
- accept numeric RAM/Dual RAM log address options instead of only Long values
- show selected RAM addresses as Memory[n] in timing/log signal lists
- read the selected memory address value for timing traces instead of returning NIL
- add regression coverage for RAM and Dual Port RAM address log options

Verification
- .\gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.std.memory.RamLoggerTest
- .\gradlew.bat compileJava checkstyleMain checkstyleTest

Fixes #2464