### PR TITLE
appearance: pan canvas with middle mouse drag

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceCanvas.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceCanvas.java
@@ -52,6 +52,11 @@ public class AppearanceCanvas extends Canvas implements CanvasPaneContents, Acti
   private CanvasPane canvasPane;
   private Bounds oldPreferredSize;
   private LayoutPopupManager popupManager;
+  private int panStartScreenX;
+  private int panStartScreenY;
+  private int panStartScrollX;
+  private int panStartScrollY;
+  private boolean middleButtonPanning;
 
   public AppearanceCanvas(CanvasTool selectTool) {
     this.selectTool = selectTool;
@@ -230,12 +235,14 @@ public class AppearanceCanvas extends Canvas implements CanvasPaneContents, Acti
 
   @Override
   protected void processMouseEvent(MouseEvent e) {
+    if (handleMiddleButtonPanEvent(e)) return;
     repairEvent(e, grid.getZoomFactor());
     super.processMouseEvent(e);
   }
 
   @Override
   protected void processMouseMotionEvent(MouseEvent e) {
+    if (handleMiddleButtonPanMotion(e)) return;
     repairEvent(e, grid.getZoomFactor());
     super.processMouseMotionEvent(e);
   }
@@ -266,6 +273,40 @@ public class AppearanceCanvas extends Canvas implements CanvasPaneContents, Acti
       final var newy = (int) Math.round(e.getY() / zoom);
       e.translatePoint(newx - oldx, newy - oldy);
     }
+  }
+
+  private boolean handleMiddleButtonPanEvent(MouseEvent e) {
+    if (e.getButton() == MouseEvent.BUTTON2 && e.getID() == MouseEvent.MOUSE_PRESSED) {
+      if (canvasPane != null) {
+        middleButtonPanning = true;
+        panStartScreenX = e.getXOnScreen();
+        panStartScreenY = e.getYOnScreen();
+        panStartScrollX = canvasPane.getHorizontalScrollBar().getValue();
+        panStartScrollY = canvasPane.getVerticalScrollBar().getValue();
+      }
+      e.consume();
+      return true;
+    }
+    if (e.getButton() == MouseEvent.BUTTON2 && e.getID() == MouseEvent.MOUSE_RELEASED) {
+      middleButtonPanning = false;
+      e.consume();
+      return true;
+    }
+    return false;
+  }
+
+  private boolean handleMiddleButtonPanMotion(MouseEvent e) {
+    if (!middleButtonPanning || (e.getModifiersEx() & MouseEvent.BUTTON2_DOWN_MASK) == 0) {
+      return false;
+    }
+    canvasPane
+        .getHorizontalScrollBar()
+        .setValue(panStartScrollX + panStartScreenX - e.getXOnScreen());
+    canvasPane
+        .getVerticalScrollBar()
+        .setValue(panStartScrollY + panStartScreenY - e.getYOnScreen());
+    e.consume();
+    return true;
   }
 
   //

--- a/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
+++ b/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
@@ -10,6 +10,7 @@
 package com.cburch.logisim.gui.appear;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -30,6 +31,8 @@ import com.cburch.logisim.gui.generic.AttrTable;
 import com.cburch.logisim.gui.main.AttrTableCircuitModel;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.proj.Project;
+import java.awt.Dimension;
+import java.awt.event.MouseEvent;
 import org.junit.jupiter.api.Test;
 
 class AppearanceViewTest {
@@ -67,6 +70,26 @@ class AppearanceViewTest {
     assertTrue(table.getAttrTableModel().getRowCount() > 1);
   }
 
+  @Test
+  void middleButtonDragPansAppearanceCanvas() {
+    final var view = newAppearanceView();
+    final var canvas = (AppearanceCanvas) view.getCanvas();
+    final var pane = view.getCanvasPane();
+
+    canvas.setPreferredSize(new Dimension(1000, 1000));
+    pane.setSize(200, 200);
+    pane.doLayout();
+    pane.getHorizontalScrollBar().setValues(80, 20, 0, 1000);
+    pane.getVerticalScrollBar().setValues(90, 20, 0, 1000);
+
+    canvas.processMouseEvent(mouse(canvas, MouseEvent.MOUSE_PRESSED, 40, 40, MouseEvent.BUTTON2));
+    canvas.processMouseMotionEvent(
+        mouse(canvas, MouseEvent.MOUSE_DRAGGED, 10, 20, MouseEvent.BUTTON2));
+
+    assertEquals(110, pane.getHorizontalScrollBar().getValue());
+    assertEquals(110, pane.getVerticalScrollBar().getValue());
+  }
+
   private static AppearanceView newAppearanceView() {
     final var project = mock(Project.class);
     final var circuitState = mock(CircuitState.class);
@@ -89,5 +112,12 @@ class AppearanceViewTest {
 
   private static AttributeSet attributeSet(String label) {
     return AttributeSets.fixedSet(new Attribute<?>[] {StdAttr.LABEL}, new Object[] {label});
+  }
+
+  private static MouseEvent mouse(
+      AppearanceCanvas canvas, int id, int x, int y, int button) {
+    final var modifiers =
+        button == MouseEvent.BUTTON2 ? MouseEvent.BUTTON2_DOWN_MASK : MouseEvent.BUTTON1_DOWN_MASK;
+    return new MouseEvent(canvas, id, 0, modifiers, x, y, x, y, 1, false, button);
   }
 }


### PR DESCRIPTION
Summary
- add middle-button drag panning to the Circuit Appearance editor canvas
- keep the behavior local to the appearance canvas without changing drawing tools or zoom handling
- cover the pan behavior with a focused AppearanceViewTest regression test

Verification
- ./gradlew.bat test --tests com.cburch.logisim.gui.appear.AppearanceViewTest
- ./gradlew.bat compileJava checkstyleMain checkstyleTest

Addresses #2437
