### PR TITLE
Improve board IO mapping

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/data/IoComponentTypes.java
+++ b/src/main/java/com/cburch/logisim/fpga/data/IoComponentTypes.java
@@ -236,7 +236,7 @@ public enum IoComponentTypes {
             var pinIndex = 0;
             pinIndex = switch (mapRotation) {
               case ROTATION_CCW_90 -> (int) ((height - heightIndex - 1) / part);
-              case ROTATION_CW_90 -> (int) (height / part);
+              case ROTATION_CW_90 -> (int) (heightIndex / part);
               default -> (int) (widthIndex / part);
             };
             partialMap[widthIndex][heightIndex] = pinIndex;

--- a/src/main/java/com/cburch/logisim/fpga/gui/BoardManipulator.java
+++ b/src/main/java/com/cburch/logisim/fpga/gui/BoardManipulator.java
@@ -471,29 +471,25 @@ public class BoardManipulator extends JPanel implements BaseMouseListenerContrac
   @Override
   public void valueChanged(ListSelectionEvent event) {
     if (event.getSource().equals(unmappedList)) {
+      ioComps.removeSelectable(scale);
       if (unmappedList.getSelectedIndex() >= 0) {
         mappedList.clearSelection();
         if (unmapButton != null) unmapButton.setEnabled(false);
         ioComps.setSelectable(unmappedList.getSelectedValue(), scale);
-      } else ioComps.removeSelectable(scale);
+      }
     } else if (event.getSource().equals(mappedList)) {
+      ioComps.removeSelectable(scale);
       if (mappedList.getSelectedIndex() >= 0) {
         unmappedList.clearSelection();
         if (unmapButton != null) unmapButton.setEnabled(true);
         ioComps.setSelectable(mappedList.getSelectedValue(), scale);
-      } else ioComps.removeSelectable(scale);
+      }
       if (mappedList.getModel().getSize() > 0) {
         if (unmapAllButton != null) unmapAllButton.setEnabled(true);
       } else {
         if (unmapAllButton != null) unmapAllButton.setEnabled(false);
       }
     }
-  }
-
-  @Override
-  public void windowDeactivated(WindowEvent event) {
-    ioComps.removeSelectable(scale);
-    if (unmapButton != null) unmapButton.setEnabled(false);
   }
 
   @Override


### PR DESCRIPTION
- Fixes -90° rotated dipswitches not showing individual switches during the mapping step.
- No longer removes the possible physical components a component can be mapped to (by removes I mean it would stop rendering the blue rectangles) when the window is no longer in focus.
- Fixes weird visual artifacts that were created when selecting different types of components. E.g., 1 dipswitch and 1 LED bar in the unmapped components -> first select the dipswitch, then the LED bar. Observe that some of the blue rectangles mapped to buttons and switches are rendered, even though we are trying to map the LED bar. If you hover over the rendering artifacts, they disappear.