### PR TITLE
appearance: switch edited circuits to custom appearance

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/appear/CanvasActionAdapter.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/CanvasActionAdapter.java
@@ -12,9 +12,11 @@ package com.cburch.logisim.gui.appear;
 import com.cburch.draw.actions.ModelAction;
 import com.cburch.draw.undo.UndoAction;
 import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.CircuitAttributes;
 import com.cburch.logisim.circuit.CircuitMutator;
 import com.cburch.logisim.circuit.CircuitTransaction;
 import com.cburch.logisim.circuit.appear.AppearanceElement;
+import com.cburch.logisim.data.AttributeOption;
 import com.cburch.logisim.proj.Project;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,10 +24,13 @@ import java.util.Map;
 public class CanvasActionAdapter extends com.cburch.logisim.proj.Action {
   private final Circuit circuit;
   private final UndoAction canvasAction;
+  private final AttributeOption previousAppearance;
 
   public CanvasActionAdapter(Circuit circuit, UndoAction action) {
     this.circuit = circuit;
     this.canvasAction = action;
+    previousAppearance =
+        circuit.getStaticAttributes().getValue(CircuitAttributes.APPEARANCE_ATTR);
   }
 
   private boolean affectsPorts() {
@@ -43,6 +48,7 @@ public class CanvasActionAdapter extends com.cburch.logisim.proj.Action {
       final var xn = new ActionTransaction(true);
       xn.execute();
     } else {
+      setCustomAppearance();
       canvasAction.doIt();
     }
   }
@@ -59,6 +65,25 @@ public class CanvasActionAdapter extends com.cburch.logisim.proj.Action {
       xn.execute();
     } else {
       canvasAction.undo();
+      restorePreviousAppearance();
+    }
+  }
+
+  private boolean shouldManageAppearanceAttribute() {
+    return previousAppearance != CircuitAttributes.APPEAR_CUSTOM;
+  }
+
+  private void setCustomAppearance() {
+    if (shouldManageAppearanceAttribute()) {
+      circuit.getStaticAttributes()
+          .setValue(CircuitAttributes.APPEARANCE_ATTR, CircuitAttributes.APPEAR_CUSTOM);
+    }
+  }
+
+  private void restorePreviousAppearance() {
+    if (shouldManageAppearanceAttribute()) {
+      circuit.getStaticAttributes()
+          .setValue(CircuitAttributes.APPEARANCE_ATTR, previousAppearance);
     }
   }
 
@@ -81,9 +106,11 @@ public class CanvasActionAdapter extends com.cburch.logisim.proj.Action {
     @Override
     protected void run(CircuitMutator mutator) {
       if (forward) {
+        setCustomAppearance();
         canvasAction.doIt();
       } else {
         canvasAction.undo();
+        restorePreviousAppearance();
       }
     }
   }

--- a/src/test/java/com/cburch/logisim/gui/appear/CanvasActionAdapterTest.java
+++ b/src/test/java/com/cburch/logisim/gui/appear/CanvasActionAdapterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.appear;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.draw.actions.ModelAddAction;
+import com.cburch.draw.shapes.Rectangle;
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.CircuitAttributes;
+import org.junit.jupiter.api.Test;
+
+class CanvasActionAdapterTest {
+
+  @Test
+  void drawingEditSwitchesCircuitToCustomAndUndoRestoresPreviousAppearance() {
+    final var circuit = new Circuit("main", null, null);
+    circuit.getStaticAttributes()
+        .setValue(CircuitAttributes.APPEARANCE_ATTR, CircuitAttributes.APPEAR_CLASSIC);
+    final var model = circuit.getAppearance().getCustomAppearanceDrawing();
+    final var rectangle = new Rectangle(10, 10, 30, 20);
+    final var action = new CanvasActionAdapter(circuit, new ModelAddAction(model, rectangle));
+
+    action.doIt(null);
+
+    assertEquals(
+        CircuitAttributes.APPEAR_CUSTOM,
+        circuit.getStaticAttributes().getValue(CircuitAttributes.APPEARANCE_ATTR));
+    assertTrue(circuit.getAppearance().getCustomObjectsFromBottom().contains(rectangle));
+
+    action.undo(null);
+
+    assertEquals(
+        CircuitAttributes.APPEAR_CLASSIC,
+        circuit.getStaticAttributes().getValue(CircuitAttributes.APPEARANCE_ATTR));
+    assertFalse(circuit.getAppearance().getCustomObjectsFromBottom().contains(rectangle));
+
+    action.doIt(null);
+
+    assertEquals(
+        CircuitAttributes.APPEAR_CUSTOM,
+        circuit.getStaticAttributes().getValue(CircuitAttributes.APPEARANCE_ATTR));
+    assertTrue(circuit.getAppearance().getCustomObjectsFromBottom().contains(rectangle));
+  }
+
+  @Test
+  void undoKeepsCustomAppearanceWhenCircuitWasAlreadyCustom() {
+    final var circuit = new Circuit("main", null, null);
+    circuit.getStaticAttributes()
+        .setValue(CircuitAttributes.APPEARANCE_ATTR, CircuitAttributes.APPEAR_CUSTOM);
+    final var model = circuit.getAppearance().getCustomAppearanceDrawing();
+    final var rectangle = new Rectangle(10, 10, 30, 20);
+    final var action = new CanvasActionAdapter(circuit, new ModelAddAction(model, rectangle));
+
+    action.doIt(null);
+    action.undo(null);
+
+    assertEquals(
+        CircuitAttributes.APPEAR_CUSTOM,
+        circuit.getStaticAttributes().getValue(CircuitAttributes.APPEARANCE_ATTR));
+    assertFalse(circuit.getAppearance().getCustomObjectsFromBottom().contains(rectangle));
+  }
+}


### PR DESCRIPTION
Summary
- automatically switch a circuit's Appearance attribute to Custom when an appearance-editor drawing action modifies its custom appearance
- preserve undo/redo behavior by restoring the previous default appearance when the first custom edit is undone
- add regression coverage for default-to-custom editing and already-custom editing

Root cause
The appearance editor updated the custom drawing model, but circuits that still had Classic/Evolution/Holy Cross selected continued to render the generated default appearance. This made custom edits look like they had no effect until the user manually changed the circuit Appearance property to Custom.

Verification
- ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.gui.appear.CanvasActionAdapterTest --tests com.cburch.logisim.gui.appear.AppearanceViewTest checkstyleMain checkstyleTest --rerun-tasks
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check

Closes #1780