### PR TITLE
docs: update development release notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,36 @@
     * Corrected disjoint corners on Square Root arithmetic components.
     * Corrected disjoint corners on unpressed Button components.
     * Reduced line reordering errors in TikZ/SVG image exports.
+  * Improved Timing Diagram recording and exports:
+    * Corrected vector and GIF exports.
+    * Corrected reset offsets, non-50% duty-cycle clocks, real-time traces, and RAM memory traces.
+  * Improved custom circuit appearance editing and dynamic appearance elements:
+    * Circuit attributes are shown when no item is selected.
+    * Dynamic elements preserve nested paths and can display nested Probe/Register values correctly.
+    * Corrected drag selection, selected-object attributes, and automatic switching to custom appearance.
+  * Improved memory and hex editor tools:
+    * Added a go-to-address control to the hex editor.
+    * Limited generated save previews for large memories.
+    * Corrected memory display layout in exported graphics.
+  * Fixed several HDL and FPGA generation issues, including wide Random generator HDL, PortIO bubble
+    ranges, scanning I/O constraints, and Xilinx download placeholder handling.
+  * Improved project editing stability:
+    * Moving components preserves component state.
+    * Floating subcircuit inputs now propagate floating values.
+    * Nested library tools resolve correctly.
+    * No-op text edits no longer create undo actions.
+  * Improved VHDL editing and simulation UI:
+    * VHDL entity appearance is configured through entity properties.
+    * VHDL code view no longer paints a circuit canvas without a circuit.
+    * VHDL simulator log split pane remains recoverable after being maximized.
+  * Improved command-line output and localization:
+    * Command-line help now honors the selected locale.
+    * TTY table output includes bit widths in headers.
+    * Localized the Assembly Viewer.
+  * Added and updated documentation for Telnet, FPGA Commander reports, the board editor, JAR
+    libraries, wire values, transistor behavior, and unused-library save options.
+  * Added a default text-tool color preference and synchronized string-option preference updates.
+  * Many other bug fixes.
 
 * v4.1.0 (2026-02-15)
   * Increased number of components which may be displayed on custom circuit appearances and increased


### PR DESCRIPTION
Closes #2647.

This updates the development release notes with grouped one-line summaries for recent merged PRs by `@hewzhew`.

The entries are grouped by user-visible area instead of listing every small fix individually:

- timing diagram recording and exports
- custom circuit appearance and dynamic elements
- memory and hex editor tools
- HDL/FPGA generation fixes
- project editing stability
- VHDL UI behavior
- command-line output and localization
- recently added/updated documentation

I intentionally did not include the RAM line-enable behavior change from #2601 here because that PR is still open. I will add that compatibility note on the #2601 branch itself.

Verification:
- `git diff --check origin/main...HEAD`
