### PR TITLE
Restrict the height of the RAM/ROM/DUALRAM components to a maximum of 8 "datablocks".

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/DualRamAppearance.java
+++ b/src/main/java/com/cburch/logisim/std/memory/DualRamAppearance.java
@@ -235,7 +235,7 @@ public class DualRamAppearance {
     if (classicAppearance(attrs)) {
       return Math.max(70, portsLen);
     } else {
-      int dataLen = attrs.getValue(Mem.DATA_ATTR).getWidth() * 40;
+      int dataLen = Math.min(8, attrs.getValue(Mem.DATA_ATTR).getWidth()) * 40;
       return Math.max(dataLen, portsLen);
     }
   }
@@ -481,7 +481,7 @@ public class DualRamAppearance {
     ypos += (portIndex % split) * 10;
 
     if (portIndex >= split) {
-      ypos += isClassic ? getClassicPortBoffset(attrs) : (bits.getWidth() * 20);
+      ypos += isClassic ? getClassicPortBoffset(attrs) : (Math.min(8, bits.getWidth()) * 20);
     }
 
     final var result = new Port(0, ypos, Port.INPUT, bits);
@@ -524,7 +524,7 @@ public class DualRamAppearance {
       ypos += 10;
     ypos += (portIndex % splitIndex) * 10;
     if (portIndex >= splitIndex) {
-      ypos += isClassic ? getClassicPortBoffset(attrs) : (bits.getWidth() * 20);
+      ypos += isClassic ? getClassicPortBoffset(attrs) : (Math.min(8, bits.getWidth()) * 20);
     }
 
     final var result = new Port(xpos, ypos, portType, bits);
@@ -775,10 +775,11 @@ public class DualRamAppearance {
             ypos[1] = ypos[2] = y + 10;
             g.setFont(font.deriveFont(7.0f));
             g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
-            for (var j = 0; j < nrOfBits; j++) {
+            for (var j = 0; j < Math.min(8, nrOfBits); j++) {
               g.drawPolyline(xpos, ypos, 3);
-              GraphicsUtil.drawText(g, Integer.toString(j), xpos[2] - 3, ypos[2] - 3, GraphicsUtil.H_RIGHT,
-                  GraphicsUtil.V_BASELINE);
+              if (nrOfBits <= 8) {
+                GraphicsUtil.drawText(g, Integer.toString(j), xpos[2] - 3, ypos[2] - 3, GraphicsUtil.H_RIGHT, GraphicsUtil.V_BASELINE);
+              }
               ypos[0] += 20;
               ypos[1] += 20;
               ypos[2] += 20;
@@ -789,7 +790,7 @@ public class DualRamAppearance {
             xpos[1] = xpos[2] = x + 5;
             ypos[0] = y;
             ypos[1] = y + 5;
-            ypos[2] = y + 5 + (nrOfBits - 1) * 20;
+            ypos[2] = y + 5 + Math.min(7, (nrOfBits - 1)) * 20;
             g.drawPolyline(xpos, ypos, 3);
           }
         }
@@ -843,10 +844,12 @@ public class DualRamAppearance {
             ypos[1] = ypos[2] = y + 10;
             g.setFont(font.deriveFont(7.0f));
             g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
-            for (var j = 0; j < nrOfBits; j++) {
+            for (var j = 0; j < Math.min(8, nrOfBits); j++) {
               g.drawPolyline(xpos, ypos, 3);
-              GraphicsUtil.drawText(g, Integer.toString(j), xpos[2] + 3, ypos[2] - 3, GraphicsUtil.H_LEFT,
-                  GraphicsUtil.V_BASELINE);
+              if (nrOfBits <= 8) {
+                GraphicsUtil.drawText(g, Integer.toString(j), xpos[2] + 3, ypos[2] - 3, GraphicsUtil.H_LEFT,
+                    GraphicsUtil.V_BASELINE);
+              }
               if (!seperate)
                 drawBidir(g, xpos[2], ypos[2]);
               ypos[0] += 20;
@@ -859,7 +862,7 @@ public class DualRamAppearance {
             xpos[1] = xpos[2] = x - 5;
             ypos[0] = y;
             ypos[1] = y + 5;
-            ypos[2] = y + 5 + (nrOfBits - 1) * 20;
+            ypos[2] = y + 5 + Math.min(7, (nrOfBits - 1)) * 20;
             g.drawPolyline(xpos, ypos, 3);
           }
         }
@@ -1067,7 +1070,7 @@ public class DualRamAppearance {
     for (int p = 0; p < 2; p++) {
       var y = base_y;
       if (p == 1)
-        y += (nrOfBits * 20);
+        y += Math.min(8, nrOfBits) * 20;
       String label = "A" + (p + 1);
       final var doutLabel = new StringBuilder();
       final var dinLabel = new StringBuilder();
@@ -1115,7 +1118,7 @@ public class DualRamAppearance {
 
       final var DLabel = seperate ? "" : "D";
 
-      for (var i = 0; i < nrOfBits; i++) {
+      for (var i = 0; i < Math.min(8, nrOfBits); i++) {
         g.setStroke(new BasicStroke(2));
         g.drawRect(x, y, width, height);
         g.setStroke(new BasicStroke(1));

--- a/src/main/java/com/cburch/logisim/std/memory/RamAppearance.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAppearance.java
@@ -204,7 +204,7 @@ public class RamAppearance {
       return Bounds.create(0, 0, Mem.SymbolWidth + 40, getControlHeight(attrs) + len);
     } else {
       final var dataBlockHeight = attrs.getValue(Mem.DATA_ATTR).getWidth() * 20;
-      final var len = Math.max( (dataBlockHeight > 160) ? 160 : dataBlockHeight, (getNrLEPorts(attrs) + 1) * 10);
+      final var len = Math.max((dataBlockHeight > 160) ? 160 : dataBlockHeight, (getNrLEPorts(attrs) + 1) * 10);
       return Bounds.create(0, 0, Mem.SymbolWidth + xoffset, getControlHeight(attrs) + len);
     }
 

--- a/src/main/java/com/cburch/logisim/std/memory/RamAppearance.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAppearance.java
@@ -197,13 +197,14 @@ public class RamAppearance {
   }
 
   public static Bounds getBounds(AttributeSet attrs) {
-    int xoffset = (seperatedBus(attrs)) ? 40 : 50;
+    final var xoffset = (seperatedBus(attrs)) ? 40 : 50;
 
     if (classicAppearance(attrs)) {
-      int len = Math.max(64, (getNrLEPorts(attrs) + 1) * 10);
+      final var len = Math.max(64, (getNrLEPorts(attrs) + 1) * 10);
       return Bounds.create(0, 0, Mem.SymbolWidth + 40, getControlHeight(attrs) + len);
     } else {
-      int len = Math.max(attrs.getValue(Mem.DATA_ATTR).getWidth() * 20, (getNrLEPorts(attrs) + 1) * 10);
+      final var dataBlockHeight = attrs.getValue(Mem.DATA_ATTR).getWidth() * 20;
+      final var len = Math.max( (dataBlockHeight > 160) ? 160 : dataBlockHeight, (getNrLEPorts(attrs) + 1) * 10);
       return Bounds.create(0, 0, Mem.SymbolWidth + xoffset, getControlHeight(attrs) + len);
     }
 
@@ -562,9 +563,11 @@ public class RamAppearance {
             ypos[1] = ypos[2] = y + 10;
             g.setFont(font.deriveFont(7.0f));
             g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
-            for (var j = 0; j < nrOfBits; j++) {
+            for (var j = 0; j < Math.min(8, nrOfBits); j++) {
               g.drawPolyline(xpos, ypos, 3);
-              GraphicsUtil.drawText(g, Integer.toString(j), xpos[2] - 3, ypos[2] - 3, GraphicsUtil.H_RIGHT, GraphicsUtil.V_BASELINE);
+              if (nrOfBits <= 8) {
+                GraphicsUtil.drawText(g, Integer.toString(j), xpos[2] - 3, ypos[2] - 3, GraphicsUtil.H_RIGHT, GraphicsUtil.V_BASELINE);
+              }
               ypos[0] += 20;
               ypos[1] += 20;
               ypos[2] += 20;
@@ -575,7 +578,7 @@ public class RamAppearance {
             xpos[1] = xpos[2] = x + 5;
             ypos[0] = y;
             ypos[1] = y + 5;
-            ypos[2] = y + 5 + (nrOfBits - 1) * 20;
+            ypos[2] = y + 5 + Math.min(7, (nrOfBits - 1)) * 20;
             g.drawPolyline(xpos, ypos, 3);
           }
         }
@@ -625,9 +628,11 @@ public class RamAppearance {
             ypos[1] = ypos[2] = y + 10;
             g.setFont(font.deriveFont(7.0f));
             g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
-            for (var j = 0; j < nrOfBits; j++) {
+            for (var j = 0; j < Math.min(8, nrOfBits); j++) {
               g.drawPolyline(xpos, ypos, 3);
-              GraphicsUtil.drawText(g, Integer.toString(j), xpos[2] + 3, ypos[2] - 3, GraphicsUtil.H_LEFT, GraphicsUtil.V_BASELINE);
+              if (nrOfBits <= 8) {
+                GraphicsUtil.drawText(g, Integer.toString(j), xpos[2] + 3, ypos[2] - 3, GraphicsUtil.H_LEFT, GraphicsUtil.V_BASELINE);
+              }
               if (!seperate) drawBidir(g, xpos[2], ypos[2]);
               ypos[0] += 20;
               ypos[1] += 20;
@@ -639,7 +644,7 @@ public class RamAppearance {
             xpos[1] = xpos[2] = x - 5;
             ypos[0] = y;
             ypos[1] = y + 5;
-            ypos[2] = y + 5 + (nrOfBits - 1) * 20;
+            ypos[2] = y + 5 + Math.min(7, (nrOfBits - 1)) * 20;
             g.drawPolyline(xpos, ypos, 3);
           }
         }
@@ -862,7 +867,7 @@ public class RamAppearance {
     }
     final var appendBE = getNrBEPorts(attrs) > 0;
     final var DLabel = seperate ? "" : "D";
-    for (var i = 0; i < nrOfBits; i++) {
+    for (var i = 0; i < Math.min(nrOfBits, 8); i++) {
       g.setStroke(new BasicStroke(2));
       g.drawRect(x, y, width, height);
       g.setStroke(new BasicStroke(1));

--- a/src/main/java/com/cburch/logisim/std/memory/Rom.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Rom.java
@@ -164,7 +164,7 @@ public class Rom extends Mem {
 
   @Override
   public Bounds getOffsetBounds(AttributeSet attrs) {
-    final var len = attrs.getValue(Mem.DATA_ATTR).getWidth();
+    final var len = Math.min(8, attrs.getValue(Mem.DATA_ATTR).getWidth());
     if (attrs.getValue(StdAttr.APPEARANCE) == StdAttr.APPEAR_CLASSIC) {
       return Bounds.create(0, 0, SymbolWidth + 40, 140);
     } else {


### PR DESCRIPTION
Important: This breaks backward compatibility of the DUALRAM for the data port B connections