### PR TITLE
Add null check in FileUtil.correctPath to avoid NullPointerException when Questa path is empty

### DIFF
--- a/src/main/java/com/cburch/logisim/util/FileUtil.java
+++ b/src/main/java/com/cburch/logisim/util/FileUtil.java
@@ -24,6 +24,7 @@ public final class FileUtil {
   }
 
   public static String correctPath(String path) {
+    if (path == null) return null;
     return path.endsWith(File.separator) ? path : path + File.separator;
   }
 


### PR DESCRIPTION
Fixes #2660.

### What changed
Add null check in FileUtil.correctPath to avoid NullPointerException when Questa path is empty

### Why
The bug occurs because VhdlSimulatorTclBinder.init() calls FileUtil.correctPath(path) with a null path when the Questa Advanced Simulator path preference is empty and the user cancels the file chooser. The null is passed to correctPath, which invokes path.endsWith() without a null check, causing a NullPointerException. The minimal fix is to add a null guard in correctPath, returning the original value if null, preserving existing behavior for non-null paths. This is the safest approach as it prevents the crash regardless of where null paths might be passed.

### Verification
- java text sanity passed

### Not run
- Repository runtime tests were not run outside the configured static/sandbox policy.

### Changed files
- `src/main/java/com/cburch/logisim/util/FileUtil.java`