### PR TITLE
docs: link FPGA menu help in localized docs

### DIFF
--- a/src/main/resources/doc/de/html/guide/menu/index.html
+++ b/src/main/resources/doc/de/html/guide/menu/index.html
@@ -21,7 +21,7 @@
 	<br><a href="edit.html">Das Menü Bearbeiten</a>
 	<br><a href="project.html">Das Menü Projekt</a>
 	<br><a href="simulate.html">Das Menü Simulation</a>
-    <br><a href="fpga.html">Das Menü FPGA</a>
+    <br><a href="../../../../en/html/guide/menu/fpga.html">Das Menü FPGA</a>
 	<br><a href="winhelp.html">Die Menüs Fenster und Hilfe</a>
 </blockquote>
 Viele Menüpunkte beziehen sich speziell auf ein aktuell geöffnetes Projekt. Aber einige Logisim-Fenster (insbesondere das Fenster <a

--- a/src/main/resources/doc/en/contents.xml
+++ b/src/main/resources/doc/en/contents.xml
@@ -79,6 +79,7 @@
 			<tocitem target="menu_edit" text="The Edit menu" />
 			<tocitem target="menu_project" text="The Project menu" />
 			<tocitem target="menu_simulate" text="The Simulate menu" />
+			<tocitem target="menu_fpga" text="The FPGA menu" />
 			<tocitem target="menu_winhelp" text="The Window and Help menus" />
 			<tocitem target="menu_exportab" text="Export Image"/>
 			<tocitem target="menu_printertab" text="Printing "/>

--- a/src/main/resources/doc/fr/html/guide/menu/index.html
+++ b/src/main/resources/doc/fr/html/guide/menu/index.html
@@ -24,7 +24,7 @@
         <a href="edit.html">Le menu Editer</a><br>
         <a href="project.html">Le menu Projet</a><br>
         <a href="simulate.html">Le menu Simulation</a><br>
-		<a href="fpga.html">Le menu FPGA</a><br>
+		<a href="../../../../en/html/guide/menu/fpga.html">Le menu FPGA</a><br>
         <a href="winhelp.html">Le menu Fenêtre et Aide</a>
       </blockquote>de nombreux éléments de menu se rapporte spécifiquement à un projet actuellement ouvert. Mais quelques fenêtres de Logisim (en particulier la fenêtre <a href="../analyze/index.html">Analyse combinatoire</a> et la fenêtre <a href="../prefs/index.html">Préférences d'application</a>) ne sont pas associées à des projets. Pour ces fenêtres, les éléments de menu spécifiques au projet seront désactivés.
       <p>

--- a/src/main/resources/doc/map_de.jhm
+++ b/src/main/resources/doc/map_de.jhm
@@ -100,6 +100,7 @@
 	<mapID target="menu_edit"           url="de/html/guide/menu/edit.html" />
 	<mapID target="menu_project"        url="de/html/guide/menu/project.html" />
 	<mapID target="menu_simulate"       url="de/html/guide/menu/simulate.html" />
+	<mapID target="menu_fpga"           url="en/html/guide/menu/fpga.html" />
 	<mapID target="menu_winhelp"        url="de/html/guide/menu/winhelp.html" />
 	<mapID target="menu_exportab"       url="de/html/guide/menu/exportab.html" />
 	<mapID target="menu_printertab"     url="de/html/guide/menu/printertab.html" />

--- a/src/main/resources/doc/map_en.jhm
+++ b/src/main/resources/doc/map_en.jhm
@@ -100,6 +100,7 @@
 	<mapID target="menu_edit"           url="en/html/guide/menu/edit.html" />
 	<mapID target="menu_project"        url="en/html/guide/menu/project.html" />
 	<mapID target="menu_simulate"       url="en/html/guide/menu/simulate.html" />
+	<mapID target="menu_fpga"           url="en/html/guide/menu/fpga.html" />
 	<mapID target="menu_winhelp"        url="en/html/guide/menu/winhelp.html" />
 	<mapID target="menu_exportab"       url="en/html/guide/menu/exportab.html" />
 	<mapID target="menu_printertab"     url="en/html/guide/menu/printertab.html" />

--- a/src/main/resources/doc/map_fr.jhm
+++ b/src/main/resources/doc/map_fr.jhm
@@ -99,6 +99,7 @@
 	<mapID target="menu_edit"           url="fr/html/guide/menu/edit.html" />
 	<mapID target="menu_project"        url="fr/html/guide/menu/project.html" />
 	<mapID target="menu_simulate"       url="fr/html/guide/menu/simulate.html" />
+	<mapID target="menu_fpga"           url="en/html/guide/menu/fpga.html" />
 	<mapID target="menu_winhelp"        url="fr/html/guide/menu/winhelp.html" />
 	<mapID target="menu_exportab"       url="fr/html/guide/menu/exportab.html" />
 	<mapID target="menu_printertab"     url="fr/html/guide/menu/printertab.html" />

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -99,6 +99,7 @@
 	<mapID target="menu_edit"           url="pt/html/guide/menu/edit.html" />
 	<mapID target="menu_project"        url="pt/html/guide/menu/project.html" />
 	<mapID target="menu_simulate"       url="pt/html/guide/menu/simulate.html" />
+	<mapID target="menu_fpga"           url="en/html/guide/menu/fpga.html" />
 	<mapID target="menu_winhelp"        url="pt/html/guide/menu/winhelp.html" />
 	<mapID target="menu_exportab"       url="pt/html/guide/menu/exportab.html" />
 	<mapID target="menu_printertab"     url="pt/html/guide/menu/printertab.html" />

--- a/src/main/resources/doc/map_ru.jhm
+++ b/src/main/resources/doc/map_ru.jhm
@@ -100,6 +100,7 @@
 	<mapID target="menu_edit"           url="ru/html/guide/menu/edit.html" />
 	<mapID target="menu_project"        url="ru/html/guide/menu/project.html" />
 	<mapID target="menu_simulate"       url="ru/html/guide/menu/simulate.html" />
+	<mapID target="menu_fpga"           url="en/html/guide/menu/fpga.html" />
 	<mapID target="menu_winhelp"        url="ru/html/guide/menu/winhelp.html" />
 	<mapID target="menu_exportab"       url="ru/html/guide/menu/exportab.html" />
 	<mapID target="menu_printertab"     url="ru/html/guide/menu/printertab.html" />

--- a/src/main/resources/doc/map_zh.jhm
+++ b/src/main/resources/doc/map_zh.jhm
@@ -101,6 +101,7 @@
 	<mapID target="menu_edit"           url="zh/html/guide/menu/edit.html" />
 	<mapID target="menu_project"        url="zh/html/guide/menu/project.html" />
 	<mapID target="menu_simulate"       url="zh/html/guide/menu/simulate.html" />
+	<mapID target="menu_fpga"           url="en/html/guide/menu/fpga.html" />
 	<mapID target="menu_winhelp"        url="zh/html/guide/menu/winhelp.html" />
 	<mapID target="menu_exportab"       url="zh/html/guide/menu/exportab.html" />
 	<mapID target="menu_printertab"     url="zh/html/guide/menu/printertab.html" />

--- a/src/main/resources/doc/pt/contents.xml
+++ b/src/main/resources/doc/pt/contents.xml
@@ -71,6 +71,7 @@
 			<tocitem target="menu_edit" text="O menu Editar" />
 			<tocitem target="menu_project" text="O menu Projeto" />
 			<tocitem target="menu_simulate" text="O menu Simular" />
+			<tocitem target="menu_fpga" text="O menu FPGA" />
 			<tocitem target="menu_winhelp" text="Os menus Janela e Ajuda" />
 			<tocitem target="menu_exportab" text="Export Image"/>  
 			<tocitem target="menu_printertab" text="Printing "/>

--- a/src/main/resources/doc/pt/html/guide/menu/index.html
+++ b/src/main/resources/doc/pt/html/guide/menu/index.html
@@ -24,7 +24,7 @@
         <a href="edit.html">O menu Editar</a><br>
         <a href="project.html">O menu Projeto</a><br>
         <a href="simulate.html">O menu Simular</a><br>
-        <a href="fpga.html">O menu FPGA</a><br>
+        <a href="../../../../en/html/guide/menu/fpga.html">O menu FPGA</a><br>
         <a href="winhelp.html">Os menus Janela e Ajuda</a>
       </blockquote>Muitos itens do menu se referem especificamente ao projeto em foco. Mas algumas janelas do Logisim (particularmente <a href="../analyze/index.html">Análise Combinacional</a> e <a href="../prefs/index.html">Preferências da Aplicação</a> ) não estão associadas aos projetos. Para essas janelas, os itens de menu específicos de projeto estarão desativados.
       <p>

--- a/src/main/resources/doc/ru/html/guide/menu/index.html
+++ b/src/main/resources/doc/ru/html/guide/menu/index.html
@@ -24,7 +24,7 @@
         <a href="edit.html">Меню Правка</a><br>
         <a href="project.html">Меню Проект</a><br>
         <a href="simulate.html">Меню Моделировать</a><br>
-		<a href="fpga.html">Меню FPGA</a><br>
+		<a href="../../../../en/html/guide/menu/fpga.html">Меню FPGA</a><br>
         <a href="winhelp.html">Меню Окно и Справка</a>
       </blockquote>Многие пункты меню касаются конкретно открытого в данный момент проекта. Но некоторые окна Logisim (в частности, окна <a href="../analyze/index.html">Комбинационный анализ</a> и <a href="../prefs/index.html">Настройки приложения</a>) не связаны с проектами. Для этих окон специфичные для проекта элементы меню будут отключены.
       <p>

--- a/src/main/resources/doc/zh/contents.xml
+++ b/src/main/resources/doc/zh/contents.xml
@@ -151,6 +151,8 @@
 
 			<!-- <tocitem target="menu_simulate" text="The Simulate menu" /> -->
 			<tocitem target="menu_simulate" text="仿真菜单" />
+			<!-- <tocitem target="menu_fpga" text="The FPGA menu" /> -->
+			<tocitem target="menu_fpga" text="FPGA 菜单" />
 			<!-- <tocitem target="menu_winhelp" text="The Window and Help menus" /> -->
 			<tocitem target="menu_winhelp" text="窗口与帮助菜单" />
 

--- a/src/main/resources/doc/zh/html/guide/menu/index.html
+++ b/src/main/resources/doc/zh/html/guide/menu/index.html
@@ -44,7 +44,7 @@
     </a>
     <br/>
     <!-- <a href="fpga.html">The FPGA menu</a><br> -->
-    <a href="fpga.html">
+    <a href="../../../../en/html/guide/menu/fpga.html">
      FPGA 菜单
     </a>
     <br/>


### PR DESCRIPTION
Summary
- add the missing `menu_fpga` help-map target for all online-help locales
- add missing FPGA menu TOC entries for English, Portuguese, and Simplified Chinese
- point translated menu-index FPGA links to the existing English help page until localized versions are added

Verification
- `git diff --cached --check`
- `./gradlew.bat processResources`
- custom check that every `menu_fpga` map target resolves to an existing file
- custom check that translated `fpga.html` menu links resolve

Follow-up to #2627 and refs #376.
