### PR TITLE
gui: add navigation pane visibility toggle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -137,7 +137,8 @@
   * Added TTL 74670: 4-by-4 register file with three-state outputs
   * Added 16 bit floating point support for floating point arithmetic
   * Added partial support for VHDL time units
-  * Fixed the problem of keys getting assigned to focusing on the cell of the table in "properties" section along with its actual intent
+  * Fixed the problem of keys getting assigned to focusing on the cell of the table in
+    "properties" section along with its actual intent
 
 * v3.8.0 (2022-10-02)
   * Added reset value attribute to input pins

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * @dev (????-??-??)
   * Added support for opening project files by dragging them into the application window.
+  * Added a Window menu option to hide or show the navigation pane.
   * Added ability to load multiple RAM or ROM memories from the command line
   * Added Real-Time Clock component.
   * Improved drawing appearance:

--- a/docs/test_vector.md
+++ b/docs/test_vector.md
@@ -5,8 +5,9 @@ This document describes the enhanced Test Vector functionality, including sequen
 
 ## Overview
 
-The Test Vector window allows you to load a test vector from a file, and Logisim will automatically run tests on the current circuit.
-The Test Vector module runs a separate copy of the circuit simulator, so it does not interfere with the simulation in the project window.
+The Test Vector window allows you to load a test vector from a file, and Logisim will automatically run tests on the
+current circuit. The Test Vector module runs a separate copy of the circuit simulator, so it does not interfere with the
+simulation in the project window.
 
 Any incorrect outputs will be flagged in red. Hover the mouse over the red box to see what the output should have been,
 according to the test vector. Rows with incorrect outputs are sorted to the top of the window.
@@ -46,7 +47,8 @@ Each row in the Test Vector window has two buttons that allow you to manually in
 
 ## Basic File Format
 
-The file format is simple. You can use the Logging module (with "Include Header Line" selected in the file output tab) to get started,
+The file format is simple. You can use the Logging module (with "Include Header Line" selected in the file output tab)
+to get started,
 since in most cases the Logging module outputs the same format as used by the Test Vector module.
 
 Here is an example test vector file:
@@ -63,7 +65,8 @@ A[32] B[32] C[32] Cin Cout
 
 - Blank lines are ignored
 - Anything following a '#' character is a comment
-- The first non-blank, non-comment line lists the name of each circuit input/output pin and its width (if > 1), separated by whitespace
+- The first non-blank, non-comment line lists the name of each circuit input/output pin and its width (if > 1),
+  separated by whitespace
 - The remaining lines list each value separated by whitespace
 
 **Value Formats:**
@@ -247,7 +250,8 @@ All existing test vector files continue to work without modification. The new fe
 
 1. **Use sequences for stateful circuits**: If your circuit has memory (flip-flops, registers, counters),
 use sequential tests to verify state transitions
-2. **Use don't care for partial verification**: When testing complex circuits, use `<DC>` for outputs you're not currently verifying
+2. **Use don't care for partial verification**: When testing complex circuits, use `<DC>` for outputs you're not
+   currently verifying
 3. **Use floating for tri-state testing**: Use `<float>` to test circuits with tri-state outputs or high-impedance states
 4. **Organize with sets**: Use the `<set>` column to group related tests, even though it doesn't affect execution
 5. **Mix combinational and sequential**: You can mix combinational tests (seq=0) with sequential tests in the same file

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -98,6 +98,9 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
   public static final String EDIT_LAYOUT = "layout";
   public static final String EDIT_APPEARANCE = "appearance";
   public static final String EDIT_HDL = "hdl";
+  private static final double DEFAULT_EXPLORER_SPLIT = 0.25;
+  private static final double MIN_EXPLORER_SPLIT = 0.05;
+  private static final double MAX_EXPLORER_SPLIT = 0.95;
   private static final double DEFAULT_VHDL_CONSOLE_SPLIT = 0.75;
   private static final double MIN_VHDL_CONSOLE_SPLIT = 0.05;
   private static final double MAX_VHDL_CONSOLE_SPLIT = 0.95;
@@ -133,6 +136,8 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
   private final AttrTableSelectionModel attrTableSelectionModel;
   // for the Appearance view
   private AppearanceView appearance;
+  private Double lastExplorerFraction =
+      sanitizeExplorerSplitFraction(AppPreferences.WINDOW_MAIN_SPLIT.get());
   private Double lastFraction = AppPreferences.WINDOW_RIGHT_SPLIT.get();
   private final RegTabContent regTabContent;
 
@@ -230,6 +235,9 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     project.getVhdlSimulator().addVhdlSimStateListener(state);
 
     mainRegion = new MainRegionVerticalSplitPane(leftRegion, rightPanel);
+    if (!AppPreferences.WINDOW_EXPLORER_VISIBLE.getBoolean()) {
+      mainRegion.setFraction(0.0);
+    }
     getContentPane().add(mainRegion, BorderLayout.CENTER);
 
     localeChanged();
@@ -404,8 +412,11 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     private Direction orientation;
 
     public MainRegionVerticalSplitPane(JComponent componentTree, JComponent mainCanvas) {
-      this(componentTree, mainCanvas, AppPreferences.WINDOW_MAIN_SPLIT.get(),
-              Direction.parse(AppPreferences.CANVAS_PLACEMENT.get()));
+      this(
+          componentTree,
+          mainCanvas,
+          sanitizeExplorerSplitFraction(AppPreferences.WINDOW_MAIN_SPLIT.get()),
+          Direction.parse(AppPreferences.CANVAS_PLACEMENT.get()));
     }
 
     public MainRegionVerticalSplitPane(JComponent componentTree, JComponent mainCanvas, double fraction,
@@ -558,7 +569,9 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
   }
 
   public void resetLayout() {
-    mainRegion.setFraction(0.25);
+    lastExplorerFraction = DEFAULT_EXPLORER_SPLIT;
+    mainRegion.setFraction(DEFAULT_EXPLORER_SPLIT);
+    AppPreferences.WINDOW_EXPLORER_VISIBLE.set(true);
     mainRegion.setOrientation(Direction.EAST);
     leftRegion.setFraction(0.5);
     rightRegion.setFraction(1.0);
@@ -755,7 +768,11 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     if (isUsableVhdlConsoleSplitFraction(rightFraction)) {
       AppPreferences.WINDOW_RIGHT_SPLIT.set(rightFraction);
     }
-    if (mainRegion.getFraction() > 0) AppPreferences.WINDOW_MAIN_SPLIT.set(mainRegion.getFraction());
+    final var explorerFraction = mainRegion.getFraction();
+    AppPreferences.WINDOW_EXPLORER_VISIBLE.set(explorerFraction > 0.0);
+    if (isUsableExplorerSplitFraction(explorerFraction)) {
+      AppPreferences.WINDOW_MAIN_SPLIT.set(explorerFraction);
+    }
     AppPreferences.DIALOG_DIRECTORY.set(JFileChoosers.getCurrentDirectory());
   }
 
@@ -791,6 +808,44 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     }
     rightRegion.setFractionBounds(0.0, 1.0);
     rightRegion.setFraction(1);
+  }
+
+  public boolean isExplorerVisible() {
+    return mainRegion.getFraction() > 0.0;
+  }
+
+  public void setExplorerVisible(boolean visible) {
+    final var oldVisible = isExplorerVisible();
+
+    if (visible) {
+      lastExplorerFraction = sanitizeExplorerSplitFraction(lastExplorerFraction);
+      mainRegion.setFraction(lastExplorerFraction);
+    } else {
+      final var explorerFraction = mainRegion.getFraction();
+      if (isUsableExplorerSplitFraction(explorerFraction)) {
+        lastExplorerFraction = explorerFraction;
+      }
+      mainRegion.setFraction(0.0);
+    }
+
+    AppPreferences.WINDOW_EXPLORER_VISIBLE.set(visible);
+    final var newVisible = isExplorerVisible();
+    if (oldVisible != newVisible) {
+      firePropertyChange(EXPLORER_VIEW, oldVisible, newVisible);
+    }
+  }
+
+  static double sanitizeExplorerSplitFraction(Double fraction) {
+    if (fraction == null || !isUsableExplorerSplitFraction(fraction)) {
+      return DEFAULT_EXPLORER_SPLIT;
+    }
+    return fraction;
+  }
+
+  static boolean isUsableExplorerSplitFraction(double fraction) {
+    return Double.isFinite(fraction)
+        && fraction >= MIN_EXPLORER_SPLIT
+        && fraction <= MAX_EXPLORER_SPLIT;
   }
 
   static double sanitizeVhdlConsoleSplitFraction(Double fraction) {

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -811,7 +811,7 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
   }
 
   public boolean isExplorerVisible() {
-    return mainRegion.getFraction() > 0.0;
+    return mainRegion != null && mainRegion.getFraction() > 0.0;
   }
 
   public void setExplorerVisible(boolean visible) {

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -894,6 +894,7 @@ public class AppPreferences {
 
   public static void resetWindow() {
     CANVAS_PLACEMENT.set(Direction.EAST.toString());
+    WINDOW_EXPLORER_VISIBLE.set(true);
     WINDOW_MAIN_SPLIT.set(0.251);
     WINDOW_LEFT_SPLIT.set(0.51);
     WINDOW_RIGHT_SPLIT.set(0.751);
@@ -904,6 +905,9 @@ public class AppPreferences {
 
   public static final PrefMonitor<Double> WINDOW_MAIN_SPLIT =
       create(new PrefMonitorDouble("windowMainSplit", 0.25));
+
+  public static final PrefMonitor<Boolean> WINDOW_EXPLORER_VISIBLE =
+      create(new PrefMonitorBoolean("windowExplorerVisible", true));
 
   public static final PrefMonitor<Double> WINDOW_LEFT_SPLIT =
       create(new PrefMonitorDouble("windowLeftSplit", 0.5));

--- a/src/main/java/com/cburch/logisim/util/WindowMenu.java
+++ b/src/main/java/com/cburch/logisim/util/WindowMenu.java
@@ -42,6 +42,8 @@ public class WindowMenu extends Menu {
         doClose();
       } else if (src == toolbar) {
         doToolbar();
+      } else if (src == explorer) {
+        doExplorer();
       } else if (src instanceof WindowMenuItem choice) {
         if (choice.isSelected()) {
           final var item = findOwnerItem();
@@ -77,12 +79,15 @@ public class WindowMenu extends Menu {
               ? S.get("windowZoomItemMac")
               : S.get("windowZoomItem"));
       toolbar.setText(S.get("windowShowToolbarItem"));
+      explorer.setText(S.get("windowShowNavigationPaneItem"));
     }
 
     @Override
     public void propertyChange(PropertyChangeEvent event) {
       if (AppPreferences.TOOLBAR_PLACEMENT.isSource(event)) {
         toolbar.setState(isToolbarVisible());
+      } else if (AppPreferences.WINDOW_EXPLORER_VISIBLE.isSource(event)) {
+        explorer.setState(isExplorerVisible());
       }
     }
   }
@@ -95,6 +100,7 @@ public class WindowMenu extends Menu {
   private final JMenuItem zoom = new JMenuItem();
   private final JCheckBoxMenuItem toolbar = new JCheckBoxMenuItem();
   private final JMenuItem close = new JMenuItem();
+  private final JCheckBoxMenuItem explorer = new JCheckBoxMenuItem();
   private final JRadioButtonMenuItem nullItem = new JRadioButtonMenuItem();
   private final ArrayList<WindowMenuItem> persistentItems = new ArrayList<>();
   private final ArrayList<WindowMenuItem> transientItems = new ArrayList<>();
@@ -132,6 +138,13 @@ public class WindowMenu extends Menu {
     toolbar.addActionListener(myListener);
     AppPreferences.TOOLBAR_PLACEMENT.addPropertyChangeListener(myListener);
 
+    if (hasExplorerToggle()) {
+      explorer.setEnabled(true);
+      explorer.setState(isExplorerVisible());
+      explorer.addActionListener(myListener);
+      AppPreferences.WINDOW_EXPLORER_VISIBLE.addPropertyChangeListener(myListener);
+    }
+
     computeEnabled();
     computeContents();
 
@@ -167,6 +180,9 @@ public class WindowMenu extends Menu {
     add(close);
     addSeparator();
     add(toolbar);
+    if (hasExplorerToggle()) {
+      add(explorer);
+    }
 
     if (!persistentItems.isEmpty()) {
       addSeparator();
@@ -199,6 +215,10 @@ public class WindowMenu extends Menu {
     minimize.setEnabled(currentManager != null);
     zoom.setEnabled(currentManager != null);
     close.setEnabled(currentManager != null);
+    if (hasExplorerToggle()) {
+      explorer.setEnabled(true);
+      explorer.setState(isExplorerVisible());
+    }
   }
 
   void doClose() {
@@ -284,5 +304,20 @@ public class WindowMenu extends Menu {
 
   void doToolbar() {
     setToolbarVisibility(toolbar.getState());
+  }
+
+  private boolean hasExplorerToggle() {
+    return owner instanceof com.cburch.logisim.gui.main.Frame;
+  }
+
+  private boolean isExplorerVisible() {
+    return owner instanceof com.cburch.logisim.gui.main.Frame frame && frame.isExplorerVisible();
+  }
+
+  void doExplorer() {
+    if (owner instanceof com.cburch.logisim.gui.main.Frame frame) {
+      frame.setExplorerVisible(explorer.getState());
+      explorer.setState(frame.isExplorerVisible());
+    }
   }
 }

--- a/src/main/resources/resources/logisim/strings/util/util.properties
+++ b/src/main/resources/resources/logisim/strings/util/util.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = Error: Detected VHDL keyword!\n
 windowCloseItem = Close
 windowMenu = Window
 windowMinimizeItem = Minimize
+windowShowNavigationPaneItem = Show Navigation Pane
 windowShowToolbarItem = Show Toolbar
 windowZoomItem = Maximize
 windowZoomItemMac = Zoom

--- a/src/main/resources/resources/logisim/strings/util/util_de.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_de.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = Fehler: Erkanntes VHDL-Schlüsselwort!
 windowCloseItem = Schließen
 windowMenu = Fenster
 windowMinimizeItem = Minimieren
+# ==> windowShowNavigationPaneItem =
 windowShowToolbarItem = Werkzeugleiste anzeigen
 windowZoomItem = Maximieren
 windowZoomItemMac = Zoom

--- a/src/main/resources/resources/logisim/strings/util/util_el.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_el.properties
@@ -96,6 +96,7 @@ LMyesButtonText = Ναί
 windowCloseItem = Κλείσιμο
 windowMenu = Παράθυρο
 windowMinimizeItem = Ελαχιστοποίηση
+# ==> windowShowNavigationPaneItem =
 # ==> windowShowToolbarItem = 
 windowZoomItem = Μεγιστοποίηση
 windowZoomItemMac = Κλίμακα

--- a/src/main/resources/resources/logisim/strings/util/util_es.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_es.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = Error: Palabra clave VHDL detectada!
 windowCloseItem = Cerrar
 windowMenu = Ventana
 windowMinimizeItem = Minimizar
+# ==> windowShowNavigationPaneItem =
 # ==> windowShowToolbarItem =
 windowZoomItem = Maximizar
 windowZoomItemMac = Zoom

--- a/src/main/resources/resources/logisim/strings/util/util_fr.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_fr.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = Erreur : mot clé VHDL détecté !\n
 windowCloseItem = Fermer
 windowMenu = Fenêtre
 windowMinimizeItem = Réduire
+# ==> windowShowNavigationPaneItem =
 windowShowToolbarItem = Afficher la barre d’outils
 windowZoomItem = Agrandir
 windowZoomItemMac = Zoom

--- a/src/main/resources/resources/logisim/strings/util/util_it.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_it.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = Errore: Rilevato VHDL parola chiave!
 windowCloseItem = Chiudi
 windowMenu = Finestra
 windowMinimizeItem = Minimizza
+# ==> windowShowNavigationPaneItem =
 # ==> windowShowToolbarItem =
 windowZoomItem = Massimizza
 windowZoomItemMac = Zoom

--- a/src/main/resources/resources/logisim/strings/util/util_ja.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_ja.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = Error: VHDLキーワードを検出しました!\n
 windowCloseItem = 閉じる
 windowMenu = ウィンドウ
 windowMinimizeItem = 最小化
+# ==> windowShowNavigationPaneItem =
 # ==> windowShowToolbarItem =
 windowZoomItem = 最大化
 windowZoomItemMac = ズーム

--- a/src/main/resources/resources/logisim/strings/util/util_nl.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_nl.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = Fout: VHDL-sleutelwoord gedetecteerd!
 windowCloseItem = Sluiten
 windowMenu = Venster
 windowMinimizeItem = Minimaliseren
+# ==> windowShowNavigationPaneItem =
 # ==> windowShowToolbarItem =
 windowZoomItem = Maximaliseren
 windowZoomItemMac = Zoom

--- a/src/main/resources/resources/logisim/strings/util/util_pl.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_pl.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = Błąd: Wykryto słowo kluczowe VHDL!\n
 windowCloseItem = Zamknij
 windowMenu = Okno
 windowMinimizeItem = Minimalizuj
+# ==> windowShowNavigationPaneItem =
 # ==> windowShowToolbarItem =
 windowZoomItem = Maksymalizuj
 windowZoomItemMac = Zoom

--- a/src/main/resources/resources/logisim/strings/util/util_pt.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_pt.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = Erro: Detectada palavra-chave VHDL!
 windowCloseItem = Fechar
 windowMenu = Janela
 windowMinimizeItem = Minimizar
+# ==> windowShowNavigationPaneItem =
 # ==> windowShowToolbarItem =
 windowZoomItem = Maximizar
 windowZoomItemMac = Zoom

--- a/src/main/resources/resources/logisim/strings/util/util_ru.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_ru.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = Ошибка: Обнаружено ключевое сло
 windowCloseItem = Закрыть
 windowMenu = Окно
 windowMinimizeItem = Минимизировать
+# ==> windowShowNavigationPaneItem =
 # ==> windowShowToolbarItem =
 windowZoomItem = Максимизировать
 windowZoomItemMac = Масштабировать

--- a/src/main/resources/resources/logisim/strings/util/util_zh.properties
+++ b/src/main/resources/resources/logisim/strings/util/util_zh.properties
@@ -96,6 +96,7 @@ variableVHDLKeyword = 错误：检测到 VHDL 关键字\n
 windowCloseItem = 关闭
 windowMenu = 窗口
 windowMinimizeItem = 最小化
+windowShowNavigationPaneItem = 显示导航窗格
 windowShowToolbarItem = 显示工具栏
 windowZoomItem = 最大化
 windowZoomItemMac = 缩放

--- a/src/test/java/com/cburch/logisim/gui/main/FrameTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/FrameTest.java
@@ -58,4 +58,46 @@ class FrameTest {
     assertFalse(Frame.isUsableVhdlConsoleSplitFraction(1.0));
     assertFalse(Frame.isUsableVhdlConsoleSplitFraction(Double.POSITIVE_INFINITY));
   }
+
+  @Test
+  void restoresDefaultWhenExplorerSplitWouldHideNavigationPane() {
+    assertEquals(0.25, Frame.sanitizeExplorerSplitFraction(null), FRACTION_DELTA);
+    assertEquals(0.25, Frame.sanitizeExplorerSplitFraction(Double.NaN), FRACTION_DELTA);
+    assertEquals(
+        0.25, Frame.sanitizeExplorerSplitFraction(Double.NEGATIVE_INFINITY), FRACTION_DELTA);
+    assertEquals(0.25, Frame.sanitizeExplorerSplitFraction(0.0), FRACTION_DELTA);
+    assertEquals(0.25, Frame.sanitizeExplorerSplitFraction(0.04), FRACTION_DELTA);
+    assertEquals(0.05, Frame.sanitizeExplorerSplitFraction(0.05), FRACTION_DELTA);
+  }
+
+  @Test
+  void restoresDefaultWhenExplorerSplitWouldHideCanvas() {
+    assertEquals(0.25, Frame.sanitizeExplorerSplitFraction(1.0), FRACTION_DELTA);
+    assertEquals(0.25, Frame.sanitizeExplorerSplitFraction(0.99), FRACTION_DELTA);
+    assertEquals(
+        0.25, Frame.sanitizeExplorerSplitFraction(Double.POSITIVE_INFINITY), FRACTION_DELTA);
+  }
+
+  @Test
+  void preservesUsableExplorerSplit() {
+    assertEquals(0.05, Frame.sanitizeExplorerSplitFraction(0.05), FRACTION_DELTA);
+    assertEquals(0.25, Frame.sanitizeExplorerSplitFraction(0.25), FRACTION_DELTA);
+    assertEquals(0.75, Frame.sanitizeExplorerSplitFraction(0.75), FRACTION_DELTA);
+    assertEquals(0.95, Frame.sanitizeExplorerSplitFraction(0.95), FRACTION_DELTA);
+  }
+
+  @Test
+  void rejectsUnusableExplorerSplitForPersistence() {
+    assertFalse(Frame.isUsableExplorerSplitFraction(Double.NaN));
+    assertFalse(Frame.isUsableExplorerSplitFraction(Double.NEGATIVE_INFINITY));
+    assertFalse(Frame.isUsableExplorerSplitFraction(0.0));
+    assertFalse(Frame.isUsableExplorerSplitFraction(0.04));
+    assertTrue(Frame.isUsableExplorerSplitFraction(0.05));
+    assertTrue(Frame.isUsableExplorerSplitFraction(0.25));
+    assertTrue(Frame.isUsableExplorerSplitFraction(0.75));
+    assertTrue(Frame.isUsableExplorerSplitFraction(0.95));
+    assertFalse(Frame.isUsableExplorerSplitFraction(0.99));
+    assertFalse(Frame.isUsableExplorerSplitFraction(1.0));
+    assertFalse(Frame.isUsableExplorerSplitFraction(Double.POSITIVE_INFINITY));
+  }
 }

--- a/src/test/java/com/cburch/logisim/gui/main/FrameTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/FrameTest.java
@@ -19,6 +19,13 @@ class FrameTest {
   private static final double FRACTION_DELTA = 1.0e-4;
 
   @Test
+  void unfinishedFrameDoesNotReportExplorerVisibleDuringMenuConstruction() throws Exception {
+    final var frame = (Frame) allocateWithoutConstructor(Frame.class);
+
+    assertFalse(frame.isExplorerVisible());
+  }
+
+  @Test
   void restoresDefaultWhenVhdlConsoleSplitWouldCollapseEditor() {
     assertEquals(0.75, Frame.sanitizeVhdlConsoleSplitFraction(null), FRACTION_DELTA);
     assertEquals(0.75, Frame.sanitizeVhdlConsoleSplitFraction(Double.NaN), FRACTION_DELTA);
@@ -99,5 +106,13 @@ class FrameTest {
     assertFalse(Frame.isUsableExplorerSplitFraction(0.99));
     assertFalse(Frame.isUsableExplorerSplitFraction(1.0));
     assertFalse(Frame.isUsableExplorerSplitFraction(Double.POSITIVE_INFINITY));
+  }
+
+  private static Object allocateWithoutConstructor(Class<?> type) throws Exception {
+    final var unsafeClass = Class.forName("sun.misc.Unsafe");
+    final var unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+    unsafeField.setAccessible(true);
+    final var unsafe = unsafeField.get(null);
+    return unsafeClass.getMethod("allocateInstance", Class.class).invoke(unsafe, type);
   }
 }


### PR DESCRIPTION
Summary
- add a Window menu checkbox for showing or hiding the navigation pane
- persist the navigation pane visibility separately from its last usable split width
- sanitize explorer split persistence/restoration so collapsed or near-collapsed panes are not saved as the normal width
- add release note and localization key placeholders

Verification
- ./gradlew.bat test --tests com.cburch.logisim.gui.main.FrameTest
- ./gradlew.bat test --tests com.cburch.logisim.gui.main.FrameTest compileJava checkstyleMain checkstyleTest
- git diff --check

Notes
- I also ran the same trans-tool version used by CI against util.properties with UTF-8 enabled. The report still contains pre-existing quotation/punctuation warnings in util translations, but the new key is present in every util locale file, with English and zh-CN values plus placeholder comments for unreviewed languages.

Closes #1980