### PR TITLE
gui: support text label editing shortcuts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
     * Moving components preserves component state.
     * Floating subcircuit inputs now propagate floating values.
     * Nested library tools resolve correctly.
+    * Text label editing handles menu-shortcut actions and in-place undo/redo consistently.
     * No-op text edits no longer create undo actions.
   * Improved VHDL editing and simulation UI:
     * VHDL entity appearance is configured through entity properties.

--- a/src/main/java/com/cburch/logisim/comp/TextFieldCaret.java
+++ b/src/main/java/com/cburch/logisim/comp/TextFieldCaret.java
@@ -14,6 +14,7 @@ import com.cburch.logisim.tools.Caret;
 import com.cburch.logisim.tools.CaretEvent;
 import com.cburch.logisim.tools.CaretListener;
 import com.cburch.logisim.util.GraphicsUtil;
+import com.cburch.logisim.util.MacCompatibility;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Toolkit;
@@ -22,7 +23,9 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.LinkedList;
 
 class TextFieldCaret implements Caret, TextFieldListener {
@@ -32,16 +35,26 @@ class TextFieldCaret implements Caret, TextFieldListener {
   public static final Color SELECTION_BACKGROUND = new Color(0x99, 0xcc, 0xff);
 
   private final LinkedList<CaretListener> listeners = new LinkedList<>();
+  private final Deque<EditState> redoStack = new ArrayDeque<>();
+  private final Deque<EditState> undoStack = new ArrayDeque<>();
   private final TextField field;
   private final Graphics g;
+  private final boolean metaMenuShortcutEnabled;
   private String oldText;
   private String curText;
   private int pos;
   private int end;
 
+  private record EditState(String text, int pos, int end) {}
+
   public TextFieldCaret(TextField field, Graphics g, int pos) {
+    this(field, g, pos, MacCompatibility.isRunningOnMac());
+  }
+
+  TextFieldCaret(TextField field, Graphics g, int pos, boolean metaMenuShortcutEnabled) {
     this.field = field;
     this.g = g;
+    this.metaMenuShortcutEnabled = metaMenuShortcutEnabled;
     this.oldText = field.getText();
     this.curText = field.getText();
     this.pos = pos;
@@ -77,6 +90,7 @@ class TextFieldCaret implements Caret, TextFieldListener {
     curText = text;
     pos = curText.length();
     end = pos;
+    clearEditHistory();
     field.setText(text);
   }
 
@@ -132,13 +146,16 @@ class TextFieldCaret implements Caret, TextFieldListener {
 
   @Override
   public void keyPressed(KeyEvent e) {
-    final var ign = InputEvent.ALT_DOWN_MASK | InputEvent.META_DOWN_MASK;
-    if ((e.getModifiersEx() & ign) != 0) return;
+    if ((e.getModifiersEx() & InputEvent.ALT_DOWN_MASK) != 0) return;
     final var shift = ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0);
     final var ctrl = ((e.getModifiersEx() & InputEvent.CTRL_DOWN_MASK) != 0);
-    arrowKeyMaybePressed(e, shift, ctrl);
+    final var meta = ((e.getModifiersEx() & InputEvent.META_DOWN_MASK) != 0);
+    final var metaMenuShortcut = metaMenuShortcutEnabled && meta;
+    if (meta && !metaMenuShortcut) return;
+    final var menuShortcut = ctrl || metaMenuShortcut;
+    if (!metaMenuShortcut) arrowKeyMaybePressed(e, shift, ctrl);
     if (e.isConsumed()) return;
-    if (ctrl)
+    if (menuShortcut)
       controlKeyPressed(e, shift);
     else
       normalKeyPressed(e, shift);
@@ -197,10 +214,8 @@ class TextFieldCaret implements Caret, TextFieldListener {
           final var sel = new StringSelection(s);
           Toolkit.getDefaultToolkit().getSystemClipboard().setContents(sel, null);
           if (cut) {
-            normalizeSelection();
-            curText =
-                curText.substring(0, pos) + (end < curText.length() ? curText.substring(end) : "");
-            end = pos;
+            rememberEdit();
+            deleteSelection();
           }
         }
         e.consume();
@@ -212,23 +227,25 @@ class TextFieldCaret implements Caret, TextFieldListener {
           String s =
               (String)
                   Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
-          var lastWasSpace = false;
-          for (var i = 0; i < s.length(); i++) {
-            var c = s.charAt(i);
-            if (!allowedCharacter(c)) {
-              if (lastWasSpace) continue;
-              c = ' ';
-            }
-            lastWasSpace = (c == ' ');
-            normalizeSelection();
-            curText = (end < curText.length())
-                    ? curText.substring(0, pos) + c + curText.substring(end)
-                    : curText.substring(0, pos) + c;
-            ++pos;
-            end = pos;
+          final var replacement = normalizePastedText(s);
+          if (!replacement.isEmpty()) {
+            rememberEdit();
+            replaceSelection(replacement);
           }
         } catch (Exception ignored) {
         }
+        e.consume();
+        break;
+      case KeyEvent.VK_Z:
+        if (shift) {
+          redoEdit();
+        } else {
+          undoEdit();
+        }
+        e.consume();
+        break;
+      case KeyEvent.VK_Y:
+        redoEdit();
         e.consume();
         break;
       default:// ignore
@@ -274,28 +291,30 @@ class TextFieldCaret implements Caret, TextFieldListener {
     switch (e.getKeyCode()) {
       case KeyEvent.VK_ESCAPE, KeyEvent.VK_CANCEL -> cancelEditing();
       case KeyEvent.VK_CLEAR -> {
-        curText = "";
-        end = pos = 0;
+        if (!curText.isEmpty()) {
+          rememberEdit();
+          curText = "";
+          end = pos = 0;
+        }
       }
       case KeyEvent.VK_ENTER -> stopEditing();
       case KeyEvent.VK_BACK_SPACE -> {
-        normalizeSelection();
         if (pos != end) {
-          curText = curText.substring(0, pos) + curText.substring(end);
-          end = pos;
+          rememberEdit();
+          deleteSelection();
         } else if (pos > 0) {
+          rememberEdit();
           curText = curText.substring(0, pos - 1) + curText.substring(pos);
           --pos;
           end = pos;
         }
       }
       case KeyEvent.VK_DELETE -> {
-        normalizeSelection();
         if (pos != end) {
-          curText =
-              curText.substring(0, pos) + (end < curText.length() ? curText.substring(end) : "");
-          end = pos;
+          rememberEdit();
+          deleteSelection();
         } else if (pos < curText.length()) {
+          rememberEdit();
           curText = curText.substring(0, pos) + curText.substring(pos + 1);
         }
       }
@@ -312,17 +331,74 @@ class TextFieldCaret implements Caret, TextFieldListener {
 
     final var c = e.getKeyChar();
     if (allowedCharacter(c)) {
-      normalizeSelection();
-      if (end < curText.length()) {
-        curText = curText.substring(0, pos) + c + curText.substring(end);
-      } else {
-        curText = curText.substring(0, pos) + c;
-      }
-      ++pos;
-      end = pos;
+      rememberEdit();
+      replaceSelection(String.valueOf(c));
     } else if (c == '\n') {
       stopEditing();
     }
+  }
+
+  private void clearEditHistory() {
+    redoStack.clear();
+    undoStack.clear();
+  }
+
+  private EditState currentEditState() {
+    return new EditState(curText, pos, end);
+  }
+
+  private void deleteSelection() {
+    normalizeSelection();
+    curText = curText.substring(0, pos) + (end < curText.length() ? curText.substring(end) : "");
+    end = pos;
+  }
+
+  private String normalizePastedText(String s) {
+    final var result = new StringBuilder();
+    var lastWasSpace = false;
+    for (var i = 0; i < s.length(); i++) {
+      var c = s.charAt(i);
+      if (!allowedCharacter(c)) {
+        if (lastWasSpace) continue;
+        c = ' ';
+      }
+      lastWasSpace = (c == ' ');
+      result.append(c);
+    }
+    return result.toString();
+  }
+
+  private void redoEdit() {
+    if (redoStack.isEmpty()) return;
+    undoStack.push(currentEditState());
+    restoreEditState(redoStack.pop());
+  }
+
+  private void rememberEdit() {
+    undoStack.push(currentEditState());
+    redoStack.clear();
+  }
+
+  private void replaceSelection(String replacement) {
+    normalizeSelection();
+    curText =
+        (end < curText.length())
+            ? curText.substring(0, pos) + replacement + curText.substring(end)
+            : curText.substring(0, pos) + replacement;
+    pos += replacement.length();
+    end = pos;
+  }
+
+  private void restoreEditState(EditState state) {
+    curText = state.text();
+    pos = state.pos();
+    end = state.end();
+  }
+
+  private void undoEdit() {
+    if (undoStack.isEmpty()) return;
+    redoStack.push(currentEditState());
+    restoreEditState(undoStack.pop());
   }
 
   protected void normalizeSelection() {
@@ -377,5 +453,6 @@ class TextFieldCaret implements Caret, TextFieldListener {
     oldText = curText;
     pos = curText.length();
     end = pos;
+    clearEditHistory();
   }
 }

--- a/src/main/java/com/cburch/logisim/comp/TextFieldCaret.java
+++ b/src/main/java/com/cburch/logisim/comp/TextFieldCaret.java
@@ -440,7 +440,6 @@ class TextFieldCaret implements Caret, TextFieldListener {
   @Override
   public void stopEditing() {
     final var e = new CaretEvent(this, oldText, curText);
-    field.setText(curText);
     for (final var l : new ArrayList<>(listeners)) {
       l.editingStopped(e);
     }

--- a/src/main/java/com/cburch/logisim/tools/TextTool.java
+++ b/src/main/java/com/cburch/logisim/tools/TextTool.java
@@ -25,6 +25,7 @@ import com.cburch.logisim.data.Location;
 import com.cburch.logisim.gui.main.Canvas;
 import com.cburch.logisim.gui.main.SelectionActions;
 import com.cburch.logisim.proj.Action;
+import com.cburch.logisim.proj.JoinedAction;
 import com.cburch.logisim.std.base.Text;
 import com.cburch.logisim.util.StringUtil;
 import java.awt.Cursor;
@@ -93,6 +94,10 @@ public class TextTool extends Tool {
           final var xn = new CircuitMutation(caretCircuit);
           xn.add(caretComponent);
           a = xn.toAction(S.getter("addComponentAction", Text.FACTORY.getDisplayGetter()));
+          final var editable = (TextEditable) caretComponent.getFeature(TextEditable.class);
+          final var editAction =
+              editable == null ? null : editable.getCommitAction(caretCircuit, e.getOldText(), val);
+          if (editAction != null) a = new JoinedAction(a, editAction);
         } else {
           // don't add the blank text field
           a = null;

--- a/src/test/java/com/cburch/logisim/comp/TextFieldCaretTest.java
+++ b/src/test/java/com/cburch/logisim/comp/TextFieldCaretTest.java
@@ -15,6 +15,7 @@ import java.awt.Canvas;
 import java.awt.Component;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class TextFieldCaretTest {
@@ -73,6 +74,32 @@ class TextFieldCaretTest {
         keyPressed(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK));
 
     assertEquals("abcd", caret.getText());
+  }
+
+  @Test
+  void stopEditingNotifiesCaretListenersBeforeUpdatingTextField() {
+    final var field = new TextField(0, 0, TextField.H_LEFT, TextField.V_BASELINE);
+    field.setText("abc");
+    final var mirroredText = new AtomicReference<>(field.getText());
+    field.addTextFieldListener(e -> mirroredText.set(e.getText()));
+    final var caret = new TextFieldCaret(field, null, 3, false);
+    final var mirroredTextWhenCommitted = new AtomicReference<String>();
+
+    caret.addCaretListener(
+        new com.cburch.logisim.tools.CaretListener() {
+          @Override
+          public void editingCanceled(com.cburch.logisim.tools.CaretEvent e) {}
+
+          @Override
+          public void editingStopped(com.cburch.logisim.tools.CaretEvent e) {
+            mirroredTextWhenCommitted.set(mirroredText.get());
+          }
+        });
+
+    caret.keyTyped(keyTyped('d'));
+    caret.stopEditing();
+
+    assertEquals("abc", mirroredTextWhenCommitted.get());
   }
 
   private static TextFieldCaret caret(String text, int pos) {

--- a/src/test/java/com/cburch/logisim/comp/TextFieldCaretTest.java
+++ b/src/test/java/com/cburch/logisim/comp/TextFieldCaretTest.java
@@ -1,0 +1,97 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.comp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Canvas;
+import java.awt.Component;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import org.junit.jupiter.api.Test;
+
+class TextFieldCaretTest {
+  private static final Component EVENT_SOURCE = new Canvas();
+
+  @Test
+  void metaMenuShortcutSelectsAllText() {
+    final var caret = caret("abc", 0, true);
+
+    caret.keyPressed(keyPressed(KeyEvent.VK_A, InputEvent.META_DOWN_MASK));
+    caret.keyTyped(keyTyped('x'));
+
+    assertEquals("x", caret.getText());
+  }
+
+  @Test
+  void metaMenuShortcutIsIgnoredWhenDisabled() {
+    final var caret = caret("abc", 0, false);
+
+    caret.keyPressed(keyPressed(KeyEvent.VK_A, InputEvent.META_DOWN_MASK));
+    caret.keyTyped(keyTyped('x'));
+
+    assertEquals("xabc", caret.getText());
+  }
+
+  @Test
+  void menuShortcutZUndoesInProgressTextEdit() {
+    final var caret = caret("abc", 3);
+
+    caret.keyTyped(keyTyped('d'));
+    caret.keyPressed(keyPressed(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK));
+
+    assertEquals("abc", caret.getText());
+  }
+
+  @Test
+  void menuShortcutYRedoesInProgressTextEdit() {
+    final var caret = caret("abc", 3);
+
+    caret.keyTyped(keyTyped('d'));
+    caret.keyPressed(keyPressed(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK));
+    assertEquals("abc", caret.getText());
+    caret.keyPressed(keyPressed(KeyEvent.VK_Y, InputEvent.CTRL_DOWN_MASK));
+
+    assertEquals("abcd", caret.getText());
+  }
+
+  @Test
+  void menuShortcutShiftZRedoesInProgressTextEdit() {
+    final var caret = caret("abc", 3);
+
+    caret.keyTyped(keyTyped('d'));
+    caret.keyPressed(keyPressed(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK));
+    assertEquals("abc", caret.getText());
+    caret.keyPressed(
+        keyPressed(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK));
+
+    assertEquals("abcd", caret.getText());
+  }
+
+  private static TextFieldCaret caret(String text, int pos) {
+    return caret(text, pos, false);
+  }
+
+  private static TextFieldCaret caret(String text, int pos, boolean metaMenuShortcutEnabled) {
+    final var field = new TextField(0, 0, TextField.H_LEFT, TextField.V_BASELINE);
+    field.setText(text);
+    return new TextFieldCaret(field, null, pos, metaMenuShortcutEnabled);
+  }
+
+  private static KeyEvent keyPressed(int keyCode, int modifiers) {
+    return new KeyEvent(
+        EVENT_SOURCE, KeyEvent.KEY_PRESSED, 0, modifiers, keyCode, KeyEvent.CHAR_UNDEFINED);
+  }
+
+  private static KeyEvent keyTyped(char keyChar) {
+    return new KeyEvent(
+        EVENT_SOURCE, KeyEvent.KEY_TYPED, 0, 0, KeyEvent.VK_UNDEFINED, keyChar);
+  }
+}

--- a/src/test/java/com/cburch/logisim/instance/InstanceTextFieldTest.java
+++ b/src/test/java/com/cburch/logisim/instance/InstanceTextFieldTest.java
@@ -9,10 +9,15 @@
 
 package com.cburch.logisim.instance;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.cburch.logisim.circuit.CircuitMutation;
 import com.cburch.logisim.data.Location;
+import com.cburch.logisim.file.Loader;
+import com.cburch.logisim.file.LogisimFile;
+import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.base.Text;
 import com.cburch.logisim.tools.TextEditable;
 import org.junit.jupiter.api.Test;
@@ -27,6 +32,28 @@ public class InstanceTextFieldTest {
   @Test
   public void unchangedTextCommitCreatesNoAction() {
     assertNull(newTextEditable().getCommitAction(null, "same", "same"));
+  }
+
+  @Test
+  public void committedTextChangeCanBeUndoneByProjectUndoManager() {
+    final var file = LogisimFile.createNew(new Loader(null), null);
+    final var project = new Project(file);
+    final var circuit = file.getMainCircuit();
+    final var attrs = Text.FACTORY.createAttributeSet();
+    attrs.setValue(Text.ATTR_TEXT, "old");
+    final var comp = Text.FACTORY.createComponent(Location.create(0, 0, false), attrs);
+    final var addComponent = new CircuitMutation(circuit);
+    addComponent.add(comp);
+    addComponent.execute();
+    final var editable = (TextEditable) comp.getFeature(TextEditable.class);
+
+    final var action = editable.getCommitAction(circuit, "old", "new");
+
+    assertNotNull(action);
+    project.doAction(action);
+    assertEquals("new", comp.getAttributeSet().getValue(Text.ATTR_TEXT));
+    project.undoAction();
+    assertEquals("old", comp.getAttributeSet().getValue(Text.ATTR_TEXT));
   }
 
   private static TextEditable newTextEditable() {


### PR DESCRIPTION
Summary
- handle platform menu shortcuts while editing text labels, including Cmd shortcuts on macOS
- add local in-progress undo/redo for text label edits before committing the final text
- cover menu shortcut, undo, redo, and existing no-op text commit behavior with tests

Verification
- ./gradlew.bat compileJava checkstyleMain compileTestJava checkstyleTest test --tests com.cburch.logisim.comp.TextFieldCaretTest --tests com.cburch.logisim.instance.InstanceTextFieldTest

Addresses #2097