### PR TITLE
Fix timing diagram signals not resetting cleanly

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/log/Model.java
+++ b/src/main/java/com/cburch/logisim/gui/log/Model.java
@@ -443,7 +443,6 @@ public class Model implements CircuitListener, SignalInfo.Listener {
     mode = m;
     granularity = g;
     simulatorReset();
-    fireSignalsExtended(null); // reset, not extended, but works fine for now
     fireModeChanged(null);
   }
 
@@ -580,7 +579,6 @@ public class Model implements CircuitListener, SignalInfo.Listener {
 
   private void extendWithOldValues(long duration) {
     for (final var s : signals) {
-      final var v = s.info.fetchValue(circuitState);
       s.extend(duration);
     }
     elapsedSinceTrigger += duration;
@@ -738,6 +736,7 @@ public class Model implements CircuitListener, SignalInfo.Listener {
     }
     elapsedSinceTrigger += duration;
     timeEnd = duration;
+    fireSignalsReset(null);
   }
 
   public void setFile(File value) {


### PR DESCRIPTION
There's an issue with signals not cleanly resetting in the chronograph when you reset the simulation.
Here are the reproduction steps:

1. Open the timing diagram of a circuit
2. Enable clock ticks
3. Let the simulation run for a bit
4. Pause the simulation
5. Reset the simulation
6. Observe how the signals in the chronograph aren't reset. If you hover over a signal, it adopts the reset value.

This PR intends to fix that behavior. I removed the `fireSignalsExtended` call as it seems redundant now, but I haven't checked all cases (I've only tested GUI).

---

Additionally, I remove an unused variable (having nothing to do with simulation reset), which I'm hoping doesn't have any side effects.