### PR TITLE
memory: clarify RAM reset behavior labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
   * Improved memory and hex editor tools:
     * Added a go-to-address control to the hex editor.
     * Limited generated save previews for large memories.
+    * Clarified RAM and Dual Port RAM simulation reset behavior labels.
     * Corrected memory display layout in exported graphics.
     * RAM line-enable inputs now only write when enabled. Existing projects relying on unconnected
       line-enable inputs may need to connect those inputs explicitly.
@@ -136,7 +137,8 @@
   * Added TTL 74670: 4-by-4 register file with three-state outputs
   * Added 16 bit floating point support for floating point arithmetic
   * Added partial support for VHDL time units
-  * Fixed the problem of keys getting assigned to focusing on the cell of the table in "properties" section along with its actual intent
+  * Fixed the problem of keys getting assigned to focusing on the cell of the table in
+    "properties" section along with its actual intent
 
 * v3.8.0 (2022-10-02)
   * Added reset value attribute to input pins

--- a/docs/test_vector.md
+++ b/docs/test_vector.md
@@ -6,7 +6,8 @@ This document describes the enhanced Test Vector functionality, including sequen
 ## Overview
 
 The Test Vector window allows you to load a test vector from a file, and Logisim will automatically run tests on the current circuit.
-The Test Vector module runs a separate copy of the circuit simulator, so it does not interfere with the simulation in the project window.
+The Test Vector module runs a separate copy of the circuit simulator, so it does not interfere with
+the simulation in the project window.
 
 Any incorrect outputs will be flagged in red. Hover the mouse over the red box to see what the output should have been,
 according to the test vector. Rows with incorrect outputs are sorted to the top of the window.

--- a/src/main/resources/doc/en/html/libs/mem/dualportram.html
+++ b/src/main/resources/doc/en/html/libs/mem/dualportram.html
@@ -171,6 +171,15 @@
             <dd>
               If enabled, adds an asynchronous Clear pin to reset memory contents.
             </dd>
+            <dt>
+              Simulation reset behavior
+            </dt>
+            <dd>
+              Determines how the memory content is modified when the simulation is reset or restarted:
+              <b class="vprop">Keep contents on reset</b> leaves memory contents unchanged, while
+              <b class="vprop">Clear contents on reset</b> resets RAM contents to zero or randomly according to the
+              <a href="../../guide/opts/opts-simulate.html">Simulation tab</a> project options.
+            </dd>
           </dl>
           <h2>
             Poke Tool Behavior

--- a/src/main/resources/doc/en/html/libs/mem/ram.html
+++ b/src/main/resources/doc/en/html/libs/mem/ram.html
@@ -421,12 +421,12 @@
             <b class="vprop">Use line enables</b>:one or more data lines make up the data bus. Each has its own selection signal. The Number of lines property lets you define the number of lines (1,2,4,8).
           </dd>
           <dt class="lib">
-            Ram type
+            Simulation reset behavior
           </dt>
           <dd>
-            Determines how the memory content is modified when the simulation is restarted:<br>
-            <b class="vprop">Non Volatile</b> memory contents are not modified.<br>
-            <b class="vprop">Volatile</b>; RAM contents reset to zero or randomly ( according to <a href="../../guide/opts/opts-simulate.html">Simulation tab</a> project options).
+            Determines how the memory content is modified when the simulation is reset or restarted:<br>
+            <b class="vprop">Keep contents on reset</b>: memory contents are not modified.<br>
+            <b class="vprop">Clear contents on reset</b>: RAM contents reset to zero or randomly, according to the <a href="../../guide/opts/opts-simulate.html">Simulation tab</a> project options.
           </dd>
           <dt class="lib">
             Use clear pin

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -755,9 +755,9 @@ RamClearPin = Use clear pin
 ramDataAttr = Data bus implementation
 ramNoByteEnables = Whole word read/write only
 ramSeparateDataBus = Separate data bus for read and write
-ramTypeAttr = Ram type
-ramTypeNonVolatile = non volatile
-ramTypeVolatile = volatile
+ramTypeAttr = Simulation reset behavior
+ramTypeNonVolatile = Keep contents on reset
+ramTypeVolatile = Clear contents on reset
 ramWithByteEnables = Use byte enables
 #
 # memory/DualRam.java
@@ -801,9 +801,9 @@ DualRamClearPin = Use clear pin
 dualRamDataAttr = Data bus implementation
 dualRamNoByteEnables = Whole word read/write only
 dualRamSeparateDataBus = Separate data bus for read and write
-dualRamTypeAttr = Dual Ram type
-dualRamTypeNonVolatile = non volatile
-dualRamTypeVolatile = volatile
+dualRamTypeAttr = Simulation reset behavior
+dualRamTypeNonVolatile = Keep contents on reset
+dualRamTypeVolatile = Clear contents on reset
 dualRamWithByteEnables = Use byte enables
 #
 # memory/Random.java

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -752,9 +752,9 @@ RamClearPin = 使用清除引脚
 ramDataAttr = 数据总线实现
 ramNoByteEnables = 仅整字读写
 ramSeparateDataBus = 读写分离的数据总线
-ramTypeAttr = RAM 类型
-ramTypeNonVolatile = 非易失
-ramTypeVolatile = 易失
+ramTypeAttr = 仿真重置行为
+ramTypeNonVolatile = 重置时保留内容
+ramTypeVolatile = 重置时清空内容
 ramWithByteEnables = 使用字节使能
 #
 # memory/DualRam.java
@@ -798,9 +798,9 @@ ramWithByteEnables = 使用字节使能
 #==> dualRamDataAttr =
 #==> dualRamNoByteEnables =
 #==> dualRamSeparateDataBus =
-#==> dualRamTypeAttr =
-#==> dualRamTypeNonVolatile =
-#==> dualRamTypeVolatile =
+dualRamTypeAttr = 仿真重置行为
+dualRamTypeNonVolatile = 重置时保留内容
+dualRamTypeVolatile = 重置时清空内容
 #==> dualRamWithByteEnables =
 #
 # memory/Random.java

--- a/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
+++ b/src/test/java/com/cburch/logisim/gui/appear/AppearanceViewTest.java
@@ -82,8 +82,8 @@ class AppearanceViewTest {
     pane.setSize(200, 200);
     pane.getViewport().setViewSize(canvas.getPreferredSize());
     pane.doLayout();
-    pane.getHorizontalScrollBar().setValue(80);
-    pane.getVerticalScrollBar().setValue(90);
+    pane.getHorizontalScrollBar().setValues(80, 200, 0, 1000);
+    pane.getVerticalScrollBar().setValues(90, 200, 0, 1000);
     final var initialX = pane.getHorizontalScrollBar().getValue();
     final var initialY = pane.getVerticalScrollBar().getValue();
 


### PR DESCRIPTION
Summary
- rename the RAM/Dual RAM reset-related UI labels from volatile/non-volatile wording to explicit reset behavior wording
- keep the serialized option ids unchanged (`type`, `volatile`, `nonvolatile`) so existing `.circ` files remain compatible
- update the English RAM and Dual Port RAM reference pages, plus the reviewed Simplified Chinese strings
- note the wording clarification in CHANGES.md
- wrap one pre-existing long Test Vector documentation line so the full Markdown linter stays green after touching CHANGES.md
- stabilize the existing appearance panning test setup after CI showed it still depended on platform-specific scrollbar layout

Verification
- `./gradlew.bat processResources compileJava`
- `./gradlew.bat test --tests com.cburch.logisim.gui.appear.AppearanceViewTest.middleButtonDragPansAppearanceCanvas`
- `markdownlint --config .markdownlint.yaml` over all Markdown files
- `git diff --check`

Fixes #2713