### PR TITLE
vhdl: rebuild simulator work library

### DIFF
--- a/src/main/resources/resources/logisim/sim/run.tcl
+++ b/src/main/resources/resources/logisim/sim/run.tcl
@@ -20,9 +20,14 @@
 
 puts "Run simulation environnment build..."
 
-# Create work library
-vlib work
-vmap work work
+# Create a fresh physical library for the logical work library.
+# Rebuilding it avoids reusing a stale or incomplete ModelSim/Questa library.
+set logisim_worklib logisim_work
+if {[file exists $logisim_worklib]} {
+  file delete -force $logisim_worklib
+}
+vlib $logisim_worklib
+vmap work $logisim_worklib
 
 # Compile vhdl
 do ../comp.tcl

--- a/src/test/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorScriptTest.java
+++ b/src/test/java/com/cburch/logisim/vhdl/sim/VhdlSimulatorScriptTest.java
@@ -1,0 +1,36 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.vhdl.sim;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class VhdlSimulatorScriptTest {
+
+  @Test
+  void runScriptRebuildsDedicatedPhysicalWorkLibrary() throws IOException {
+    final var resource =
+        VhdlSimulatorScriptTest.class.getResourceAsStream("/resources/logisim/sim/run.tcl");
+    assertNotNull(resource);
+
+    final var script = new String(resource.readAllBytes(), StandardCharsets.UTF_8);
+
+    assertTrue(script.contains("set logisim_worklib logisim_work"));
+    assertTrue(script.contains("file delete -force $logisim_worklib"));
+    assertTrue(script.contains("vlib $logisim_worklib"));
+    assertTrue(script.contains("vmap work $logisim_worklib"));
+    assertFalse(script.contains("vlib work\nvmap work work"));
+  }
+}


### PR DESCRIPTION
Summary
- rebuild the ModelSim/Questa physical work library before each VHDL simulation startup
- map the logical `work` library to a dedicated `logisim_work` directory instead of reusing a physical directory also named `work`
- add a regression test for the generated run script

Root cause
The VHDL simulator script used `vlib work` followed by `vmap work work`. If a stale or incomplete physical `work` directory already existed, ModelSim/Questa could treat it as an existing library and then fail later when compiling or starting the simulation.

This keeps the logical HDL library name `work`, but makes the physical directory Logisim-owned and disposable.

Verification
- `./gradlew.bat compileJava checkstyleMain compileTestJava checkstyleTest test --tests com.cburch.logisim.vhdl.sim.VhdlSimulatorScriptTest`
- Manual ModelSim 2020.4 check with an intentionally empty `work` directory present: `vsim -c` created/mapped `logisim_work` and exited with code 0.

Fixes #1325
