### PR TITLE
gui: add go-to-address control to hex editor

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/hex/HexFrame.java
+++ b/src/main/java/com/cburch/logisim/gui/hex/HexFrame.java
@@ -14,6 +14,7 @@ import static com.cburch.logisim.gui.Strings.S;
 import com.cburch.hex.HexEditor;
 import com.cburch.hex.HexModel;
 import com.cburch.logisim.gui.generic.LFrame;
+import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.gui.menu.LogisimMenuBar;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.proj.Project;
@@ -29,8 +30,10 @@ import java.awt.event.ActionListener;
 import java.awt.event.WindowEvent;
 import javax.swing.JButton;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTextField;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -44,6 +47,9 @@ public class HexFrame extends LFrame.SubWindow {
   private final JButton open = new JButton();
   private final JButton save = new JButton();
   private final JButton close = new JButton();
+  private final JLabel addressLabel = new JLabel();
+  private final JTextField addressField = new JTextField(12);
+  private final JButton goAddress = new JButton();
   private final Instance instance;
 
   public HexFrame(Project project, Instance instance, HexModel model) {
@@ -57,9 +63,14 @@ public class HexFrame extends LFrame.SubWindow {
     final var buttonPanel = new JPanel();
     buttonPanel.add(open);
     buttonPanel.add(save);
+    buttonPanel.add(addressLabel);
+    buttonPanel.add(addressField);
+    buttonPanel.add(goAddress);
     buttonPanel.add(close);
     open.addActionListener(myListener);
     save.addActionListener(myListener);
+    addressField.addActionListener(myListener);
+    goAddress.addActionListener(myListener);
     close.addActionListener(myListener);
 
     final var pref = editor.getPreferredSize();
@@ -90,6 +101,25 @@ public class HexFrame extends LFrame.SubWindow {
     editor.getCaret().setDot(0, false);
     editListener.register(menubar);
     setLocationRelativeTo(project.getFrame());
+  }
+
+  static long parseAddress(String text, HexModel model) {
+    final var address = parseAddress(text);
+    if (model == null || address < model.getFirstOffset() || address > model.getLastOffset()) {
+      throw new NumberFormatException();
+    }
+    return address;
+  }
+
+  private static long parseAddress(String text) {
+    var normalized = text == null ? "" : text.trim();
+    if (normalized.startsWith("0x") || normalized.startsWith("0X")) {
+      normalized = normalized.substring(2);
+    }
+    if (normalized.isEmpty()) {
+      throw new NumberFormatException();
+    }
+    return Long.parseLong(normalized, 16);
   }
 
   public void closeAndDispose() {
@@ -164,6 +194,20 @@ public class HexFrame extends LFrame.SubWindow {
         HexFile.open((MemContents) model, HexFrame.this, project, instance);
       } else if (src == save) {
         HexFile.save((MemContents) model, HexFrame.this, project, instance);
+      } else if (src == addressField || src == goAddress) {
+        try {
+          editor.getCaret().setDot(parseAddress(addressField.getText(), model), false);
+          editor.requestFocusInWindow();
+        } catch (NumberFormatException e) {
+          OptionPane.showMessageDialog(
+              HexFrame.this,
+              S.get(
+                  "hexAddressInvalidMessage",
+                  Long.toHexString(model.getFirstOffset()),
+                  Long.toHexString(model.getLastOffset())),
+              S.get("hexAddressInvalidTitle"),
+              OptionPane.ERROR_MESSAGE);
+        }
       } else if (src == close) {
         WindowEvent e = new WindowEvent(HexFrame.this, WindowEvent.WINDOW_CLOSING);
         HexFrame.this.processWindowEvent(e);
@@ -175,6 +219,8 @@ public class HexFrame extends LFrame.SubWindow {
       setTitle(S.get("hexFrameTitle"));
       open.setText(S.get("openButton"));
       save.setText(S.get("saveButton"));
+      addressLabel.setText(S.get("hexAddressLabel"));
+      goAddress.setText(S.get("hexAddressGo"));
       close.setText(S.get("closeButton"));
     }
   }

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Hex Editor
 hexFrameTitle = Hex Editor
 openButton = Open…
 saveButton = Save…
+hexAddressLabel = Address:
+hexAddressGo = Go
+hexAddressInvalidTitle = Invalid Address
+hexAddressInvalidMessage = Enter a hexadecimal address from %s to %s
 dragOpenNonProjectTitle = Open File
 dragOpenNonProjectMessage = File "%s" does not use the %s extension. Try opening it anyway?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Hex-Editor
 hexFrameTitle = Hex-Editor
 openButton = Öffnen…
 saveButton = Speichern…
+hexAddressLabel = Adresse:
+hexAddressGo = Gehe zu
+hexAddressInvalidTitle = Ungültige Adresse
+hexAddressInvalidMessage = Geben Sie eine hexadezimale Adresse von %s bis %s ein
 dragOpenNonProjectTitle = Datei öffnen
 dragOpenNonProjectMessage = Die Datei "%s" hat nicht die Erweiterung %s. Trotzdem versuchen, sie zu öffnen?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Δεκαεξαδικός Συντάκτης
 hexFrameTitle = Δεκαεξαδικός Συντάκτης
 openButton = Άνοιγμα…
 saveButton = Αποθήκευση…
+hexAddressLabel = Διεύθυνση:
+hexAddressGo = Μετάβαση
+hexAddressInvalidTitle = Μη έγκυρη διεύθυνση
+hexAddressInvalidMessage = Εισαγάγετε μια δεκαεξαδική διεύθυνση από %s έως %s
 dragOpenNonProjectTitle = Άνοιγμα αρχείου
 dragOpenNonProjectMessage = Το αρχείο "%s" δεν χρησιμοποιεί την επέκταση %s. Να γίνει προσπάθεια ανοίγματος παρ' όλα αυτά;
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -145,10 +145,10 @@ hexFrameMenuItem = Δεκαεξαδικός Συντάκτης
 hexFrameTitle = Δεκαεξαδικός Συντάκτης
 openButton = Άνοιγμα…
 saveButton = Αποθήκευση…
-hexAddressLabel = Διεύθυνση:
-hexAddressGo = Μετάβαση
-hexAddressInvalidTitle = Μη έγκυρη διεύθυνση
-hexAddressInvalidMessage = Εισαγάγετε μια δεκαεξαδική διεύθυνση από %s έως %s
+# ==> hexAddressLabel = Address:
+# ==> hexAddressGo = Go
+# ==> hexAddressInvalidTitle = Invalid Address
+# ==> hexAddressInvalidMessage = Enter a hexadecimal address from %s to %s
 dragOpenNonProjectTitle = Άνοιγμα αρχείου
 dragOpenNonProjectMessage = Το αρχείο "%s" δεν χρησιμοποιεί την επέκταση %s. Να γίνει προσπάθεια ανοίγματος παρ' όλα αυτά;
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -145,10 +145,10 @@ hexFrameMenuItem = Editor hexadecimal
 hexFrameTitle = Editor hexadecimal
 openButton = Abrir…
 saveButton = Guardar…
-hexAddressLabel = Dirección:
-hexAddressGo = Ir
-hexAddressInvalidTitle = Dirección no válida
-hexAddressInvalidMessage = Introduzca una dirección hexadecimal entre %s y %s
+# ==> hexAddressLabel = Address:
+# ==> hexAddressGo = Go
+# ==> hexAddressInvalidTitle = Invalid Address
+# ==> hexAddressInvalidMessage = Enter a hexadecimal address from %s to %s
 dragOpenNonProjectTitle = Abrir archivo
 dragOpenNonProjectMessage = El archivo "%s" no usa la extensión %s. ¿Intentar abrirlo de todos modos?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Editor hexadecimal
 hexFrameTitle = Editor hexadecimal
 openButton = Abrir…
 saveButton = Guardar…
+hexAddressLabel = Dirección:
+hexAddressGo = Ir
+hexAddressInvalidTitle = Dirección no válida
+hexAddressInvalidMessage = Introduzca una dirección hexadecimal entre %s y %s
 dragOpenNonProjectTitle = Abrir archivo
 dragOpenNonProjectMessage = El archivo "%s" no usa la extensión %s. ¿Intentar abrirlo de todos modos?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Editeur Hexadécimal
 hexFrameTitle = éditeur Hexadécimal
 openButton = Ouvrir…
 saveButton = Enregistrer…
+hexAddressLabel = Adresse :
+hexAddressGo = Aller
+hexAddressInvalidTitle = Adresse invalide
+hexAddressInvalidMessage = Saisissez une adresse hexadécimale comprise entre %s et %s
 dragOpenNonProjectTitle = Ouvrir le fichier
 dragOpenNonProjectMessage = Le fichier "%s" n’utilise pas l’extension %s. Voulez-vous quand même essayer de l’ouvrir ?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Editor Esadecimale
 hexFrameTitle = Editor Esadecimale
 openButton = Apri…
 saveButton = Salva…
+hexAddressLabel = Indirizzo:
+hexAddressGo = Vai
+hexAddressInvalidTitle = Indirizzo non valido
+hexAddressInvalidMessage = Inserire un indirizzo esadecimale compreso tra %s e %s
 dragOpenNonProjectTitle = Apri file
 dragOpenNonProjectMessage = Il file "%s" non usa l'estensione %s. Vuoi comunque provare ad aprirlo?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -145,10 +145,10 @@ hexFrameMenuItem = Editor Esadecimale
 hexFrameTitle = Editor Esadecimale
 openButton = Apri…
 saveButton = Salva…
-hexAddressLabel = Indirizzo:
-hexAddressGo = Vai
-hexAddressInvalidTitle = Indirizzo non valido
-hexAddressInvalidMessage = Inserire un indirizzo esadecimale compreso tra %s e %s
+# ==> hexAddressLabel = Address:
+# ==> hexAddressGo = Go
+# ==> hexAddressInvalidTitle = Invalid Address
+# ==> hexAddressInvalidMessage = Enter a hexadecimal address from %s to %s
 dragOpenNonProjectTitle = Apri file
 dragOpenNonProjectMessage = Il file "%s" non usa l'estensione %s. Vuoi comunque provare ad aprirlo?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = 16進数 エディタ
 hexFrameTitle = 16進数エディタ
 openButton = 開く…
 saveButton = 保存…
+hexAddressLabel = アドレス:
+hexAddressGo = 移動
+hexAddressInvalidTitle = 無効なアドレス
+hexAddressInvalidMessage = %s から %s までの 16 進アドレスを入力してください
 dragOpenNonProjectTitle = ファイルを開く
 dragOpenNonProjectMessage = ファイル「%s」は拡張子 %s を使用していません。それでも開こうとしますか？
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -145,10 +145,10 @@ hexFrameMenuItem = 16進数 エディタ
 hexFrameTitle = 16進数エディタ
 openButton = 開く…
 saveButton = 保存…
-hexAddressLabel = アドレス:
-hexAddressGo = 移動
-hexAddressInvalidTitle = 無効なアドレス
-hexAddressInvalidMessage = %s から %s までの 16 進アドレスを入力してください
+# ==> hexAddressLabel = Address:
+# ==> hexAddressGo = Go
+# ==> hexAddressInvalidTitle = Invalid Address
+# ==> hexAddressInvalidMessage = Enter a hexadecimal address from %s to %s
 dragOpenNonProjectTitle = ファイルを開く
 dragOpenNonProjectMessage = ファイル「%s」は拡張子 %s を使用していません。それでも開こうとしますか？
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Hex-editor
 hexFrameTitle = Hex-editor
 openButton = Open…
 saveButton = Opslaan…
+hexAddressLabel = Adres:
+hexAddressGo = Ga
+hexAddressInvalidTitle = Ongeldig adres
+hexAddressInvalidMessage = Voer een hexadecimaal adres in van %s tot %s
 dragOpenNonProjectTitle = Bestand openen
 dragOpenNonProjectMessage = Bestand "%s" gebruikt de extensie %s niet. Toch proberen het te openen?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -145,10 +145,10 @@ hexFrameMenuItem = Edytor szesnastkowy
 hexFrameTitle = Edytor szesnastkowy
 openButton = Otwórz…
 saveButton = Zapisz…
-hexAddressLabel = Adres:
-hexAddressGo = Idź
-hexAddressInvalidTitle = Nieprawidłowy adres
-hexAddressInvalidMessage = Wprowadź adres szesnastkowy od %s do %s
+# ==> hexAddressLabel = Address:
+# ==> hexAddressGo = Go
+# ==> hexAddressInvalidTitle = Invalid Address
+# ==> hexAddressInvalidMessage = Enter a hexadecimal address from %s to %s
 dragOpenNonProjectTitle = Otwórz plik
 dragOpenNonProjectMessage = Plik „%s” nie ma rozszerzenia %s. Czy mimo to spróbować go otworzyć?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Edytor szesnastkowy
 hexFrameTitle = Edytor szesnastkowy
 openButton = Otwórz…
 saveButton = Zapisz…
+hexAddressLabel = Adres:
+hexAddressGo = Idź
+hexAddressInvalidTitle = Nieprawidłowy adres
+hexAddressInvalidMessage = Wprowadź adres szesnastkowy od %s do %s
 dragOpenNonProjectTitle = Otwórz plik
 dragOpenNonProjectMessage = Plik „%s” nie ma rozszerzenia %s. Czy mimo to spróbować go otworzyć?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -145,10 +145,10 @@ hexFrameMenuItem = Editor hexadecimal
 hexFrameTitle = Editor hexadecimal
 openButton = Abrir…
 saveButton = Salvar…
-hexAddressLabel = Endereço:
-hexAddressGo = Ir
-hexAddressInvalidTitle = Endereço inválido
-hexAddressInvalidMessage = Insira um endereço hexadecimal de %s a %s
+# ==> hexAddressLabel = Address:
+# ==> hexAddressGo = Go
+# ==> hexAddressInvalidTitle = Invalid Address
+# ==> hexAddressInvalidMessage = Enter a hexadecimal address from %s to %s
 dragOpenNonProjectTitle = Abrir arquivo
 dragOpenNonProjectMessage = O arquivo "%s" não usa a extensão %s. Deseja tentar abri-lo mesmo assim?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Editor hexadecimal
 hexFrameTitle = Editor hexadecimal
 openButton = Abrir…
 saveButton = Salvar…
+hexAddressLabel = Endereço:
+hexAddressGo = Ir
+hexAddressInvalidTitle = Endereço inválido
+hexAddressInvalidMessage = Insira um endereço hexadecimal de %s a %s
 dragOpenNonProjectTitle = Abrir arquivo
 dragOpenNonProjectMessage = O arquivo "%s" não usa a extensão %s. Deseja tentar abri-lo mesmo assim?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Шестнадцатеричный редактор
 hexFrameTitle = шестнадцатеричный редактор
 openButton = Открыть…
 saveButton = Сохранить…
+hexAddressLabel = Адрес:
+hexAddressGo = Перейти
+hexAddressInvalidTitle = Недопустимый адрес
+hexAddressInvalidMessage = Введите шестнадцатеричный адрес от %s до %s
 dragOpenNonProjectTitle = Открыть файл
 dragOpenNonProjectMessage = Файл "%s" не имеет расширения %s. Всё равно попытаться открыть его?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -145,10 +145,10 @@ hexFrameMenuItem = Шестнадцатеричный редактор
 hexFrameTitle = шестнадцатеричный редактор
 openButton = Открыть…
 saveButton = Сохранить…
-hexAddressLabel = Адрес:
-hexAddressGo = Перейти
-hexAddressInvalidTitle = Недопустимый адрес
-hexAddressInvalidMessage = Введите шестнадцатеричный адрес от %s до %s
+# ==> hexAddressLabel = Address:
+# ==> hexAddressGo = Go
+# ==> hexAddressInvalidTitle = Invalid Address
+# ==> hexAddressInvalidMessage = Enter a hexadecimal address from %s to %s
 dragOpenNonProjectTitle = Открыть файл
 dragOpenNonProjectMessage = Файл "%s" не имеет расширения %s. Всё равно попытаться открыть его?
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -145,6 +145,10 @@ hexFrameMenuItem = Hex 编辑器
 hexFrameTitle = Hex 编辑器
 openButton = 打开…
 saveButton = 保存…
+hexAddressLabel = 地址：
+hexAddressGo = 跳转
+hexAddressInvalidTitle = 地址无效
+hexAddressInvalidMessage = 请输入 %s 到 %s 之间的十六进制地址
 dragOpenNonProjectTitle = 打开文件
 dragOpenNonProjectMessage = 文件“%s”不是 %s 扩展名。仍要尝试打开它吗？
 #

--- a/src/test/java/com/cburch/logisim/gui/hex/HexFrameTest.java
+++ b/src/test/java/com/cburch/logisim/gui/hex/HexFrameTest.java
@@ -1,0 +1,93 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.hex;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.cburch.hex.HexModel;
+import com.cburch.hex.HexModelListener;
+import org.junit.jupiter.api.Test;
+
+class HexFrameTest {
+  @Test
+  void parseAddressAcceptsHexWithOptionalPrefix() {
+    final var model = new RangeModel(0, 0x2f);
+
+    assertEquals(0x1a, HexFrame.parseAddress("1a", model));
+    assertEquals(0x1a, HexFrame.parseAddress("1A", model));
+    assertEquals(0x1a, HexFrame.parseAddress("0x1a", model));
+    assertEquals(0x1a, HexFrame.parseAddress("  0X1A  ", model));
+  }
+
+  @Test
+  void parseAddressRequiresAddressWithinModelRange() {
+    final var model = new RangeModel(0x10, 0x2f);
+
+    assertEquals(0x10, HexFrame.parseAddress("10", model));
+    assertEquals(0x2f, HexFrame.parseAddress("2f", model));
+    assertThrows(NumberFormatException.class, () -> HexFrame.parseAddress("f", model));
+    assertThrows(NumberFormatException.class, () -> HexFrame.parseAddress("30", model));
+  }
+
+  @Test
+  void parseAddressRejectsBlankOrInvalidInput() {
+    final var model = new RangeModel(0, 0x2f);
+
+    assertThrows(NumberFormatException.class, () -> HexFrame.parseAddress("", model));
+    assertThrows(NumberFormatException.class, () -> HexFrame.parseAddress("0x", model));
+    assertThrows(NumberFormatException.class, () -> HexFrame.parseAddress("not-hex", model));
+  }
+
+  private static class RangeModel implements HexModel {
+    private final long firstOffset;
+    private final long lastOffset;
+
+    RangeModel(long firstOffset, long lastOffset) {
+      this.firstOffset = firstOffset;
+      this.lastOffset = lastOffset;
+    }
+
+    @Override
+    public void addHexModelListener(HexModelListener l) {}
+
+    @Override
+    public void fill(long start, long length, long value) {}
+
+    @Override
+    public long get(long address) {
+      return 0;
+    }
+
+    @Override
+    public long getFirstOffset() {
+      return firstOffset;
+    }
+
+    @Override
+    public long getLastOffset() {
+      return lastOffset;
+    }
+
+    @Override
+    public int getValueWidth() {
+      return 8;
+    }
+
+    @Override
+    public void removeHexModelListener(HexModelListener l) {}
+
+    @Override
+    public void set(long address, long value) {}
+
+    @Override
+    public void set(long start, long[] values) {}
+  }
+}


### PR DESCRIPTION
Summary
- add an address field and Go button to the hex editor window
- parse hexadecimal addresses with optional 0x/0X prefix and validate them against the current HexModel range before jumping
- add localized strings and parser/range regression coverage

Verification
- ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.gui.hex.HexFrameTest checkstyleMain checkstyleTest
- git diff --check
- local trans-tool check for the gui bundle; the repository still reports pre-existing translation issues, and the new hexAddress keys do not add formatter errors

Fixes #1532