### PR TITLE
chrono: initialize clock trace duration

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/log/ComponentSelector.java
+++ b/src/main/java/com/cburch/logisim/gui/log/ComponentSelector.java
@@ -20,6 +20,7 @@ import com.cburch.logisim.std.wiring.Pin;
 import com.cburch.logisim.util.CollectionUtil;
 import java.awt.Color;
 import java.awt.Graphics;
+import java.awt.GraphicsEnvironment;
 import java.awt.datatransfer.Transferable;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -397,7 +398,7 @@ public class ComponentSelector extends JTable {
     // setAutoResizeMode(AUTO_RESIZE_OFF);
     setShowGrid(false);
     setFillsViewportHeight(true);
-    setDragEnabled(true);
+    if (!GraphicsEnvironment.isHeadless()) setDragEnabled(true);
     setDropMode(DropMode.ON_OR_INSERT); // ?
     setTransferHandler(new ComponentTransferHandler());
 

--- a/src/main/java/com/cburch/logisim/gui/log/Model.java
+++ b/src/main/java/com/cburch/logisim/gui/log/Model.java
@@ -140,7 +140,7 @@ public class Model implements CircuitListener, SignalInfo.Listener {
     }
 
     // set up initial signal values (after sorting)
-    final var duration = captureContinuous() ? gateDelay : timeScale;
+    final var duration = getInitialDuration();
     for (int i = 0; i < info.size(); i++) {
       final var item = info.get(i);
       signals.add(new Signal(i, item, item.fetchValue(circuitState), duration, 0, historyLimit));
@@ -333,6 +333,20 @@ public class Model implements CircuitListener, SignalInfo.Listener {
     return isFine()
         || (mode == CLOCK_HIGH && curClockVal.equals(HI))
         || (mode == CLOCK_LOW && curClockVal.equals(LO));
+  }
+
+  private long getInitialDuration() {
+    if (mode >= CLOCKED) {
+      if (captureContinuous()) return gateDelay;
+      final var cc = ClockSource.getCycleInfo(clockSource);
+      if (mode == CLOCK_HIGH || mode == CLOCK_LOW) {
+        return (mode == CLOCK_HIGH ? cc.lo : cc.hi) * timeScale;
+      }
+      final var ticks =
+          (mode == CLOCK_DUAL) ? (curClockVal.equals(Value.FALSE) ? cc.lo : cc.hi) : cc.ticks;
+      return timeScale * ticks;
+    }
+    return mode == STEP ? timeScale : gateDelay;
   }
 
   public int getHistoryLimit() {
@@ -679,27 +693,10 @@ public class Model implements CircuitListener, SignalInfo.Listener {
   }
 
   public void simulatorReset() {
-    long duration;
     if (mode >= CLOCKED) {
       curClockVal = clockSource.fetchValue(circuitState);
-      final var cc = ClockSource.getCycleInfo(clockSource);
-      if (captureContinuous()) { // fine-grained, or active level-sensitive clock
-        duration = gateDelay;
-      } else if (mode == CLOCK_HIGH || mode == CLOCK_LOW) { // inactive level-sensitive
-        final var activeDuration = (mode == CLOCK_HIGH ? cc.hi : cc.lo) * timeScale;
-        final var stableDuration = (mode == CLOCK_HIGH ? cc.lo : cc.hi) * timeScale;
-        duration = isFine() ? gateDelay : stableDuration;
-      } else { // edge-triggered clock, fine or coarse
-        final var ticks =
-            (mode == CLOCK_DUAL) ? (curClockVal.equals(Value.FALSE) ? cc.lo : cc.hi) : cc.ticks;
-        final var stableDuration = timeScale * ticks;
-        duration = isFine() ? gateDelay : stableDuration;
-      }
-    } else if (mode == STEP) {
-      duration = timeScale;
-    } else { // mode == REAL
-      duration = gateDelay;
     }
+    long duration = getInitialDuration();
     if (mode == REAL) lastRealtimeUpdate = System.nanoTime();
     elapsedSinceTrigger = 0;
     for (final var s : signals) {

--- a/src/test/java/com/cburch/logisim/gui/log/ModelTest.java
+++ b/src/test/java/com/cburch/logisim/gui/log/ModelTest.java
@@ -1,0 +1,61 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.log;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.file.Loader;
+import com.cburch.logisim.file.LogisimFile;
+import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.wiring.Clock;
+import org.junit.jupiter.api.Test;
+
+class ModelTest {
+
+  @Test
+  void clockModeInitializesToCurrentClockPhaseDuration() {
+    final var fixture = new Fixture();
+    final var attrs = Clock.FACTORY.createAttributeSet();
+    attrs.setValue(Clock.ATTR_LOW, 2);
+    final var clock = Clock.FACTORY.createComponent(Location.create(100, 100, true), attrs);
+    add(fixture.circuit, clock);
+
+    final var model = new Model(fixture.state);
+
+    assertEquals(10_000, model.getEndTime());
+    assertDoesNotThrow(() -> model.propagationCompleted(false, false, true));
+  }
+
+  private static void add(Circuit circuit, Component component) {
+    final var mutation = new CircuitMutation(circuit);
+    mutation.add(component);
+    mutation.execute();
+  }
+
+  private static final class Fixture {
+    private final Circuit circuit;
+    private final CircuitState state;
+
+    private Fixture() {
+      final var file = LogisimFile.createNew(new Loader(null), null);
+      final var project = new Project(file);
+      circuit = file.getMainCircuit();
+      circuit.setProject(project);
+      project.setCurrentCircuit(circuit);
+      state = project.getCircuitState();
+    }
+  }
+}


### PR DESCRIPTION
Summary
- initialize Timing Diagram signals with the active clock phase duration instead of always one tick
- share the same initial-duration calculation with simulator reset
- avoid enabling `ComponentSelector` drag support in headless test environments so clock discovery can be regression-tested in CI
- add a regression test for a clock whose low phase lasts multiple ticks

Root cause
When a Timing Diagram model was first opened on a non-50% clock phase, its initial signal history only covered one `timeScale` tick. In coarse clock mode the next propagation can back-date the current value to the full current phase duration, so a 2-tick low phase tried to replace 10000 ns of history when only 5000 ns existed.

Verification
- `./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.gui.log.ModelTest checkstyleMain checkstyleTest`
- `JAVA_TOOL_OPTIONS=-Djava.awt.headless=true ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.gui.log.ModelTest --rerun-tasks`

I also attempted a local headless `./gradlew.bat build -x checkstyleMain -x checkstyleTest`, but this Windows environment still fails existing `HexFileTest` cases because the external `xxd` command is not installed.

Fixes #2110
