### PR TITLE
gui: remember layout view per circuit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
   * Fixed several HDL and FPGA generation issues, including wide Random generator HDL, PortIO bubble
     ranges, scanning I/O constraints, and Xilinx download placeholder handling.
   * Improved project editing stability:
+    * Layout zoom and scroll position are remembered separately for each circuit during a session.
     * Moving components preserves component state.
     * Floating subcircuit inputs now propagate floating values.
     * Nested library tools resolve correctly.

--- a/src/main/java/com/cburch/logisim/gui/main/CircuitViewMemory.java
+++ b/src/main/java/com/cburch/logisim/gui/main/CircuitViewMemory.java
@@ -1,0 +1,36 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.main;
+
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.gui.generic.ZoomModel;
+import java.awt.Point;
+import java.util.IdentityHashMap;
+import java.util.function.Consumer;
+
+final class CircuitViewMemory {
+  private final IdentityHashMap<Circuit, ViewState> states = new IdentityHashMap<>();
+
+  void remember(Circuit circuit, ZoomModel zoomModel, Point viewPosition) {
+    if (circuit == null || zoomModel == null || viewPosition == null) return;
+    states.put(circuit, new ViewState(zoomModel.getZoomFactor(), new Point(viewPosition)));
+  }
+
+  boolean restore(Circuit circuit, ZoomModel zoomModel, Consumer<Point> viewPositionSetter) {
+    if (circuit == null || zoomModel == null || viewPositionSetter == null) return false;
+    final var state = states.get(circuit);
+    if (state == null) return false;
+    zoomModel.setZoomFactor(state.zoomFactor);
+    viewPositionSetter.accept(new Point(state.viewPosition));
+    return true;
+  }
+
+  private record ViewState(double zoomFactor, Point viewPosition) {}
+}

--- a/src/main/java/com/cburch/logisim/gui/main/CircuitViewMemory.java
+++ b/src/main/java/com/cburch/logisim/gui/main/CircuitViewMemory.java
@@ -23,6 +23,10 @@ final class CircuitViewMemory {
     states.put(circuit, new ViewState(zoomModel.getZoomFactor(), new Point(viewPosition)));
   }
 
+  void forget(Circuit circuit) {
+    if (circuit != null) states.remove(circuit);
+  }
+
   boolean restore(Circuit circuit, ZoomModel zoomModel, Consumer<Point> viewPositionSetter) {
     if (circuit == null || zoomModel == null || viewPositionSetter == null) return false;
     final var state = states.get(circuit);

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -17,6 +17,7 @@ import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.CircuitEvent;
 import com.cburch.logisim.circuit.CircuitListener;
 import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.circuit.SubcircuitFactory;
 import com.cburch.logisim.comp.Component;
 import com.cburch.logisim.data.AttributeEvent;
 import com.cburch.logisim.data.AttributeSet;
@@ -43,6 +44,7 @@ import com.cburch.logisim.proj.ProjectActions;
 import com.cburch.logisim.proj.ProjectEvent;
 import com.cburch.logisim.proj.ProjectListener;
 import com.cburch.logisim.proj.Projects;
+import com.cburch.logisim.tools.AddTool;
 import com.cburch.logisim.tools.Tool;
 import com.cburch.logisim.util.HorizontalSplitPane;
 import com.cburch.logisim.util.JFileChoosers;
@@ -891,6 +893,10 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
       } else if (e.getAction() == LibraryEvent.DIRTY_STATE) {
         buildTitleString();
         enableSave();
+      } else if (e.getAction() == LibraryEvent.REMOVE_TOOL
+          && e.getData() instanceof AddTool tool
+          && tool.getFactory() instanceof SubcircuitFactory subcircuitFactory) {
+        layoutViewMemory.forget(subcircuitFactory.getSubcircuit());
       }
     }
 

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -122,6 +122,8 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
   // for the Layout view
   private final LayoutToolbarModel layoutToolbarModel;
   private final Canvas layoutCanvas;
+  private final CanvasPane layoutCanvasPane;
+  private final CircuitViewMemory layoutViewMemory = new CircuitViewMemory();
   private final VhdlSimulatorConsole vhdlSimulatorConsole;
   private final HdlContentView hdlEditor;
   private final ZoomModel layoutZoomModel;
@@ -147,14 +149,14 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     // set up elements for the Layout view
     layoutToolbarModel = new LayoutToolbarModel(this, project);
     layoutCanvas = new Canvas(project);
-    final var canvasPane = new CanvasPane(layoutCanvas);
+    layoutCanvasPane = new CanvasPane(layoutCanvas);
 
     layoutZoomModel =
         new BasicZoomModel(
             AppPreferences.LAYOUT_SHOW_GRID,
             AppPreferences.LAYOUT_ZOOM,
             buildZoomSteps(),
-            canvasPane);
+            layoutCanvasPane);
 
     layoutCanvas.getGridPainter().setZoomModel(layoutZoomModel);
     layoutEditHandler = new LayoutEditHandler(this);
@@ -185,9 +187,9 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
 
     // set up the central area
     mainPanelSuper = new JPanel(new BorderLayout());
-    canvasPane.setZoomModel(layoutZoomModel);
+    layoutCanvasPane.setZoomModel(layoutZoomModel);
     mainPanel = new CardPanel();
-    mainPanel.addView(EDIT_LAYOUT, canvasPane);
+    mainPanel.addView(EDIT_LAYOUT, layoutCanvasPane);
     mainPanel.setView(EDIT_LAYOUT);
     mainPanelSuper.add(mainPanel, BorderLayout.CENTER);
 
@@ -676,6 +678,21 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     return layoutZoomModel;
   }
 
+  private void rememberLayoutView(Object active) {
+    if (active instanceof CircuitState state) {
+      layoutViewMemory.remember(
+          state.getCircuit(), layoutZoomModel, layoutCanvasPane.getViewport().getViewPosition());
+    }
+  }
+
+  private void restoreLayoutView(Circuit circuit) {
+    layoutCanvas.computeSize(true);
+    layoutViewMemory.restore(
+        circuit,
+        layoutZoomModel,
+        position -> layoutCanvasPane.getViewport().setViewPosition(position));
+  }
+
   @Override
   public void localeChanged() {
     buildTitleString();
@@ -893,8 +910,10 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
           }
         }
       } else if (action == ProjectEvent.ACTION_SET_CURRENT) {
-        if (event.getData() instanceof Circuit) {
+        rememberLayoutView(event.getOldData());
+        if (event.getData() instanceof Circuit circuit) {
           setEditorView(EDIT_LAYOUT);
+          restoreLayoutView(circuit);
           if (appearance != null) {
             appearance.setCircuit(project, project.getCircuitState());
           }

--- a/src/test/java/com/cburch/logisim/gui/main/CircuitViewMemoryTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/CircuitViewMemoryTest.java
@@ -1,0 +1,123 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.gui.generic.ZoomModel;
+import java.awt.Point;
+import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeListener;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class CircuitViewMemoryTest {
+  private static final double ZOOM_DELTA = 1.0e-6;
+
+  @Test
+  void restoresSavedViewForCircuit() {
+    final var circuit = new Circuit("main", null, null);
+    final var memory = new CircuitViewMemory();
+    final var zoom = new TestZoomModel();
+    final var savedPosition = new Point(120, 80);
+
+    zoom.setZoomFactor(1.5);
+    memory.remember(circuit, zoom, savedPosition);
+    savedPosition.setLocation(0, 0);
+
+    zoom.setZoomFactor(0.75);
+    final var restoredPosition = new AtomicReference<Point>();
+
+    assertTrue(memory.restore(circuit, zoom, restoredPosition::set));
+    assertEquals(1.5, zoom.getZoomFactor(), ZOOM_DELTA);
+    assertEquals(new Point(120, 80), restoredPosition.get());
+  }
+
+  @Test
+  void usesCircuitIdentityInsteadOfName() {
+    final var first = new Circuit("same", null, null);
+    final var second = new Circuit("same", null, null);
+    final var memory = new CircuitViewMemory();
+    final var zoom = new TestZoomModel();
+
+    zoom.setZoomFactor(2.0);
+    memory.remember(first, zoom, new Point(30, 40));
+
+    zoom.setZoomFactor(1.0);
+    final var restoredPosition = new AtomicReference<Point>();
+
+    assertFalse(memory.restore(second, zoom, restoredPosition::set));
+    assertEquals(1.0, zoom.getZoomFactor(), ZOOM_DELTA);
+    assertNull(restoredPosition.get());
+  }
+
+  @Test
+  void restorePassesCopyOfSavedPosition() {
+    final var circuit = new Circuit("main", null, null);
+    final var memory = new CircuitViewMemory();
+    final var zoom = new TestZoomModel();
+    final var restoredPosition = new AtomicReference<Point>();
+
+    memory.remember(circuit, zoom, new Point(10, 20));
+    assertTrue(memory.restore(circuit, zoom, restoredPosition::set));
+    restoredPosition.get().setLocation(99, 99);
+
+    assertTrue(memory.restore(circuit, zoom, restoredPosition::set));
+    assertEquals(new Point(10, 20), restoredPosition.get());
+  }
+
+  private static class TestZoomModel implements ZoomModel {
+    private double zoomFactor = 1.0;
+
+    @Override
+    public boolean getShowGrid() {
+      return false;
+    }
+
+    @Override
+    public void setShowGrid(boolean value) {}
+
+    @Override
+    public double getZoomFactor() {
+      return zoomFactor;
+    }
+
+    @Override
+    public List<Double> getZoomOptions() {
+      return List.of();
+    }
+
+    @Override
+    public void setZoomFactor(double value) {
+      zoomFactor = value;
+    }
+
+    @Override
+    public void setZoomFactor(double value, MouseEvent e) {
+      zoomFactor = value;
+    }
+
+    @Override
+    public void setZoomFactorCenter(double value) {
+      zoomFactor = value;
+    }
+
+    @Override
+    public void addPropertyChangeListener(String prop, PropertyChangeListener l) {}
+
+    @Override
+    public void removePropertyChangeListener(String prop, PropertyChangeListener l) {}
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/main/CircuitViewMemoryTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/CircuitViewMemoryTest.java
@@ -64,6 +64,35 @@ class CircuitViewMemoryTest {
   }
 
   @Test
+  void forgetRemovesSavedViewForCircuit() {
+    final var circuit = new Circuit("main", null, null);
+    final var memory = new CircuitViewMemory();
+    final var zoom = new TestZoomModel();
+    final var restoredPosition = new AtomicReference<Point>();
+
+    memory.remember(circuit, zoom, new Point(10, 20));
+    memory.forget(circuit);
+
+    assertFalse(memory.restore(circuit, zoom, restoredPosition::set));
+    assertNull(restoredPosition.get());
+  }
+
+  @Test
+  void forgetUsesCircuitIdentityInsteadOfName() {
+    final var first = new Circuit("same", null, null);
+    final var second = new Circuit("same", null, null);
+    final var memory = new CircuitViewMemory();
+    final var zoom = new TestZoomModel();
+    final var restoredPosition = new AtomicReference<Point>();
+
+    memory.remember(first, zoom, new Point(30, 40));
+    memory.forget(second);
+
+    assertTrue(memory.restore(first, zoom, restoredPosition::set));
+    assertEquals(new Point(30, 40), restoredPosition.get());
+  }
+
+  @Test
   void restorePassesCopyOfSavedPosition() {
     final var circuit = new Circuit("main", null, null);
     final var memory = new CircuitViewMemory();


### PR DESCRIPTION
Summary
- remember the layout canvas zoom and scroll position separately for each circuit during a session
- restore the saved layout view when switching back to a circuit
- add focused coverage for circuit identity, saved zoom/position restore, and defensive position copies

Notes
- This intentionally does not persist the camera position into .circ files yet. It covers the low-risk in-session part of #2012 first, without changing the project file format.

Verification
- ./gradlew.bat compileJava checkstyleMain checkstyleTest test --tests com.cburch.logisim.gui.main.CircuitViewMemoryTest --tests com.cburch.logisim.gui.main.FrameTest
- git diff --check