### PR TITLE
docs: add FPGA Commander report help

### DIFF
--- a/src/main/resources/doc/en/contents.xml
+++ b/src/main/resources/doc/en/contents.xml
@@ -92,7 +92,7 @@
 <!--	<tocitem target="prefs_simulation" text="The  simulation tab"/> -->
 			<tocitem target="prefs_exp" text="The Experimental tab" />
 <!--	<tocitem target="prefs_sofware" text="The Sofware tab"/> -->
-<!--	<tocitem target="prefs_fpga" text="The FPGA Commander settings tab"/> -->
+			<tocitem target="prefs_fpga" text="The FPGA Commander settings tab"/>
 			<tocitem target="prefs_cmdline" text="The command line" />
 		</tocitem>
 		<tocitem target="opts" text="Project options">

--- a/src/main/resources/doc/en/html/guide/prefs/pref-fpgacommander.html
+++ b/src/main/resources/doc/en/html/guide/prefs/pref-fpgacommander.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>
+      The FPGA Commander Settings tab
+    </title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        The FPGA Commander Settings tab
+      </h1>
+      <p>
+        This tab contains application-wide preferences used by the FPGA Commander.
+      </p>
+      <ul>
+        <li>
+          <p>
+            <b>Workspace location:</b> Selects the directory where FPGA Commander writes generated HDL files, scripts, constraints, and tool output.
+          </p>
+        </li>
+        <li>
+          <p>
+            <b>Hardware description language:</b> Selects the HDL used for FPGA projects.
+          </p>
+        </li>
+        <li>
+          <p>
+            <b>VHDL options:</b> Controls VHDL generation preferences, such as whether generated VHDL keywords are written in upper case.
+          </p>
+        </li>
+        <li>
+          <p>
+            <b>Board editor colors:</b> Configures the colors used while defining components on an FPGA board image.
+          </p>
+        </li>
+        <li>
+          <p>
+            <b>Board map colors:</b> Configures the colors used while mapping circuit components to FPGA board resources.
+          </p>
+        </li>
+        <li>
+          <p>
+            <b>DRC reporter options:</b> Controls whether selected design-rule-check warnings, such as gated-clock and open-input warnings, are shown in the FPGA Commander report.
+          </p>
+        </li>
+      </ul>
+      <h2>
+        FPGA Commander reports
+      </h2>
+      <p>
+        The FPGA Commander report area contains tabs for information messages, warnings, errors, and console output. Because the embedded report tabs are small, you can double-click a report tab to detach it into a separate resizable window. Closing the detached window returns the tab to the FPGA Commander.
+      </p>
+      <p>
+        Warning and error entries that include a DRC icon are linked to objects in the circuit. Selecting such an entry highlights the related circuit elements with red markers. Selecting another DRC entry moves the highlight, and closing a detached warning or error window clears the active highlight.
+      </p>
+      <p>
+        <b>Next:</b> <a href="pref-cmdline.html">The Command-line options</a>.
+      </p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/map_en.jhm
+++ b/src/main/resources/doc/map_en.jhm
@@ -74,6 +74,7 @@
 	<mapID target="prefs_window"        url="en/html/guide/prefs/pref-window.html" />
 	<mapID target="prefs_layout"        url="en/html/guide/prefs/pref-layout.html" />
 	<mapID target="prefs_exp"           url="en/html/guide/prefs/pref-exp.html" />
+	<mapID target="prefs_fpga"          url="en/html/guide/prefs/pref-fpgacommander.html" />
 	<mapID target="prefs_cmdline"       url="en/html/guide/prefs/pref-cmdline.html" />
 	<mapID target="opts"                url="en/html/guide/opts/index.html" />
 	<mapID target="opts_simulate"       url="en/html/guide/opts/opts-simulate.html" />


### PR DESCRIPTION
Summary
- add the missing English FPGA Commander settings help page
- document the report tabs, detached report windows, and DRC-linked warning/error highlighting
- register the page in the English JavaHelp map and table of contents

Verification
- Parsed src/main/resources/doc/en/contents.xml
- Parsed src/main/resources/doc/map_en.jhm
- Verified prefs_fpga maps to an existing HTML file
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check

Notes
- This updates the English help page only. Translation placeholders can be added if maintainers prefer them in this PR.

Closes #2475
Closes #2476