### PR TITLE
wiring: preserve splitter mapping on fanout changes

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/SplitterAttributes.java
+++ b/src/main/java/com/cburch/logisim/circuit/SplitterAttributes.java
@@ -267,6 +267,17 @@ public class SplitterAttributes extends AbstractAttributeSet {
     }
   }
 
+  private void clampBitEndsToFanout() {
+    final var offs = INIT_ATTRIBUTES.size();
+    for (var i = 0; i < bitEnd.length; i++) {
+      if (bitEnd[i] > fanout) {
+        final var attr = (BitOutAttribute) attrs.get(offs + i);
+        bitEnd[i] = fanout;
+        fireAttributeValueChanged(attr, (int) bitEnd[i], null);
+      }
+    }
+  }
+
   @Override
   protected void copyInto(AbstractAttributeSet destObj) {
     final var dest = (SplitterAttributes) destObj;
@@ -330,14 +341,10 @@ public class SplitterAttributes extends AbstractAttributeSet {
       parameters = null;
     } else if (attr == ATTR_FANOUT) {
       int newValue = (Integer) value;
-      final var bits = bitEnd;
-      for (var i = 0; i < bits.length; i++) {
-        if (bits[i] > newValue) bits[i] = (byte) newValue;
-      }
       if (fanout == (byte) newValue) return;
       fanout = (byte) newValue;
       configureOptions();
-      configureDefaults();
+      clampBitEndsToFanout();
       parameters = null;
     } else if (attr == ATTR_WIDTH) {
       final var width = (BitWidth) value;

--- a/src/test/java/com/cburch/logisim/circuit/SplitterAttributesTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/SplitterAttributesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.circuit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.data.BitWidth;
+import org.junit.jupiter.api.Test;
+
+class SplitterAttributesTest {
+  @Test
+  void fanoutIncreasePreservesCustomBitMapping() {
+    final var attrs = new SplitterAttributes();
+    attrs.setValue(SplitterAttributes.ATTR_WIDTH, BitWidth.create(8));
+    for (var i = 0; i < 7; i++) {
+      setBitEnd(attrs, i, 1);
+    }
+    setBitEnd(attrs, 7, 2);
+
+    attrs.setValue(SplitterAttributes.ATTR_FANOUT, 3);
+
+    assertArrayEquals(new byte[] {1, 1, 1, 1, 1, 1, 1, 2}, attrs.bitEnd);
+  }
+
+  @Test
+  void fanoutDecreaseMapsRemovedEndsToLastRemainingEnd() {
+    final var attrs = new SplitterAttributes();
+    attrs.setValue(SplitterAttributes.ATTR_WIDTH, BitWidth.create(5));
+    attrs.setValue(SplitterAttributes.ATTR_FANOUT, 4);
+    setBitEnd(attrs, 0, 1);
+    setBitEnd(attrs, 1, 2);
+    setBitEnd(attrs, 2, 3);
+    setBitEnd(attrs, 3, 4);
+    setBitEnd(attrs, 4, 4);
+
+    attrs.setValue(SplitterAttributes.ATTR_FANOUT, 3);
+
+    assertArrayEquals(new byte[] {1, 2, 3, 3, 3}, attrs.bitEnd);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void setBitEnd(SplitterAttributes attrs, int bit, int end) {
+    attrs.setValue((Attribute<Integer>) attrs.getBitOutAttribute(bit), end);
+  }
+}


### PR DESCRIPTION
Summary
- preserve custom Splitter bit mappings when changing Fan Out
- clamp mappings that pointed to removed outputs onto the last remaining output
- add regression coverage for increasing and decreasing Fan Out

Closes #617.

Verification
- .\gradlew.bat test --tests com.cburch.logisim.circuit.SplitterAttributesTest
- .\gradlew.bat compileJava checkstyleMain checkstyleTest
