### PR TITLE
gui: resize analyzer after locale changes

### DIFF
--- a/src/main/java/com/cburch/logisim/analyze/gui/Analyzer.java
+++ b/src/main/java/com/cburch/logisim/analyze/gui/Analyzer.java
@@ -88,6 +88,7 @@ public class Analyzer extends LFrame.SubWindow {
       buildCircuit.localeChanged();
       exportTable.localeChanged();
       exportTex.localeChanged();
+      resizeForLocaleChange();
     }
   }
 
@@ -237,6 +238,27 @@ public class Analyzer extends LFrame.SubWindow {
       model.getOutputExpressions().disableUpdates();
     }
     tabbedPane.setSelectedIndex(index);
+  }
+
+  private void resizeForLocaleChange() {
+    getContentPane().invalidate();
+    invalidate();
+
+    final var current = getSize();
+    if (current.width <= 0 || current.height <= 0) return;
+
+    final var expanded = expandedSizeForLocaleChange(current, getPreferredSize());
+    if (!expanded.equals(current)) {
+      setSize(expanded);
+    }
+    validate();
+    repaint();
+  }
+
+  static Dimension expandedSizeForLocaleChange(Dimension current, Dimension preferred) {
+    return new Dimension(
+        Math.max(current.width, preferred.width),
+        Math.max(current.height, preferred.height));
   }
 
   public abstract static class PleaseWait<T> extends JDialog {

--- a/src/test/java/com/cburch/logisim/analyze/gui/AnalyzerTest.java
+++ b/src/test/java/com/cburch/logisim/analyze/gui/AnalyzerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.analyze.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Dimension;
+import org.junit.jupiter.api.Test;
+
+class AnalyzerTest {
+  @Test
+  void localeChangeKeepsManualWindowSizeWhenPreferredSizeIsSmaller() {
+    final var current = new Dimension(800, 600);
+    final var preferred = new Dimension(700, 500);
+
+    assertEquals(current, Analyzer.expandedSizeForLocaleChange(current, preferred));
+  }
+
+  @Test
+  void localeChangeExpandsWindowWhenPreferredSizeGrows() {
+    final var current = new Dimension(800, 600);
+    final var preferred = new Dimension(900, 650);
+
+    assertEquals(preferred, Analyzer.expandedSizeForLocaleChange(current, preferred));
+  }
+
+  @Test
+  void localeChangeExpandsOnlyTheDimensionThatNeedsMoreSpace() {
+    final var current = new Dimension(800, 600);
+    final var preferred = new Dimension(900, 500);
+
+    assertEquals(new Dimension(900, 600), Analyzer.expandedSizeForLocaleChange(current, preferred));
+  }
+}


### PR DESCRIPTION
Summary
- resize the Combinational Analysis window after locale changes when translated labels require more room
- preserve manually enlarged window dimensions by expanding only dimensions that are smaller than the new preferred size
- add unit coverage for the locale-change resize policy

Verification
- ./gradlew.bat compileJava
- ./gradlew.bat test --tests com.cburch.logisim.analyze.gui.AnalyzerTest
- ./gradlew.bat compileJava checkstyleMain checkstyleTest

Notes
- Addresses #343.
