### PR TITLE
Use OS file separator for workspace and saving board editor files

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/gui/BoardEditor.java
+++ b/src/main/java/com/cburch/logisim/fpga/gui/BoardEditor.java
@@ -211,8 +211,8 @@ public class BoardEditor implements ActionListener, BaseComponentListenerContrac
   }
 
   private String checkIfEndsWithSlash(String path) {
-    if (!path.endsWith("/")) {
-      path += "/";
+    if (!path.endsWith(File.separator)) {
+      path += File.separator;
     }
     return (path);
   }

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -516,7 +516,7 @@ public class AppPreferences {
   public static final PrefMonitor<String> FPGA_Workspace =
       create(
           new PrefMonitorString(
-              "FPGAWorkspace", System.getProperty("user.home") + "/logisim_evolution_workspace"));
+              "FPGAWorkspace", System.getProperty("user.home") + File.separator + "logisim_evolution_workspace"));
   public static final PrefMonitor<String> HdlType =
       create(
           new PrefMonitorStringOpts(


### PR DESCRIPTION
These changes don't impact Linux at all, it's only native Windows that will be impacted.
The workspace settings change is an improvement, as it's a user facing setting. I don't think this should impact previously saved user settings.
The board editor change isn't visible to the user, but should make copying & pasting paths within the save window safer to use.