### PR TITLE
circuit: propagate floating subcircuit inputs

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/SubcircuitFactory.java
+++ b/src/main/java/com/cburch/logisim/circuit/SubcircuitFactory.java
@@ -396,7 +396,10 @@ public class SubcircuitFactory extends InstanceFactory {
       // Accounts for 10% speedup.
       final var pinState = subState.getReusableInstanceState(pin);
       if (Pin.FACTORY.isInputPin(pin)) {
-        final var newVal = stateInContext.getPortValue(i);
+        var newVal = stateInContext.getPortValue(i);
+        if (newVal == Value.NIL) {
+          newVal = Value.createUnknown(pin.getAttributeValue(StdAttr.WIDTH));
+        }
         final var oldVal = Pin.FACTORY.getValue(pinState);
         if (!newVal.equals(oldVal)) {
           Pin.FACTORY.driveInputPin(pinState, newVal);

--- a/src/main/java/com/cburch/logisim/std/wiring/Pin.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Pin.java
@@ -1257,6 +1257,7 @@ public class Pin extends InstanceFactory {
   public void driveInputPin(InstanceState state, Value value) {
     PinAttributes attrs = (PinAttributes) state.getAttributeSet();
     PinState myState = getState(state);
+    if (value == Value.NIL) value = Value.createUnknown(attrs.width);
     // don't pull here -- instead, pull when displaying and propagating
     myState.intendedValue = value; // pull(attrs, value);
   }

--- a/src/test/java/com/cburch/logisim/circuit/CircuitStateTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/CircuitStateTest.java
@@ -14,7 +14,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.comp.EndData;
 import com.cburch.logisim.data.Location;
+import com.cburch.logisim.data.Value;
 import com.cburch.logisim.file.Loader;
 import com.cburch.logisim.file.LogisimFile;
 import com.cburch.logisim.proj.Project;
@@ -25,12 +27,14 @@ import org.junit.jupiter.api.Test;
 class CircuitStateTest {
 
   private static final class Fixture {
+    private final LogisimFile file;
+    private final Project project;
     private final Circuit circuit;
     private final CircuitState state;
 
     private Fixture() {
-      final var file = LogisimFile.createNew(new Loader(null), null);
-      final var project = new Project(file);
+      file = LogisimFile.createNew(new Loader(null), null);
+      project = new Project(file);
       circuit = file.getMainCircuit();
       circuit.setProject(project);
       project.setCurrentCircuit(circuit);
@@ -71,6 +75,39 @@ class CircuitStateTest {
 
     assertNull(fixture.state.getData(ram));
     assertNull(fixture.state.getData(pin));
+  }
+
+  @Test
+  void disconnectedSubcircuitInputPropagatesUnknownInsideSubcircuit() {
+    final var fixture = new Fixture();
+    final var child = new Circuit("child", fixture.file, fixture.project);
+    fixture.file.addCircuit(child);
+    final var input = Pin.FACTORY.createComponent(Location.create(100, 100, true), Pin.FACTORY.createAttributeSet());
+    final var outputAttrs = Pin.FACTORY.createAttributeSet();
+    outputAttrs.setValue(Pin.ATTR_TYPE, Pin.OUTPUT);
+    final var output = Pin.FACTORY.createComponent(Location.create(140, 100, true), outputAttrs);
+    add(child, input);
+    add(child, output);
+    add(child, Wire.create(input.getLocation(), output.getLocation()));
+
+    final var childInstance =
+        child
+            .getSubcircuitFactory()
+            .createComponent(Location.create(200, 100, true), child.getSubcircuitFactory().createAttributeSet());
+    add(fixture.circuit, childInstance);
+
+    final var state = CircuitState.createRootState(fixture.project, fixture.circuit, Thread.currentThread());
+    state.getPropagator().propagate();
+    state.getPropagator().propagate();
+    state.getPropagator().propagate();
+    state.getPropagator().propagate();
+
+    final var subState = child.getSubcircuitFactory().getSubstate(state, childInstance);
+    assertEquals(Value.UNKNOWN, subState.getValue(input.getLocation()));
+    assertEquals(Value.UNKNOWN, subState.getValue(output.getLocation()));
+    final var outputEnd =
+        childInstance.getEnds().stream().filter(EndData::isOutput).findFirst().orElseThrow();
+    assertEquals(Value.UNKNOWN, state.getValue(outputEnd.getLocation()));
   }
 
   private static void add(Circuit circuit, Component component) {


### PR DESCRIPTION
Fixes #1441.

Summary
- treat disconnected subcircuit input ports as unknown before driving the child input pin
- keep Pin input state from storing widthless NIL values, so floating parent inputs cannot collapse to the pin default 0
- add regression coverage for a disconnected subcircuit input feeding an internal wire/output

Root cause
- a floating subcircuit input arrives as Value.NIL, which has no bit width
- when that NIL value was stored in the child Pin state, Pin.getState() later extended it using the simple input pin's default bit value, turning it into 0

Verification
- ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.circuit.CircuitStateTest.disconnectedSubcircuitInputPropagatesUnknownInsideSubcircuit --rerun-tasks
- ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.circuit.CircuitStateTest checkstyleMain checkstyleTest --rerun-tasks
- ./gradlew.bat compileJava compileTestJava test --tests com.cburch.logisim.circuit.* checkstyleMain checkstyleTest --rerun-tasks
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check