### PR TITLE
naming: centralize label key checks

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/Circuit.java
+++ b/src/main/java/com/cburch/logisim/circuit/Circuit.java
@@ -161,7 +161,7 @@ public class Circuit {
     if (myFactory instanceof Tunnel) return true;
     if (circuitName != null
         && !circuitName.isEmpty()
-        && circuitName.equalsIgnoreCase(name)
+        && CircuitLabelValidator.labelsMatch(circuitName, name)
         && myFactory instanceof Pin) {
       if (showDialog) {
         final var msg = S.get("ComponentLabelEqualCircuitName");
@@ -176,7 +176,7 @@ public class Circuit {
   private static boolean isComponentName(String name, Set<Component> comps, Boolean showDialog) {
     if (name.isEmpty()) return false;
     for (final var comp : comps) {
-      if (comp.getFactory().getName().equalsIgnoreCase(name)) {
+      if (CircuitLabelValidator.labelsMatch(comp.getFactory().getName(), name)) {
         if (showDialog) {
           final var msg = S.get("ComponentLabelNameError");
           OptionPane.showMessageDialog(null, "\"" + name + "\" : " + msg);
@@ -197,7 +197,7 @@ public class Circuit {
             (comp.getAttributeSet().containsAttribute(StdAttr.LABEL))
                 ? comp.getAttributeSet().getValue(StdAttr.LABEL)
                 : "";
-        if (Label.equalsIgnoreCase(name)) {
+        if (CircuitLabelValidator.labelsMatch(Label, name)) {
           if (showDialog) {
             final var msg = S.get("UsedLabelNameError");
             OptionPane.showMessageDialog(null, "\"" + name + "\" : " + msg);
@@ -327,14 +327,14 @@ public class Circuit {
       if (attrs.containsAttribute(StdAttr.LABEL)) {
         final var label = attrs.getValue(StdAttr.LABEL);
         if (!label.isEmpty()) {
-          if (labelNames.contains(label.toUpperCase())) {
+          if (labelNames.contains(CircuitLabelValidator.labelKey(label))) {
             final var act = new SetAttributeAction(this, S.getter("changeComponentAttributesAction"));
             act.set(comp, StdAttr.LABEL, "");
             proj.doAction(act);
             // FIXME: hardcoded string
             Reporter.report.addSevereWarning("Removed duplicated label " + this.getName() + "/" + label);
           } else {
-            labelNames.add(label.toUpperCase());
+            labelNames.add(CircuitLabelValidator.labelKey(label));
           }
         }
       }
@@ -785,13 +785,13 @@ public class Circuit {
           if (comp.equals(c) || comp.getFactory() instanceof Tunnel) continue;
           if (comp.getAttributeSet().containsAttribute(StdAttr.LABEL)) {
             final var label = comp.getAttributeSet().getValue(StdAttr.LABEL);
-            if (StringUtil.isNotEmpty(label)) labels.add(label.toUpperCase());
+            if (StringUtil.isNotEmpty(label)) labels.add(CircuitLabelValidator.labelKey(label));
           }
         }
         /* we also have to check for the entity name */
-        if (getName() != null && !getName().isEmpty()) labels.add(getName());
+        if (getName() != null && !getName().isEmpty()) labels.add(CircuitLabelValidator.labelKey(getName()));
         final var label = c.getAttributeSet().getValue(StdAttr.LABEL);
-        if (StringUtil.isNotEmpty(label) && labels.contains(label.toUpperCase())) {
+        if (StringUtil.isNotEmpty(label) && labels.contains(CircuitLabelValidator.labelKey(label))) {
           c.getAttributeSet().setValue(StdAttr.LABEL, "");
         }
       }
@@ -860,7 +860,7 @@ public class Circuit {
       final var attrs = comp.getAttributeSet();
       if (attrs.containsAttribute(StdAttr.LABEL)) {
         final var compLabel = attrs.getValue(StdAttr.LABEL);
-        if (label.equalsIgnoreCase(compLabel)) {
+        if (CircuitLabelValidator.labelsMatch(label, compLabel)) {
           attrs.setValue(StdAttr.LABEL, "");
           changed = true;
         }

--- a/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
@@ -117,8 +117,8 @@ public class CircuitAttributes extends AbstractAttributeSet {
           } else {
             for (final var component : source.getNonWires()) {
               if (component.getFactory() instanceof Pin) {
-                final var label = component.getAttributeSet().getValue(StdAttr.LABEL).toUpperCase();
-                if (!label.isEmpty() && label.equals(NewName.toUpperCase())) {
+                final var label = component.getAttributeSet().getValue(StdAttr.LABEL);
+                if (!label.isEmpty() && CircuitLabelValidator.labelsMatch(label, NewName)) {
                   final var msg = S.get("CircuitSameInputOutputLabel");
                   OptionPane.showMessageDialog(null, "\"" + NewName + "\" : " + msg);
                   e.getSource().setValue(NAME_ATTR, OldName);

--- a/src/main/java/com/cburch/logisim/circuit/CircuitLabelValidator.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitLabelValidator.java
@@ -1,0 +1,24 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.circuit;
+
+import java.util.Locale;
+
+final class CircuitLabelValidator {
+  private CircuitLabelValidator() {}
+
+  static String labelKey(String label) {
+    return label.toUpperCase(Locale.ROOT);
+  }
+
+  static boolean labelsMatch(String first, String second) {
+    return first.equalsIgnoreCase(second);
+  }
+}

--- a/src/main/java/com/cburch/logisim/fpga/designrulecheck/CorrectLabel.java
+++ b/src/main/java/com/cburch/logisim/fpga/designrulecheck/CorrectLabel.java
@@ -18,6 +18,7 @@ import com.cburch.logisim.fpga.hdlgenerator.Vhdl;
 import com.cburch.logisim.gui.generic.OptionPane;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 public class CorrectLabel {
   public static String getCorrectLabel(String label) {
@@ -26,6 +27,14 @@ public class CorrectLabel {
     if (NUMBERS.contains(label.substring(0, 1))) result.append("L_");
     result.append(label.replace(" ", "_").replace("-", "_"));
     return result.toString();
+  }
+
+  public static String hdlLabelKey(String label) {
+    return hdlNameKey(getCorrectLabel(label));
+  }
+
+  public static String hdlNameKey(String hdlName) {
+    return hdlName.toUpperCase(Locale.ROOT);
   }
 
   public static boolean isCorrectLabel(String label, String errorIdentifierString) {

--- a/src/main/java/com/cburch/logisim/fpga/designrulecheck/Netlist.java
+++ b/src/main/java/com/cburch/logisim/fpga/designrulecheck/Netlist.java
@@ -318,7 +318,7 @@ public class Netlist {
       }
       // we check that all components that require a non zero label (annotation) have a label set
       if (comp.getFactory().requiresNonZeroLabel()) {
-        final var label = CorrectLabel.getCorrectLabel(comp.getAttributeSet().getValue(StdAttr.LABEL)).toUpperCase();
+        final var label = CorrectLabel.hdlLabelKey(comp.getAttributeSet().getValue(StdAttr.LABEL));
         final var componentName = comp.getFactory().getHDLName(comp.getAttributeSet());
         if (label.isEmpty()) {
           drc.get(0).addMarkComponent(comp);
@@ -343,7 +343,7 @@ public class Netlist {
         }
         if (comp.getFactory() instanceof final SubcircuitFactory sub) {
           // Special care has to be taken for sub-circuits
-          if (label.equals(componentName.toUpperCase())) {
+          if (label.equals(CorrectLabel.hdlNameKey(componentName))) {
             drc.get(1).addMarkComponent(comp);
             drcStatus |= DRC_ERROR;
           }

--- a/src/test/java/com/cburch/logisim/circuit/CircuitLabelValidationTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/CircuitLabelValidationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.circuit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.std.wiring.Pin;
+import com.cburch.logisim.std.wiring.Tunnel;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class CircuitLabelValidationTest {
+  @Test
+  void rejectsLabelsThatOnlyDifferByCaseFromAnotherComponent() {
+    final var existingPin = pinWithLabel("A");
+    final var components = componentSet(existingPin);
+
+    assertFalse(
+        Circuit.isCorrectLabel(
+            "main", "a", components, Pin.FACTORY.createAttributeSet(), Pin.FACTORY, false));
+  }
+
+  @Test
+  void allowsChangingOnlyTheCaseOfTheSameComponentLabel() {
+    final var existingPin = pinWithLabel("A");
+    final var components = componentSet(existingPin);
+
+    assertTrue(
+        Circuit.isCorrectLabel(
+            "main", "a", components, existingPin.getAttributeSet(), Pin.FACTORY, false));
+  }
+
+  @Test
+  void rejectsPinLabelsThatOnlyDifferByCaseFromCircuitName() {
+    assertFalse(
+        Circuit.isCorrectLabel(
+            "Display", "display", Set.of(), Pin.FACTORY.createAttributeSet(), Pin.FACTORY, false));
+  }
+
+  @Test
+  void allowsTunnelLabelsToReuseComponentLabels() {
+    final var existingPin = pinWithLabel("A");
+    final var tunnelAttrs = Tunnel.FACTORY.createAttributeSet();
+
+    assertTrue(
+        Circuit.isCorrectLabel(
+            "main", "a", componentSet(existingPin), tunnelAttrs, Tunnel.FACTORY, false));
+  }
+
+  private static Component pinWithLabel(String label) {
+    final var attrs = Pin.FACTORY.createAttributeSet();
+    attrs.setValue(StdAttr.LABEL, label);
+    return Pin.FACTORY.createComponent(Location.create(0, 0, true), attrs);
+  }
+
+  private static Set<Component> componentSet(Component component) {
+    final var components = new HashSet<Component>();
+    components.add(component);
+    return components;
+  }
+}

--- a/src/test/java/com/cburch/logisim/circuit/CircuitLabelValidatorTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/CircuitLabelValidatorTest.java
@@ -1,0 +1,29 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.circuit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CircuitLabelValidatorTest {
+  @Test
+  void labelKeysRepresentCurrentCaseInsensitiveIdentity() {
+    assertEquals(CircuitLabelValidator.labelKey("A"), CircuitLabelValidator.labelKey("a"));
+  }
+
+  @Test
+  void labelsMatchIgnoringCase() {
+    assertTrue(CircuitLabelValidator.labelsMatch("SegmentA", "segmenta"));
+    assertFalse(CircuitLabelValidator.labelsMatch("SegmentA", "SegmentB"));
+  }
+}

--- a/src/test/java/com/cburch/logisim/fpga/designrulecheck/CorrectLabelTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/designrulecheck/CorrectLabelTest.java
@@ -1,0 +1,30 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.fpga.designrulecheck;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class CorrectLabelTest {
+  @Test
+  void hdlLabelKeysRepresentNormalizedCaseInsensitiveIdentity() {
+    assertEquals(CorrectLabel.hdlLabelKey("A"), CorrectLabel.hdlLabelKey("a"));
+    assertEquals(CorrectLabel.hdlLabelKey("A B"), CorrectLabel.hdlLabelKey("a-b"));
+    assertEquals("L_1A", CorrectLabel.getCorrectLabel("1A"));
+    assertEquals("L_1A", CorrectLabel.hdlLabelKey("1a"));
+  }
+
+  @Test
+  void hdlNameKeysOnlyFoldCaseForAlreadyGeneratedHdlNames() {
+    assertEquals(CorrectLabel.hdlNameKey("ComponentA"), CorrectLabel.hdlNameKey("componenta"));
+    assertEquals("A-B", CorrectLabel.hdlNameKey("a-b"));
+  }
+}


### PR DESCRIPTION
Summary
- centralize the current circuit-level case-insensitive label key checks in a small helper
- add HDL label/name key helpers so DRC duplicate checks use an explicit normalized key
- add characterization tests for the existing strict behavior: case-only label duplicates are rejected, same-component case edits remain allowed, tunnel labels stay exempt, and HDL keys fold case after label normalization

Notes
This is intended as groundwork for #2580. It does not relax editor-side naming yet; it makes the current strict behavior explicit and easier to change safely in a later project-level naming-mode PR.

Verification
- ./gradlew.bat test --tests com.cburch.logisim.circuit.CircuitLabelValidatorTest --tests com.cburch.logisim.circuit.CircuitLabelValidationTest --tests com.cburch.logisim.fpga.designrulecheck.CorrectLabelTest compileJava checkstyleMain checkstyleTest
- git diff --check

Refs #2580
