### PR TITLE
cli: apply locale before printing help

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/start/Startup.java
+++ b/src/main/java/com/cburch/logisim/gui/start/Startup.java
@@ -318,6 +318,7 @@ public class Startup implements AWTEventListener {
    * @return Instance of Startup class.
    */
   public static Startup parseArgs(String[] args) {
+    preloadLocale(args);
 
     final var opts = new Options();
     addOption(opts, "argHelpOption", ARG_HELP_LONG, ARG_HELP_SHORT);
@@ -445,6 +446,21 @@ public class Startup implements AWTEventListener {
   }
 
   /* ********************************************************************************************* */
+
+  private static void preloadLocale(String[] args) {
+    for (var i = 0; i < args.length; i++) {
+      final var arg = args[i];
+      if (arg.equals("--" + ARG_LOCALE_LONG) || arg.equals("-" + ARG_LOCALE_SHORT)) {
+        if (i + 1 < args.length) {
+          trySetLocale(args[++i]);
+        }
+      } else if (arg.startsWith("--" + ARG_LOCALE_LONG + "=")) {
+        trySetLocale(arg.substring(ARG_LOCALE_LONG.length() + 3));
+      } else if (arg.startsWith("-" + ARG_LOCALE_SHORT) && arg.length() > 2) {
+        trySetLocale(arg.substring(2));
+      }
+    }
+  }
 
   /**
    * Supported return codes from command handlers;
@@ -768,14 +784,21 @@ public class Startup implements AWTEventListener {
 
   /* ********************************************************************************************* */
 
-  private static void setLocale(String lang) {
+  private static boolean trySetLocale(String lang) {
     final var opts = S.getLocaleOptions();
     for (final var locale : opts) {
       if (lang.equals(locale.toString())) {
         LocaleManager.setLocale(locale);
-        return;
+        return true;
       }
     }
+    return false;
+  }
+
+  private static void setLocale(String lang) {
+    if (trySetLocale(lang)) return;
+
+    final var opts = S.getLocaleOptions();
     logger.warn(S.get("invalidLocaleError"));
     logger.warn(S.get("invalidLocaleOptionsHeader"));
 

--- a/src/test/java/com/cburch/logisim/gui/start/StartupTest.java
+++ b/src/test/java/com/cburch/logisim/gui/start/StartupTest.java
@@ -1,0 +1,44 @@
+/*
+ * Logisim-evolution - digital logic design tool
+ * Copyright by the logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.start;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.Main;
+import com.cburch.logisim.util.LocaleManager;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class StartupTest {
+
+  @Test
+  void localeOptionAppliesToHelpText() {
+    final var originalOut = System.out;
+    final var originalLocale = LocaleManager.getLocale();
+    final var originalHeadless = Main.headless;
+    final var output = new ByteArrayOutputStream();
+    try {
+      System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
+
+      Startup.parseArgs(new String[] {"--tty", "table", "--locale", "zh", "--help"});
+
+      final var helpText = output.toString(StandardCharsets.UTF_8);
+      assertTrue(helpText.contains("显示本参数摘要帮助页。"));
+      assertFalse(helpText.contains("Displays this argument summary help page."));
+    } finally {
+      System.setOut(originalOut);
+      LocaleManager.setLocale(originalLocale);
+      Main.headless = originalHeadless;
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Preload a valid `--locale` / `-o` argument before command-line options are constructed.
- Keep the normal locale option handler for validation and existing behavior.
- Add regression coverage that `--locale zh --help` prints localized help text.

Verification
- ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.gui.start.StartupTest checkstyleMain checkstyleTest
- ./gradlew.bat --quiet run --args="--tty table --locale zh --help"

Fixes #986