### PR TITLE
soc: allow bus traces to be hidden

### DIFF
--- a/src/main/java/com/cburch/logisim/soc/bus/SocBusAttributes.java
+++ b/src/main/java/com/cburch/logisim/soc/bus/SocBusAttributes.java
@@ -114,7 +114,7 @@ public class SocBusAttributes extends AbstractAttributeSet {
     }
     if (attr == StdAttr.LABEL_VISIBILITY) {
       final var v = (Boolean) value;
-      if (labelVisible.equals(v)) {
+      if (!labelVisible.equals(v)) {
         labelVisible = v;
         fireAttributeValueChanged(attr, value, oldValue);
       }
@@ -126,7 +126,7 @@ public class SocBusAttributes extends AbstractAttributeSet {
     }
     if (attr == SOC_TRACE_VISIBLE) {
       final var v = (Boolean) value;
-      if (traceVisible.equals(v)) {
+      if (!traceVisible.equals(v)) {
         traceVisible = v;
         fireAttributeValueChanged(attr, value, oldValue);
       }

--- a/src/test/java/com/cburch/logisim/soc/bus/SocBusAttributesTest.java
+++ b/src/test/java/com/cburch/logisim/soc/bus/SocBusAttributesTest.java
@@ -1,0 +1,40 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.soc.bus;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.instance.StdAttr;
+import org.junit.jupiter.api.Test;
+
+class SocBusAttributesTest {
+  @Test
+  void traceVisibilityCanBeDisabled() {
+    final var attrs = new SocBusAttributes();
+
+    assertTrue(attrs.getValue(SocBusAttributes.SOC_TRACE_VISIBLE));
+
+    attrs.setValue(SocBusAttributes.SOC_TRACE_VISIBLE, false);
+
+    assertFalse(attrs.getValue(SocBusAttributes.SOC_TRACE_VISIBLE));
+  }
+
+  @Test
+  void labelVisibilityCanBeDisabled() {
+    final var attrs = new SocBusAttributes();
+
+    assertTrue(attrs.getValue(StdAttr.LABEL_VISIBILITY));
+
+    attrs.setValue(StdAttr.LABEL_VISIBILITY, false);
+
+    assertFalse(attrs.getValue(StdAttr.LABEL_VISIBILITY));
+  }
+}


### PR DESCRIPTION
Summary
- Fix the SoC bus boolean attribute setters so Trace Visible = No is applied instead of ignored.
- Apply the same corrected change detection to the SoC bus label visibility setter.
- Add regression coverage for disabling both boolean attributes.

Root cause
`SocBusAttributes.setValue()` only updated these booleans when the new value was equal to the old value. Changing the default `true` value to `false` skipped both assignment and change notification.

Verification
- `./gradlew.bat test --tests com.cburch.logisim.soc.bus.SocBusAttributesTest`
- `./gradlew.bat compileJava checkstyleMain checkstyleTest`
- `git diff --check`

Closes #2673
