### PR TITLE
chrono: fix real-time timing diagram recording

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/log/Model.java
+++ b/src/main/java/com/cburch/logisim/gui/log/Model.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.LongSupplier;
 
 public class Model implements CircuitListener, SignalInfo.Listener {
 
@@ -74,6 +75,7 @@ public class Model implements CircuitListener, SignalInfo.Listener {
   }
 
   final CircuitState circuitState;
+  private final LongSupplier nanoTime;
   private final ArrayList<SignalInfo> info = new ArrayList<>();
   private final ArrayList<Signal> signals = new ArrayList<>();
   private long timeEnd = -1; // signals go from 0 <= t < tEnd
@@ -95,7 +97,12 @@ public class Model implements CircuitListener, SignalInfo.Listener {
   private long lastRealtimeUpdate;
 
   public Model(CircuitState root) {
+    this(root, System::nanoTime);
+  }
+
+  Model(CircuitState root, LongSupplier nanoTime) {
     circuitState = root;
+    this.nanoTime = nanoTime;
     // Add top-level pins, clocks, etc.
     final var circ = circuitState.getCircuit();
     for (final var comp : circ.getNonWires()) {
@@ -346,7 +353,11 @@ public class Model implements CircuitListener, SignalInfo.Listener {
           (mode == CLOCK_DUAL) ? (curClockVal.equals(Value.FALSE) ? cc.lo : cc.hi) : cc.ticks;
       return timeScale * ticks;
     }
-    return mode == STEP ? timeScale : gateDelay;
+    return mode == STEP ? timeScale : getRealTimeEventDuration();
+  }
+
+  private long getRealTimeEventDuration() {
+    return Math.min(gateDelay, timeScale);
   }
 
   public int getHistoryLimit() {
@@ -617,10 +628,32 @@ public class Model implements CircuitListener, SignalInfo.Listener {
   }
 
   private void updateSignalsRealMode() {
-    long now = System.nanoTime();
+    long now = nanoTime.getAsLong();
     double duration = (now - lastRealtimeUpdate) * (double) timeScale / 1000000000;
-    extendWithNewValues(Math.max((long) duration, 1));
+    extendRealTimeWithNewValues(Math.max((long) duration, 1));
     lastRealtimeUpdate = now;
+  }
+
+  private void extendRealTimeWithNewValues(long elapsedDuration) {
+    final var values = new Value[signals.size()];
+    var valuesChanged = timeEnd <= 0;
+    for (var i = 0; i < signals.size(); i++) {
+      final var s = signals.get(i);
+      final var v = s.info.fetchValue(circuitState);
+      values[i] = v;
+      if (!valuesChanged) {
+        final var previous = s.getValue(timeEnd - 1);
+        valuesChanged = previous == null || !previous.equals(v);
+      }
+      s.extend(elapsedDuration);
+    }
+    final var eventDuration = valuesChanged ? getRealTimeEventDuration() : 0;
+    for (var i = 0; i < signals.size() && valuesChanged; i++) {
+      signals.get(i).extend(values[i], eventDuration);
+    }
+    elapsedSinceTrigger += elapsedDuration + eventDuration;
+    timeEnd += elapsedDuration + eventDuration;
+    fireSignalsExtended(null);
   }
 
   private void updateSignalsClockMode() {
@@ -697,7 +730,7 @@ public class Model implements CircuitListener, SignalInfo.Listener {
       curClockVal = clockSource.fetchValue(circuitState);
     }
     long duration = getInitialDuration();
-    if (mode == REAL) lastRealtimeUpdate = System.nanoTime();
+    if (mode == REAL) lastRealtimeUpdate = nanoTime.getAsLong();
     elapsedSinceTrigger = 0;
     for (final var s : signals) {
       final var v = s.info.fetchValue(circuitState);

--- a/src/test/java/com/cburch/logisim/gui/log/ModelTest.java
+++ b/src/test/java/com/cburch/logisim/gui/log/ModelTest.java
@@ -17,10 +17,13 @@ import com.cburch.logisim.circuit.CircuitMutation;
 import com.cburch.logisim.circuit.CircuitState;
 import com.cburch.logisim.comp.Component;
 import com.cburch.logisim.data.Location;
+import com.cburch.logisim.data.Value;
 import com.cburch.logisim.file.Loader;
 import com.cburch.logisim.file.LogisimFile;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.wiring.Clock;
+import com.cburch.logisim.std.wiring.Pin;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 
 class ModelTest {
@@ -37,6 +40,71 @@ class ModelTest {
 
     assertEquals(10_000, model.getEndTime());
     assertDoesNotThrow(() -> model.propagationCompleted(false, false, true));
+  }
+
+  @Test
+  void realTimeModeKeepsInitialValueUntilFirstObservedChange() throws Exception {
+    final var fixture = new Fixture();
+    final var pin = Pin.FACTORY.createComponent(Location.create(100, 100, true), Pin.FACTORY.createAttributeSet());
+    add(fixture.circuit, pin);
+    Pin.FACTORY.driveInputPin(fixture.state.getInstanceState(pin), Value.FALSE);
+
+    final var now = new AtomicLong(0);
+    final var model = new Model(fixture.state, now::get);
+    model.setRealMode(1_000_000_000, false);
+
+    now.set(20_000_000);
+    Pin.FACTORY.driveInputPin(fixture.state.getInstanceState(pin), Value.TRUE);
+    model.propagationCompleted(false, false, true);
+
+    final var signal = model.getSignal(0);
+    assertEquals(Value.FALSE, signal.getValue(model.getEndTime() / 2));
+    assertEquals(Value.TRUE, signal.getValue(model.getEndTime() - 1));
+  }
+
+  @Test
+  void realTimeModeInitialDurationDoesNotExceedTimeScale() {
+    final var fixture = new Fixture();
+    final var model = new Model(fixture.state);
+
+    model.setRealMode(5, false);
+
+    assertEquals(5, model.getEndTime());
+  }
+
+  @Test
+  void realTimeModeChangeDurationDoesNotExceedTimeScale() throws Exception {
+    final var fixture = new Fixture();
+    final var pin = Pin.FACTORY.createComponent(Location.create(100, 100, true), Pin.FACTORY.createAttributeSet());
+    add(fixture.circuit, pin);
+    Pin.FACTORY.driveInputPin(fixture.state.getInstanceState(pin), Value.FALSE);
+
+    final var now = new AtomicLong(0);
+    final var model = new Model(fixture.state, now::get);
+    model.setRealMode(5, false);
+
+    now.set(1_000_000_000);
+    Pin.FACTORY.driveInputPin(fixture.state.getInstanceState(pin), Value.TRUE);
+    model.propagationCompleted(false, false, true);
+
+    assertEquals(15, model.getEndTime());
+  }
+
+  @Test
+  void realTimeModeUnchangedSignalsOnlyRecordElapsedTime() throws Exception {
+    final var fixture = new Fixture();
+    final var pin = Pin.FACTORY.createComponent(Location.create(100, 100, true), Pin.FACTORY.createAttributeSet());
+    add(fixture.circuit, pin);
+    Pin.FACTORY.driveInputPin(fixture.state.getInstanceState(pin), Value.FALSE);
+
+    final var now = new AtomicLong(0);
+    final var model = new Model(fixture.state, now::get);
+    model.setRealMode(5, false);
+
+    now.set(1_000_000_000);
+    model.propagationCompleted(false, false, true);
+
+    assertEquals(10, model.getEndTime());
   }
 
   private static void add(Circuit circuit, Component component) {


### PR DESCRIPTION
Summary
- keep the previous signal value across the elapsed wall-clock interval in real-time timing diagram mode
- only append a short change marker when a recorded signal actually changes
- cap real-time placeholder durations by the selected time scale, so very small scales are not stretched by the default gate delay
- add regression coverage for shifted real-time values, unchanged real-time propagations, and small-scale real-time durations

Root cause
Real-time mode used the elapsed wall-clock duration with the newly fetched value, so the period before the first observed change was rendered using the post-change value. It also used the fixed gate delay as the initial/change placeholder duration, which made small time scales show disproportionately long short segments.

Verification
- `./gradlew.bat test --tests com.cburch.logisim.gui.log.ModelTest.realTimeModeKeepsInitialValueUntilFirstObservedChange --tests com.cburch.logisim.gui.log.ModelTest.realTimeModeInitialDurationDoesNotExceedTimeScale --tests com.cburch.logisim.gui.log.ModelTest.realTimeModeChangeDurationDoesNotExceedTimeScale --tests com.cburch.logisim.gui.log.ModelTest.realTimeModeUnchangedSignalsOnlyRecordElapsedTime`
- `./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.gui.log.ModelTest --tests com.cburch.logisim.gui.chrono.RightPanelTest checkstyleMain checkstyleTest`
- `git diff --check`

Fixes #1822
