### PR TITLE
docs: link Telnet help in localized docs

### DIFF
--- a/src/main/resources/doc/de/contents.xml
+++ b/src/main/resources/doc/de/contents.xml
@@ -179,6 +179,7 @@
 			<tocitem target="io_hexdig" text="Hexadezimale Anzeige" image="icon_hexdig" />
 			<tocitem target="io_dotmat" text="LED-Matrix" image="icon_dotmat" />
 			<tocitem target="io_tty" text="Terminal" image="icon_tty" />
+			<tocitem target="io_telnet" text="Telnet" image="icon_telnet" />
 			<tocitem target="io_Port_IO" text="Port I/O" image="icon_Port_IO" />
 			<tocitem target="io_Repetar" text="Reptar Local Bus" image="icon_repetar" />
 			<tocitem target="io_videorgb" text="Video RGB" image="icon_videorgb" />

--- a/src/main/resources/doc/de/html/libs/io/index.html
+++ b/src/main/resources/doc/de/html/libs/io/index.html
@@ -29,6 +29,8 @@ with a user.</p>
 	<td><a href="dotmat.html">LED-Matrix</a></td></tr>
 <tr><td align="right"><a href="tty.html"><img border="0" src="../../../../icons/tty.gif" width="16" height="16"></a></td>
 	<td><a href="tty.html">Terminal</a></td></tr>
+<tr><td align="right"><a href="../../../../en/html/libs/io/telnet.html"><img border="0" src="../../../../icons/1616/telnet.png" width="16" height="16"></a></td>
+	<td><a href="../../../../en/html/libs/io/telnet.html">Telnet</a></td></tr>
 </table>
 
 <p><a href="../index.html">Zurück zur <em>Bibliotheksreferenz</em></a></p>

--- a/src/main/resources/doc/fr/contents.xml
+++ b/src/main/resources/doc/fr/contents.xml
@@ -179,6 +179,7 @@
 			<tocitem target="io_hexdig" image="icon_hexdig" text="Afficheur Hexadecimal"/>
 			<tocitem target="io_dotmat" image="icon_dotmat" text="Matrice de LED"/>
 			<tocitem target="io_tty" image="icon_tty" text="TTY"/>
+			<tocitem target="io_telnet" image="icon_telnet" text="Telnet"/>
 			<tocitem target="io_Port_IO" image="icon_Port_IO" text="Port I/O"  />
 			<tocitem target="io_Repetar"  image="icon_repetar" text="Reptar Local Bus"/>
 			<tocitem target="io_videorgb"  image="icon_videorgb" text="Afficheur Video RVB"/>

--- a/src/main/resources/doc/map_de.jhm
+++ b/src/main/resources/doc/map_de.jhm
@@ -168,9 +168,10 @@
 	<mapID target="io_7seg"             url="de/html/libs/io/7seg.html" />
 	<mapID target="io_hexdig"           url="de/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="de/html/libs/io/dotmat.html" />
-	<mapID target="io_tty"              url="de/html/libs/io/tty.html" />	
-    <mapID target="io_Port_IO"          url="de/html/libs/io/Port_io.html" />	
-	<mapID target="io_Repetar"          url="de/html/libs/io/repetar.html" />	
+	<mapID target="io_tty"              url="de/html/libs/io/tty.html" />
+	<mapID target="io_telnet"           url="en/html/libs/io/telnet.html" />
+    <mapID target="io_Port_IO"          url="de/html/libs/io/Port_io.html" />
+	<mapID target="io_Repetar"          url="de/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="de/html/libs/io/videorvb.html" />
 	<mapID target="tcl"                 url="de/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="de/html/libs/tcl/reds_console.html" />
@@ -246,6 +247,7 @@
 	<mapID target="icon_hexdig"      url="icons/1616/hexdig.png" />
 	<mapID target="icon_dotmat"      url="icons/1616/dotmat.png" />
 	<mapID target="icon_tty"         url="icons/1616/tty.png" />
+	<mapID target="icon_telnet"      url="icons/1616/telnet.png" />
 	<mapID target="icon_Port_IO"     url="icons/1616/portio.png" />
 	<mapID target="icon_repetar"     url="icons/1616/repetar.png" />
 	<mapID target="icon_videorgb"    url="icons/1616/rgbvideo.png" />	

--- a/src/main/resources/doc/map_fr.jhm
+++ b/src/main/resources/doc/map_fr.jhm
@@ -168,6 +168,7 @@
 	<mapID target="io_hexdig"           url="en/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="en/html/libs/io/dotmat.html" />
 	<mapID target="io_tty"              url="en/html/libs/io/tty.html" />	
+	<mapID target="io_telnet"           url="en/html/libs/io/telnet.html" />
     <mapID target="io_Port_IO"          url="en/html/libs/io/Port_io.html" />	
 	<mapID target="io_Repetar"          url="en/html/libs/io/repetar.html" />	
 	<mapID target="io_videorvb"         url="en/html/libs/io/videorvb.html" />
@@ -245,6 +246,7 @@
 	<mapID target="icon_hexdig"      url="icons/1616/hexdig.png" />
 	<mapID target="icon_dotmat"      url="icons/1616/dotmat.png" />
 	<mapID target="icon_tty"         url="icons/1616/tty.png" />
+	<mapID target="icon_telnet"      url="icons/1616/telnet.png" />
 	<mapID target="icon_Port_IO"     url="icons/1616/portio.png" />
 	<mapID target="icon_repetar"     url="icons/1616/repetar.png" />
 	<mapID target="icon_videorgb"    url="icons/1616/rgbvideo.png" />	

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -166,9 +166,10 @@
 	<mapID target="io_7seg"             url="pt/html/libs/io/7seg.html" />
 	<mapID target="io_hexdig"           url="pt/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="pt/html/libs/io/dotmat.html" />
-	<mapID target="io_tty"              url="pt/html/libs/io/tty.html" />	
-    <mapID target="io_Port_IO"          url="pt/html/libs/io/Port_io.html" />	
-	<mapID target="io_Repetar"          url="pt/html/libs/io/repetar.html" />	
+	<mapID target="io_tty"              url="pt/html/libs/io/tty.html" />
+	<mapID target="io_telnet"           url="en/html/libs/io/telnet.html" />
+    <mapID target="io_Port_IO"          url="pt/html/libs/io/Port_io.html" />
+	<mapID target="io_Repetar"          url="pt/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="pt/html/libs/io/videorvb.html" />
 	<mapID target="tcl"                 url="pt/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="pt/html/libs/tcl/reds_console.html" />
@@ -244,6 +245,7 @@
 	<mapID target="icon_hexdig"      url="icons/1616/hexdig.png" />
 	<mapID target="icon_dotmat"      url="icons/1616/dotmat.png" />
 	<mapID target="icon_tty"         url="icons/1616/tty.png" />
+	<mapID target="icon_telnet"      url="icons/1616/telnet.png" />
 	<mapID target="icon_Port_IO"     url="icons/1616/portio.png" />
 	<mapID target="icon_repetar"     url="icons/1616/repetar.png" />
 	<mapID target="icon_videorgb"    url="icons/1616/rgbvideo.png" />	

--- a/src/main/resources/doc/map_ru.jhm
+++ b/src/main/resources/doc/map_ru.jhm
@@ -167,9 +167,10 @@
 	<mapID target="io_7seg"             url="ru/html/libs/io/7seg.html" />
 	<mapID target="io_hexdig"           url="ru/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="ru/html/libs/io/dotmat.html" />
-	<mapID target="io_tty"              url="ru/html/libs/io/tty.html" />	
-    <mapID target="io_Port_IO"          url="ru/html/libs/io/Port_io.html" />	
-	<mapID target="io_Repetar"          url="ru/html/libs/io/repetar.html" />	
+	<mapID target="io_tty"              url="ru/html/libs/io/tty.html" />
+	<mapID target="io_telnet"           url="en/html/libs/io/telnet.html" />
+    <mapID target="io_Port_IO"          url="ru/html/libs/io/Port_io.html" />
+	<mapID target="io_Repetar"          url="ru/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="ru/html/libs/io/videorvb.html" />
 	<mapID target="tcl"                 url="ru/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="ru/html/libs/tcl/reds_console.html" />
@@ -245,6 +246,7 @@
 	<mapID target="icon_hexdig"      url="icons/1616/hexdig.png" />
 	<mapID target="icon_dotmat"      url="icons/1616/dotmat.png" />
 	<mapID target="icon_tty"         url="icons/1616/tty.png" />
+	<mapID target="icon_telnet"      url="icons/1616/telnet.png" />
 	<mapID target="icon_Port_IO"     url="icons/1616/portio.png" />
 	<mapID target="icon_repetar"     url="icons/1616/repetar.png" />
 	<mapID target="icon_videorgb"    url="icons/1616/rgbvideo.png" />	

--- a/src/main/resources/doc/map_zh.jhm
+++ b/src/main/resources/doc/map_zh.jhm
@@ -170,9 +170,10 @@
 	<mapID target="io_7seg"             url="zh/html/libs/io/7seg.html" />
 	<mapID target="io_hexdig"           url="zh/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="zh/html/libs/io/dotmat.html" />
-	<mapID target="io_tty"              url="zh/html/libs/io/tty.html" />	
-    <mapID target="io_Port_IO"          url="zh/html/libs/io/Port_io.html" />	
-	<mapID target="io_Repetar"          url="zh/html/libs/io/repetar.html" />	
+	<mapID target="io_tty"              url="zh/html/libs/io/tty.html" />
+	<mapID target="io_telnet"           url="en/html/libs/io/telnet.html" />
+    <mapID target="io_Port_IO"          url="zh/html/libs/io/Port_io.html" />
+	<mapID target="io_Repetar"          url="zh/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="zh/html/libs/io/videorvb.html" />
 	<mapID target="tcl"                 url="zh/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="zh/html/libs/tcl/reds_console.html" />
@@ -248,6 +249,7 @@
 	<mapID target="icon_hexdig"      url="icons/1616/hexdig.png" />
 	<mapID target="icon_dotmat"      url="icons/1616/dotmat.png" />
 	<mapID target="icon_tty"         url="icons/1616/tty.png" />
+	<mapID target="icon_telnet"      url="icons/1616/telnet.png" />
 	<mapID target="icon_Port_IO"     url="icons/1616/portio.png" />
 	<mapID target="icon_repetar"     url="icons/1616/repetar.png" />
 	<mapID target="icon_videorgb"    url="icons/1616/rgbvideo.png" />	

--- a/src/main/resources/doc/pt/contents.xml
+++ b/src/main/resources/doc/pt/contents.xml
@@ -179,6 +179,7 @@
 			<tocitem target="io_hexdig" text="Display hexadecimal" image="icon_hexdig" />
 			<tocitem target="io_dotmat" text="Matriz de LEDs" image="icon_dotmat" />
 			<tocitem target="io_tty" text="TTY" image="icon_tty" />
+			<tocitem target="io_telnet" text="Telnet" image="icon_telnet" />
 			<tocitem target="io_Port_IO" text="Port I/O" image="icon_Port_IO" />
 			<tocitem target="io_Repetar" text="Reptar Local Bus" image="icon_repetar" />
 			<tocitem target="io_videorgb" text="Video RGB" image="icon_videorgb" />

--- a/src/main/resources/doc/pt/html/libs/io/index.html
+++ b/src/main/resources/doc/pt/html/libs/io/index.html
@@ -30,6 +30,8 @@ com um usuário. </p>
 	<td><a href="dotmat.html">Matriz de LEDs</a></td></tr>
 <tr><td align="right"><a href="tty.html"><img border="0" src="../../../../icons/tty.gif"></a></td>
 	<td><a href="tty.html">TTY</a></td></tr>
+<tr><td align="right"><a href="../../../../en/html/libs/io/telnet.html"><img border="0" src="../../../../icons/1616/telnet.png"></a></td>
+	<td><a href="../../../../en/html/libs/io/telnet.html">Telnet</a></td></tr>
 </table>
 
 <p><a href="../index.html">Voltar à <em>Referência para bibliotecas</em></a></p>

--- a/src/main/resources/doc/ru/contents.xml
+++ b/src/main/resources/doc/ru/contents.xml
@@ -178,6 +178,7 @@
 			<tocitem target="io_hexdig" text="Шестнадцатеричный индикатор" image="icon_hexdig" />
 			<tocitem target="io_dotmat" text="Светодиодная матрица" image="icon_dotmat" />
 			<tocitem target="io_tty" text="Терминал" image="icon_tty" />
+			<tocitem target="io_telnet" text="Telnet" image="icon_telnet" />
 			<tocitem target="io_Port_IO" text="Port I/O" image="icon_Port_IO" />
 			<tocitem target="io_Repetar" text="Reptar Local Bus" image="icon_repetar" />
 			<tocitem target="io_videorgb" text="Video RGB" image="icon_videorgb" />

--- a/src/main/resources/doc/ru/html/libs/io/index.html
+++ b/src/main/resources/doc/ru/html/libs/io/index.html
@@ -27,6 +27,8 @@
 	<td><a href="dotmat.html">Светодиодная матрица</a></td></tr>
 <tr><td align="right"><a href="tty.html"><img border="0" src="../../../../icons/tty.gif" width="16" height="16"></a></td>
 	<td><a href="tty.html">Терминал</a></td></tr>
+<tr><td align="right"><a href="../../../../en/html/libs/io/telnet.html"><img border="0" src="../../../../icons/1616/telnet.png" width="16" height="16"></a></td>
+	<td><a href="../../../../en/html/libs/io/telnet.html">Telnet</a></td></tr>
 </table>
 
 <p><a href="../index.html">Назад к <em>Справке по библиотеке</em></a></p>

--- a/src/main/resources/doc/zh/contents.xml
+++ b/src/main/resources/doc/zh/contents.xml
@@ -429,6 +429,8 @@
 
 			<tocitem target="io_tty" text="TTY 终端" image="icon_tty" />
 
+			<tocitem target="io_telnet" text="Telnet" image="icon_telnet" />
+
      		<!-- <tocitem target="io_Port_IO" text="Port I/O" image="icon_Port_IO" /> -->
 			<tocitem target="io_Port_IO" text="端口 IO" image="icon_Port_IO" />
 

--- a/src/main/resources/doc/zh/html/libs/io/index.html
+++ b/src/main/resources/doc/zh/html/libs/io/index.html
@@ -173,6 +173,20 @@
      </tr>
      <tr>
       <td align="right">
+       <a href="../../../../en/html/libs/io/telnet.html">
+        <img alt="#########" border="0" class="iconlibs" height="32" src="../../../../icons/6464/telnet.png" width="32"/>
+       </a>
+      </td>
+      <td>
+      </td>
+      <td>
+       <a href="../../../../en/html/libs/io/telnet.html">
+        Telnet
+       </a>
+      </td>
+     </tr>
+     <tr>
+      <td align="right">
        <a href="./portio.html">
         <img alt="#########" border="0" class="iconlibs" height="32" src="../../../../icons/6464/portio.png" width="32"/>
        </a>


### PR DESCRIPTION
Summary
- add Telnet entries to localized online-help contents trees
- add io_telnet and icon_telnet mappings for localized help maps
- link localized IO library index pages to the existing English Telnet documentation where no translated page exists

Verification
- .\gradlew.bat processResources

Fixes #2352