### PR TITLE
hdl: fix priority encoder Verilog selection tree

### DIFF
--- a/src/main/java/com/cburch/logisim/std/plexers/PriorityEncoderHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/PriorityEncoderHdlGeneratorFactory.java
@@ -125,8 +125,8 @@ public class PriorityEncoderHdlGeneratorFactory extends AbstractHdlGeneratorFact
           assign address = (~enable) ? 0 : s_address[{{selBits}}-1:0];
           assign s_inIsZero = (inputVector == 0) ? 1'b1 : 1'b0;
 
-          assign s_selectVector0[63:{{selBits}}] = 0;
-          assign s_selectVector0[{{selBits}}-1:0] = inputVector;
+          assign s_selectVector0[63:{{inBits}}] = 0;
+          assign s_selectVector0[{{inBits}}-1:0] = inputVector;
           assign s_address[5] = (s_selectVector0[63:32] == 0) ? 1'b0 : 1'b1;
           assign s_selectVector1 = (s_selectVector0[63:32] == 0) ? s_selectVector0[31:0] : s_selectVector0[63:32];
           assign s_address[4] = (s_selectVector1[31:16] == 0) ? 1'b0 : 1'b1;
@@ -134,7 +134,7 @@ public class PriorityEncoderHdlGeneratorFactory extends AbstractHdlGeneratorFact
           assign s_address[3] = (s_selectVector2[15:8] == 0) ? 1'b0 : 1'b1;
           assign s_selectVector3 = (s_selectVector2[15:8] == 0) ? s_selectVector2[7:0] : s_selectVector2[15:8];
           assign s_address[2] = (s_selectVector3[7:4] == 0) ? 1'b0 : 1'b1;
-          assign s_selectVector4 = (s_selectVector3[7:4] == 0) ? s_selectVector3[3:0] : s_selectVector2[7:4];
+          assign s_selectVector4 = (s_selectVector3[7:4] == 0) ? s_selectVector3[3:0] : s_selectVector3[7:4];
           assign s_address[1] = (s_selectVector4[3:2] == 0) ? 1'b0 : 1'b1;
           assign s_address[0] = (s_selectVector4[3:2] == 0) ? s_selectVector4[1] : s_selectVector4[3];
           """);

--- a/src/test/java/com/cburch/logisim/std/plexers/PriorityEncoderHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/std/plexers/PriorityEncoderHdlGeneratorFactoryTest.java
@@ -1,0 +1,60 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.plexers;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
+import com.cburch.logisim.prefs.AppPreferences;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class PriorityEncoderHdlGeneratorFactoryTest {
+
+  private final String originalHdlType = AppPreferences.HdlType.get();
+
+  @AfterEach
+  void restoreHdlType() {
+    AppPreferences.HdlType.set(originalHdlType);
+  }
+
+  @Test
+  void verilogCopiesFullInputVectorIntoSelectionTree() {
+    final var hdl = functionality(HdlGeneratorFactory.VERILOG, 3);
+
+    assertTrue(hdl.contains("assign s_selectVector0[63:nrOfInputBits] = 0;"));
+    assertTrue(hdl.contains("assign s_selectVector0[nrOfInputBits-1:0] = inputVector;"));
+    assertTrue(
+        hdl.contains(
+            "assign s_selectVector4 = (s_selectVector3[7:4] == 0) ? "
+                + "s_selectVector3[3:0] : s_selectVector3[7:4];"));
+    assertFalse(hdl.contains("assign s_selectVector0[63:nrOfSelectBits] = 0;"));
+    assertFalse(hdl.contains("assign s_selectVector0[nrOfSelectBits-1:0] = inputVector;"));
+    assertFalse(hdl.contains("s_selectVector2[7:4]"));
+  }
+
+  @Test
+  void vhdlCopiesFullInputVectorIntoSelectionTree() {
+    final var hdl = functionality(HdlGeneratorFactory.VHDL, 3);
+
+    assertTrue(hdl.contains("s_selectVector0(63 DOWNTO nrOfInputBits)  <= (OTHERS => '0');"));
+    assertTrue(hdl.contains("s_selectVector0(nrOfInputBits-1 DOWNTO 0) <= inputVector;"));
+  }
+
+  private static String functionality(String hdlType, int selectBits) {
+    AppPreferences.HdlType.set(hdlType);
+    final var attrs = new PriorityEncoder().createAttributeSet();
+    attrs.setValue(PlexersLibrary.ATTR_SELECT, BitWidth.create(selectBits));
+    return String.join(
+        "\n", new PriorityEncoderHdlGeneratorFactory().getModuleFunctionality(null, attrs).get());
+  }
+}


### PR DESCRIPTION
Summary
- use the full `nrOfInputBits` width when copying the Priority Encoder input vector into the Verilog selection tree
- fix the final Verilog selection stage to keep selecting from `s_selectVector3`, matching the VHDL logic
- add focused HDL generator coverage for the VHDL and Verilog Priority Encoder paths

This addresses the current reproducible HDL generation issue in #1429. The VHDL path is covered as the expected reference behavior; the Verilog path now matches it.

Verification
- `./gradlew.bat test --tests com.cburch.logisim.std.plexers.PriorityEncoderHdlGeneratorFactoryTest`
- `./gradlew.bat compileJava checkstyleMain checkstyleTest`
- `git diff --check`