### PR TITLE
fpga: use correct PortIO bubble ranges

### DIFF
--- a/src/main/java/com/cburch/logisim/std/io/PortHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/io/PortHdlGeneratorFactory.java
@@ -22,8 +22,16 @@ public class PortHdlGeneratorFactory extends InlinedHdlGeneratorFactory {
       Netlist nets, Long componentId, netlistComponent componentInfo, String circuitName) {
     final var contents = LineBuffer.getHdlBuffer();
     final var portType = componentInfo.getComponent().getAttributeSet().getValue(PortIo.ATTR_DIR);
-    var nrOfPins = componentInfo.getComponent().getAttributeSet().getValue(PortIo.ATTR_SIZE).getWidth();
-    final var startIndex = componentInfo.getLocalBubbleInputStartId();
+    var nrOfPins =
+        componentInfo.getComponent().getAttributeSet().getValue(PortIo.ATTR_SIZE).getWidth();
+    final int startIndex;
+    if (portType == PortIo.INPUT) {
+      startIndex = componentInfo.getLocalBubbleInputStartId();
+    } else if (portType == PortIo.OUTPUT) {
+      startIndex = componentInfo.getLocalBubbleOutputStartId();
+    } else {
+      startIndex = componentInfo.getLocalBubbleInOutStartId();
+    }
     final var endIndex = startIndex + nrOfPins - 1;
     if (portType == PortIo.INPUT) {
       if (nrOfPins == 1) {

--- a/src/main/java/com/cburch/logisim/std/io/PortIo.java
+++ b/src/main/java/com/cburch/logisim/std/io/PortIo.java
@@ -258,6 +258,7 @@ public class PortIo extends InstanceFactory {
         .setValue(
             StdAttr.MAPINFO,
             new ComponentMapInformationContainer(0, 0, dipSize, null, null, getLabels(dipSize)));
+    updateMapInfo(instance);
   }
 
   private void updatePorts(Instance instance) {
@@ -347,24 +348,7 @@ public class PortIo extends InstanceFactory {
       instance.recomputeBounds();
       updatePorts(instance);
       instance.computeLabelTextField(Instance.AVOID_BOTTOM);
-      ComponentMapInformationContainer map = instance.getAttributeValue(StdAttr.MAPINFO);
-      if (map != null) {
-        final var nrPins = instance.getAttributeValue(ATTR_SIZE).getWidth();
-        var inputs = 0;
-        var outputs = 0;
-        var ios = 0;
-        final var labels = getLabels(nrPins);
-        if (instance.getAttributeValue(ATTR_DIR) == INPUT) {
-          inputs = nrPins;
-        } else if (instance.getAttributeValue(ATTR_DIR) == OUTPUT) {
-          outputs = nrPins;
-        } else {
-          ios = nrPins;
-        }
-        map.setNrOfInports(inputs, labels);
-        map.setNrOfOutports(outputs, labels);
-        map.setNrOfInOutports(ios, labels);
-      }
+      updateMapInfo(instance);
       if (attr == ATTR_DIR) {
         // we have to reset simulatio, as otherwise strange things can happen.
         final var stateImpl = instance.getComponent().getInstanceStateImpl();
@@ -380,6 +364,26 @@ public class PortIo extends InstanceFactory {
         simulator.reset();
       }
     }
+  }
+
+  private static void updateMapInfo(Instance instance) {
+    ComponentMapInformationContainer map = instance.getAttributeValue(StdAttr.MAPINFO);
+    if (map == null) return;
+    final var nrPins = instance.getAttributeValue(ATTR_SIZE).getWidth();
+    var inputs = 0;
+    var outputs = 0;
+    var ios = 0;
+    final var labels = getLabels(nrPins);
+    if (instance.getAttributeValue(ATTR_DIR) == INPUT) {
+      inputs = nrPins;
+    } else if (instance.getAttributeValue(ATTR_DIR) == OUTPUT) {
+      outputs = nrPins;
+    } else {
+      ios = nrPins;
+    }
+    map.setNrOfInports(inputs, labels);
+    map.setNrOfOutports(outputs, labels);
+    map.setNrOfInOutports(ios, labels);
   }
 
   @Override

--- a/src/test/java/com/cburch/logisim/std/io/PortHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/std/io/PortHdlGeneratorFactoryTest.java
@@ -1,0 +1,112 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import com.cburch.logisim.data.AttributeOption;
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.fpga.designrulecheck.netlistComponent;
+import com.cburch.logisim.fpga.hdlgenerator.Hdl;
+import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
+import com.cburch.logisim.prefs.AppPreferences;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class PortHdlGeneratorFactoryTest {
+
+  private final String originalHdlType = AppPreferences.HdlType.get();
+
+  @AfterEach
+  void restoreHdlType() {
+    AppPreferences.HdlType.set(originalHdlType);
+  }
+
+  @Test
+  void mapInformationMatchesConfiguredDirectionWhenComponentIsCreated() {
+    assertMapInformation(PortIo.INPUT, 4, 4, 0, 0);
+    assertMapInformation(PortIo.OUTPUT, 4, 0, 4, 0);
+    assertMapInformation(PortIo.INOUTSE, 4, 0, 0, 4);
+    assertMapInformation(PortIo.INOUTME, 4, 0, 0, 4);
+  }
+
+  @Test
+  void outputOnlyPortsUseOutputBubbleRange() {
+    AppPreferences.HdlType.set(HdlGeneratorFactory.VHDL);
+    final var nets = mock(Netlist.class);
+    final var componentInfo = portComponent(PortIo.OUTPUT, 4);
+    componentInfo.setLocalBubbleID(3, 2, 8, 4, 20, 5);
+
+    try (final var hdl = mockStatic(Hdl.class, CALLS_REAL_METHODS)) {
+      hdl.when(() -> Hdl.getBusName(componentInfo, 0, nets)).thenReturn("portData");
+
+      final var code =
+          String.join(
+              "\n",
+              new PortHdlGeneratorFactory()
+                  .getInlinedCode(nets, 1L, componentInfo, "main")
+                  .get());
+
+      assertTrue(code.contains("logisimOutputBubbles(11 DOWNTO 8) <= portData;"));
+      assertFalse(code.contains("logisimOutputBubbles(6 DOWNTO 3)"));
+    }
+  }
+
+  @Test
+  void inOutPortsUseInOutBubbleRange() {
+    AppPreferences.HdlType.set(HdlGeneratorFactory.VHDL);
+    final var nets = mock(Netlist.class);
+    final var componentInfo = portComponent(PortIo.INOUTSE, 4);
+    componentInfo.setLocalBubbleID(3, 2, 8, 4, 20, 5);
+
+    try (final var hdl = mockStatic(Hdl.class, CALLS_REAL_METHODS)) {
+      hdl.when(() -> Hdl.getBusName(componentInfo, 2, nets)).thenReturn("readData");
+      hdl.when(() -> Hdl.getBusName(componentInfo, 1, nets)).thenReturn("writeData");
+      hdl.when(() -> Hdl.getNetName(componentInfo, 0, true, nets)).thenReturn("enable");
+
+      final var code =
+          String.join(
+              "\n",
+              new PortHdlGeneratorFactory()
+                  .getInlinedCode(nets, 1L, componentInfo, "main")
+                  .get());
+
+      assertTrue(code.contains("readData <= logisimInOutBubbles(23 DOWNTO 20);"));
+      assertTrue(
+          code.contains(
+              "logisimInOutBubbles(23 DOWNTO 20) <= writeData WHEN enable = '1' "
+                  + "ELSE (OTHERS => 'Z');"));
+      assertFalse(code.contains("logisimInOutBubbles(6 DOWNTO 3)"));
+    }
+  }
+
+  private static netlistComponent portComponent(AttributeOption direction, int width) {
+    final var port = new PortIo();
+    final var attrs = port.createAttributeSet();
+    attrs.setValue(PortIo.ATTR_DIR, direction);
+    attrs.setValue(PortIo.ATTR_SIZE, BitWidth.create(width));
+    return new netlistComponent(port.createComponent(Location.create(0, 0, true), attrs));
+  }
+
+  private static void assertMapInformation(
+      AttributeOption direction, int width, int inputs, int outputs, int inOuts) {
+    final var mapInfo = portComponent(direction, width).getMapInformationContainer();
+    assertEquals(inputs, mapInfo.getNrOfInPorts());
+    assertEquals(outputs, mapInfo.getNrOfOutPorts());
+    assertEquals(inOuts, mapInfo.getNrOfInOutPorts());
+  }
+}


### PR DESCRIPTION
Summary
- choose PortIO HDL bubble ranges from the configured direction instead of always using input bubble indexes
- initialize PortIO FPGA map information from the configured direction when the component is created
- add regression coverage for output-only PortIO, inout PortIO, and direction-specific map information

Root cause
- PortIO HDL generation computed the bubble range from getLocalBubbleInputStartId() for every direction, so output-only and inout PortIO components could emit HDL assignments against the wrong bubble group.
- That also matches the multiple-PortIO symptom in #2071, where the second inout PortIO still referenced the first PortIO's inout bubble range.

Verification
- ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.std.io.PortHdlGeneratorFactoryTest checkstyleMain checkstyleTest
- git diff --check

Fixes #2537
Fixes #2071