### PR TITLE
file: resolve tools from nested libraries

### DIFF
--- a/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
@@ -82,7 +82,7 @@ public class XmlCircuitReader extends CircuitTransaction {
       throw new XmlReaderException(S.get("compUnknownError", "no-lib"));
     }
 
-    final var tool = lib.getTool(name);
+    final var tool = reader.findTool(lib, name);
     if (!(tool instanceof AddTool)) {
       final var msg =
           StringUtil.isNullOrEmpty(libName)

--- a/src/main/java/com/cburch/logisim/file/XmlReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlReader.java
@@ -557,13 +557,23 @@ class XmlReader {
       builder.execute();
     }
 
+    Tool findTool(Library lib, String name) {
+      final var tool = lib.getTool(name);
+      if (tool != null) return tool;
+      for (final var sub : lib.getLibraries()) {
+        final var ret = findTool(sub, name);
+        if (ret != null) return ret;
+      }
+      return null;
+    }
+
     Tool toTool(Element elt) throws XmlReaderException {
       final var lib = findLibrary(elt.getAttribute("lib"));
       final var name = elt.getAttribute("name");
       if (name == null || "".equals(name)) {
         throw new XmlReaderException(S.get("toolNameMissing"));
       }
-      final var tool = lib.getTool(name);
+      final var tool = findTool(lib, name);
       if (tool == null) {
         throw new XmlReaderException(S.get("toolNotFound"));
       }

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -258,7 +258,7 @@ final class XmlWriter {
   Library findLibrary(ComponentFactory source) {
     if (file.contains(source)) return file;
     for (final var lib : file.getLibraries()) {
-      if (lib.contains(source)) return lib;
+      if (libraryContains(lib, source)) return lib;
     }
     return null;
   }
@@ -389,7 +389,7 @@ final class XmlWriter {
       final var tools = lib.getTools();
       for (final var circuit : file.getCircuits()) {
         for (final var tool : circuit.getNonWires()) {
-          isUsed |= lib.contains(tool.getFactory());
+          isUsed |= libraryContains(lib, tool.getFactory());
         }
       }
       for (final var tool : file.getOptions().getToolbarData().getContents()) {
@@ -544,6 +544,17 @@ final class XmlWriter {
   boolean libraryContains(Library lib, Tool query) {
     for (final var tool : lib.getTools()) {
       if (tool.sharesSource(query)) return true;
+    }
+    for (final var sub : lib.getLibraries()) {
+      if (libraryContains(sub, query)) return true;
+    }
+    return false;
+  }
+
+  boolean libraryContains(Library lib, ComponentFactory query) {
+    if (lib.contains(query)) return true;
+    for (final var sub : lib.getLibraries()) {
+      if (libraryContains(sub, query)) return true;
     }
     return false;
   }

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
@@ -321,9 +321,7 @@ public class ProjectExplorer extends JTree implements LocaleListener {
     }
 
     private boolean isPathValid(TreePath path) {
-      return (path == null || path.getPathCount() > 3)
-          ? false
-          : path.getLastPathComponent() instanceof ProjectExplorerToolNode;
+      return path != null && path.getLastPathComponent() instanceof ProjectExplorerToolNode;
     }
 
     @Override

--- a/src/test/java/com/cburch/logisim/file/NestedLibraryResolutionTest.java
+++ b/src/test/java/com/cburch/logisim/file/NestedLibraryResolutionTest.java
@@ -1,0 +1,122 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.file;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.tools.AddTool;
+import com.cburch.logisim.tools.Library;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class NestedLibraryResolutionTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void savesAndReloadsComponentsFromNestedLogisimLibraries() throws Exception {
+    final var aPath = tempDir.resolve("A.circ").toFile();
+    final var bPath = tempDir.resolve("B.circ").toFile();
+    final var cPath = tempDir.resolve("C.circ").toFile();
+
+    final var aLoader = new RecordingLoader();
+    final var aFile = newProject(aLoader, "Leaf");
+    save(aLoader, aFile, aPath);
+
+    final var bLoader = new RecordingLoader();
+    final var bFile = newProject(bLoader, "Middle");
+    final var aLibrary = bLoader.loadLogisimLibrary(aPath);
+    assertNotNull(aLibrary, bLoader.errors());
+    bFile.addLibrary(aLibrary);
+    addComponent(bFile.getMainCircuit(), tool(aLibrary, "Leaf"));
+    save(bLoader, bFile, bPath);
+
+    final var cLoader = new RecordingLoader();
+    final var cFile = newProject(cLoader, "Top");
+    final var bLibrary = cLoader.loadLogisimLibrary(bPath);
+    assertNotNull(bLibrary, cLoader.errors());
+    cFile.addLibrary(bLibrary);
+    final var nestedALibrary = findLibrary(bLibrary, "A");
+    addComponent(cFile.getMainCircuit(), tool(nestedALibrary, "Leaf"));
+    save(cLoader, cFile, cPath);
+
+    final var reloadLoader = new RecordingLoader();
+    final var reloaded = reloadLoader.openLogisimFile(cPath);
+    assertNotNull(reloaded, reloadLoader.errors());
+    assertTrue(
+        reloaded.getMainCircuit().getNonWires().stream()
+            .anyMatch(component -> component.getFactory().getName().equals("Leaf")));
+    assertFalse(reloadLoader.hasErrors(), reloadLoader.errors());
+  }
+
+  private static void addComponent(Circuit circuit, AddTool tool) {
+    final var factory = tool.getFactory();
+    final var component =
+        factory.createComponent(Location.create(100, 100, true), factory.createAttributeSet());
+    final var mutation = new CircuitMutation(circuit);
+    mutation.add(component);
+    mutation.execute();
+  }
+
+  private static Library findLibrary(Library library, String name) {
+    for (final var sub : library.getLibraries()) {
+      if (sub.getName().equals(name)) return sub;
+    }
+    return fail("library not found: " + name);
+  }
+
+  private static LogisimFile newProject(RecordingLoader loader, String circuitName) {
+    final var file = LogisimFile.createNew(loader, null);
+    file.getMainCircuit().setName(circuitName);
+    return file;
+  }
+
+  private static void save(RecordingLoader loader, LogisimFile file, File path) {
+    assertTrue(loader.save(file, path), loader.errors());
+    assertFalse(loader.hasErrors(), loader.errors());
+  }
+
+  private static AddTool tool(Library library, String name) {
+    final var tool = library.getTool(name);
+    assertTrue(tool instanceof AddTool, "tool not found: " + name);
+    return (AddTool) tool;
+  }
+
+  private static class RecordingLoader extends Loader {
+    private final List<String> errors = new ArrayList<>();
+
+    RecordingLoader() {
+      super(null);
+    }
+
+    String errors() {
+      return String.join("\n", errors);
+    }
+
+    boolean hasErrors() {
+      return !errors.isEmpty();
+    }
+
+    @Override
+    public void showError(String description) {
+      errors.add(description);
+    }
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/generic/ProjectExplorerTest.java
+++ b/src/test/java/com/cburch/logisim/gui/generic/ProjectExplorerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.generic;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.cburch.logisim.file.Loader;
+import com.cburch.logisim.file.LogisimFile;
+import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.wiring.Pin;
+import com.cburch.logisim.tools.AddTool;
+import com.cburch.logisim.tools.Library;
+import com.cburch.logisim.tools.Tool;
+import java.util.Enumeration;
+import java.util.List;
+import javax.swing.tree.TreePath;
+import org.junit.jupiter.api.Test;
+
+class ProjectExplorerTest {
+
+  @Test
+  void selectsToolsFromNestedLibraries() {
+    final var leafTool = new AddTool(Pin.FACTORY);
+    final var leafLibrary = new TestLibrary("leaf", List.of(leafTool), List.of());
+    final var parentLibrary = new TestLibrary("parent", List.of(), List.of(leafLibrary));
+    final var file = LogisimFile.createNew(new Loader(null), null);
+    file.addLibrary(parentLibrary);
+
+    try {
+      final var project = new Project(file);
+      final var explorer = new ProjectExplorer(project, false);
+      final var root = (ProjectExplorerLibraryNode) explorer.getModel().getRoot();
+      final var parentNode = findLibraryNode(root, parentLibrary);
+      final var leafNode = findLibraryNode(parentNode, leafLibrary);
+      final var toolNode = findToolNode(leafNode, leafTool);
+
+      explorer.setSelectionPath(new TreePath(new Object[] {root, parentNode, leafNode, toolNode}));
+
+      assertSame(leafTool, explorer.getSelectedTool());
+    } finally {
+      file.stopAutosaveThread(false);
+    }
+  }
+
+  private static ProjectExplorerLibraryNode findLibraryNode(
+      ProjectExplorerLibraryNode parent, Library library) {
+    for (final var children = parent.children(); children.hasMoreElements(); ) {
+      final var child = children.nextElement();
+      if (child instanceof ProjectExplorerLibraryNode node && node.getValue() == library) {
+        return node;
+      }
+    }
+    return fail("library node not found: " + library.getName());
+  }
+
+  private static ProjectExplorerToolNode findToolNode(ProjectExplorerLibraryNode parent, Tool tool) {
+    for (final Enumeration<?> children = parent.children(); children.hasMoreElements(); ) {
+      final var child = children.nextElement();
+      if (child instanceof ProjectExplorerToolNode node && node.getValue() == tool) {
+        return node;
+      }
+    }
+    return fail("tool node not found: " + tool.getName());
+  }
+
+  private static class TestLibrary extends Library {
+    private final String name;
+    private final List<Tool> tools;
+    private final List<Library> libraries;
+
+    TestLibrary(String name, List<Tool> tools, List<Library> libraries) {
+      this.name = name;
+      this.tools = tools;
+      this.libraries = libraries;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public List<Library> getLibraries() {
+      return libraries;
+    }
+
+    @Override
+    public List<? extends Tool> getTools() {
+      return tools;
+    }
+  }
+}


### PR DESCRIPTION
Summary
- allow selecting tools from nested sub-libraries in the project explorer
- resolve component, toolbar, and mapping tools recursively when reading/writing libraries
- add regression coverage for nested project-tree selection and A -> B -> C library save/reload

Verification
- ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.gui.generic.ProjectExplorerTest --tests com.cburch.logisim.file.NestedLibraryResolutionTest checkstyleMain checkstyleTest

Fixes #2380