### PR TITLE
gui: keep VHDL console split recoverable

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -96,6 +96,9 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
   public static final String EDIT_LAYOUT = "layout";
   public static final String EDIT_APPEARANCE = "appearance";
   public static final String EDIT_HDL = "hdl";
+  private static final double DEFAULT_VHDL_CONSOLE_SPLIT = 0.75;
+  private static final double MIN_VHDL_CONSOLE_SPLIT = 0.05;
+  private static final double MAX_VHDL_CONSOLE_SPLIT = 0.95;
   private final Timer timer = new Timer();
   private final Project project;
   private final MyProjectListener myProjectListener = new MyProjectListener();
@@ -729,7 +732,10 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     }
     if (loc != null) AppPreferences.WINDOW_LOCATION.set(loc.x + "," + loc.y);
     if (leftRegion.getFraction() > 0) AppPreferences.WINDOW_LEFT_SPLIT.set(leftRegion.getFraction());
-    if (rightRegion.getFraction() < 1.0) AppPreferences.WINDOW_RIGHT_SPLIT.set(rightRegion.getFraction());
+    final var rightFraction = rightRegion.getFraction();
+    if (isUsableVhdlConsoleSplitFraction(rightFraction)) {
+      AppPreferences.WINDOW_RIGHT_SPLIT.set(rightFraction);
+    }
     if (mainRegion.getFraction() > 0) AppPreferences.WINDOW_MAIN_SPLIT.set(mainRegion.getFraction());
     AppPreferences.DIALOG_DIRECTORY.set(JFileChoosers.getCurrentDirectory());
   }
@@ -754,12 +760,31 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
   }
 
   public void setVhdlSimulatorConsoleStatusVisible() {
+    lastFraction = sanitizeVhdlConsoleSplitFraction(lastFraction);
+    rightRegion.setFractionBounds(MIN_VHDL_CONSOLE_SPLIT, MAX_VHDL_CONSOLE_SPLIT);
     rightRegion.setFraction(lastFraction);
   }
 
   public void setVhdlSimulatorConsoleStatusInvisible() {
-    lastFraction = rightRegion.getFraction();
+    final var rightFraction = rightRegion.getFraction();
+    if (isUsableVhdlConsoleSplitFraction(rightFraction)) {
+      lastFraction = rightFraction;
+    }
+    rightRegion.setFractionBounds(0.0, 1.0);
     rightRegion.setFraction(1);
+  }
+
+  static double sanitizeVhdlConsoleSplitFraction(Double fraction) {
+    if (fraction == null || !isUsableVhdlConsoleSplitFraction(fraction)) {
+      return DEFAULT_VHDL_CONSOLE_SPLIT;
+    }
+    return fraction;
+  }
+
+  static boolean isUsableVhdlConsoleSplitFraction(double fraction) {
+    return Double.isFinite(fraction)
+        && fraction >= MIN_VHDL_CONSOLE_SPLIT
+        && fraction <= MAX_VHDL_CONSOLE_SPLIT;
   }
 
   public HdlModel getHdlEditorView() {

--- a/src/main/java/com/cburch/logisim/util/HorizontalSplitPane.java
+++ b/src/main/java/com/cburch/logisim/util/HorizontalSplitPane.java
@@ -167,6 +167,8 @@ public class HorizontalSplitPane extends JPanel {
   private final JComponent comp1;
   private final MyDragbar dragbar;
   private double fraction;
+  private double minimumFraction = 0.0;
+  private double maximumFraction = 1.0;
 
   public HorizontalSplitPane(JComponent comp0, JComponent comp1) {
     this(comp0, comp1, 0.5);
@@ -188,9 +190,23 @@ public class HorizontalSplitPane extends JPanel {
     return fraction;
   }
 
+  public void setFractionBounds(double minimumFraction, double maximumFraction) {
+    if (!Double.isFinite(minimumFraction)
+        || !Double.isFinite(maximumFraction)
+        || minimumFraction < 0.0
+        || maximumFraction > 1.0
+        || minimumFraction > maximumFraction) {
+      throw new IllegalArgumentException("invalid fraction bounds");
+    }
+    this.minimumFraction = minimumFraction;
+    this.maximumFraction = maximumFraction;
+    setFraction(fraction);
+  }
+
   public void setFraction(double value) {
-    if (value < 0.0) value = 0.0;
-    if (value > 1.0) value = 1.0;
+    if (Double.isNaN(value)) return;
+    if (value < minimumFraction) value = minimumFraction;
+    if (value > maximumFraction) value = maximumFraction;
     if (fraction != value) {
       fraction = value;
       revalidate();

--- a/src/test/java/com/cburch/logisim/gui/main/FrameTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/FrameTest.java
@@ -1,0 +1,61 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class FrameTest {
+  private static final double FRACTION_DELTA = 1.0e-4;
+
+  @Test
+  void restoresDefaultWhenVhdlConsoleSplitWouldCollapseEditor() {
+    assertEquals(0.75, Frame.sanitizeVhdlConsoleSplitFraction(null), FRACTION_DELTA);
+    assertEquals(0.75, Frame.sanitizeVhdlConsoleSplitFraction(Double.NaN), FRACTION_DELTA);
+    assertEquals(
+        0.75, Frame.sanitizeVhdlConsoleSplitFraction(Double.NEGATIVE_INFINITY), FRACTION_DELTA);
+    assertEquals(0.75, Frame.sanitizeVhdlConsoleSplitFraction(0.0), FRACTION_DELTA);
+    assertEquals(0.75, Frame.sanitizeVhdlConsoleSplitFraction(0.04), FRACTION_DELTA);
+    assertEquals(0.05, Frame.sanitizeVhdlConsoleSplitFraction(0.05), FRACTION_DELTA);
+  }
+
+  @Test
+  void restoresDefaultWhenVhdlConsoleSplitWouldHideConsole() {
+    assertEquals(0.75, Frame.sanitizeVhdlConsoleSplitFraction(1.0), FRACTION_DELTA);
+    assertEquals(0.75, Frame.sanitizeVhdlConsoleSplitFraction(0.99), FRACTION_DELTA);
+    assertEquals(
+        0.75, Frame.sanitizeVhdlConsoleSplitFraction(Double.POSITIVE_INFINITY), FRACTION_DELTA);
+  }
+
+  @Test
+  void preservesUsableVhdlConsoleSplit() {
+    assertEquals(0.25, Frame.sanitizeVhdlConsoleSplitFraction(0.25), FRACTION_DELTA);
+    assertEquals(0.75, Frame.sanitizeVhdlConsoleSplitFraction(0.75), FRACTION_DELTA);
+    assertEquals(0.95, Frame.sanitizeVhdlConsoleSplitFraction(0.95), FRACTION_DELTA);
+  }
+
+  @Test
+  void rejectsUnusableVhdlConsoleSplitForPersistence() {
+    assertFalse(Frame.isUsableVhdlConsoleSplitFraction(Double.NaN));
+    assertFalse(Frame.isUsableVhdlConsoleSplitFraction(Double.NEGATIVE_INFINITY));
+    assertFalse(Frame.isUsableVhdlConsoleSplitFraction(0.0));
+    assertFalse(Frame.isUsableVhdlConsoleSplitFraction(0.04));
+    assertTrue(Frame.isUsableVhdlConsoleSplitFraction(0.05));
+    assertTrue(Frame.isUsableVhdlConsoleSplitFraction(0.25));
+    assertTrue(Frame.isUsableVhdlConsoleSplitFraction(0.75));
+    assertTrue(Frame.isUsableVhdlConsoleSplitFraction(0.95));
+    assertFalse(Frame.isUsableVhdlConsoleSplitFraction(0.99));
+    assertFalse(Frame.isUsableVhdlConsoleSplitFraction(1.0));
+    assertFalse(Frame.isUsableVhdlConsoleSplitFraction(Double.POSITIVE_INFINITY));
+  }
+}

--- a/src/test/java/com/cburch/logisim/util/HorizontalSplitPaneTest.java
+++ b/src/test/java/com/cburch/logisim/util/HorizontalSplitPaneTest.java
@@ -1,0 +1,75 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.swing.JPanel;
+import org.junit.jupiter.api.Test;
+
+class HorizontalSplitPaneTest {
+  private static final double FRACTION_DELTA = 1.0e-4;
+
+  @Test
+  void defaultFractionBoundsAllowCollapsedPanes() {
+    final var pane = new HorizontalSplitPane(new JPanel(), new JPanel(), 0.5);
+
+    pane.setFraction(0.0);
+    assertEquals(0.0, pane.getFraction(), FRACTION_DELTA);
+
+    pane.setFraction(1.0);
+    assertEquals(1.0, pane.getFraction(), FRACTION_DELTA);
+  }
+
+  @Test
+  void fractionBoundsClampFractionChanges() {
+    final var pane = new HorizontalSplitPane(new JPanel(), new JPanel(), 0.5);
+    pane.setFractionBounds(0.05, 0.95);
+
+    pane.setFraction(0.0);
+    assertEquals(0.05, pane.getFraction(), FRACTION_DELTA);
+
+    pane.setFraction(1.0);
+    assertEquals(0.95, pane.getFraction(), FRACTION_DELTA);
+  }
+
+  @Test
+  void fractionIgnoresNan() {
+    final var pane = new HorizontalSplitPane(new JPanel(), new JPanel(), 0.5);
+
+    pane.setFraction(Double.NaN);
+
+    assertEquals(0.5, pane.getFraction(), FRACTION_DELTA);
+  }
+
+  @Test
+  void fractionBoundsCanBeRelaxedForProgrammaticHiding() {
+    final var pane = new HorizontalSplitPane(new JPanel(), new JPanel(), 0.5);
+    pane.setFractionBounds(0.05, 0.95);
+    pane.setFractionBounds(0.0, 1.0);
+
+    pane.setFraction(1.0);
+    assertEquals(1.0, pane.getFraction(), FRACTION_DELTA);
+  }
+
+  @Test
+  void fractionBoundsRejectInvalidRanges() {
+    final var pane = new HorizontalSplitPane(new JPanel(), new JPanel(), 0.5);
+
+    assertThrows(IllegalArgumentException.class, () -> pane.setFractionBounds(-0.1, 0.9));
+    assertThrows(IllegalArgumentException.class, () -> pane.setFractionBounds(0.1, 1.1));
+    assertThrows(IllegalArgumentException.class, () -> pane.setFractionBounds(0.9, 0.1));
+    assertThrows(IllegalArgumentException.class, () -> pane.setFractionBounds(Double.NaN, 0.9));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> pane.setFractionBounds(0.1, Double.POSITIVE_INFINITY));
+  }
+}


### PR DESCRIPTION
Summary
- sanitize the saved/restored VHDL simulator console split fraction
- avoid persisting split positions that collapse the editor area or effectively hide the console
- clamp VHDL console drag operations so the separator cannot be dragged into an unrecoverable full-console layout
- add regression coverage for usable/unusable split values and drag-only split bounds

Verification
- ./gradlew.bat test --tests com.cburch.logisim.gui.main.FrameTest --tests com.cburch.logisim.util.HorizontalSplitPaneTest
- ./gradlew.bat compileJava checkstyleMain compileTestJava checkstyleTest

Closes #2630