### PR TITLE
gui: route edit menu to active text labels

### DIFF
--- a/src/main/java/com/cburch/logisim/comp/TextFieldCaret.java
+++ b/src/main/java/com/cburch/logisim/comp/TextFieldCaret.java
@@ -13,6 +13,7 @@ import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.tools.Caret;
 import com.cburch.logisim.tools.CaretEvent;
 import com.cburch.logisim.tools.CaretListener;
+import com.cburch.logisim.tools.TextEditActions;
 import com.cburch.logisim.util.GraphicsUtil;
 import com.cburch.logisim.util.MacCompatibility;
 import java.awt.Color;
@@ -28,7 +29,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedList;
 
-class TextFieldCaret implements Caret, TextFieldListener {
+class TextFieldCaret implements Caret, TextFieldListener, TextEditActions {
 
   public static final Color EDIT_BACKGROUND = new Color(0xff, 0xff, 0x99);
   public static final Color EDIT_BORDER = Color.DARK_GRAY;
@@ -194,58 +195,37 @@ class TextFieldCaret implements Caret, TextFieldListener {
 
   @SuppressWarnings("fallthrough")
   protected void controlKeyPressed(KeyEvent e, boolean shift) {
-    var cut = false;
     switch (e.getKeyCode()) {
       case KeyEvent.VK_A:
-        pos = 0;
-        end = curText.length();
+        selectAll();
         e.consume();
         break;
       case KeyEvent.VK_CUT:
       case KeyEvent.VK_X:
-        cut = true;
-        // fall through
+        cut();
+        e.consume();
+        break;
       case KeyEvent.VK_COPY:
       case KeyEvent.VK_C:
-        if (end != pos) {
-          final var pp = (Math.min(pos, end));
-          final var ee = (Math.max(pos, end));
-          final var s = curText.substring(pp, ee);
-          final var sel = new StringSelection(s);
-          Toolkit.getDefaultToolkit().getSystemClipboard().setContents(sel, null);
-          if (cut) {
-            rememberEdit();
-            deleteSelection();
-          }
-        }
+        copy();
         e.consume();
         break;
       case KeyEvent.VK_INSERT:
       case KeyEvent.VK_PASTE:
       case KeyEvent.VK_V:
-        try {
-          String s =
-              (String)
-                  Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
-          final var replacement = normalizePastedText(s);
-          if (!replacement.isEmpty()) {
-            rememberEdit();
-            replaceSelection(replacement);
-          }
-        } catch (Exception ignored) {
-        }
+        paste();
         e.consume();
         break;
       case KeyEvent.VK_Z:
         if (shift) {
-          redoEdit();
+          redoTextEdit();
         } else {
-          undoEdit();
+          undoTextEdit();
         }
         e.consume();
         break;
       case KeyEvent.VK_Y:
-        redoEdit();
+        redoTextEdit();
         e.consume();
         break;
       default:// ignore
@@ -343,6 +323,59 @@ class TextFieldCaret implements Caret, TextFieldListener {
     undoStack.clear();
   }
 
+  @Override
+  public boolean canCopy() {
+    return pos != end;
+  }
+
+  @Override
+  public boolean canCut() {
+    return canCopy();
+  }
+
+  @Override
+  public boolean canPaste() {
+    try {
+      return Toolkit.getDefaultToolkit()
+          .getSystemClipboard()
+          .isDataFlavorAvailable(DataFlavor.stringFlavor);
+    } catch (Exception ignored) {
+      return false;
+    }
+  }
+
+  @Override
+  public boolean canRedoTextEdit() {
+    return !redoStack.isEmpty();
+  }
+
+  @Override
+  public boolean canSelectAll() {
+    return !curText.isEmpty();
+  }
+
+  @Override
+  public boolean canUndoTextEdit() {
+    return !undoStack.isEmpty();
+  }
+
+  @Override
+  public void copy() {
+    if (!canCopy()) return;
+    final var selection = getSelectedText();
+    Toolkit.getDefaultToolkit()
+        .getSystemClipboard()
+        .setContents(new StringSelection(selection), null);
+  }
+
+  @Override
+  public void cut() {
+    if (!canCut()) return;
+    copy();
+    rememberEdit();
+    deleteSelection();
+  }
+
   private EditState currentEditState() {
     return new EditState(curText, pos, end);
   }
@@ -351,6 +384,12 @@ class TextFieldCaret implements Caret, TextFieldListener {
     normalizeSelection();
     curText = curText.substring(0, pos) + (end < curText.length() ? curText.substring(end) : "");
     end = pos;
+  }
+
+  private String getSelectedText() {
+    final var pp = Math.min(pos, end);
+    final var ee = Math.max(pos, end);
+    return curText.substring(pp, ee);
   }
 
   private String normalizePastedText(String s) {
@@ -374,6 +413,11 @@ class TextFieldCaret implements Caret, TextFieldListener {
     restoreEditState(redoStack.pop());
   }
 
+  @Override
+  public void redoTextEdit() {
+    redoEdit();
+  }
+
   private void rememberEdit() {
     undoStack.push(currentEditState());
     redoStack.clear();
@@ -395,10 +439,37 @@ class TextFieldCaret implements Caret, TextFieldListener {
     end = state.end();
   }
 
+  @Override
+  public void paste() {
+    try {
+      String s =
+          (String)
+              Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
+      final var replacement = normalizePastedText(s);
+      if (!replacement.isEmpty()) {
+        rememberEdit();
+        replaceSelection(replacement);
+      }
+    } catch (Exception ignored) {
+      // no text available from clipboard
+    }
+  }
+
+  @Override
+  public void selectAll() {
+    pos = 0;
+    end = curText.length();
+  }
+
   private void undoEdit() {
     if (undoStack.isEmpty()) return;
     redoStack.push(currentEditState());
     restoreEditState(undoStack.pop());
+  }
+
+  @Override
+  public void undoTextEdit() {
+    undoEdit();
   }
 
   protected void normalizeSelection() {

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -634,6 +634,11 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     return (getHdlEditorView() != null ? EDIT_HDL : mainPanel.getView());
   }
 
+  public void computeEditMenuEnabled() {
+    menuListener.computeEditEnabled();
+    menubar.refreshEditUndoRedoItems();
+  }
+
   public void setEditorView(String view) {
     final var curView = mainPanel.getView();
     if (hdlEditor.getHdlModel() == null && curView.equals(view)) return;

--- a/src/main/java/com/cburch/logisim/gui/main/LayoutEditHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/main/LayoutEditHandler.java
@@ -18,6 +18,8 @@ import com.cburch.logisim.proj.ProjectEvent;
 import com.cburch.logisim.proj.ProjectListener;
 import com.cburch.logisim.std.base.BaseLibrary;
 import com.cburch.logisim.tools.EditTool;
+import com.cburch.logisim.tools.TextEditActions;
+import com.cburch.logisim.tools.TextTool;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
@@ -45,6 +47,7 @@ public class LayoutEditHandler extends EditHandler
     final var sel = proj == null ? null : proj.getSelection();
     final var selEmpty = (sel == null || sel.isEmpty());
     final var canChange = proj != null && proj.getLogisimFile().contains(proj.getCurrentCircuit());
+    final var textEditActions = getTextEditActions();
 
     var selectAvailable = false;
     for (final var lib : proj.getLogisimFile().getLibraries()) {
@@ -52,6 +55,22 @@ public class LayoutEditHandler extends EditHandler
         selectAvailable = true;
         break;
       }
+    }
+
+    if (textEditActions != null) {
+      setEnabled(LogisimMenuBar.CUT, canChange && textEditActions.canCut());
+      setEnabled(LogisimMenuBar.COPY, textEditActions.canCopy());
+      setEnabled(LogisimMenuBar.PASTE, canChange);
+      setEnabled(LogisimMenuBar.DELETE, false);
+      setEnabled(LogisimMenuBar.DUPLICATE, false);
+      setEnabled(LogisimMenuBar.SELECT_ALL, textEditActions.canSelectAll());
+      setEnabled(LogisimMenuBar.RAISE, false);
+      setEnabled(LogisimMenuBar.LOWER, false);
+      setEnabled(LogisimMenuBar.RAISE_TOP, false);
+      setEnabled(LogisimMenuBar.LOWER_BOTTOM, false);
+      setEnabled(LogisimMenuBar.ADD_CONTROL, false);
+      setEnabled(LogisimMenuBar.REMOVE_CONTROL, false);
+      return;
     }
 
     setEnabled(LogisimMenuBar.CUT, !selEmpty && selectAvailable && canChange);
@@ -70,6 +89,13 @@ public class LayoutEditHandler extends EditHandler
 
   @Override
   public void copy() {
+    final var textEditActions = getTextEditActions();
+    if (textEditActions != null) {
+      textEditActions.copy();
+      refreshAfterTextEditAction();
+      return;
+    }
+
     final var proj = frame.getProject();
     final var sel = frame.getCanvas().getSelection();
     proj.doAction(SelectionActions.copy(sel));
@@ -77,6 +103,13 @@ public class LayoutEditHandler extends EditHandler
 
   @Override
   public void cut() {
+    final var textEditActions = getTextEditActions();
+    if (textEditActions != null) {
+      textEditActions.cut();
+      refreshAfterTextEditAction();
+      return;
+    }
+
     final var proj = frame.getProject();
     final var sel = frame.getCanvas().getSelection();
     proj.doAction(SelectionActions.cut(sel));
@@ -118,6 +151,13 @@ public class LayoutEditHandler extends EditHandler
 
   @Override
   public void paste() {
+    final var textEditActions = getTextEditActions();
+    if (textEditActions != null) {
+      textEditActions.paste();
+      refreshAfterTextEditAction();
+      return;
+    }
+
     final var proj = frame.getProject();
     final var sel = frame.getCanvas().getSelection();
     selectSelectTool(proj);
@@ -135,6 +175,8 @@ public class LayoutEditHandler extends EditHandler
     } else if (action == ProjectEvent.ACTION_SET_CURRENT) {
       computeEnabled();
     } else if (action == ProjectEvent.ACTION_SELECTION) {
+      computeEnabled();
+    } else if (action == ProjectEvent.ACTION_SET_TOOL) {
       computeEnabled();
     }
   }
@@ -163,6 +205,13 @@ public class LayoutEditHandler extends EditHandler
 
   @Override
   public void selectAll() {
+    final var textEditActions = getTextEditActions();
+    if (textEditActions != null) {
+      textEditActions.selectAll();
+      refreshAfterTextEditAction();
+      return;
+    }
+
     final var proj = frame.getProject();
     final var sel = frame.getCanvas().getSelection();
     selectSelectTool(proj);
@@ -179,5 +228,18 @@ public class LayoutEditHandler extends EditHandler
         if (tool != null) proj.setTool(tool);
       }
     }
+  }
+
+  private TextEditActions getTextEditActions() {
+    final var proj = frame.getProject();
+    if (proj != null && proj.getTool() instanceof TextTool textTool) {
+      return textTool.getTextEditActions();
+    }
+    return null;
+  }
+
+  private void refreshAfterTextEditAction() {
+    frame.computeEditMenuEnabled();
+    frame.getProject().repaintCanvas();
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/menu/LogisimMenuBar.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/LogisimMenuBar.java
@@ -190,6 +190,10 @@ public class LogisimMenuBar extends JMenuBar {
     enableListeners.remove(l);
   }
 
+  public void refreshEditUndoRedoItems() {
+    edit.refreshUndoRedoItems();
+  }
+
   public void setCircuitState(Simulator sim, CircuitState state) {
     simulate.setCurrentState(sim, state);
   }

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
@@ -16,6 +16,8 @@ import com.cburch.logisim.prefs.PrefMonitorKeyStroke;
 import com.cburch.logisim.proj.Action;
 import com.cburch.logisim.proj.ProjectEvent;
 import com.cburch.logisim.proj.ProjectListener;
+import com.cburch.logisim.tools.TextEditActions;
+import com.cburch.logisim.tools.TextTool;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
@@ -197,6 +199,10 @@ class MenuEdit extends Menu {
     remCtrl.setText(S.get("editRemoveControlItem"));
   }
 
+  void refreshUndoRedoItems() {
+    myListener.projectChanged(null);
+  }
+
   private void populateUndoHistoryMenu() {
     undoHistory.removeAll();
     final var proj = menubar.getSaveProject();
@@ -253,9 +259,24 @@ class MenuEdit extends Menu {
     public void actionPerformed(ActionEvent e) {
       final var src = e.getSource();
       final var proj = menubar.getSaveProject();
+      final var textEditActions = getTextEditActions();
       if (src == undo && proj != null) {
+        if (textEditActions != null) {
+          if (textEditActions.canUndoTextEdit()) {
+            textEditActions.undoTextEdit();
+            refreshAfterTextEditAction(proj);
+          }
+          return;
+        }
         proj.undoAction();
       } else if (src == redo && proj != null) {
+        if (textEditActions != null) {
+          if (textEditActions.canRedoTextEdit()) {
+            textEditActions.redoTextEdit();
+            refreshAfterTextEditAction(proj);
+          }
+          return;
+        }
         proj.redoAction();
       } else if (src == clearHistory && proj != null) {
         final var result = JOptionPane.showConfirmDialog(
@@ -274,6 +295,12 @@ class MenuEdit extends Menu {
     @Override
     public void projectChanged(ProjectEvent e) {
       final var proj = menubar.getSaveProject();
+      final var textEditActions = getTextEditActions();
+      if (textEditActions != null) {
+        updateTextEditUndoRedoItems(proj, textEditActions);
+        return;
+      }
+
       final var last = (proj != null) ? proj.getLastAction() : null;
       if (last == null) {
         undo.setText(S.get("editCantUndoItem"));
@@ -299,6 +326,48 @@ class MenuEdit extends Menu {
 
       final var historyExists = (last != null || canRedo);
       clearHistory.setEnabled(historyExists);
+    }
+
+    private TextEditActions getTextEditActions() {
+      final var proj = menubar.getSaveProject();
+      if (proj != null && proj.getTool() instanceof TextTool textTool) {
+        return textTool.getTextEditActions();
+      }
+      return null;
+    }
+
+    private void refreshAfterTextEditAction(com.cburch.logisim.proj.Project proj) {
+      proj.repaintCanvas();
+      projectChanged(null);
+    }
+
+    private String textEditActionName() {
+      return com.cburch.logisim.tools.Strings.S.get("textTool");
+    }
+
+    private void updateTextEditUndoRedoItems(
+        com.cburch.logisim.proj.Project proj, TextEditActions textEditActions) {
+      if (textEditActions.canUndoTextEdit()) {
+        undo.setText(S.get("editUndoItem", textEditActionName()));
+        undo.setEnabled(true);
+      } else {
+        undo.setText(S.get("editCantUndoItem"));
+        undo.setEnabled(false);
+      }
+      undoHistory.setEnabled(false);
+
+      if (textEditActions.canRedoTextEdit()) {
+        redo.setText(S.get("editRedoItem", textEditActionName()));
+        redo.setEnabled(true);
+      } else {
+        redo.setText(S.get("editCantRedoItem"));
+        redo.setEnabled(false);
+      }
+      redoHistory.setEnabled(false);
+
+      final var projectHistoryExists =
+          proj != null && (proj.getLastAction() != null || proj.getCanRedo());
+      clearHistory.setEnabled(projectHistoryExists);
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/menu/MenuListener.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuListener.java
@@ -45,6 +45,10 @@ public class MenuListener {
     menubar.doAction(item);
   }
 
+  public void computeEditEnabled() {
+    editListener.computeEnabled();
+  }
+
   public LogisimMenuBar getMenuBar() {
     return menubar;
   }

--- a/src/main/java/com/cburch/logisim/tools/TextEditActions.java
+++ b/src/main/java/com/cburch/logisim/tools/TextEditActions.java
@@ -1,0 +1,36 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.tools;
+
+public interface TextEditActions {
+  boolean canCopy();
+
+  boolean canCut();
+
+  boolean canPaste();
+
+  boolean canRedoTextEdit();
+
+  boolean canSelectAll();
+
+  boolean canUndoTextEdit();
+
+  void copy();
+
+  void cut();
+
+  void paste();
+
+  void redoTextEdit();
+
+  void selectAll();
+
+  void undoTextEdit();
+}

--- a/src/main/java/com/cburch/logisim/tools/TextTool.java
+++ b/src/main/java/com/cburch/logisim/tools/TextTool.java
@@ -69,11 +69,15 @@ public class TextTool extends Tool {
       }
       caret.removeCaretListener(this);
       caretCircuit.removeCircuitListener(this);
+      final var canvas = caretCanvas;
 
       caretCircuit = null;
       caretComponent = null;
       caretCreatingText = false;
       caret = null;
+      caretCanvas = null;
+
+      refreshEditMenu(canvas);
     }
 
     @Override
@@ -84,11 +88,12 @@ public class TextTool extends Tool {
       }
       caret.removeCaretListener(this);
       caretCircuit.removeCircuitListener(this);
+      final var canvas = caretCanvas;
 
       final var val = caret.getText();
       var isEmpty = StringUtil.isNullOrEmpty(val);
       Action a;
-      final var proj = caretCanvas.getProject();
+      final var proj = canvas.getProject();
       if (caretCreatingText) {
         if (!isEmpty) {
           final var xn = new CircuitMutation(caretCircuit);
@@ -123,8 +128,10 @@ public class TextTool extends Tool {
       caretComponent = null;
       caretCreatingText = false;
       caret = null;
+      caretCanvas = null;
 
       if (a != null) proj.doAction(a);
+      refreshEditMenu(canvas);
     }
   }
 
@@ -180,6 +187,10 @@ public class TextTool extends Tool {
     return S.get("textToolDesc");
   }
 
+  public TextEditActions getTextEditActions() {
+    return caret instanceof TextEditActions actions ? actions : null;
+  }
+
   @Override
   public String getDisplayName() {
     return S.get("textTool");
@@ -195,6 +206,7 @@ public class TextTool extends Tool {
     if (caret != null) {
       caret.keyPressed(e);
       canvas.getProject().repaintCanvas();
+      refreshEditMenu(canvas);
     }
   }
 
@@ -203,6 +215,7 @@ public class TextTool extends Tool {
     if (caret != null) {
       caret.keyReleased(e);
       canvas.getProject().repaintCanvas();
+      refreshEditMenu(canvas);
     }
   }
 
@@ -211,6 +224,7 @@ public class TextTool extends Tool {
     if (caret != null) {
       caret.keyTyped(e);
       canvas.getProject().repaintCanvas();
+      refreshEditMenu(canvas);
     }
   }
 
@@ -229,6 +243,7 @@ public class TextTool extends Tool {
     if (caret != null) {
       caret.mouseDragged(e);
       proj.repaintCanvas();
+      refreshEditMenu(canvas);
     }
   }
 
@@ -254,6 +269,7 @@ public class TextTool extends Tool {
       if (caret.getBounds(g).contains(e.getX(), e.getY())) { // Yes
         caret.mousePressed(e);
         proj.repaintCanvas();
+        refreshEditMenu(canvas);
         return;
       } else {
         // No. End the current caret.
@@ -318,6 +334,7 @@ public class TextTool extends Tool {
       caretCircuit.addCircuitListener(listener);
     }
     proj.repaintCanvas();
+    refreshEditMenu(canvas);
   }
 
   @Override
@@ -334,11 +351,18 @@ public class TextTool extends Tool {
     if (caret != null) {
       caret.mouseReleased(e);
       proj.repaintCanvas();
+      refreshEditMenu(canvas);
     }
   }
 
   @Override
   public void paintIcon(ComponentDrawContext c, int x, int y) {
     Text.FACTORY.paintIcon(c, x, y, null);
+  }
+
+  private void refreshEditMenu(Canvas canvas) {
+    if (canvas == null) return;
+    final var frame = canvas.getProject().getFrame();
+    if (frame != null) frame.computeEditMenuEnabled();
   }
 }

--- a/src/test/java/com/cburch/logisim/comp/TextFieldCaretTest.java
+++ b/src/test/java/com/cburch/logisim/comp/TextFieldCaretTest.java
@@ -11,6 +11,7 @@ package com.cburch.logisim.comp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.cburch.logisim.tools.TextEditActions;
 import java.awt.Canvas;
 import java.awt.Component;
 import java.awt.event.InputEvent;
@@ -73,6 +74,30 @@ class TextFieldCaretTest {
     caret.keyPressed(
         keyPressed(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK));
 
+    assertEquals("abcd", caret.getText());
+  }
+
+  @Test
+  void textEditActionsSelectAllText() {
+    final TextEditActions actions = caret("abc", 0);
+    final var caret = (TextFieldCaret) actions;
+
+    actions.selectAll();
+    caret.keyTyped(keyTyped('x'));
+
+    assertEquals("x", caret.getText());
+  }
+
+  @Test
+  void textEditActionsUndoAndRedoInProgressTextEdit() {
+    final TextEditActions actions = caret("abc", 3);
+    final var caret = (TextFieldCaret) actions;
+
+    caret.keyTyped(keyTyped('d'));
+    actions.undoTextEdit();
+    assertEquals("abc", caret.getText());
+
+    actions.redoTextEdit();
     assertEquals("abcd", caret.getText());
   }
 

--- a/src/test/java/com/cburch/logisim/tools/TextToolTest.java
+++ b/src/test/java/com/cburch/logisim/tools/TextToolTest.java
@@ -1,0 +1,103 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.tools;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.cburch.logisim.data.Bounds;
+import java.awt.Graphics;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class TextToolTest {
+  @Test
+  void returnsNoTextEditActionsWhenNoCaretIsActive() {
+    final var tool = new TextTool();
+
+    assertNull(tool.getTextEditActions());
+  }
+
+  @Test
+  void returnsActiveCaretTextEditActions() throws Exception {
+    final var tool = new TextTool();
+    final var actions = new TestCaret();
+
+    setCaret(tool, actions);
+
+    assertSame(actions, tool.getTextEditActions());
+  }
+
+  private static void setCaret(TextTool tool, Caret caret) throws Exception {
+    final Field field = TextTool.class.getDeclaredField("caret");
+    field.setAccessible(true);
+    field.set(tool, caret);
+  }
+
+  private static class TestCaret implements Caret, TextEditActions {
+    @Override
+    public Bounds getBounds(Graphics g) {
+      return Bounds.EMPTY_BOUNDS;
+    }
+
+    @Override
+    public String getText() {
+      return "";
+    }
+
+    @Override
+    public boolean canCopy() {
+      return false;
+    }
+
+    @Override
+    public boolean canCut() {
+      return false;
+    }
+
+    @Override
+    public boolean canPaste() {
+      return false;
+    }
+
+    @Override
+    public boolean canRedoTextEdit() {
+      return false;
+    }
+
+    @Override
+    public boolean canSelectAll() {
+      return false;
+    }
+
+    @Override
+    public boolean canUndoTextEdit() {
+      return false;
+    }
+
+    @Override
+    public void copy() {}
+
+    @Override
+    public void cut() {}
+
+    @Override
+    public void paste() {}
+
+    @Override
+    public void redoTextEdit() {}
+
+    @Override
+    public void selectAll() {}
+
+    @Override
+    public void undoTextEdit() {}
+  }
+}


### PR DESCRIPTION
Summary
- expose active text caret edit actions for menu routing
- route Edit menu Cut/Copy/Paste/Select All to the active text label while editing
- route Edit menu Undo/Redo to the active text label's in-progress undo stack while editing, then fall back to project undo/redo after editing ends

Context
- Follow-up to #2698.
- Addresses the remaining part of #2097 where menu items did not match the active text label editor behavior.

Verification
- ./gradlew.bat test --tests com.cburch.logisim.comp.TextFieldCaretTest --tests com.cburch.logisim.tools.TextToolTest --tests com.cburch.logisim.instance.InstanceTextFieldTest compileJava compileTestJava checkstyleMain checkstyleTest
- git diff --check

Manual verification is still useful before marking ready: edit a text label, use the Edit menu entries for Select All/Cut/Copy/Paste/Undo/Redo, then finish editing and confirm project-level undo still reverts the full label change.
