### PR TITLE
memory: keep wide shift register states inside bounds

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/ShiftRegister.java
+++ b/src/main/java/com/cburch/logisim/std/memory/ShiftRegister.java
@@ -337,22 +337,22 @@ public class ShiftRegister extends InstanceFactory {
       else if (data_value.isErrorValue()) g.setColor(Color.RED);
       else g.setColor(Color.BLUE);
       final var yoff = (currentStage == 0) ? 10 : 0;
-      final var len = (nrOfBits + 3) / 4;
-      final var boxXpos = ((blockWidth - 30) / 2 + 30) - (len * 4);
-      g.fillRect(realXpos + boxXpos, realYpos + yoff + 2, 2 + len * 8, 16);
-      String value;
+      final var valueBounds = getStageValueBounds(nrOfBits);
+      g.fillRect(
+          realXpos + valueBounds.getX(),
+          realYpos + yoff + valueBounds.getY(),
+          valueBounds.getWidth(),
+          valueBounds.getHeight());
       if (data_value.isFullyDefined()) {
         g.setColor(Color.DARK_GRAY);
-        value = StringUtil.toHexString(nrOfBits, data_value.toLongValue());
       } else {
         g.setColor(Color.YELLOW);
-        value = (data_value.isUnknown()) ? "?" : "!";
       }
       GraphicsUtil.drawText(
           g,
-          value,
-          realXpos + boxXpos + 1,
-          realYpos + yoff + 10,
+          getStageValueText(nrOfBits, data_value),
+          realXpos + valueBounds.getX() + 1,
+          realYpos + yoff + valueBounds.getY() + valueBounds.getHeight() / 2,
           GraphicsUtil.H_LEFT,
           GraphicsUtil.V_CENTER);
       g.setColor(componentColor);

--- a/src/main/java/com/cburch/logisim/std/memory/ShiftRegister.java
+++ b/src/main/java/com/cburch/logisim/std/memory/ShiftRegister.java
@@ -56,6 +56,21 @@ public class ShiftRegister extends InstanceFactory {
   static final int LD = 5;
   static final int symbolWidth = 100;
 
+  static Bounds getStageValueBounds(int nrOfBits) {
+    final var fullDigits = (nrOfBits + 3) / 4;
+    final var displayedSlots = Math.min(fullDigits, 9);
+    final var boxWidth = 2 + displayedSlots * 8;
+    final var preferredX =
+        ((symbolWidth - 30) / 2 + 30) - displayedSlots * 4;
+    return Bounds.create(Math.min(preferredX, symbolWidth - boxWidth), 2, boxWidth, 16);
+  }
+
+  static String getStageValueText(int nrOfBits, Value value) {
+    if (!value.isFullyDefined()) return value.isUnknown() ? "?" : "!";
+    final var text = StringUtil.toHexString(nrOfBits, value.toLongValue());
+    return text.length() <= 9 ? text : ".." + text.substring(text.length() - 7);
+  }
+
   public ShiftRegister() {
     super(_ID, S.getter("shiftRegisterComponent"), new ShiftRegisterHdlGeneratorFactory());
     setAttributes(

--- a/src/main/java/com/cburch/logisim/std/memory/ShiftRegisterPoker.java
+++ b/src/main/java/com/cburch/logisim/std/memory/ShiftRegisterPoker.java
@@ -40,13 +40,12 @@ public class ShiftRegisterPoker extends InstancePoker {
       if (x < 0 || x >= lenObj * 10) return -1;
       return x / 10;
     } else {
-      final var len = (widObj.getWidth() + 3) / 4;
-      final var boxXpos = ((ShiftRegister.symbolWidth - 30) / 2 + 30) - (len * 4);
-      final var boxXend = boxXpos + 2 + len * 8;
+      final var valueBounds = ShiftRegister.getStageValueBounds(widObj.getWidth());
       final var y = e.getY() - bds.getY() - 80;
       if (y < 0) return -1;
       final var x = e.getX() - bds.getX() - 10;
-      if ((x < boxXpos) || (x > boxXend)) return -1;
+      if (x < valueBounds.getX()
+          || x > valueBounds.getX() + valueBounds.getWidth()) return -1;
       return (y / 20);
     }
   }
@@ -154,12 +153,12 @@ public class ShiftRegisterPoker extends InstancePoker {
       g.setColor(Color.RED);
       g.drawRect(x, y - 6, 10, 13);
     } else {
-      final var len = (widObj.getWidth() + 3) / 4;
-      final var boxXpos = ((ShiftRegister.symbolWidth - 30) / 2 + 30) - (len * 4) + bds.getX() + 10;
-      final var y = bds.getY() + 82 + loc * 20;
+      final var valueBounds = ShiftRegister.getStageValueBounds(widObj.getWidth());
+      final var boxXpos = bds.getX() + 10 + valueBounds.getX();
+      final var y = bds.getY() + 80 + loc * 20 + valueBounds.getY();
       final var g = painter.getGraphics();
       g.setColor(Color.RED);
-      g.drawRect(boxXpos, y, 2 + len * 8, 16);
+      g.drawRect(boxXpos, y, valueBounds.getWidth(), valueBounds.getHeight());
     }
   }
 }

--- a/src/test/java/com/cburch/logisim/std/memory/ShiftRegisterAppearanceTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/ShiftRegisterAppearanceTest.java
@@ -1,0 +1,121 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Bounds;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.instance.Instance;
+import com.cburch.logisim.instance.StdAttr;
+import org.junit.jupiter.api.Test;
+
+class ShiftRegisterAppearanceTest {
+
+  @Test
+  void stageValueBoundsStayInsideDataBlockForEverySupportedWidth() {
+    for (var width = 1; width <= 64; width++) {
+      final var bounds = ShiftRegister.getStageValueBounds(width);
+
+      assertTrue(bounds.getX() >= 0, "left edge for width " + width);
+      assertTrue(
+          bounds.getX() + bounds.getWidth() <= ShiftRegister.symbolWidth,
+          "right edge for width " + width);
+      assertEquals(2, bounds.getY());
+      assertEquals(16, bounds.getHeight());
+    }
+  }
+
+  @Test
+  void stageValueBoundsPreserveNarrowLayoutAndFitNineDigits() {
+    assertBounds(ShiftRegister.getStageValueBounds(1), 61, 2, 10, 16);
+    assertBounds(ShiftRegister.getStageValueBounds(32), 33, 2, 66, 16);
+    assertBounds(ShiftRegister.getStageValueBounds(36), 26, 2, 74, 16);
+  }
+
+  @Test
+  void stageValueTextPreservesValuesThroughNineHexDigits() {
+    assertEquals(
+        "89abcdef",
+        ShiftRegister.getStageValueText(
+            32, Value.createKnown(BitWidth.create(32), 0x89ABCDEFL)));
+    assertEquals(
+        "123456789",
+        ShiftRegister.getStageValueText(
+            36, Value.createKnown(BitWidth.create(36), 0x123456789L)));
+  }
+
+  @Test
+  void stageValueTextSummarizesLowOrderDigitsAboveNineHexDigits() {
+    assertEquals(
+        "..fffffff",
+        ShiftRegister.getStageValueText(
+            37, Value.createKnown(BitWidth.create(37), 0x1FFFFFFFFFL)));
+    assertEquals(
+        "..456789a",
+        ShiftRegister.getStageValueText(
+            40, Value.createKnown(BitWidth.create(40), 0x123456789AL)));
+    assertEquals(
+        "..9abcdef",
+        ShiftRegister.getStageValueText(
+            64, Value.createKnown(BitWidth.create(64), 0x0123456789ABCDEFL)));
+  }
+
+  @Test
+  void stageValueTextPreservesUnknownAndErrorMarkers() {
+    assertEquals(
+        "?", ShiftRegister.getStageValueText(64, Value.createUnknown(BitWidth.create(64))));
+    assertEquals(
+        "!", ShiftRegister.getStageValueText(64, Value.createError(BitWidth.create(64))));
+  }
+
+  @Test
+  void wideEvolutionAppearanceKeepsBoundsAndPortsStable() {
+    final var instance = createEvolutionShiftRegisterInstance(64);
+
+    assertEquals(120, instance.getBounds().getWidth());
+    assertEquals(240, instance.getBounds().getHeight());
+    assertPortLocation(instance, ShiftRegister.IN, 0, 80);
+    assertPortLocation(instance, ShiftRegister.OUT, 120, 230);
+    assertPortLocation(instance, ShiftRegister.CK, 0, 50);
+    assertPortLocation(instance, ShiftRegister.CLR, 0, 20);
+    assertPortLocation(instance, ShiftRegister.SH, 0, 40);
+    assertPortLocation(instance, ShiftRegister.LD, 0, 30);
+    assertPortLocation(instance, 6, 0, 90);
+    assertPortLocation(instance, 7, 120, 90);
+  }
+
+  private static Instance createEvolutionShiftRegisterInstance(int width) {
+    final var shiftRegister = new ShiftRegister();
+    final var attrs = shiftRegister.createAttributeSet();
+    attrs.setValue(StdAttr.WIDTH, BitWidth.create(width));
+    attrs.setValue(ShiftRegister.ATTR_LENGTH, 8);
+    attrs.setValue(ShiftRegister.ATTR_LOAD, true);
+    attrs.setValue(StdAttr.APPEARANCE, StdAttr.APPEAR_EVOLUTION);
+    return Instance.getInstanceFor(
+        shiftRegister.createComponent(Location.create(0, 0, false), attrs));
+  }
+
+  private static void assertBounds(Bounds bounds, int x, int y, int width, int height) {
+    assertEquals(x, bounds.getX());
+    assertEquals(y, bounds.getY());
+    assertEquals(width, bounds.getWidth());
+    assertEquals(height, bounds.getHeight());
+  }
+
+  private static void assertPortLocation(Instance instance, int portIndex, int x, int y) {
+    final var location = instance.getPortLocation(portIndex);
+    assertEquals(x, location.getX());
+    assertEquals(y, location.getY());
+  }
+}


### PR DESCRIPTION
## Summary

- keep Evolution Shift Register stage values inside the existing 100-pixel data block for all supported widths
- preserve the full hexadecimal value through 36 bits and show `..` plus the seven low-order digits for wider values
- share one bounds helper between painting, Poker hit testing, and the red edit outline
- add deterministic regression coverage for widths 1 through 64 and unchanged component bounds and ports

## Root cause

The Evolution stage-value background grew by eight pixels for every hexadecimal digit while the symbol width stayed fixed. At 64 bits, the background extended beyond the component and overlapped its output area. The same geometry was duplicated in the Poker code.

This keeps the existing footprint and port coordinates unchanged. Classic appearance, simulation behavior, attributes, and circuit serialization are unaffected.

## Testing

- `./gradlew --rerun-tasks test checkstyleMain checkstyleTest --console=plain`
- manually verified Evolution widths 32, 36, 37, 40, and 64, including Poker editing, red-outline alignment, and output-wire clearance
- manually verified unchanged Classic behavior at widths 4 and 64

With #2682 already addressing the Counter, this completes the remaining Shift Register part of the issue.

Closes #2561
