### PR TITLE
ci: ignore deleted files in checkstyle filter

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -40,7 +40,7 @@ jobs:
         list-files: 'escape'
         filters: |
           src:
-            - 'src/**/*.java'
+            - added|modified: 'src/**/*.java'
 
     - name: "WILL JAVA LINT STEP BE RUN?"
       run: |


### PR DESCRIPTION
Summary
- filter Checkstyle inputs to added or modified Java files only
- avoid passing deleted Java paths to the Checkstyle jar

Verification
- git diff --check
- checked the dorny/paths-filter v4 documentation for the `added|modified` filter syntax

Addresses #1147
