### PR TITLE
Fix pin value editor initial sizing

### DIFF
--- a/src/main/java/com/cburch/logisim/std/wiring/Pin.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/Pin.java
@@ -166,6 +166,10 @@ public class Pin extends InstanceFactory {
       gbc.gridy = 0;
       gbc.gridwidth = GridBagConstraints.REMAINDER;
       gbc.anchor = GridBagConstraints.BASELINE;
+      gbc.fill = GridBagConstraints.HORIZONTAL;
+      gbc.weightx = 1.0;
+      gbc.ipadx = AppPreferences.getScaled(8);
+      gbc.ipady = AppPreferences.getScaled(4);
       gbc.insets = new Insets(8, 4, 8, 4);
       text.addKeyListener(this);
       text.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
@@ -323,6 +327,10 @@ public class Pin extends InstanceFactory {
       gbc.gridy = 0;
       gbc.gridwidth = GridBagConstraints.REMAINDER;
       gbc.anchor = GridBagConstraints.BASELINE;
+      gbc.fill = GridBagConstraints.HORIZONTAL;
+      gbc.weightx = 1.0;
+      gbc.ipadx = AppPreferences.getScaled(8);
+      gbc.ipady = AppPreferences.getScaled(4);
       gbc.insets = new Insets(8, 4, 8, 4);
       text.addKeyListener(this);
       text.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));


### PR DESCRIPTION
## Summary
- add horizontal fill and a small scaled padding to the Pin value editor text field
- apply the same sizing guard to the decimal and floating-point Pin editors so the packed dialog does not clip the input field on Windows display scaling combinations

## Validation
- git diff --check
- ./gradlew.bat compileJava
- ./gradlew.bat checkstyleMain

Fixes #2372