### PR TITLE
fpga: fix scanning io constraints

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/download/AlteraDownload.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/AlteraDownload.java
@@ -256,8 +256,8 @@ public class AlteraDownload implements VendorDownload {
       }
     }
     final var ledArrayMap = DownloadBase.getScanningMaps(mapInfo, rootNetList, boardInfo);
-    for (final var key : ledArrayMap.keySet())
-      contents.add("set_location_assignment {{1}} -to {{2}}", ledArrayMap.get(key), key);
+    for (final var pin : ledArrayMap)
+      contents.add("set_location_assignment {{1}} -to {{2}}", pin.pinLocation(), pin.hdlSignal());
     return contents.getWithIndent(4);
   }
 

--- a/src/main/java/com/cburch/logisim/fpga/download/DownloadBase.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/DownloadBase.java
@@ -12,6 +12,8 @@ package com.cburch.logisim.fpga.download;
 import static com.cburch.logisim.fpga.Strings.S;
 
 import com.cburch.logisim.fpga.data.BoardInformation;
+import com.cburch.logisim.fpga.data.DriveStrength;
+import com.cburch.logisim.fpga.data.FpgaIoInformationContainer;
 import com.cburch.logisim.fpga.data.IoComponentTypes;
 import com.cburch.logisim.fpga.data.LedArrayDriving;
 import com.cburch.logisim.fpga.data.MappableResourcesContainer;
@@ -35,9 +37,7 @@ import com.cburch.logisim.std.io.SevenSegmentScanningGenericHdlGenerator;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 
 public abstract class DownloadBase {
 
@@ -373,6 +373,13 @@ public abstract class DownloadBase {
     return base + HDLPaths[identifier] + File.separator;
   }
 
+  public record ScanningIoPin(
+      String hdlSignal, String pinLocation, char ioStandard, char pullBehavior, char driveStrength) {
+    public ScanningIoPin(String hdlSignal, String pinLocation, FpgaIoInformationContainer info) {
+      this(hdlSignal, pinLocation, info.getIoStandard(), info.getPullBehavior(), info.getDrive());
+    }
+  }
+
   private boolean cleanDirectory(String dir) {
     try {
       final var thisDir = new File(dir);
@@ -391,9 +398,9 @@ public abstract class DownloadBase {
     }
   }
 
-  public static Map<String, String> getScanningMaps(
+  public static ArrayList<ScanningIoPin> getScanningMaps(
       MappableResourcesContainer maps, Netlist nets, BoardInformation board) {
-    final var pinMaps = new HashMap<String, String>();
+    final var pinMaps = new ArrayList<ScanningIoPin>();
     var hasMappedClockedArray = false;
     var hasScanningSevenSegment = false;
     for (final var comp : maps.getIoComponentInformation().getComponents()) {
@@ -402,14 +409,15 @@ public abstract class DownloadBase {
           hasMappedClockedArray |=
               LedArrayGenericHdlGeneratorFactory.requiresClock(comp.getArrayDriveMode());
           for (var pin = 0; pin < comp.getExternalPinCount(); pin++) {
-            pinMaps.put(
+            pinMaps.add(new ScanningIoPin(
                 LedArrayGenericHdlGeneratorFactory.getExternalSignalName(
                     comp.getArrayDriveMode(),
                     comp.getNrOfRows(),
                     comp.getNrOfColumns(),
                     comp.getArrayId(),
                     pin),
-                comp.getPinLocation(pin));
+                comp.getPinLocation(pin),
+                comp));
           }
         }
       }
@@ -417,12 +425,13 @@ public abstract class DownloadBase {
         if (comp.hasMap()) {
           hasScanningSevenSegment = true;
           for (var pin = 0; pin < comp.getExternalPinCount(); pin++) {
-            pinMaps.put(
+            pinMaps.add(new ScanningIoPin(
                 SevenSegmentScanningGenericHdlGenerator.getExternalSignalName(
                     comp.getNrOfRows(),
                     comp.getArrayId(),
                     pin),
-                comp.getPinLocation(pin));
+                comp.getPinLocation(pin),
+                comp));
           }
         }
       }
@@ -430,8 +439,13 @@ public abstract class DownloadBase {
     if ((hasMappedClockedArray || hasScanningSevenSegment)
         && (nets.numberOfClockTrees() == 0)
         && !nets.requiresGlobalClockConnection()) {
-      pinMaps.put(
-          TickComponentHdlGeneratorFactory.FPGA_CLOCK, board.fpga.getClockPinLocation());
+      pinMaps.add(
+          new ScanningIoPin(
+              TickComponentHdlGeneratorFactory.FPGA_CLOCK,
+              board.fpga.getClockPinLocation(),
+              board.fpga.getClockStandard(),
+              board.fpga.getClockPull(),
+              DriveStrength.UNKNOWN));
     }
     return pinMaps;
   }

--- a/src/main/java/com/cburch/logisim/fpga/download/OpenFpgaDownload.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/OpenFpgaDownload.java
@@ -201,10 +201,20 @@ public class OpenFpgaDownload  implements VendorDownload {
         }
       }
     }
-    final var LedArrayMap = DownloadBase.getScanningMaps(mapInfo, rootNetList, boardInfo);
-    // TODO: add pull, drive and ioStandard
-    for (var key : LedArrayMap.keySet()) {
-      pinInfo.add("LOCATE COMP \"{{1}}\" SITE \"{{2}}\";", key, LedArrayMap.get(key));
+    final var ledArrayMap = DownloadBase.getScanningMaps(mapInfo, rootNetList, boardInfo);
+    for (var pin : ledArrayMap) {
+      pinInfo.add("LOCATE COMP \"{{1}}\" SITE \"{{2}}\";", pin.hdlSignal(), pin.pinLocation());
+      final var pullString = PullBehaviors.getPullString(pin.pullBehavior());
+      final String pull = (pullString == null) ? " PULLMODE=NONE" :
+          LineBuffer.format(" PULLMODE={{1}}", pullString.toUpperCase());
+      final var ioTypeString = IoStandards.getIoString(pin.ioStandard());
+      final String ioType = (ioTypeString == null) ? "" :
+          LineBuffer.format(" IO_TYPE={{1}}", ioTypeString.toUpperCase());
+      final var driveString = DriveStrength.getDriveString(pin.driveStrength());
+      final String drive = (driveString == null) ? "" :
+          LineBuffer.format(" DRIVE={{1}}", driveString);
+      if (pullString != null || ioTypeString != null || driveString != null)
+        pinInfo.add("IOBUF PORT \"{{1}}\"{{2}}{{3}}{{4}};", pin.hdlSignal(), pull, ioType, drive);
     }
     return pinInfo.get();
   }

--- a/src/main/java/com/cburch/logisim/fpga/download/VivadoDownload.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/VivadoDownload.java
@@ -12,6 +12,7 @@ package com.cburch.logisim.fpga.download;
 import static com.cburch.logisim.fpga.Strings.S;
 
 import com.cburch.logisim.fpga.data.BoardInformation;
+import com.cburch.logisim.fpga.data.DriveStrength;
 import com.cburch.logisim.fpga.data.IoStandards;
 import com.cburch.logisim.fpga.data.MappableResourcesContainer;
 import com.cburch.logisim.fpga.data.PullBehaviors;
@@ -231,21 +232,39 @@ public class VivadoDownload implements VendorDownload {
           contents.add("set_property PACKAGE_PIN {{1}} [get_ports {{{2}}}]", map.getPinLocation(i), netName);
           final var info = map.getFpgaInfo(i);
           if (info != null) {
-            final var ioStandard = info.getIoStandard();
-            if (ioStandard != IoStandards.UNKNOWN && ioStandard != IoStandards.DEFAULT_STANDARD)
-              contents.add("    set_property IOSTANDARD {{1}} [get_ports {{{2}}}]", IoStandards.getConstraintedIoStandard(info.getIoStandard()), netName);
-            final var pullBehavior = info.getPullBehavior();
-            if (pullBehavior == PullBehaviors.PULL_DOWN || pullBehavior == PullBehaviors.PULL_UP)
-              contents.add("    set_property {{1}} TRUE [get_ports {{{2}}}]", PullBehaviors.getConstrainedPullString(pullBehavior), netName);
+            addIoProperties(contents, info.getIoStandard(), info.getPullBehavior(), info.getDrive(), netName);
           }
         }
       }
     }
-    final var LedArrayMap = DownloadBase.getScanningMaps(mapInfo, rootNetList, boardInfo);
-    for (final var key : LedArrayMap.keySet()) {
-      contents.add("set_property PACKAGE_PIN {{1}} [get_ports {{{2}}}]", key, LedArrayMap.get(key));
+    final var ledArrayMap = DownloadBase.getScanningMaps(mapInfo, rootNetList, boardInfo);
+    for (final var pin : ledArrayMap) {
+      contents.add("set_property PACKAGE_PIN {{1}} [get_ports {{{2}}}]", pin.pinLocation(), pin.hdlSignal());
+      addIoProperties(contents, pin.ioStandard(), pin.pullBehavior(), pin.driveStrength(), pin.hdlSignal());
     }
     return contents.get();
+  }
+
+  private static void addIoProperties(
+      LineBuffer contents, char ioStandard, char pullBehavior, char driveStrength, String netName) {
+    if (ioStandard != IoStandards.UNKNOWN && ioStandard != IoStandards.DEFAULT_STANDARD) {
+      contents.add(
+          "    set_property IOSTANDARD {{1}} [get_ports {{{2}}}]",
+          IoStandards.getConstraintedIoStandard(ioStandard),
+          netName);
+    }
+    if (pullBehavior == PullBehaviors.PULL_DOWN || pullBehavior == PullBehaviors.PULL_UP) {
+      contents.add(
+          "    set_property {{1}} TRUE [get_ports {{{2}}}]",
+          PullBehaviors.getConstrainedPullString(pullBehavior),
+          netName);
+    }
+    if (driveStrength != DriveStrength.UNKNOWN && driveStrength != DriveStrength.DEFAULT_STENGTH) {
+      contents.add(
+          "    set_property DRIVE {{1}} [get_ports {{{2}}}]",
+          DriveStrength.getConstrainedDriveStrength(driveStrength).trim(),
+          netName);
+    }
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/fpga/download/XilinxDownload.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/XilinxDownload.java
@@ -296,9 +296,30 @@ public class XilinxDownload implements VendorDownload {
         }
       }
     }
-    final var LedArrayMap = DownloadBase.getScanningMaps(mapInfo, rootNetList, boardInfo);
-    for (var key : LedArrayMap.keySet()) {
-      contents.add("NET \"" + LedArrayMap.get(key) + "\" LOC=\"" + key + "\";");
+    final var ledArrayMap = DownloadBase.getScanningMaps(mapInfo, rootNetList, boardInfo);
+    for (var pin : ledArrayMap) {
+      temp.setLength(0);
+      temp.append("NET \"").append(pin.hdlSignal()).append("\" ");
+      temp.append("LOC = \"").append(pin.pinLocation()).append("\" ");
+      if (pin.pullBehavior() != PullBehaviors.UNKNOWN && pin.pullBehavior() != PullBehaviors.FLOAT) {
+        temp.append("| ")
+            .append(PullBehaviors.getConstrainedPullString(pin.pullBehavior()))
+            .append(" ");
+      }
+      if (pin.driveStrength() != DriveStrength.UNKNOWN
+          && pin.driveStrength() != DriveStrength.DEFAULT_STENGTH) {
+        temp.append("| DRIVE = ")
+            .append(DriveStrength.getConstrainedDriveStrength(pin.driveStrength()))
+            .append(" ");
+      }
+      if (pin.ioStandard() != IoStandards.UNKNOWN
+          && pin.ioStandard() != IoStandards.DEFAULT_STANDARD) {
+        temp.append("| IOSTANDARD = ")
+            .append(IoStandards.getConstraintedIoStandard(pin.ioStandard()))
+            .append(" ");
+      }
+      temp.append(";");
+      contents.add(temp.toString());
     }
     return contents;
   }

--- a/src/test/java/com/cburch/logisim/fpga/download/ScanningConstraintTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/download/ScanningConstraintTest.java
@@ -1,0 +1,160 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.fpga.download;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.fpga.data.BoardInformation;
+import com.cburch.logisim.fpga.data.DriveStrength;
+import com.cburch.logisim.fpga.data.FpgaIoInformationContainer;
+import com.cburch.logisim.fpga.data.IoComponentTypes;
+import com.cburch.logisim.fpga.data.IoComponentsInformation;
+import com.cburch.logisim.fpga.data.IoStandards;
+import com.cburch.logisim.fpga.data.MappableResourcesContainer;
+import com.cburch.logisim.fpga.data.PinActivity;
+import com.cburch.logisim.fpga.data.PullBehaviors;
+import com.cburch.logisim.fpga.data.SevenSegmentScanningDriving;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ScanningConstraintTest {
+
+  @Test
+  void vivadoScanningConstraintsUsePinLocationsAndIoStandards() throws Exception {
+    final var board = createBoard();
+    final var netlist = createNetlistWithoutUserClock();
+    final var downloader =
+        new VivadoDownload("build/test-scanning-constraints", netlist, board, List.of(), List.of());
+    downloader.setMapableResources(createScanningResources());
+
+    final var constraints = getPinLocStrings(downloader);
+
+    assertTrue(
+        constraints.contains("set_property PACKAGE_PIN T5 [get_ports {Displ0_Segment_A}]"),
+        () -> String.join("\n", constraints));
+    assertTrue(
+        constraints.contains(
+            "    set_property IOSTANDARD LVCMOS33 [get_ports {Displ0_Segment_A}]"));
+    assertTrue(constraints.contains("set_property PACKAGE_PIN P9 [get_ports {Displ0Select[0]}]"));
+    assertTrue(constraints.contains("set_property PACKAGE_PIN N14 [get_ports {fpgaGlobalClock}]"));
+    assertTrue(
+        constraints.contains("    set_property IOSTANDARD LVCMOS33 [get_ports {fpgaGlobalClock}]"));
+    assertFalse(constraints.contains("set_property PACKAGE_PIN Displ0_Segment_A [get_ports {T5}]"));
+  }
+
+  @Test
+  void xilinxScanningConstraintsUsePinLocationsAndIoStandards() throws Exception {
+    final var board = createBoard();
+    final var netlist = createNetlistWithoutUserClock();
+    final var downloader =
+        new XilinxDownload(
+            "build/test-scanning-constraints",
+            netlist,
+            board,
+            List.of(),
+            List.of(),
+            HdlGeneratorFactory.VHDL,
+            false);
+    downloader.setMapableResources(createScanningResources());
+
+    final var constraints = getPinLocStrings(downloader);
+
+    assertTrue(
+        constraints.stream()
+            .anyMatch(
+                line ->
+                    line.startsWith("NET \"Displ0_Segment_A\" LOC = \"T5\"")
+                        && line.contains("PULLUP")
+                        && line.contains("DRIVE = 4")
+                        && line.contains("IOSTANDARD = LVCMOS33")),
+        () -> String.join("\n", constraints));
+    assertTrue(
+        constraints.stream()
+            .anyMatch(
+                line ->
+                    line.startsWith("NET \"Displ0Select[0]\" LOC = \"P9\"")
+                        && line.contains("PULLUP")
+                        && line.contains("DRIVE = 4")
+                        && line.contains("IOSTANDARD = LVCMOS33")));
+    assertTrue(
+        constraints.contains("NET \"fpgaGlobalClock\" LOC = \"N14\" | IOSTANDARD = LVCMOS33 ;"));
+    assertFalse(constraints.contains("NET \"T5\" LOC=\"Displ0_Segment_A\";"));
+  }
+
+  private static BoardInformation createBoard() {
+    final var board = new BoardInformation();
+    board.fpga.set(
+        100_000_000,
+        "N14",
+        "Float",
+        "LVCMOS33",
+        "Artix-7",
+        "xc7a35t",
+        "ftg256",
+        "-1",
+        "VIVADO",
+        "Float",
+        false,
+        "1",
+        "",
+        "2");
+    return board;
+  }
+
+  private static Netlist createNetlistWithoutUserClock() {
+    final var netlist = mock(Netlist.class);
+    when(netlist.numberOfClockTrees()).thenReturn(0);
+    when(netlist.requiresGlobalClockConnection()).thenReturn(false);
+    return netlist;
+  }
+
+  private static MappableResourcesContainer createScanningResources() {
+    final var segment = mock(FpgaIoInformationContainer.class);
+    when(segment.getType()).thenReturn(IoComponentTypes.SevenSegmentScanning);
+    when(segment.hasMap()).thenReturn(true);
+    when(segment.getArrayDriveMode()).thenReturn(SevenSegmentScanningDriving.SEVEN_SEG_SCANNING_ACTIVE_LOW);
+    when(segment.getNrOfRows()).thenReturn(4);
+    when(segment.getNrOfColumns()).thenReturn(-1);
+    when(segment.getArrayId()).thenReturn(0);
+    when(segment.getExternalPinCount()).thenReturn(12);
+    final var pins = List.of("T5", "R5", "T9", "R6", "R7", "T7", "T8", "T10", "P9", "N9", "R8", "P8");
+    for (var index = 0; index < pins.size(); index++) {
+      when(segment.getPinLocation(index)).thenReturn(pins.get(index));
+    }
+    when(segment.getIoStandard()).thenReturn(IoStandards.LVCMOS33);
+    when(segment.getPullBehavior()).thenReturn(PullBehaviors.PULL_UP);
+    when(segment.getDrive()).thenReturn(DriveStrength.DRIVE_4);
+    when(segment.getActivityLevel()).thenReturn(PinActivity.ACTIVE_LOW);
+
+    final var ioComponents = mock(IoComponentsInformation.class);
+    when(ioComponents.getComponents()).thenReturn(List.of(segment));
+
+    final var resources = mock(MappableResourcesContainer.class);
+    when(resources.getMappableResources()).thenReturn(Collections.emptyMap());
+    when(resources.getIoComponentInformation()).thenReturn(ioComponents);
+    return resources;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<String> getPinLocStrings(Object downloader)
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    final Method method = downloader.getClass().getDeclaredMethod("getPinLocStrings");
+    method.setAccessible(true);
+    return (List<String>) method.invoke(downloader);
+  }
+}


### PR DESCRIPTION
Summary
- represent scanning-array external pins as structured HDL signal / FPGA pin / I/O attribute entries
- write scanning-array constraints with the correct signal/pin order for Vivado, Xilinx ISE, Altera, and OpenFPGA
- emit IOSTANDARD/PULL/DRIVE metadata for scanning resources, including the implicit fpgaGlobalClock required by scanned arrays
- add regression coverage for Vivado and Xilinx scanning constraints

Fixes #2117

Verification
- .\gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.fpga.download.ScanningConstraintTest checkstyleMain checkstyleTest --rerun-tasks
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check