### PR TITLE
Fix FlatLaf restricted native access warning on Java 21+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Fixed FlatLaf "restricted native access" warning on newer Java versions.
   * Added support for opening project files by dragging them into the application window.
   * Added ability to load multiple RAM or ROM memories from the command line
   * Added Real-Time Clock component.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ repositories {
 
 application {
   mainClass.set("com.cburch.logisim.Main")
+  applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
 }
 
 dependencies {
@@ -171,6 +172,7 @@ extra.apply {
       "--input", packageInputDir,
       "--main-class", "com.cburch.logisim.Main",
       "--main-jar", shadowJarFilename,
+      "--java-options", "--enable-native-access=ALL-UNNAMED",
       "--copyright", copyrights,
       "--description", "Digital logic design tool and simulator",
       "--vendor", "${project.name} developers",
@@ -861,6 +863,7 @@ tasks {
 
   test {
     useJUnitPlatform()
+    jvmArgs("--enable-native-access=ALL-UNNAMED")
 //    testLogging {
 //      events("passed", "skipped", "failed")
 //    }


### PR DESCRIPTION
Fixes #2681 
This PR resolves the `java.lang.System` native access warnings that appear in the terminal when running Logisim-evolution on Java 21+. 
I added the `--enable-native-access=ALL-UNNAMED` JVM argument to `build.gradle.kts` to explicitly allow FlatLaf to load its native window decorations without the JVM throwing security warnings.