### PR TITLE
memory: refresh display layout for export graphics

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/MemState.java
+++ b/src/main/java/com/cburch/logisim/std/memory/MemState.java
@@ -191,11 +191,23 @@ class MemState implements InstanceData, Cloneable, HexModelListener {
     setBits(contents.getLogLength(), contents.getWidth());
   }
 
-  private boolean windowChanged(int offsetX, int offsetY, int displayWidth, int displayHeight) {
+  private boolean displayMetricsChanged(Graphics g) {
+    final var fm = g.getFontMetrics(g.getFont());
+    final var addrBits = getAddrBits();
+    final var dataBits = contents.getWidth();
+    return charHeight != fm.getHeight()
+        || addrBlockSize != ((fm.stringWidth(StringUtil.toHexString(addrBits, 0)) + 9) / 10) * 10
+        || dataSize != fm.stringWidth(StringUtil.toHexString(dataBits, 0) + " ")
+        || spaceSize != fm.stringWidth(" ");
+  }
+
+  private boolean windowChanged(
+      Graphics g, int offsetX, int offsetY, int displayWidth, int displayHeight) {
     return displayWindow.getX() != offsetX
         || displayWindow.getY() != offsetY
         || displayWindow.getWidth() != displayWidth
-        || displayWindow.getHeight() != displayHeight;
+        || displayWindow.getHeight() != displayHeight
+        || displayMetricsChanged(g);
   }
 
   public void paint(
@@ -207,7 +219,7 @@ class MemState implements InstanceData, Cloneable, HexModelListener {
       int displayWidth,
       int displayHeight,
       int nrItemsToHighlight) {
-    if (recalculateParameters || windowChanged(offsetX, offsetY, displayWidth, displayHeight))
+    if (recalculateParameters || windowChanged(g, offsetX, offsetY, displayWidth, displayHeight))
       calculateDisplayParameters(g, offsetX, offsetY, displayWidth, displayHeight);
     final var blockHeight = nrOfLines * (charHeight + 2);
     final var totalNrOfEntries = (1 << getAddrBits());

--- a/src/test/java/com/cburch/logisim/std/memory/MemStateTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/MemStateTest.java
@@ -1,0 +1,38 @@
+/*
+ * Logisim-evolution - digital logic design tool
+ * Copyright by the logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.memory;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Font;
+import java.awt.image.BufferedImage;
+import org.junit.jupiter.api.Test;
+
+class MemStateTest {
+
+  @Test
+  void paintRecalculatesLayoutWhenFontMetricsChange() {
+    final var state = new MemState(MemContents.create(8, 8, false));
+    final var image = new BufferedImage(200, 200, BufferedImage.TYPE_INT_RGB);
+    final var graphics = image.createGraphics();
+    try {
+      graphics.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 8));
+      state.paint(graphics, 0, 0, 0, 0, 100, 100, 1);
+      final var smallFontLines = state.getNrOfLines();
+
+      graphics.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 24));
+      state.paint(graphics, 0, 0, 0, 0, 100, 100, 1);
+
+      assertTrue(state.getNrOfLines() < smallFontLines);
+    } finally {
+      graphics.dispose();
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Recalculate the cached memory display layout when the Graphics font metrics change, not only when the display window bounds change.
- Add regression coverage for repainting the same memory state with different font metrics.

Why
- In non-printer export, Logisim-Classic memory/RAM contents are drawn through the same MemState cache used on screen.
- The previous cache key ignored Graphics/font metrics, so an export paint could reuse stale screen layout measurements and place ROM/RAM contents incorrectly.

Verification
- ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.std.memory.MemStateTest checkstyleMain checkstyleTest

Fixes #1677