### PR TITLE
appearance: repair dynamic element paths

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitMutatorImpl.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitMutatorImpl.java
@@ -9,6 +9,7 @@
 
 package com.cburch.logisim.circuit;
 
+import com.cburch.logisim.circuit.appear.DynamicElementProvider;
 import com.cburch.logisim.comp.Component;
 import com.cburch.logisim.data.Attribute;
 import java.util.ArrayList;
@@ -50,6 +51,7 @@ class CircuitMutatorImpl implements CircuitMutator {
     final var repl = new ReplacementMap();
     for (final var comp : comps) repl.remove(comp);
     getMap(circuit).append(repl);
+    DynamicElementProvider.repairDynamicElementPaths(circuit, repl);
 
     circuit.mutatorClear();
   }
@@ -93,6 +95,7 @@ class CircuitMutatorImpl implements CircuitMutator {
       final var repl = new ReplacementMap();
       repl.remove(comp);
       getMap(circuit).append(repl);
+      DynamicElementProvider.repairDynamicElementPaths(circuit, repl);
 
       circuit.mutatorRemove(comp);
     }
@@ -111,6 +114,7 @@ class CircuitMutatorImpl implements CircuitMutator {
 
       repl.freeze();
       getMap(circuit).append(repl);
+      DynamicElementProvider.repairDynamicElementPaths(circuit, repl);
 
       for (final var component : repl.getRemovals()) {
         circuit.mutatorRemove(component);

--- a/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearance.java
@@ -17,6 +17,7 @@ import com.cburch.draw.model.Drawing;
 import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.CircuitAttributes;
 import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.circuit.ReplacementMap;
 import com.cburch.logisim.data.AttributeEvent;
 import com.cburch.logisim.data.AttributeListener;
 import com.cburch.logisim.data.AttributeOption;
@@ -438,6 +439,35 @@ public class CircuitAppearance extends Drawing implements AttributeListener {
       suppressRecompute = oldSuppress;
     }
     fireCircuitAppearanceChanged(CircuitAppearanceEvent.ALL_TYPES);
+  }
+
+  public void repairDynamicElementPaths(ReplacementMap replacements) {
+    final var removals = replacements.getRemovals();
+    if (removals.isEmpty()) return;
+
+    var changed = false;
+    final var toRemove = new ArrayList<CanvasObject>();
+    for (final var obj : super.getObjectsFromBottom()) {
+      if (obj instanceof DynamicElement el && el.getPath().containsAny(removals)) {
+        if (el.getPath().replaceComponents(replacements)) {
+          changed = true;
+        } else {
+          toRemove.add(obj);
+        }
+      }
+    }
+
+    if (!toRemove.isEmpty()) {
+      var oldSuppress = suppressRecompute;
+      try {
+        suppressRecompute = true;
+        removeObjects(toRemove);
+      } finally {
+        suppressRecompute = oldSuppress;
+      }
+      changed = true;
+    }
+    if (changed) fireCircuitAppearanceChanged(CircuitAppearanceEvent.ALL_TYPES);
   }
 
   void replaceAutomatically(List<AppearancePort> removes, List<AppearancePort> adds) {

--- a/src/main/java/com/cburch/logisim/circuit/appear/DynamicElement.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DynamicElement.java
@@ -20,6 +20,7 @@ import com.cburch.draw.shapes.SvgCreator;
 import com.cburch.draw.shapes.SvgReader;
 import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.circuit.ReplacementMap;
 import com.cburch.logisim.circuit.SubcircuitFactory;
 import com.cburch.logisim.comp.Component;
 import com.cburch.logisim.data.Attribute;
@@ -35,6 +36,7 @@ import com.cburch.logisim.util.UnmodifiableList;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics;
+import java.util.Collection;
 import java.util.List;
 import org.w3c.dom.Element;
 
@@ -76,8 +78,38 @@ public abstract class DynamicElement extends AbstractCanvasObject {
       return false;
     }
 
+    public boolean containsAny(Collection<? extends Component> comps) {
+      for (final var comp : comps) {
+        if (contains(comp)) return true;
+      }
+      return false;
+    }
+
     public InstanceComponent leaf() {
       return elt[elt.length - 1];
+    }
+
+    public boolean replaceComponents(ReplacementMap replacements) {
+      for (var i = 0; i < elt.length; i++) {
+        final var oldComponent = elt[i];
+        final var replacement = findReplacement(oldComponent, replacements.getReplacementsFor(oldComponent));
+        if (replacement == null) return false;
+        elt[i] = replacement;
+      }
+      return true;
+    }
+
+    private static InstanceComponent findReplacement(
+        InstanceComponent oldComponent, Collection<Component> candidates) {
+      if (candidates == null) return oldComponent;
+      for (final var candidate : candidates) {
+        if (candidate == oldComponent) return oldComponent;
+        if (candidate instanceof InstanceComponent instanceComponent
+            && candidate.getFactory() == oldComponent.getFactory()) {
+          return instanceComponent;
+        }
+      }
+      return null;
     }
 
     @Override

--- a/src/main/java/com/cburch/logisim/circuit/appear/DynamicElementProvider.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/DynamicElementProvider.java
@@ -10,6 +10,7 @@
 package com.cburch.logisim.circuit.appear;
 
 import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.ReplacementMap;
 import com.cburch.logisim.comp.Component;
 import com.cburch.logisim.instance.InstanceComponent;
 import java.util.HashSet;
@@ -19,8 +20,7 @@ public interface DynamicElementProvider {
 
   DynamicElement createDynamicElement(int x, int y, DynamicElement.Path path);
 
-  static void removeDynamicElements(Circuit circuit, Component comp) {
-    if (!(comp instanceof InstanceComponent)) return;
+  private static HashSet<Circuit> collectAffectedCircuits(Circuit circuit) {
     final var allAffected = new HashSet<Circuit>();
     final var todo = new LinkedList<Circuit>();
     todo.add(circuit);
@@ -31,7 +31,18 @@ public interface DynamicElementProvider {
       for (final var other : circ.getCircuitsUsingThis())
         if (!allAffected.contains(other)) todo.add(other);
     }
-    for (final var circ : allAffected)
+    return allAffected;
+  }
+
+  static void removeDynamicElements(Circuit circuit, Component comp) {
+    if (!(comp instanceof InstanceComponent)) return;
+    for (final var circ : collectAffectedCircuits(circuit))
       circ.getAppearance().removeDynamicElement((InstanceComponent) comp);
+  }
+
+  static void repairDynamicElementPaths(Circuit circuit, ReplacementMap replacements) {
+    if (replacements.isEmpty()) return;
+    for (final var circ : collectAffectedCircuits(circuit))
+      circ.getAppearance().repairDynamicElementPaths(replacements);
   }
 }

--- a/src/test/java/com/cburch/logisim/circuit/appear/DynamicElementTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/appear/DynamicElementTest.java
@@ -9,17 +9,22 @@
 
 package com.cburch.logisim.circuit.appear;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.circuit.ReplacementMap;
+import com.cburch.logisim.comp.ComponentFactory;
 import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.instance.InstanceComponent;
 import com.cburch.logisim.instance.InstanceState;
 import java.awt.Graphics;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -81,6 +86,97 @@ class DynamicElementTest {
     when(outerState.getData(subcircuit)).thenReturn(new Object());
 
     assertThrows(IllegalStateException.class, () -> element.resolveInstanceState(outerState));
+  }
+
+  @Test
+  void pathReplacementUpdatesMovedLeafComponent() {
+    final var factory = mock(ComponentFactory.class);
+    final var oldLeaf = mock(InstanceComponent.class);
+    final var newLeaf = mock(InstanceComponent.class);
+    final var path = new DynamicElement.Path(new InstanceComponent[] {oldLeaf});
+    final var replacements = new ReplacementMap(oldLeaf, newLeaf);
+
+    when(oldLeaf.getFactory()).thenReturn(factory);
+    when(newLeaf.getFactory()).thenReturn(factory);
+
+    assertTrue(path.replaceComponents(replacements));
+    assertSame(newLeaf, path.leaf());
+  }
+
+  @Test
+  void pathReplacementUpdatesMovedIntermediateComponent() {
+    final var subcircuitFactory = mock(ComponentFactory.class);
+    final var oldSubcircuit = mock(InstanceComponent.class);
+    final var newSubcircuit = mock(InstanceComponent.class);
+    final var leaf = mock(InstanceComponent.class);
+    final var path = new DynamicElement.Path(new InstanceComponent[] {oldSubcircuit, leaf});
+    final var replacements = new ReplacementMap(oldSubcircuit, newSubcircuit);
+
+    when(oldSubcircuit.getFactory()).thenReturn(subcircuitFactory);
+    when(newSubcircuit.getFactory()).thenReturn(subcircuitFactory);
+
+    assertTrue(path.replaceComponents(replacements));
+    assertSame(newSubcircuit, path.elt[0]);
+    assertSame(leaf, path.leaf());
+  }
+
+  @Test
+  void pathReplacementRejectsRemovedComponent() {
+    final var subcircuit = mock(InstanceComponent.class);
+    final var leaf = mock(InstanceComponent.class);
+    final var path = new DynamicElement.Path(new InstanceComponent[] {subcircuit, leaf});
+    final var replacements = new ReplacementMap();
+    replacements.remove(subcircuit);
+
+    assertFalse(path.replaceComponents(replacements));
+  }
+
+  @Test
+  void pathReplacementRejectsDifferentReplacementFactory() {
+    final var oldFactory = mock(ComponentFactory.class);
+    final var newFactory = mock(ComponentFactory.class);
+    final var oldLeaf = mock(InstanceComponent.class);
+    final var newLeaf = mock(InstanceComponent.class);
+    final var path = new DynamicElement.Path(new InstanceComponent[] {oldLeaf});
+    final var replacements = new ReplacementMap(oldLeaf, newLeaf);
+
+    when(oldLeaf.getFactory()).thenReturn(oldFactory);
+    when(newLeaf.getFactory()).thenReturn(newFactory);
+
+    assertFalse(path.replaceComponents(replacements));
+  }
+
+  @Test
+  void appearanceRepairUpdatesDynamicElementPath() {
+    final var factory = mock(ComponentFactory.class);
+    final var oldLeaf = mock(InstanceComponent.class);
+    final var newLeaf = mock(InstanceComponent.class);
+    final var element = new TestDynamicElement(new DynamicElement.Path(new InstanceComponent[] {oldLeaf}));
+    final var appearance = new CircuitAppearance(null);
+    final var replacements = new ReplacementMap(oldLeaf, newLeaf);
+
+    when(oldLeaf.getFactory()).thenReturn(factory);
+    when(newLeaf.getFactory()).thenReturn(factory);
+
+    appearance.addObjects(0, List.of(element));
+    appearance.repairDynamicElementPaths(replacements);
+
+    assertSame(newLeaf, element.getPath().leaf());
+    assertTrue(appearance.getCustomObjectsFromBottom().contains(element));
+  }
+
+  @Test
+  void appearanceRepairRemovesDynamicElementWhenPathCannotBeUpdated() {
+    final var oldLeaf = mock(InstanceComponent.class);
+    final var element = new TestDynamicElement(new DynamicElement.Path(new InstanceComponent[] {oldLeaf}));
+    final var appearance = new CircuitAppearance(null);
+    final var replacements = new ReplacementMap();
+    replacements.remove(oldLeaf);
+
+    appearance.addObjects(0, List.of(element));
+    appearance.repairDynamicElementPaths(replacements);
+
+    assertFalse(appearance.getCustomObjectsFromBottom().contains(element));
   }
 
   private static class TestDynamicElement extends DynamicElement {

--- a/src/test/java/com/cburch/logisim/circuit/appear/DynamicElementTransactionTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/appear/DynamicElementTransactionTest.java
@@ -1,0 +1,75 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.circuit.appear;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.file.Loader;
+import com.cburch.logisim.file.LogisimFile;
+import com.cburch.logisim.instance.InstanceComponent;
+import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.memory.Register;
+import com.cburch.logisim.std.memory.RegisterShape;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DynamicElementTransactionTest {
+
+  @Test
+  void componentReplacementUpdatesDynamicElementPath() {
+    final var fixture = new Fixture();
+    final var registerFactory = new Register();
+    final var register =
+        registerFactory.createComponent(
+            Location.create(100, 100, true), registerFactory.createAttributeSet());
+    add(fixture.circuit, register);
+
+    final var shape =
+        new RegisterShape(
+            10, 10, new DynamicElement.Path(new InstanceComponent[] {(InstanceComponent) register}));
+    fixture.circuit.getAppearance().addObjects(0, List.of(shape));
+
+    final var movedRegister =
+        registerFactory.createComponent(Location.create(140, 100, true), register.getAttributeSet());
+    replace(fixture.circuit, register, movedRegister);
+
+    assertTrue(fixture.circuit.getAppearance().getCustomObjectsFromBottom().contains(shape));
+    assertSame(movedRegister, shape.getPath().leaf());
+  }
+
+  private static final class Fixture {
+    private final Circuit circuit;
+
+    private Fixture() {
+      final var file = LogisimFile.createNew(new Loader(null), null);
+      final var project = new Project(file);
+      circuit = file.getMainCircuit();
+      circuit.setProject(project);
+      project.setCurrentCircuit(circuit);
+    }
+  }
+
+  private static void add(Circuit circuit, Component component) {
+    final var mutation = new CircuitMutation(circuit);
+    mutation.add(component);
+    mutation.execute();
+  }
+
+  private static void replace(Circuit circuit, Component oldComponent, Component newComponent) {
+    final var mutation = new CircuitMutation(circuit);
+    mutation.replace(oldComponent, newComponent);
+    mutation.execute();
+  }
+}


### PR DESCRIPTION
Summary
- keep custom-appearance dynamic element paths in sync when referenced components are moved or replaced
- remove dynamic appearance elements when a referenced component is deleted and cannot be repaired
- cover path repair, invalid removal, and a real CircuitMutation replacement of a Register dynamic element

Root cause
Dynamic appearance elements serialize target components by factory name and location. Moving a referenced component replaces the Component instance, but the saved dynamic path was not repaired. If the referenced component was an intermediate subcircuit, the old cleanup path did not remove or update the dynamic element, so the next file load could fail with a missing component location.

Verification
- .\\gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.circuit.appear.DynamicElementTest --tests com.cburch.logisim.circuit.appear.DynamicElementTransactionTest checkstyleMain checkstyleTest --rerun-tasks
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check

Fixes #2393
