### PR TITLE
Improve native Windows compatibility for the OpenFPGA toolchain

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/download/Download.java
+++ b/src/main/java/com/cburch/logisim/fpga/download/Download.java
@@ -296,6 +296,7 @@ public class Download extends DownloadBase implements Runnable, BaseWindowListen
   }
 
   public static String execute(ProcessBuilder process, List<String> report) throws IOException, InterruptedException {
+    process.redirectErrorStream(true);
     var executable = process.start();
     var is = executable.getInputStream();
     var isr = new InputStreamReader(is);
@@ -318,6 +319,7 @@ public class Download extends DownloadBase implements Runnable, BaseWindowListen
     Reporter.report.print("==>");
     Reporter.report.print("==> " + StageName);
     Reporter.report.print("==>");
+    process.redirectErrorStream(true);
     synchronized (lock) {
       executable = process.start();
     }


### PR DESCRIPTION
This PR intends to fix #2286.

The reason why nextpnr hangs on Windows is because nextpnr only prints to `stderr` (see https://github.com/YosysHQ/nextpnr/issues/250#issuecomment-473499304), whilst logisim is expecting an output on `stdout` (I don't understand why Logisim on Linux doesn't suffer from the same issue though).

The added benefit of redirecting `stderr` to `stdout` is that the console now displays the actual error messages, instead of just a generic error message in the error console. I have no idea how this impacts tools outside of the open source toolchain though, nor do I know its impact on the Linux side, so there might be unforeseen consequences.

---

There is a second problem with Logisim on native Windows with open source tooling I'd like to address: by default, VHDL is selected but it's unsupported in this specific scenario. I was hoping to be able to resolve it by temporarily switching HDL languages only on native Windows systems by adding
```java
if (downloader instanceof OpenFpgaDownload && System.getProperty("os.name").toLowerCase().contains("windows") && AppPreferences.HdlType.get().equals(HdlGeneratorFactory.VHDL)) {
  HdlType = HdlGeneratorFactory.VHDL;
  AppPreferences.HdlType.set(HdlGeneratorFactory.VERILOG);
  Reporter.report.addWarning("Using VHDL with OpenFPGA isn't supported on Windows, using Verilog instead");
}
```
before this line
https://github.com/logisim-evolution/logisim-evolution/blob/9dbaf41e8ba0ecb234bd064805a99888e0242c69/src/main/java/com/cburch/logisim/fpga/download/Download.java#L220

and changing the HDL type back once the flow has finished. It works - however, this code is rather poorly maintainable, inflexible and generally suboptimal. Would you consider adding it or is it not good enough?
