### PR TITLE
fix: notify toolbar placement listeners

### DIFF
--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorStringOpts.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorStringOpts.java
@@ -85,8 +85,10 @@ class PrefMonitorStringOpts extends AbstractPrefMonitor<String> {
   public void set(String newValue) {
     final var chosen = choose(newValue);
     if (!isSame(value, chosen)) {
+      final var oldValue = value;
       value = chosen;
       AppPreferences.getPrefs().put(getIdentifier(), chosen);
+      AppPreferences.firePropertyChange(getIdentifier(), oldValue, chosen);
     } else if (!isSame(newValue, chosen)) {
       AppPreferences.getPrefs().put(getIdentifier(), chosen);
     }

--- a/src/test/java/com/cburch/logisim/prefs/PrefMonitorStringOptsTest.java
+++ b/src/test/java/com/cburch/logisim/prefs/PrefMonitorStringOptsTest.java
@@ -10,7 +10,11 @@
 package com.cburch.logisim.prefs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,5 +37,41 @@ class PrefMonitorStringOptsTest {
     monitor.set("second");
 
     assertEquals("second", monitor.get());
+  }
+
+  @Test
+  void setFiresPropertyChangeSynchronously() {
+    preferenceName = "testStringOption-" + System.nanoTime();
+    final var monitor =
+        new PrefMonitorStringOpts(
+            preferenceName, new String[] {"first", "second"}, "first");
+    final var events = new ArrayList<PropertyChangeEvent>();
+    final PropertyChangeListener listener = events::add;
+    monitor.addPropertyChangeListener(listener);
+
+    monitor.set("second");
+
+    assertEquals("second", monitor.get());
+    assertEquals(1, events.size());
+    final var event = events.get(0);
+    assertEquals(preferenceName, event.getPropertyName());
+    assertEquals("first", event.getOldValue());
+    assertEquals("second", event.getNewValue());
+  }
+
+  @Test
+  void setDoesNotNotifyWhenNormalizedValueIsUnchanged() {
+    preferenceName = "testStringOption-" + System.nanoTime();
+    final var monitor =
+        new PrefMonitorStringOpts(
+            preferenceName, new String[] {"first", "second"}, "first");
+    final var events = new ArrayList<PropertyChangeEvent>();
+    final PropertyChangeListener listener = events::add;
+    monitor.addPropertyChangeListener(listener);
+
+    monitor.set("invalid");
+
+    assertEquals("first", monitor.get());
+    assertTrue(events.isEmpty());
   }
 }


### PR DESCRIPTION
## Summary

- fire string-option preference change events synchronously when `set()` changes the selected value
- preserve synchronous in-memory updates and avoid notifications for unchanged normalized values
- restore immediate Window > Show Toolbar updates across open project windows

## Root cause

`PrefMonitorStringOpts.set()` updated its cached value before the Java Preferences callback ran. The callback then saw no value change and skipped the property event, so open `Frame` instances never called `placeToolbar()`.

## Verification

- `.\gradlew.bat --rerun-tasks test checkstyleMain checkstyleTest`
  (with Git for Windows' existing `xxd.exe` temporarily added to the command PATH)
- `git diff --check`
- Windows manual test: hide/show updates immediately in one window and stays synchronized across two project windows

Fixes #2722
