### PR TITLE
test: stabilize appearance panning viewport setup

### DIFF
--- a/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
+++ b/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
@@ -80,6 +80,7 @@ class AppearanceViewTest {
 
     canvas.setPreferredSize(new Dimension(1000, 1000));
     pane.setSize(200, 200);
+    pane.getViewport().setViewSize(canvas.getPreferredSize());
     pane.doLayout();
     pane.getHorizontalScrollBar().setValue(80);
     pane.getVerticalScrollBar().setValue(90);


### PR DESCRIPTION
Summary
- make the appearance panning test explicitly size the viewport view before setting scrollbar values
- avoid depending on platform-specific JScrollPane layout timing in headless CI

Verification
- ./gradlew.bat test --tests com.cburch.logisim.gui.appear.AppearanceViewTest --rerun-tasks
- ./gradlew.bat checkstyleTest

Context
- Follow-up after #2697: PR #2708 hit a Linux CI failure in AppearanceViewTest.middleButtonDragPansAppearanceCanvas even though the failure is unrelated to that VHDL preference change.
