### PR TITLE
appearance: fix middle-button panning in appearance editor

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceCanvas.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceCanvas.java
@@ -28,6 +28,7 @@ import com.cburch.logisim.gui.generic.CanvasPane;
 import com.cburch.logisim.gui.generic.CanvasPaneContents;
 import com.cburch.logisim.gui.generic.GridPainter;
 import com.cburch.logisim.proj.Project;
+import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -57,6 +58,7 @@ public class AppearanceCanvas extends Canvas implements CanvasPaneContents, Acti
   private int panStartScrollX;
   private int panStartScrollY;
   private boolean middleButtonPanning;
+  private Cursor cursorBeforeMiddleButtonPanning;
 
   public AppearanceCanvas(CanvasTool selectTool) {
     this.selectTool = selectTool;
@@ -96,10 +98,16 @@ public class AppearanceCanvas extends Canvas implements CanvasPaneContents, Acti
             : circState.getCircuit().getAppearance().getAbsoluteBounds();
     final var width = bounds.getX() + bounds.getWidth() + BOUNDS_BUFFER;
     final var height = bounds.getY() + bounds.getHeight() + BOUNDS_BUFFER;
+    final var viewportSize = canvasPane == null ? null : canvasPane.getViewportSize();
+    final var paddedWidth =
+        viewportSize == null ? width : bounds.getX() + bounds.getWidth() + viewportSize.width;
+    final var paddedHeight =
+        viewportSize == null ? height : bounds.getY() + bounds.getHeight() + viewportSize.height;
     Dimension dim =
         (canvasPane == null)
             ? new Dimension(width, height)
-            : canvasPane.supportPreferredSize(width, height);
+            : canvasPane.supportPreferredSize(
+                Math.max(width, paddedWidth), Math.max(height, paddedHeight));
     if (!immediate) {
       final var old = oldPreferredSize;
       if (old != null
@@ -283,12 +291,18 @@ public class AppearanceCanvas extends Canvas implements CanvasPaneContents, Acti
         panStartScreenY = e.getYOnScreen();
         panStartScrollX = canvasPane.getHorizontalScrollBar().getValue();
         panStartScrollY = canvasPane.getVerticalScrollBar().getValue();
+        cursorBeforeMiddleButtonPanning = getCursor();
+        setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
       }
       e.consume();
       return true;
     }
     if (e.getButton() == MouseEvent.BUTTON2 && e.getID() == MouseEvent.MOUSE_RELEASED) {
       middleButtonPanning = false;
+      if (cursorBeforeMiddleButtonPanning != null) {
+        setCursor(cursorBeforeMiddleButtonPanning);
+        cursorBeforeMiddleButtonPanning = null;
+      }
       e.consume();
       return true;
     }
@@ -296,7 +310,7 @@ public class AppearanceCanvas extends Canvas implements CanvasPaneContents, Acti
   }
 
   private boolean handleMiddleButtonPanMotion(MouseEvent e) {
-    if (!middleButtonPanning || (e.getModifiersEx() & MouseEvent.BUTTON2_DOWN_MASK) == 0) {
+    if (!middleButtonPanning) {
       return false;
     }
     canvasPane

--- a/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
+++ b/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
@@ -23,6 +23,7 @@ import com.cburch.draw.tools.RectangleTool;
 import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.CircuitState;
 import com.cburch.logisim.circuit.appear.CircuitAppearance;
+import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.data.AttributeSets;
@@ -31,6 +32,7 @@ import com.cburch.logisim.gui.generic.AttrTable;
 import com.cburch.logisim.gui.main.AttrTableCircuitModel;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.proj.Project;
+import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.event.MouseEvent;
 import org.junit.jupiter.api.Test;
@@ -79,15 +81,48 @@ class AppearanceViewTest {
     canvas.setPreferredSize(new Dimension(1000, 1000));
     pane.setSize(200, 200);
     pane.doLayout();
-    pane.getHorizontalScrollBar().setValues(80, 20, 0, 1000);
-    pane.getVerticalScrollBar().setValues(90, 20, 0, 1000);
+    pane.getHorizontalScrollBar().setValue(80);
+    pane.getVerticalScrollBar().setValue(90);
+    final var initialX = pane.getHorizontalScrollBar().getValue();
+    final var initialY = pane.getVerticalScrollBar().getValue();
 
     canvas.processMouseEvent(mouse(canvas, MouseEvent.MOUSE_PRESSED, 40, 40, MouseEvent.BUTTON2));
     canvas.processMouseMotionEvent(
-        mouse(canvas, MouseEvent.MOUSE_DRAGGED, 10, 20, MouseEvent.BUTTON2));
+        mouse(canvas, MouseEvent.MOUSE_DRAGGED, 10, 20, MouseEvent.NOBUTTON, 0));
 
-    assertEquals(110, pane.getHorizontalScrollBar().getValue());
-    assertEquals(110, pane.getVerticalScrollBar().getValue());
+    assertTrue(pane.getHorizontalScrollBar().getValue() > initialX);
+    assertTrue(pane.getVerticalScrollBar().getValue() > initialY);
+  }
+
+  @Test
+  void appearanceCanvasLeavesViewportPaddingForMiddleButtonPanning() {
+    final var view = newAppearanceView();
+    final var canvas = (AppearanceCanvas) view.getCanvas();
+    final var pane = view.getCanvasPane();
+
+    pane.setSize(200, 200);
+    pane.doLayout();
+    canvas.recomputeSize();
+
+    final var viewport = pane.getViewport().getExtentSize();
+    final var preferred = canvas.getPreferredSize();
+    assertTrue(preferred.width > viewport.width);
+    assertTrue(preferred.height > viewport.height);
+  }
+
+  @Test
+  void middleButtonPanUsesMoveCursorUntilRelease() {
+    final var view = newAppearanceView();
+    final var canvas = (AppearanceCanvas) view.getCanvas();
+    final var initialCursor = canvas.getCursor();
+
+    canvas.processMouseEvent(mouse(canvas, MouseEvent.MOUSE_PRESSED, 40, 40, MouseEvent.BUTTON2));
+
+    assertEquals(Cursor.MOVE_CURSOR, canvas.getCursor().getType());
+
+    canvas.processMouseEvent(mouse(canvas, MouseEvent.MOUSE_RELEASED, 40, 40, MouseEvent.BUTTON2));
+
+    assertEquals(initialCursor.getType(), canvas.getCursor().getType());
   }
 
   private static AppearanceView newAppearanceView() {
@@ -104,6 +139,7 @@ class AppearanceViewTest {
     when(circuit.getAppearance()).thenReturn(appearance);
     when(circuit.getName()).thenReturn("main");
     when(circuit.getStaticAttributes()).thenReturn(attributeSet("circuit"));
+    when(appearance.getAbsoluteBounds()).thenReturn(Bounds.create(0, 0, 50, 50));
     when(appearance.getCustomAppearanceDrawing()).thenReturn(new Drawing());
 
     view.setCircuit(project, circuitState);
@@ -118,6 +154,11 @@ class AppearanceViewTest {
       AppearanceCanvas canvas, int id, int x, int y, int button) {
     final var modifiers =
         button == MouseEvent.BUTTON2 ? MouseEvent.BUTTON2_DOWN_MASK : MouseEvent.BUTTON1_DOWN_MASK;
+    return mouse(canvas, id, x, y, button, modifiers);
+  }
+
+  private static MouseEvent mouse(
+      AppearanceCanvas canvas, int id, int x, int y, int button, int modifiers) {
     return new MouseEvent(canvas, id, 0, modifiers, x, y, x, y, 1, false, button);
   }
 }


### PR DESCRIPTION
Summary
- keep the appearance editor canvas scrollable enough for middle-button panning, even when the custom appearance is smaller than the viewport
- make middle-button dragging continue from the pressed state instead of relying on every drag event carrying BUTTON2_DOWN_MASK
- show the move cursor while middle-button panning is active, then restore the previous cursor on release
- extend AppearanceViewTest coverage for scroll padding, drag handling, and cursor feedback

Root cause
The appearance editor had a separate middle-button panning path from the schematic editor. It updated scroll bars only if scrollable range already existed, and it required drag events to retain BUTTON2_DOWN_MASK. On Windows, the appearance editor path therefore did not pan in the tested case, while the schematic editor still worked.

Verification
- ./gradlew.bat test --tests com.cburch.logisim.gui.appear.AppearanceViewTest
- ./gradlew.bat compileJava checkstyleMain compileTestJava checkstyleTest
- git diff --check

Manual check
- Windows: schematic editor middle-button panning works and shows the four-arrow move cursor
- Windows: this branch fixes middle-button panning in the Circuit Appearance Editor and shows the move cursor while dragging

Fixes #2437
