### PR TITLE
Fix HDL setting being overwritten

### DIFF
--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -520,7 +520,7 @@ public class AppPreferences {
   public static final PrefMonitor<String> HdlType =
       create(
           new PrefMonitorStringOpts(
-              "afterAdd",
+              "hdlType",
               new String[] {HdlGeneratorFactory.VHDL, HdlGeneratorFactory.VERILOG},
               HdlGeneratorFactory.VHDL));
   public static final PrefMonitor<String> SelectedBoard =


### PR DESCRIPTION
There are 2 settings named `afterAdd`, which causes some inconsistencies - sometimes the HDL setting saves, sometimes not.