### PR TITLE
memory: compact wide counter appearance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
     * Added a go-to-address control to the hex editor.
     * Limited generated save previews for large memories.
     * Corrected memory display layout in exported graphics.
+    * Wide Counter components use compact grouped state rows in evolution appearance.
     * RAM line-enable inputs now only write when enabled. Existing projects relying on unconnected
       line-enable inputs may need to connect those inputs explicitly.
   * Fixed several HDL and FPGA generation issues, including wide Random generator HDL, PortIO bubble

--- a/src/main/java/com/cburch/logisim/std/memory/Counter.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Counter.java
@@ -115,7 +115,7 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
   }
 
   static String getOutputDataRowLabel(int row, int nrOfBits) {
-    return getBitsPerDataRow(nrOfBits) == 1 ? getDataRowLabel(row, nrOfBits) : "";
+    return getDataRowLabel(row, nrOfBits);
   }
 
   static String getDataRowValue(Value value, int row, int nrOfBits) {
@@ -143,6 +143,14 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
 
   static int getEvolutionHeight(int nrOfBits) {
     return CONTROL_HEIGHT + DATA_ROW_HEIGHT * getDataRowCount(nrOfBits);
+  }
+
+  static Bounds getControlValueBounds(int nrOfBits) {
+    final var len = (nrOfBits + 3) / 4;
+    final var valueWidth = len * 8;
+    final var preferredX = getSymbolWidth(nrOfBits) - 25 - valueWidth / 2;
+    final var rightEdge = 20 + getSymbolWidth(nrOfBits);
+    return Bounds.create(Math.min(preferredX, rightEdge - valueWidth), 22, valueWidth, 16);
   }
 
   private static int getFirstDataRowBit(int row, int nrOfBits) {
@@ -320,13 +328,16 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
     /* Draw counter Value */
     RegisterData state = (RegisterData) painter.getData();
     if (painter.getShowState() && (state != null)) {
-      final var len = (width + 3) / 4;
-      final var xcenter = getSymbolWidth(width) - 25;
+      final var valueBounds = getControlValueBounds(width);
       final var val = state.value;
       if (val.isFullyDefined()) g.setColor(Color.LIGHT_GRAY);
       else if (val.isErrorValue()) g.setColor(Color.RED);
       else g.setColor(Color.BLUE);
-      g.fillRect(xpos + xcenter - len * 4, ypos + 22, len * 8, 16);
+      g.fillRect(
+          xpos + valueBounds.getX(),
+          ypos + valueBounds.getY(),
+          valueBounds.getWidth(),
+          valueBounds.getHeight());
       var value = "";
       if (val.isFullyDefined()) {
         g.setColor(Color.DARK_GRAY);
@@ -339,8 +350,8 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
       GraphicsUtil.drawText(
           g,
           value,
-          xpos + xcenter - len * 4 + 1,
-          ypos + 30,
+          xpos + valueBounds.getX() + 1,
+          ypos + valueBounds.getY() + valueBounds.getHeight() / 2,
           GraphicsUtil.H_LEFT,
           GraphicsUtil.V_CENTER);
       g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));

--- a/src/main/java/com/cburch/logisim/std/memory/Counter.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Counter.java
@@ -81,6 +81,8 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
   public static final int EN = 6;
 
   static final int CARRY = 7;
+  private static final int CONTROL_HEIGHT = 110;
+  private static final int DATA_ROW_HEIGHT = 20;
 
   public Counter() {
     super(_ID, S.getter("counterComponent"), new CounterHdlGeneratorFactory());
@@ -93,6 +95,62 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
             new DirectionConfigurator(StdAttr.LABEL_LOC, KeyEvent.ALT_DOWN_MASK)));
     setInstanceLogger(RegisterLogger.class);
     setKeyConfigurator(new BitWidthConfigurator(StdAttr.WIDTH));
+  }
+
+  static int getBitsPerDataRow(int nrOfBits) {
+    if (nrOfBits <= 8) return 1;
+    if (nrOfBits <= 32) return 4;
+    return 8;
+  }
+
+  static int getDataRowCount(int nrOfBits) {
+    final var bitsPerRow = getBitsPerDataRow(nrOfBits);
+    return (nrOfBits + bitsPerRow - 1) / bitsPerRow;
+  }
+
+  static String getDataRowLabel(int row, int nrOfBits) {
+    final var firstBit = getFirstDataRowBit(row, nrOfBits);
+    final var lastBit = getLastDataRowBit(row, nrOfBits);
+    return firstBit == lastBit ? Integer.toString(firstBit) : firstBit + "-" + lastBit;
+  }
+
+  static String getOutputDataRowLabel(int row, int nrOfBits) {
+    return getBitsPerDataRow(nrOfBits) == 1 ? getDataRowLabel(row, nrOfBits) : "";
+  }
+
+  static String getDataRowValue(Value value, int row, int nrOfBits) {
+    final var firstBit = getFirstDataRowBit(row, nrOfBits);
+    final var lastBit = getLastDataRowBit(row, nrOfBits);
+    final var result = new StringBuilder(lastBit - firstBit + 1);
+    for (var bit = lastBit; bit >= firstBit; bit--) {
+      final var bitValue = value.get(bit);
+      if (bitValue == Value.TRUE) {
+        result.append('1');
+      } else if (bitValue == Value.FALSE) {
+        result.append('0');
+      } else if (bitValue == Value.UNKNOWN) {
+        result.append('?');
+      } else {
+        result.append('!');
+      }
+    }
+    return result.toString();
+  }
+
+  static String getDataRowControlText(int nrOfBits) {
+    return getBitsPerDataRow(nrOfBits) == 1 ? "1,6D" : "";
+  }
+
+  static int getEvolutionHeight(int nrOfBits) {
+    return CONTROL_HEIGHT + DATA_ROW_HEIGHT * getDataRowCount(nrOfBits);
+  }
+
+  private static int getFirstDataRowBit(int row, int nrOfBits) {
+    return row * getBitsPerDataRow(nrOfBits);
+  }
+
+  private static int getLastDataRowBit(int row, int nrOfBits) {
+    return Math.min(nrOfBits - 1, getFirstDataRowBit(row, nrOfBits) + getBitsPerDataRow(nrOfBits) - 1);
   }
 
   @Override
@@ -289,10 +347,11 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
     }
   }
 
-  private void drawDataBlock(InstancePainter painter, int xpos, int ypos, int bitNr, int nrOfBits) {
-    final var realYpos = ypos + bitNr * 20;
-    final var first = bitNr == 0;
-    final var last = bitNr == (nrOfBits - 1);
+  private void drawDataBlock(InstancePainter painter, int xpos, int ypos, int row, int nrOfBits) {
+    final var dataRowCount = getDataRowCount(nrOfBits);
+    final var realYpos = ypos + row * DATA_ROW_HEIGHT;
+    final var first = row == 0;
+    final var last = row == (dataRowCount - 1);
     final var g = painter.getGraphics();
     final var font = g.getFont();
     g.setFont(font.deriveFont(7.0f));
@@ -328,22 +387,25 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
     if (nrOfBits > 1) {
       GraphicsUtil.drawText(
           g,
-          Integer.toString(bitNr),
+          getOutputDataRowLabel(row, nrOfBits),
           xpos + 30 + getSymbolWidth(nrOfBits),
           realYpos + 8,
           GraphicsUtil.H_RIGHT,
           GraphicsUtil.V_BASELINE);
       GraphicsUtil.drawText(
           g,
-          Integer.toString(bitNr),
+          getDataRowLabel(row, nrOfBits),
           xpos + 10,
           realYpos + 8,
           GraphicsUtil.H_LEFT,
           GraphicsUtil.V_BASELINE);
     }
     g.setFont(font);
-    GraphicsUtil.drawText(
-        g, "1,6D", xpos + 21, realYpos + 10, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
+    final var controlText = getDataRowControlText(nrOfBits);
+    if (!controlText.isEmpty()) {
+      GraphicsUtil.drawText(
+          g, controlText, xpos + 21, realYpos + 10, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
+    }
     final var LineWidth =
         (nrOfBits == 1) ? GraphicsUtil.DATA_SINGLE_WIDTH : GraphicsUtil.DATA_MULTI_WIDTH;
     GraphicsUtil.switchToWidth(g, LineWidth);
@@ -389,24 +451,25 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
       final var widthVal = painter.getAttributeValue(StdAttr.WIDTH);
       var width = widthVal == null ? 8 : widthVal.getWidth();
       var xcenter = (getSymbolWidth(width) / 2) + 10;
-      var value = "";
+      final var value = getDataRowValue(val, row, width);
       if (val.isFullyDefined()) {
         g.setColor(Color.LIGHT_GRAY);
-        value = ((1L << bitNr) & val.toLongValue()) != 0 ? "1" : "0";
+      } else if (val.isErrorValue()) {
+        g.setColor(Color.RED);
       } else if (val.isUnknown()) {
         g.setColor(Color.BLUE);
-        value = "?";
       } else {
-        g.setColor(Color.RED);
-        value = "!";
+        g.setColor(Color.BLUE);
       }
-      g.fillRect(xpos + xcenter + 16, realYpos + 4, 8, 16);
+      final var valueWidth = Math.max(8, value.length() * 8);
+      final var valueX = xpos + xcenter + 20 - valueWidth / 2;
+      g.fillRect(valueX, realYpos + 4, valueWidth, 16);
       if (val.isFullyDefined()) g.setColor(Color.DARK_GRAY);
       else g.setColor(Color.YELLOW);
       GraphicsUtil.drawText(
           g,
           value,
-          xpos + xcenter + 20,
+          valueX + valueWidth / 2,
           realYpos + 10,
           GraphicsUtil.H_CENTER,
           GraphicsUtil.V_CENTER);
@@ -425,7 +488,7 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
     final var width = widthVal == null ? 8 : widthVal.getWidth();
     return (attrs.getValue(StdAttr.APPEARANCE) == StdAttr.APPEAR_CLASSIC)
         ? Bounds.create(-30, -20, 30, 40)
-        : Bounds.create(0, 0, getSymbolWidth(width) + 40, 110 + 20 * width);
+        : Bounds.create(0, 0, getSymbolWidth(width) + 40, getEvolutionHeight(width));
   }
 
   @Override
@@ -512,8 +575,8 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
     drawControl(painter, Xpos, Ypos);
     final var widthVal = painter.getAttributeValue(StdAttr.WIDTH);
     final var width = widthVal == null ? 8 : widthVal.getWidth();
-    for (var bit = 0; bit < width; bit++) {
-      drawDataBlock(painter, Xpos, Ypos + 110, bit, width);
+    for (var row = 0; row < getDataRowCount(width); row++) {
+      drawDataBlock(painter, Xpos, Ypos + CONTROL_HEIGHT, row, width);
     }
   }
 

--- a/src/main/java/com/cburch/logisim/std/memory/CounterPoker.java
+++ b/src/main/java/com/cburch/logisim/std/memory/CounterPoker.java
@@ -32,8 +32,12 @@ public class CounterPoker extends RegisterPoker {
         g.drawRect(bds.getX() + (bds.getWidth() - wid) / 2, bds.getY() + 4, wid, 15);
       }
     } else {
-      int xcenter = Counter.getSymbolWidth(width) - 25;
-      g.drawRect(bds.getX() + xcenter - len * 4, bds.getY() + 22, len * 8, 16);
+      final var valueBounds = Counter.getControlValueBounds(width);
+      g.drawRect(
+          bds.getX() + valueBounds.getX(),
+          bds.getY() + valueBounds.getY(),
+          valueBounds.getWidth(),
+          valueBounds.getHeight());
     }
     g.setColor(Color.BLACK);
   }

--- a/src/test/java/com/cburch/logisim/std/memory/CounterAppearanceTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/CounterAppearanceTest.java
@@ -37,9 +37,9 @@ class CounterAppearanceTest {
   }
 
   @Test
-  void compactDataRowsHideDuplicateOutputRangeLabelsForGroupedRows() {
+  void compactDataRowsShowOutputRangeLabelsForGroupedRows() {
     assertEquals("7", Counter.getOutputDataRowLabel(7, 8));
-    assertEquals("", Counter.getOutputDataRowLabel(7, 64));
+    assertEquals("56-63", Counter.getOutputDataRowLabel(7, 64));
   }
 
   @Test
@@ -51,6 +51,14 @@ class CounterAppearanceTest {
   @Test
   void compactEvolutionBoundsUseGroupedRowCount() {
     assertEquals(270, Counter.getEvolutionHeight(64));
+  }
+
+  @Test
+  void compactControlValueBoundsStayInsideControlBlockForWideCounters() {
+    final var bounds = Counter.getControlValueBounds(64);
+
+    assertEquals(16, bounds.getHeight());
+    assertEquals(20 + Counter.getSymbolWidth(64), bounds.getX() + bounds.getWidth());
   }
 
   @Test

--- a/src/test/java/com/cburch/logisim/std/memory/CounterAppearanceTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/CounterAppearanceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.instance.Instance;
+import com.cburch.logisim.instance.StdAttr;
+import org.junit.jupiter.api.Test;
+
+class CounterAppearanceTest {
+
+  @Test
+  void compactDataRowsPreserveOneBitRowsForSmallCounters() {
+    assertEquals(1, Counter.getBitsPerDataRow(8));
+    assertEquals(8, Counter.getDataRowCount(8));
+    assertEquals("0", Counter.getDataRowLabel(0, 8));
+    assertEquals("7", Counter.getDataRowLabel(7, 8));
+  }
+
+  @Test
+  void compactDataRowsGroupWideCountersIntoAtMostEightRows() {
+    assertEquals(8, Counter.getBitsPerDataRow(64));
+    assertEquals(8, Counter.getDataRowCount(64));
+    assertEquals("0-7", Counter.getDataRowLabel(0, 64));
+    assertEquals("56-63", Counter.getDataRowLabel(7, 64));
+  }
+
+  @Test
+  void compactDataRowsHideDuplicateOutputRangeLabelsForGroupedRows() {
+    assertEquals("7", Counter.getOutputDataRowLabel(7, 8));
+    assertEquals("", Counter.getOutputDataRowLabel(7, 64));
+  }
+
+  @Test
+  void compactDataRowsHideRepeatedControlTextForGroupedRows() {
+    assertEquals("1,6D", Counter.getDataRowControlText(8));
+    assertEquals("", Counter.getDataRowControlText(64));
+  }
+
+  @Test
+  void compactEvolutionBoundsUseGroupedRowCount() {
+    assertEquals(270, Counter.getEvolutionHeight(64));
+  }
+
+  @Test
+  void compactEvolutionBoundsKeepWideCounterPortsStable() {
+    final var instance = createEvolutionCounterInstance(64);
+
+    assertEquals(300, instance.getBounds().getWidth());
+    assertEquals(270, instance.getBounds().getHeight());
+    assertPortLocation(instance, Counter.IN, 0, 110);
+    assertPortLocation(instance, Counter.OUT, 300, 110);
+    assertPortLocation(instance, Counter.CK, 0, 80);
+    assertPortLocation(instance, Counter.CLR, 0, 20);
+    assertPortLocation(instance, Counter.LD, 0, 30);
+    assertPortLocation(instance, Counter.UD, 0, 50);
+    assertPortLocation(instance, Counter.EN, 0, 70);
+    assertPortLocation(instance, Counter.CARRY, 300, 50);
+  }
+
+  @Test
+  void compactDataRowValueShowsGroupedBitsFromLowToHigh() {
+    final var value = Value.createKnown(BitWidth.create(16), 0x5A3C);
+
+    assertEquals("1100", Counter.getDataRowValue(value, 0, 16));
+    assertEquals("0011", Counter.getDataRowValue(value, 1, 16));
+    assertEquals("1010", Counter.getDataRowValue(value, 2, 16));
+    assertEquals("0101", Counter.getDataRowValue(value, 3, 16));
+  }
+
+  @Test
+  void compactDataRowValuePreservesMixedBitStates() {
+    final var value =
+        Value.create(
+            new Value[] {
+              Value.TRUE,
+              Value.FALSE,
+              Value.UNKNOWN,
+              Value.ERROR,
+              Value.FALSE,
+              Value.TRUE,
+              Value.FALSE,
+              Value.TRUE,
+              Value.FALSE,
+              Value.FALSE,
+              Value.FALSE,
+              Value.FALSE,
+              Value.FALSE,
+              Value.FALSE,
+              Value.FALSE,
+              Value.TRUE
+            });
+
+    assertEquals("!?01", Counter.getDataRowValue(value, 0, 16));
+    assertEquals("1010", Counter.getDataRowValue(value, 1, 16));
+  }
+
+  private static Instance createEvolutionCounterInstance(int width) {
+    final var counter = new Counter();
+    final var attrs = counter.createAttributeSet();
+    attrs.setValue(StdAttr.WIDTH, BitWidth.create(width));
+    attrs.setValue(StdAttr.APPEARANCE, StdAttr.APPEAR_EVOLUTION);
+    return Instance.getInstanceFor(counter.createComponent(Location.create(0, 0, false), attrs));
+  }
+
+  private static void assertPortLocation(Instance instance, int portIndex, int x, int y) {
+    final var location = instance.getPortLocation(portIndex);
+    assertEquals(x, location.getX());
+    assertEquals(y, location.getY());
+  }
+}


### PR DESCRIPTION
Summary
- compact Counter evolution-appearance data rows for wide counters instead of rendering one row per bit
- keep existing Counter port coordinates stable while shrinking wide-counter bounds
- add regression coverage for grouping, bounds, port positions, and mixed bit-state display
- update CHANGES.md

Part of #2561.

Verification
- ./gradlew.bat compileJava checkstyleMain checkstyleTest test --tests com.cburch.logisim.std.memory.CounterAppearanceTest