### PR TITLE
Fix out of bound exception when reducing fanout

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/SplitterAttributes.java
+++ b/src/main/java/com/cburch/logisim/circuit/SplitterAttributes.java
@@ -269,12 +269,16 @@ public class SplitterAttributes extends AbstractAttributeSet {
 
   private void clampBitEndsToFanout() {
     final var offs = INIT_ATTRIBUTES.size();
+    List<Integer> bitEndModified = new ArrayList<>();
     for (var i = 0; i < bitEnd.length; i++) {
       if (bitEnd[i] > fanout) {
-        final var attr = (BitOutAttribute) attrs.get(offs + i);
         bitEnd[i] = fanout;
-        fireAttributeValueChanged(attr, (int) bitEnd[i], null);
+        bitEndModified.add(i);
       }
+    }
+    for (int i : bitEndModified) {
+      final var attr = (BitOutAttribute) attrs.get(offs + i);
+      fireAttributeValueChanged(attr, (int) bitEnd[i], null);
     }
   }
 


### PR DESCRIPTION
Addresses #2664.

My solution feels more like a workaround and not like an actual solution. The reason why I say that is because of the following:

1. Place down a splitter in a circuit
2. Increase the `Fan Out` from 2 to 4.
3. Increase the `Bit Width In` from 2 to 4.
4. Decrease the `Fan Out` from 4 to 2 again.

In Logisim 4.1.0, it creates a symmetric fanout, with `1-0` and `3-2` (so as it is when you place it). However, in 4.2.0 and with this fix, you get `0` and `3-1`. Personally I'm not particularly satisfied with this result, as in I prefer the 4.1.0 behavior in this particular instance, but I have no idea how it behaves in other instances - I can't judge what's better as a whole. I wish I could improve it, but I just don't have the knowledge.