### PR TITLE
docs: clarify random delay simulation limits

### DIFF
--- a/src/main/resources/doc/en/html/guide/opts/opts-simulate.html
+++ b/src/main/resources/doc/en/html/guide/opts/opts-simulate.html
@@ -42,10 +42,10 @@
         </li>
         <li>
           <p>
-            The <strong>Add Noise To Component Delays</strong> checkbox allows you to enable or disable the random noise that is added to the delays of components. The internal simulation uses a hidden clock for its simulation, and to provide a somewhat realistic simulation, each component (excluding wires and splitters) has a delay between when it receives an input and when it emits an output. If this option is enabled, Logisim will occassionally (about once every 16 component reactions) make a component take one click longer than normal.
+            The <strong>Add Noise To Component Delays</strong> checkbox allows you to enable or disable the random noise that is added to the delays of components. The internal simulation uses a hidden clock for its simulation, and to provide a somewhat realistic simulation, each component (excluding wires and splitters) has a delay between when it receives an input and when it emits an output. If this option is enabled, Logisim will occasionally (about once every 16 component reactions) make a component take one click longer than normal.
           </p>
           <p>
-            I recommend keeping this option off, as this technique does introduce rare errors with normal circuits.
+            I recommend keeping this option off for normal circuit work. It is mainly useful for studying whether a circuit is sensitive to propagation-order changes or race conditions. If enabling it causes an unexpected result, treat the result as a warning about timing-sensitive design rather than as a precise prediction of real hardware behavior.
           </p>
         </li>
 		<!--

--- a/src/main/resources/doc/en/html/guide/prop/delays.html
+++ b/src/main/resources/doc/en/html/guide/prop/delays.html
@@ -44,10 +44,10 @@
         From a technical point of view, it is relatively easy to deal with this level of sophistication in a single circuit. Dealing with gate delays well across subcircuits, though, is a bit more complex; Logisim does attempt to address this correctly by placing all primitive component's propagation values into a single schedule regardless of the subcircuit in which the component lies.
       </p>
       <p>
-        Via the <a href="../opts/index.html">Project Options</a> window's <a href="../opts/opts-simulate.html">Simulation tab</a>, you can configure Logisim to add a random, occasional delay to a component's propagation. This is intended to simulate the unevenness of real circuits. In particular, an R-S latch built using two NOR gates will oscillate without this randomness, as both gates will process their inputs in lockstep. This randomness is disabled by default.
+        Via the <a href="../opts/index.html">Project Options</a> window's <a href="../opts/opts-simulate.html">Simulation tab</a>, you can configure Logisim to add a random, occasional delay to a component's propagation. This is intended to expose circuits that are sensitive to propagation-order changes, such as races or asynchronous feedback. In particular, an R-S latch built using two NOR gates will oscillate without this randomness, as both gates will process their inputs in lockstep. This randomness is disabled by default.
       </p>
       <p>
-        Note that I'm stopping short of saying that Logisim always addresses gate delays well. But at least it tries.
+        Note that I'm stopping short of saying that Logisim always addresses gate delays well. Randomized delays remain part of Logisim's simplified propagation model; they are not a substitute for timing-aware HDL simulation or circuit-level simulation when a design relies on specific gate delays.
       </p>
       <p>
         <b>Next:</b> <a href="oscillate.html">Oscillation errors</a>.


### PR DESCRIPTION
Summary
- clarify that Add Noise To Component Delays is mainly useful for exposing propagation-order and race sensitivity
- note that randomized delays remain part of Logisim's simplified propagation model, not a precise hardware timing simulation

Verification
- git -c core.whitespace=-blank-at-eol diff --cached --check

Related to #1738.