### PR TITLE
gui: list built-in libraries in load menu

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/menu/MenuProject.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuProject.java
@@ -17,16 +17,19 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
 
 class MenuProject extends Menu {
   private static final long serialVersionUID = 1L;
   private final LogisimMenuBar menubar;
   private final MyListener myListener = new MyListener();
+  private final MyMenuListener myMenuListener = new MyMenuListener();
   private final MenuItemImpl addCircuit = new MenuItemImpl(this, LogisimMenuBar.ADD_CIRCUIT);
   private final MenuItemImpl addVhdl = new MenuItemImpl(this, LogisimMenuBar.ADD_VHDL);
   private final MenuItemImpl importVhdl = new MenuItemImpl(this, LogisimMenuBar.IMPORT_VHDL);
   private final JMenu loadLibrary = new JMenu();
-  private final JMenuItem loadBuiltin = new JMenuItem();
+  private final JMenu loadBuiltin = new JMenu();
   private final JMenuItem loadLogisim = new JMenuItem();
   private final JMenuItem loadJar = new JMenuItem();
   private final JMenuItem unload = new JMenuItem();
@@ -56,7 +59,7 @@ class MenuProject extends Menu {
     menubar.registerItem(LogisimMenuBar.ADD_CIRCUIT, addCircuit);
     menubar.registerItem(LogisimMenuBar.ADD_VHDL, addVhdl);
     menubar.registerItem(LogisimMenuBar.IMPORT_VHDL, importVhdl);
-    loadBuiltin.addActionListener(myListener);
+    loadBuiltin.addMenuListener(myMenuListener);
     loadLogisim.addActionListener(myListener);
     loadJar.addActionListener(myListener);
     unload.addActionListener(myListener);
@@ -166,9 +169,7 @@ class MenuProject extends Menu {
       if (proj == null) {
         return;
       }
-      if (src == loadBuiltin) {
-        ProjectLibraryActions.doLoadBuiltinLibrary(proj);
-      } else if (src == loadLogisim) {
+      if (src == loadLogisim) {
         ProjectLibraryActions.doLoadLogisimLibrary(proj);
       } else if (src == loadJar) {
         ProjectLibraryActions.doLoadJarLibrary(proj);
@@ -178,5 +179,20 @@ class MenuProject extends Menu {
         proj.getOptionsFrame().setVisible(true);
       }
     }
+  }
+
+  private class MyMenuListener implements MenuListener {
+    @Override
+    public void menuSelected(MenuEvent event) {
+      if (event.getSource() == loadBuiltin) {
+        ProjectLibraryActions.populateBuiltinLibraryMenu(loadBuiltin, menubar.getSaveProject());
+      }
+    }
+
+    @Override
+    public void menuDeselected(MenuEvent event) {}
+
+    @Override
+    public void menuCanceled(MenuEvent event) {}
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/menu/Popups.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/Popups.java
@@ -186,7 +186,7 @@ public class Popups {
     final JMenuItem add = new JMenuItem(S.get("projectAddCircuitItem"));
     final JMenuItem vhdl = new JMenuItem(S.get("projectAddVhdlItem"));
     final JMenu load = new JMenu(S.get("projectLoadLibraryItem"));
-    final JMenuItem loadBuiltin = new JMenuItem(S.get("projectLoadBuiltinItem"));
+    final JMenu loadBuiltin = new JMenu(S.get("projectLoadBuiltinItem"));
     final JMenuItem loadLogisim = new JMenuItem(S.get("projectLoadLogisimItem"));
     final JMenuItem loadJar = new JMenuItem(S.get("projectLoadJarItem"));
 
@@ -194,8 +194,8 @@ public class Popups {
       super(S.get("projMenu"));
       this.proj = proj;
 
+      ProjectLibraryActions.populateBuiltinLibraryMenu(loadBuiltin, proj);
       load.add(loadBuiltin);
-      loadBuiltin.addActionListener(this);
       load.add(loadLogisim);
       loadLogisim.addActionListener(this);
       load.add(loadJar);
@@ -215,8 +215,6 @@ public class Popups {
         ProjectCircuitActions.doAddCircuit(proj);
       } else if (src == vhdl) {
         ProjectCircuitActions.doAddVhdl(proj);
-      } else if (src == loadBuiltin) {
-        ProjectLibraryActions.doLoadBuiltinLibrary(proj);
       } else if (src == loadLogisim) {
         ProjectLibraryActions.doLoadLogisimLibrary(proj);
       } else if (src == loadJar) {

--- a/src/main/java/com/cburch/logisim/gui/menu/ProjectLibraryActions.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/ProjectLibraryActions.java
@@ -12,6 +12,7 @@ package com.cburch.logisim.gui.menu;
 import static com.cburch.logisim.gui.Strings.S;
 
 import com.cburch.logisim.file.Loader;
+import com.cburch.logisim.file.LogisimFile;
 import com.cburch.logisim.file.LogisimFileActions;
 import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.proj.Project;
@@ -22,16 +23,45 @@ import java.util.List;
 import java.util.jar.JarFile;
 import javax.swing.JFileChooser;
 import javax.swing.JList;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
 import javax.swing.JScrollPane;
 
 public class ProjectLibraryActions {
   private ProjectLibraryActions() {}
 
+  static List<Library> availableBuiltinLibraries(LogisimFile file) {
+    final var builtins = new ArrayList<>(file.getLoader().getBuiltin().getLibraries());
+    builtins.removeAll(file.getLibraries());
+    return builtins;
+  }
+
+  static void populateBuiltinLibraryMenu(JMenu menu, Project proj) {
+    menu.removeAll();
+    if (proj == null) {
+      menu.setEnabled(false);
+      return;
+    }
+
+    menu.setEnabled(true);
+    final var builtins = availableBuiltinLibraries(proj.getLogisimFile());
+    if (builtins.isEmpty()) {
+      final var emptyItem = new JMenuItem(S.get("loadBuiltinNoneError"));
+      emptyItem.setEnabled(false);
+      menu.add(emptyItem);
+      return;
+    }
+
+    for (final var lib : builtins) {
+      final var item = new JMenuItem(lib.getDisplayName());
+      item.addActionListener((event) -> doLoadBuiltinLibrary(proj, lib));
+      menu.add(item);
+    }
+  }
+
   public static void doLoadBuiltinLibrary(Project proj) {
     final var file = proj.getLogisimFile();
-    final var baseBuilt = file.getLoader().getBuiltin().getLibraries();
-    final var builtins = new ArrayList<>(baseBuilt);
-    builtins.removeAll(file.getLibraries());
+    final var builtins = availableBuiltinLibraries(file);
     if (builtins.isEmpty()) {
       OptionPane.showMessageDialog(
           proj.getFrame(),
@@ -53,6 +83,12 @@ public class ProjectLibraryActions {
       final var libs = list.getSelectedLibraries();
       if (libs != null)
         proj.doAction(LogisimFileActions.loadLibraries(libs, proj.getLogisimFile()));
+    }
+  }
+
+  private static void doLoadBuiltinLibrary(Project proj, Library lib) {
+    if (!proj.getLogisimFile().getLibraries().contains(lib)) {
+      proj.doAction(LogisimFileActions.loadLibrary(lib, proj.getLogisimFile()));
     }
   }
 

--- a/src/test/java/com/cburch/logisim/gui/menu/ProjectLibraryActionsTest.java
+++ b/src/test/java/com/cburch/logisim/gui/menu/ProjectLibraryActionsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.menu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.file.Loader;
+import com.cburch.logisim.file.LogisimFile;
+import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.tools.Library;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import org.junit.jupiter.api.Test;
+
+class ProjectLibraryActionsTest {
+  @Test
+  void availableBuiltinLibrariesExcludeAlreadyLoadedBuiltins() {
+    final var file = newFile();
+    final var builtins = file.getLoader().getBuiltin().getLibraries();
+    file.addLibrary(builtins.get(0));
+    file.addLibrary(builtins.get(1));
+
+    final var available = ProjectLibraryActions.availableBuiltinLibraries(file);
+
+    assertFalse(available.contains(builtins.get(0)));
+    assertFalse(available.contains(builtins.get(1)));
+    assertTrue(available.contains(builtins.get(2)));
+  }
+
+  @Test
+  void populateBuiltinLibraryMenuListsLoadableLibrariesDirectly() {
+    final var file = newFile();
+    final var project = new Project(file);
+    final var menu = new JMenu();
+
+    ProjectLibraryActions.populateBuiltinLibraryMenu(menu, project);
+
+    assertEquals(file.getLoader().getBuiltin().getLibraries().size(), menu.getItemCount());
+    assertEquals(
+        file.getLoader().getBuiltin().getLibraries().get(0).getDisplayName(),
+        menu.getItem(0).getText());
+  }
+
+  @Test
+  void clickingBuiltinLibraryMenuItemLoadsThatLibrary() {
+    final var file = newFile();
+    final var project = new Project(file);
+    final var library = file.getLoader().getBuiltin().getLibraries().get(0);
+    final var menu = new JMenu();
+
+    ProjectLibraryActions.populateBuiltinLibraryMenu(menu, project);
+    menu.getItem(0).doClick();
+
+    assertTrue(file.getLibraries().contains(library));
+  }
+
+  @Test
+  void populateBuiltinLibraryMenuShowsDisabledMessageWhenNoBuiltinsCanBeLoaded() {
+    final var file = newFile();
+    for (final Library lib : file.getLoader().getBuiltin().getLibraries()) {
+      file.addLibrary(lib);
+    }
+    final var project = new Project(file);
+    final var menu = new JMenu();
+
+    ProjectLibraryActions.populateBuiltinLibraryMenu(menu, project);
+
+    assertEquals(1, menu.getItemCount());
+    final JMenuItem item = menu.getItem(0);
+    assertFalse(item.isEnabled());
+  }
+
+  private static LogisimFile newFile() {
+    return LogisimFile.createNew(new Loader(null), null);
+  }
+}


### PR DESCRIPTION
Related to #802 and #1200.

Summary
- turn the Project > Load Library > Built-in Library entry into a submenu listing each currently unloaded built-in library directly
- apply the same direct built-in library submenu to the Library Pane project context menu
- keep the existing built-in-library selection dialog method for any remaining callers
- add regression coverage for filtering already-loaded built-ins, menu population, disabled empty-state display, and loading through a generated menu item

Notes
- This is intended as a small discoverability step before any discussion about making unused-library removal the default.
- This PR does not change `Remove unused libraries on save` defaults.
- This PR does not add new project templates such as Beginner/Advanced/Full.

Verification
- .\gradlew.bat compileJava checkstyleMain checkstyleTest test --tests com.cburch.logisim.gui.menu.ProjectLibraryActionsTest
- git diff --check