### PR TITLE
docs: clarify wire value notation

### DIFF
--- a/src/main/resources/doc/en/html/libs/gates/xor.html
+++ b/src/main/resources/doc/en/html/libs/gates/xor.html
@@ -122,7 +122,7 @@
       </p>
       <p>
         By default, any inputs that are left unconnected are ignored — that's if the input truly has nothing attached to it, not even a wire. In this way, you can insert a 5-input gate but only attach two inputs, and it will work as a 2-input gate; this relieves you from having to worry about
-        configuring the number of inputs every time you create a gate. (If all inputs are unconnected, the output is the error value <em>X</em>.) Some users, though, prefer that Logisim insist that all inputs be connected, since this is what corresponds to real-world gates. You can enable this
+        configuring the number of inputs every time you create a gate. (If all inputs are unconnected, the output is the error value <b class="evalue">E</b>.) Some users, though, prefer that Logisim insist that all inputs be connected, since this is what corresponds to real-world gates. You can enable this
         behavior by going to the Project &gt; Options… menu item, selecting the Simulation tab, and selecting <q>Error for undefined inputs</q> for <q>Gate Output When Undefined.</q>
       </p>
       <p>

--- a/src/main/resources/doc/en/html/libs/mem/counter.html
+++ b/src/main/resources/doc/en/html/libs/mem/counter.html
@@ -56,27 +56,27 @@
             </thead>
             <tbody>
             <tr>
-                <td align="center">0 or Z</td>
+                <td align="center">not 1</td>
                 <td align="center">0</td>
-                <td align="center">X</td>
+                <td align="center">any</td>
                 <td>The counter remains unchanged.</td>
             </tr>
             <tr>
-                <td align="center">0 or Z</td>
-                <td align="center">1 or Z</td>
-                <td align="center">1 or Z</td>
+                <td align="center">not 1</td>
+                <td align="center">not 0</td>
+                <td align="center">not 0</td>
                 <td>The counter <b>increments</b>.</td>
             </tr>
             <tr>
-                <td align="center">0 or Z</td>
-                <td align="center">1 or Z</td>
+                <td align="center">not 1</td>
+                <td align="center">not 0</td>
                 <td align="center">0</td>
                 <td>The counter <b>decrements</b>.</td>
             </tr>
             <tr>
                 <td align="center">1</td>
-                <td align="center">X</td>
-                <td align="center">X</td>
+                <td align="center">any</td>
+                <td align="center">any</td>
                 <td>The counter <b>loads</b> the value found at the <var>D</var> input.</td>
             </tr>
             </tbody>
@@ -115,14 +115,14 @@
 
         <dt>West edge, lower pin labeled <var>ct</var> (input, bit width 1)</dt>
         <dd>
-            <b>Enable(ct) (shown as G5):</b> When this is 1 or unconnected, the counter increments or decrements on the clock trigger,
-            provided the <var>Load</var> input is 0.
+            <b>Enable(ct) (shown as G5):</b> When this is any value other than 0, the counter increments or decrements on the clock trigger,
+            provided the <var>Load</var> input is not 1.
         </dd>
 
         <dt>North edge, labeled <var>UD</var> (input, bit width 1)</dt>
         <dd>
-            <b>Up/Down (shown as M3/M4):</b> When 1 or Z, the counter counts up. When 0, it counts down.
-            This input dictates direction when <var>Load</var> is 0 and <var>Enable(ct)</var> is 1.
+            <b>Up/Down (shown as M3/M4):</b> When this is any value other than 0, the counter counts up. When 0, it counts down.
+            This input dictates direction when <var>Load</var> is not 1 and <var>Enable(ct)</var> is not 0.
         </dd>
 
         <dt>South edge, indicated with a triangle (input, bit width 1)</dt>


### PR DESCRIPTION
Summary
- replace a remaining XOR gate help-page reference to the old error value `X` with Logisim's current `E` marker
- rewrite the Counter behavior table so `X` is no longer used as a don't-care marker and `Z` is no longer used for floating/high-impedance values
- describe the Counter control inputs as `any` / `not 0` / `not 1` where that matches the current implementation

Verification
- ./gradlew.bat processResources
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check
- rg "error value <em>X</em>|0 or Z|1 or Z|>X<|>Z<|When 1 or Z" src/main/resources/doc/en/html -n

Fixes #385