### PR TITLE
Fix LibraryManager toRelative issue with softlinks.

### DIFF
--- a/src/main/java/com/cburch/logisim/file/LibraryManager.java
+++ b/src/main/java/com/cburch/logisim/file/LibraryManager.java
@@ -127,8 +127,14 @@ public final class LibraryManager {
     } catch (IOException e) {
       // Do nothing as we already have defined the default above
     }
-    if (currentDirectory != null) {
-      final var currentParts = currentDirectory.toString().split(Pattern.quote(File.separator));
+    String currentDirectoryPath = null;
+    try {
+      currentDirectoryPath = currentDirectory.getCanonicalPath();
+    } catch (IOException e) {
+      // Do nothing as we will use filename without relative association.
+    }
+    if (currentDirectoryPath != null) {
+      final var currentParts = currentDirectoryPath.split(Pattern.quote(File.separator));
       final var newParts = fileName.split(Pattern.quote(File.separator));
       final var nrOfNewParts = newParts.length;
       // note that the newParts includes the filename, whilst the old doesn't


### PR DESCRIPTION
Recently, I ran `.gradlew test` and was surprised to find that it put up a panel asking me to find library files A.circ and B.circ. Of course, it should not be asking the user questions...

The problem came from the NestedLibraryResolutionTest. It created a temp directory for the test that was located in /var. It turns out that /var is soft-linked to /private/var on the Mac.

In building the relative reference from one B.circ to A.circ, it was using the canonical form of the path to A.circ (library), but not the canonical form of the path to B.circ (project). So they didn't match and it used `..` steps to go all the way up to `/` and then back down. But `..` does not follow a soft-link up. So it didn't get back to '/' and failed.

This PR makes sure the project path is canonical before building the relative link between them.