### PR TITLE
docs: document unused library save option

### DIFF
--- a/src/main/resources/doc/en/html/guide/prefs/pref-template.html
+++ b/src/main/resources/doc/en/html/guide/prefs/pref-template.html
@@ -28,6 +28,9 @@
       <p>
         By default, the <b class="button">Plain template</b> option will be selected, using the default template shipped with Logisim. If you want a bare-bones configuration, you might choose <b class="button">Empty template.</b> But if you want to designate another file to use as the template, select a template via the <b class="button">Select...</b> button, and then choose the <b class="button">Custom template</b> option.
       </p>
+      <p>
+        The <b class="button">Remove unused libraries on save</b> option reduces the libraries written to saved projects. When it is enabled, Logisim writes only libraries that are referenced by circuits, toolbar entries, or mouse mappings. The Base library is always kept. Built-in libraries omitted from a saved file can be shown again later; external libraries omitted from the file must be loaded again if you later want to use them.
+      </p>
 	  <p>
 	    It is also possible to select a template by a command line parameter: <b>-template</b> <i>templateFile</i>
 	  </p>


### PR DESCRIPTION
Fixes #1199.

Summary
- document the Template preferences option for removing unused libraries on save
- clarify which references keep a library in the saved project
- note that omitted built-in libraries can be shown again, while omitted external libraries need to be reloaded if needed later

Verification
- ./gradlew.bat processResources --rerun-tasks
- git diff --check