### PR TITLE
soc: snapshot CPU traces before painting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
       line-enable inputs may need to connect those inputs explicitly.
   * Fixed several HDL and FPGA generation issues, including wide Random generator HDL, PortIO bubble
     ranges, scanning I/O constraints, and Xilinx download placeholder handling.
+  * Fixed SoC execution trace painting when the trace changes during simulation.
   * Improved project editing stability:
     * Moving components preserves component state.
     * Floating subcircuit inputs now propagate floating values.

--- a/src/main/java/com/cburch/logisim/soc/gui/CpuDrawSupport.java
+++ b/src/main/java/com/cburch/logisim/soc/gui/CpuDrawSupport.java
@@ -24,6 +24,7 @@ import java.awt.Color;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.event.MouseEvent;
+import java.util.LinkedList;
 
 public class CpuDrawSupport {
 
@@ -216,12 +217,13 @@ public class CpuDrawSupport {
     GraphicsUtil.drawCenteredText(g2, S.get("Rv32imBinInstruction"), bds.getX(), bds.getY());
     bds = getBounds(215 + blockWidth, 21, 0, 0, scale);
     GraphicsUtil.drawCenteredText(g2, S.get("Rv32imAsmInstruction"), bds.getX(), bds.getY());
-    if (cpu.getTraces().isEmpty()) {
+    final var traces = new LinkedList<>(cpu.getTraces());
+    if (traces.isEmpty()) {
       bds = getBounds(207, 250, 0, 0, scale);
       GraphicsUtil.drawCenteredText(g2, S.get("Rv32imEmptyTrace"), bds.getX(), bds.getY());
     } else {
       int yOff = 30;
-      for (TraceInfo t : cpu.getTraces()) {
+      for (TraceInfo t : traces) {
         t.paint(g2, yOff, scale);
         yOff += TRACE_HEIGHT;
       }

--- a/src/test/java/com/cburch/logisim/soc/gui/CpuDrawSupportConcurrentTraceReproTest.java
+++ b/src/test/java/com/cburch/logisim/soc/gui/CpuDrawSupportConcurrentTraceReproTest.java
@@ -1,0 +1,128 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.soc.gui;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.cburch.logisim.soc.data.SocProcessorInterface;
+import com.cburch.logisim.soc.data.SocUpSimulationState;
+import com.cburch.logisim.soc.data.SocUpStateInterface;
+import com.cburch.logisim.soc.data.TraceInfo;
+import com.cburch.logisim.soc.util.AssemblerInterface;
+import java.awt.Graphics2D;
+import java.awt.event.WindowListener;
+import java.awt.image.BufferedImage;
+import java.util.LinkedList;
+import javax.swing.JPanel;
+import org.junit.jupiter.api.Test;
+
+class CpuDrawSupportConcurrentTraceReproTest {
+  @Test
+  void drawTraceHandlesTraceListChangesDuringPaint() {
+    final var traces = new LinkedList<TraceInfo>();
+    traces.add(
+        new TraceInfo(0, 0, "mutates trace list during paint", false) {
+          @Override
+          public void paint(Graphics2D g, int yOffset, boolean scale) {
+            traces.addFirst(new TraceInfo(1, 1, "new instruction", false));
+          }
+        });
+    traces.add(new TraceInfo(2, 2, "next instruction", false));
+
+    final var image = new BufferedImage(700, 700, BufferedImage.TYPE_INT_ARGB);
+    final var graphics = image.createGraphics();
+
+    assertDoesNotThrow(
+        () -> CpuDrawSupport.drawTrace(graphics, 0, 0, false, new TestCpuState(traces)));
+  }
+
+  private record TestCpuState(LinkedList<TraceInfo> traces) implements SocUpStateInterface {
+    @Override
+    public int getLastRegisterWritten() {
+      return -1;
+    }
+
+    @Override
+    public String getRegisterValueHex(int index) {
+      return "0x00000000";
+    }
+
+    @Override
+    public String getRegisterAbiName(int index) {
+      return "";
+    }
+
+    @Override
+    public String getRegisterNormalName(int index) {
+      return "r" + index;
+    }
+
+    @Override
+    public int getProgramCounter() {
+      return 0;
+    }
+
+    @Override
+    public LinkedList<TraceInfo> getTraces() {
+      return traces;
+    }
+
+    @Override
+    public void simButtonPressed() {}
+
+    @Override
+    public SocUpSimulationState getSimState() {
+      return null;
+    }
+
+    @Override
+    public boolean programLoaded() {
+      return true;
+    }
+
+    @Override
+    public WindowListener getWindowListener() {
+      return null;
+    }
+
+    @Override
+    public JPanel getAsmWindow() {
+      return null;
+    }
+
+    @Override
+    public JPanel getStatePanel() {
+      return null;
+    }
+
+    @Override
+    public AssemblerInterface getAssembler() {
+      return null;
+    }
+
+    @Override
+    public SocProcessorInterface getProcessorInterface() {
+      return null;
+    }
+
+    @Override
+    public String getProcessorType() {
+      return "nios2";
+    }
+
+    @Override
+    public int getElfType() {
+      return 0;
+    }
+
+    @Override
+    public void repaint() {}
+  }
+}


### PR DESCRIPTION
Fixes #2679.

This snapshots the CPU trace list before drawing it, so trace entries can be added while the trace panel is painting without invalidating the active iteration.

Validation:
- `./gradlew --no-daemon test --tests 'com.cburch.logisim.soc.gui.CpuDrawSupportConcurrentTraceReproTest'`
- `./gradlew --no-daemon build -x checkstyleMain -x checkstyleTest`
- `./gradlew --no-daemon checkstyleMain`
