### PR TITLE
docs: link FPGA Commander help in localized docs

### DIFF
--- a/src/main/resources/doc/de/contents.xml
+++ b/src/main/resources/doc/de/contents.xml
@@ -85,7 +85,7 @@
 <!--	<tocitem target="prefs_simulation" text="L'onglet simulation"/> -->			
 			<tocitem target="prefs_exp" text="Die Registerkarte &quot;Experimentell&quot;" />
 <!--	<tocitem target="prefs_sofware" text="L'onglet Logiciel tiers"/> -->
-<!--	<tocitem target="prefs_fpga" text="L'onglet FPGA Commander settings"/> -->			
+			<tocitem target="prefs_fpga" text="FPGA Commander settings" />
 			<tocitem target="prefs_cmdline" text="Die Kommandozeile" />
 		</tocitem>
 		<tocitem target="opts" text="Projektbezogene Einstellungen">

--- a/src/main/resources/doc/de/html/guide/prefs/index.html
+++ b/src/main/resources/doc/de/html/guide/prefs/index.html
@@ -33,6 +33,7 @@ from the command line.</p>
 	<br><a href="pref-window.html">The Window tab</a>
 	<br><a href="pref-layout.html">The Layout tab</a>
 	<br><a href="pref-exp.html">The Experimental tab</a>
+	<br><a href="../../../../en/html/guide/prefs/pref-fpgacommander.html">FPGA Commander settings</a>
 	<br><a href="pref-cmdline.html">The command line</a>
 </blockquote>
 

--- a/src/main/resources/doc/fr/contents.xml
+++ b/src/main/resources/doc/fr/contents.xml
@@ -85,7 +85,7 @@
 <!--	<tocitem target="prefs_simulation" text="L'onglet simulation"/> -->
 			<tocitem target="prefs_exp" text="L'onglet Expérimental"/>
 <!--	<tocitem target="prefs_sofware" text="L'onglet Logicile tiers"/> -->
-<!--	<tocitem target="prefs_fpga" text="L'onglet FPGA Commander settings"/> -->
+			<tocitem target="prefs_fpga" text="FPGA Commander settings" />
 			<tocitem target="prefs_cmdline" text="La ligne de commande"/>
 		</tocitem>
 		<tocitem target="opts" text="Options de projet">

--- a/src/main/resources/doc/fr/html/guide/prefs/index.html
+++ b/src/main/resources/doc/fr/html/guide/prefs/index.html
@@ -30,7 +30,7 @@
         <a href="pref-simulation.html">L'onglet Simulation</a><br>
         <a href="pref-exp.html">L'onglet Expérimental</a><br>
 		<a href="pref-software.html">L'onglet Logiciel tiers</a><br>
-		<a href="pref-fpgacommander.html">L'onglet FPGA Commander paramètres</a><br><br>
+		<a href="../../../../en/html/guide/prefs/pref-fpgacommander.html">L'onglet FPGA Commander paramètres</a><br><br>
         <a href="pref-cmdline.html">La options de la ligne de commande</a>
       </blockquote>
       <p>

--- a/src/main/resources/doc/fr/html/guide/prefs/index.html
+++ b/src/main/resources/doc/fr/html/guide/prefs/index.html
@@ -30,7 +30,7 @@
         <a href="pref-simulation.html">L'onglet Simulation</a><br>
         <a href="pref-exp.html">L'onglet Expérimental</a><br>
 		<a href="pref-software.html">L'onglet Logiciel tiers</a><br>
-		<a href="../../../../en/html/guide/prefs/pref-fpgacommander.html">L'onglet FPGA Commander paramètres</a><br><br>
+		<a href="../../../../en/html/guide/prefs/pref-fpgacommander.html">L'onglet FPGA Commander settings</a><br><br>
         <a href="pref-cmdline.html">La options de la ligne de commande</a>
       </blockquote>
       <p>

--- a/src/main/resources/doc/map_de.jhm
+++ b/src/main/resources/doc/map_de.jhm
@@ -75,6 +75,7 @@
 	<mapID target="prefs_window"        url="de/html/guide/prefs/pref-window.html" />
 	<mapID target="prefs_layout"        url="de/html/guide/prefs/pref-layout.html" />
 	<mapID target="prefs_exp"           url="de/html/guide/prefs/pref-exp.html" />
+	<mapID target="prefs_fpga"          url="en/html/guide/prefs/pref-fpgacommander.html" />
 	<mapID target="prefs_cmdline"       url="de/html/guide/prefs/pref-cmdline.html" />
 	<mapID target="opts"                url="de/html/guide/opts/index.html" />
 	<mapID target="opts_simulate"       url="de/html/guide/opts/opts-simulate.html" />

--- a/src/main/resources/doc/map_fr.jhm
+++ b/src/main/resources/doc/map_fr.jhm
@@ -74,6 +74,7 @@
 	<mapID target="prefs_window"        url="fr/html/guide/prefs/pref-window.html" />
 	<mapID target="prefs_layout"        url="fr/html/guide/prefs/pref-layout.html" />
 	<mapID target="prefs_exp"           url="fr/html/guide/prefs/pref-exp.html" />
+	<mapID target="prefs_fpga"          url="en/html/guide/prefs/pref-fpgacommander.html" />
 	<mapID target="prefs_cmdline"       url="fr/html/guide/prefs/pref-cmdline.html" />
 	<mapID target="opts"                url="fr/html/guide/opts/index.html" />
 	<mapID target="opts_simulate"       url="fr/html/guide/opts/opts-simulate.html" />

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -74,6 +74,7 @@
 	<mapID target="prefs_window"        url="pt/html/guide/prefs/pref-window.html" />
 	<mapID target="prefs_layout"        url="pt/html/guide/prefs/pref-layout.html" />
 	<mapID target="prefs_exp"           url="pt/html/guide/prefs/pref-exp.html" />
+	<mapID target="prefs_fpga"          url="en/html/guide/prefs/pref-fpgacommander.html" />
 	<mapID target="prefs_cmdline"       url="pt/html/guide/prefs/pref-cmdline.html" />
 	<mapID target="opts"                url="pt/html/guide/opts/index.html" />
 	<mapID target="opts_simulate"       url="pt/html/guide/opts/opts-simulate.html" />

--- a/src/main/resources/doc/map_ru.jhm
+++ b/src/main/resources/doc/map_ru.jhm
@@ -75,6 +75,7 @@
 	<mapID target="prefs_window"        url="ru/html/guide/prefs/pref-window.html" />
 	<mapID target="prefs_layout"        url="ru/html/guide/prefs/pref-layout.html" />
 	<mapID target="prefs_exp"           url="ru/html/guide/prefs/pref-exp.html" />
+	<mapID target="prefs_fpga"          url="en/html/guide/prefs/pref-fpgacommander.html" />
 	<mapID target="prefs_cmdline"       url="ru/html/guide/prefs/pref-cmdline.html" />
 	<mapID target="opts"                url="ru/html/guide/opts/index.html" />
 	<mapID target="opts_simulate"       url="ru/html/guide/opts/opts-simulate.html" />

--- a/src/main/resources/doc/map_zh.jhm
+++ b/src/main/resources/doc/map_zh.jhm
@@ -76,6 +76,7 @@
 	<mapID target="prefs_window"        url="zh/html/guide/prefs/pref-window.html" />
 	<mapID target="prefs_layout"        url="zh/html/guide/prefs/pref-layout.html" />
 	<mapID target="prefs_exp"           url="zh/html/guide/prefs/pref-exp.html" />
+	<mapID target="prefs_fpga"          url="en/html/guide/prefs/pref-fpgacommander.html" />
 	<mapID target="prefs_cmdline"       url="zh/html/guide/prefs/pref-cmdline.html" />
 	<mapID target="opts"                url="zh/html/guide/opts/index.html" />
 	<mapID target="opts_simulate"       url="zh/html/guide/opts/opts-simulate.html" />

--- a/src/main/resources/doc/pt/contents.xml
+++ b/src/main/resources/doc/pt/contents.xml
@@ -85,7 +85,7 @@
 <!--	<tocitem target="prefs_simulation" text="L'onglet simulation"/> -->
 			<tocitem target="prefs_exp" text="A aba Experimental" />
 <!--	<tocitem target="prefs_sofware" text="L'onglet Logicile tiers"/> -->
-<!--	<tocitem target="prefs_fpga" text="L'onglet FPGA Commander settings"/> -->
+			<tocitem target="prefs_fpga" text="FPGA Commander settings" />
 			<tocitem target="prefs_cmdline" text="A linha de comando" />
 		</tocitem>
 		<tocitem target="opts" text="Opções de projeto">

--- a/src/main/resources/doc/pt/html/guide/prefs/index.html
+++ b/src/main/resources/doc/pt/html/guide/prefs/index.html
@@ -30,7 +30,7 @@
         <a href="pref-simulation.html">A guia Simulationb</a><br>
         <a href="pref-exp.html">A guia Experimental</a><br>
         <a href="pref-software.html">A guia Programas de terceiros</a><br>
-        <a href="pref-fpgacommander.html">TA guia Configuraçöes do Comandante FPGA</a><br><br>
+        <a href="../../../../en/html/guide/prefs/pref-fpgacommander.html">TA guia Configuraçöes do Comandante FPGA</a><br><br>
         <a href="pref-cmdline.html">Opções para a linha de comandos </a>
       </blockquote>
       <p>

--- a/src/main/resources/doc/pt/html/guide/prefs/index.html
+++ b/src/main/resources/doc/pt/html/guide/prefs/index.html
@@ -30,7 +30,7 @@
         <a href="pref-simulation.html">A guia Simulationb</a><br>
         <a href="pref-exp.html">A guia Experimental</a><br>
         <a href="pref-software.html">A guia Programas de terceiros</a><br>
-        <a href="../../../../en/html/guide/prefs/pref-fpgacommander.html">TA guia Configuraçöes do Comandante FPGA</a><br><br>
+        <a href="../../../../en/html/guide/prefs/pref-fpgacommander.html">A guia Configuraçöes do Comandante FPGA</a><br><br>
         <a href="pref-cmdline.html">Opções para a linha de comandos </a>
       </blockquote>
       <p>

--- a/src/main/resources/doc/ru/contents.xml
+++ b/src/main/resources/doc/ru/contents.xml
@@ -84,7 +84,7 @@
 <!--	<tocitem target="prefs_simulation" text="L'onglet simulation"/> -->			
 			<tocitem target="prefs_exp" text="Вкладка Экспериментальные" />
 <!--	<tocitem target="prefs_sofware" text="L'onglet Logicile tiers"/> -->
-<!--	<tocitem target="prefs_fpga" text="L'onglet FPGA Commander settings"/> -->
+			<tocitem target="prefs_fpga" text="FPGA Commander settings" />
 			<tocitem target="prefs_cmdline" text="Командная строка" />
 		</tocitem>
 		<tocitem target="opts" text="Параметры проекта">

--- a/src/main/resources/doc/ru/html/guide/prefs/index.html
+++ b/src/main/resources/doc/ru/html/guide/prefs/index.html
@@ -30,7 +30,7 @@
 		<a href="pref-simulation.html">The Simulation tab</a><br>
         <a href="pref-exp.html">Вкладка Экспериментальные</a><br>
         <a href="pref-software.html">Вкладка Программное обеспечение</a><br>
-		<a href="pref-fpgacommander.html">Вкладка Настройки FPGA Commander Настройки</a><br><br>
+		<a href="../../../../en/html/guide/prefs/pref-fpgacommander.html">Вкладка Настройки FPGA Commander Настройки</a><br><br>
         <a href="pref-cmdline.html">Параметры командной строки </a>
       </blockquote>
       <p>

--- a/src/main/resources/doc/zh/contents.xml
+++ b/src/main/resources/doc/zh/contents.xml
@@ -185,7 +185,7 @@
 			<tocitem target="prefs_exp" text="实验性选项卡" />
 
 <!--	<tocitem target="prefs_sofware" text="The Sofware tab"/> -->
-<!--	<tocitem target="prefs_fpga" text="The FPGA Commander settings tab"/> -->
+			<tocitem target="prefs_fpga" text="FPGA Commander 设置选项卡" />
 			<!-- <tocitem target="prefs_cmdline" text="The command line" /> -->
 			<tocitem target="prefs_cmdline" text="命令行" />
 

--- a/src/main/resources/doc/zh/html/guide/prefs/index.html
+++ b/src/main/resources/doc/zh/html/guide/prefs/index.html
@@ -83,7 +83,7 @@
     </a>
     <br/>
     <!-- <a href="pref-fpgacommander.html">The FPGA Commander Settings tab</a><br><br> -->
-    <a href="pref-fpgacommander.html">
+    <a href="../../../../en/html/guide/prefs/pref-fpgacommander.html">
      FPGA Commander 设置选项卡
     </a>
     <br/>


### PR DESCRIPTION
Follow-up to #2621.

Summary
- add `prefs_fpga` entries to the localized online-help contents trees
- add localized help-map targets that point to the existing English FPGA Commander settings page
- update localized preferences index links so they reference the English page instead of missing local files

Verification
- `git diff --check`
- `./gradlew.bat processResources`
- custom localized-link check for `prefs_fpga` contents/map/index targets