### PR TITLE
Dark mode theme support with automatic color adaptation

### DIFF
--- a/src/main/java/com/cburch/logisim/Main.java
+++ b/src/main/java/com/cburch/logisim/Main.java
@@ -11,6 +11,7 @@ package com.cburch.logisim;
 
 import com.cburch.logisim.generated.BuildInfo;
 import com.cburch.logisim.gui.generic.OptionPane;
+import com.cburch.logisim.gui.generic.ThemeManager;
 import com.cburch.logisim.gui.start.Startup;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.formdev.flatlaf.FlatDarculaLaf;
@@ -50,7 +51,10 @@ public class Main {
         FlatMacDarkLaf.installLafInfo();
         
         UIManager.setLookAndFeel(AppPreferences.LookAndFeel.get());
-        
+
+        ThemeManager.setDarkMode(ThemeManager.isDarkLaf(UIManager.getLookAndFeel()));
+        AppPreferences.applyThemeDefaults(ThemeManager.isDarkMode());
+
         // Apply global font preference
         final var appFont = AppPreferences.APP_FONT.get();
         if (appFont != null && !appFont.isBlank()) {

--- a/src/main/java/com/cburch/logisim/data/Value.java
+++ b/src/main/java/com/cburch/logisim/data/Value.java
@@ -306,6 +306,21 @@ public final class Value {
   public static Color widthErrorCaptionBgcolor = new Color(AppPreferences.WIDTH_ERROR_BACKGROUND_COLOR.get());
   public static Color clockFrequencyColor = new Color(AppPreferences.CLOCK_FREQUENCY_COLOR.get());
 
+  public static void refreshColors() {
+    falseColor = new Color(AppPreferences.FALSE_COLOR.get());
+    trueColor = new Color(AppPreferences.TRUE_COLOR.get());
+    unknownColor = new Color(AppPreferences.UNKNOWN_COLOR.get());
+    errorColor = new Color(AppPreferences.ERROR_COLOR.get());
+    nilColor = new Color(AppPreferences.NIL_COLOR.get());
+    strokeColor = new Color(AppPreferences.STROKE_COLOR.get());
+    multiColor = new Color(AppPreferences.BUS_COLOR.get());
+    widthErrorColor = new Color(AppPreferences.WIDTH_ERROR_COLOR.get());
+    widthErrorCaptionColor = new Color(AppPreferences.WIDTH_ERROR_CAPTION_COLOR.get());
+    widthErrorHighlightColor = new Color(AppPreferences.WIDTH_ERROR_HIGHLIGHT_COLOR.get());
+    widthErrorCaptionBgcolor = new Color(AppPreferences.WIDTH_ERROR_BACKGROUND_COLOR.get());
+    clockFrequencyColor = new Color(AppPreferences.CLOCK_FREQUENCY_COLOR.get());
+  }
+
   private static final Cache cache = new Cache();
 
   private final int width;

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
@@ -384,8 +384,7 @@ public class ProjectExplorer extends JTree implements LocaleListener {
             y,
             AppPreferences.getScaled(AppPreferences.BOX_SIZE),
             AppPreferences.getScaled(AppPreferences.BOX_SIZE));
-        g.setColor(Canvas.HALO_COLOR);
-        g.setColor(Color.BLACK);
+        g.setColor(new Color(AppPreferences.COMPONENT_ICON_COLOR.get()));
         g.setClip(s);
       }
 

--- a/src/main/java/com/cburch/logisim/gui/generic/ThemeManager.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ThemeManager.java
@@ -1,0 +1,71 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.generic;
+
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.formdev.flatlaf.FlatLaf;
+import java.awt.Window;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class ThemeManager {
+
+  public static final String THEME_PROPERTY = "theme";
+
+  private static final PropertyChangeSupport support = new PropertyChangeSupport(ThemeManager.class);
+
+  private static boolean darkMode = false;
+
+  private ThemeManager() {}
+
+  public static boolean isDarkMode() {
+    return darkMode;
+  }
+
+  public static void setDarkMode(boolean dark) {
+    darkMode = dark;
+  }
+
+  public static boolean isDarkLaf(javax.swing.LookAndFeel laf) {
+    if (laf == null) return false;
+    final var name = laf.getClass().getName();
+    return name.contains("Dark") || name.contains("Darcula");
+  }
+
+  public static boolean isDarkLaf(String lafClassName) {
+    return lafClassName != null && (lafClassName.contains("Dark") || lafClassName.contains("Darcula"));
+  }
+
+  public static void applyTheme() {
+    final var laf = UIManager.getLookAndFeel();
+    final var wasDark = darkMode;
+    darkMode = isDarkLaf(laf);
+
+    AppPreferences.applyThemeDefaults(darkMode);
+    Value.refreshColors();
+
+    for (final var w : Window.getWindows()) {
+      SwingUtilities.updateComponentTreeUI(w);
+    }
+
+    support.firePropertyChange(THEME_PROPERTY, wasDark, darkMode);
+  }
+
+  public static void addPropertyChangeListener(PropertyChangeListener listener) {
+    support.addPropertyChangeListener(listener);
+  }
+
+  public static void removePropertyChangeListener(PropertyChangeListener listener) {
+    support.removePropertyChangeListener(listener);
+  }
+}

--- a/src/main/java/com/cburch/logisim/gui/icons/ButtonIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ButtonIcon.java
@@ -26,7 +26,7 @@ public class ButtonIcon extends BaseIcon {
     final int[] ypos = {y, y, scale(14), scale(14)};
     g2.setColor(Color.LIGHT_GRAY);
     g2.fillPolygon(xpos, ypos, 4);
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawPolygon(xpos, ypos, 4);
     x = wh + scale(state);
     y = scale(state);
@@ -34,11 +34,11 @@ public class ButtonIcon extends BaseIcon {
     final int[] ypos1 = {y, y + wh, scale(14), scale(3)};
     g2.setColor(Color.LIGHT_GRAY);
     g2.fillPolygon(xpos1, ypos1, 4);
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawPolygon(xpos1, ypos1, 4);
     g2.setColor(Color.WHITE);
     g2.fillRect(scale(state), scale(state), wh, wh);
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawRect(scale(state), scale(state), wh, wh);
 
     final var s = "B";

--- a/src/main/java/com/cburch/logisim/gui/icons/CompileIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/CompileIcon.java
@@ -20,7 +20,7 @@ public class CompileIcon extends BaseIcon {
   @Override
   protected void paintIcon(Graphics2D g2) {
     final var page = new int[] {0, 0, 0, 15, 15, 15, 15, 5, 10, 5, 10, 0, 15, 5, 10, 0, 0, 0};
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.setStroke(new BasicStroke(AppPreferences.getScaled(1F)));
     final var xpos = new int[9];
     final var ypos = new int[9];

--- a/src/main/java/com/cburch/logisim/gui/icons/DrcIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/DrcIcon.java
@@ -27,9 +27,6 @@ public class DrcIcon extends BaseIcon {
   protected void paintIcon(Graphics2D g2) {
     if (drawEmpty) return;
 
-    g2.setColor(Color.WHITE);
-    g2.fillRect(0, 0, getIconWidth(), getIconHeight());
-
     var p = new GeneralPath();
     p.moveTo(scale(15), 0);
     p.quadTo(scale(7), scale(7), 0, scale(6));

--- a/src/main/java/com/cburch/logisim/gui/icons/HdlIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/HdlIcon.java
@@ -27,7 +27,7 @@ public class HdlIcon extends BaseIcon {
   protected void paintIcon(Graphics2D g2) {
     g2.setColor(Color.WHITE);
     g2.fillRect(0, scale(4), scale(16), scale(12));
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawRect(0, scale(4), scale(16), scale(12));
     g2.setColor(Color.LIGHT_GRAY);
     final var font = g2.getFont().deriveFont((float) getIconWidth() / (float) 4.5);

--- a/src/main/java/com/cburch/logisim/gui/icons/JoystickIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/JoystickIcon.java
@@ -33,7 +33,7 @@ public class JoystickIcon extends BaseIcon {
     var xtop = scale(13);
     var ytop = scale(3);
     g2.setStroke(new BasicStroke(scale(2)));
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawLine(xtop, ytop, xbase, ybase);
     xtop -= scale(2);
     ytop -= scale(2);

--- a/src/main/java/com/cburch/logisim/gui/icons/KeyboardIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/KeyboardIcon.java
@@ -26,7 +26,7 @@ public class KeyboardIcon extends BaseIcon {
     final int[] ypos = {y, y, scale(14), scale(14)};
     g2.setColor(Color.LIGHT_GRAY);
     g2.fillPolygon(xpos, ypos, 4);
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawPolygon(xpos, ypos, 4);
     x = wh + scale(state);
     y = scale(state);
@@ -34,11 +34,11 @@ public class KeyboardIcon extends BaseIcon {
     final int[] ypos1 = {y, y + wh, scale(14), scale(3)};
     g2.setColor(Color.LIGHT_GRAY);
     g2.fillPolygon(xpos1, ypos1, 4);
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawPolygon(xpos1, ypos1, 4);
     g2.setColor(Color.WHITE);
     g2.fillRect(scale(state), scale(state), wh, wh);
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawRect(scale(state), scale(state), wh, wh);
 
     final var s = "K";

--- a/src/main/java/com/cburch/logisim/gui/icons/LedBarIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/LedBarIcon.java
@@ -26,7 +26,7 @@ public class LedBarIcon extends BaseIcon {
 
   @Override
   protected void paintIcon(Graphics2D g2) {
-    g2.setColor(Color.DARK_GRAY);
+    g2.setColor(g2.getColor());
     g2.fillRect(0, 0, getIconWidth(), getIconHeight());
 
     final var col1 = Color.green;

--- a/src/main/java/com/cburch/logisim/gui/icons/LedMatrixIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/LedMatrixIcon.java
@@ -20,7 +20,7 @@ public class LedMatrixIcon extends BaseIcon {
     g2.setStroke(new BasicStroke(scale(2)));
     g2.setColor(Color.WHITE);
     g2.fillRect(0, 0, scale(16), scale(16));
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawRect(0, 0, scale(16), scale(16));
     final var xint = 2;
     final var yint = 1;

--- a/src/main/java/com/cburch/logisim/gui/icons/SevenSegmentIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/SevenSegmentIcon.java
@@ -29,7 +29,7 @@ public class SevenSegmentIcon extends BaseIcon {
     g2.setStroke(new BasicStroke(scale(2)));
     g2.setColor(Color.WHITE);
     g2.fillRect(scale(2), 0, scale(10), scale(16));
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawRect(scale(2), 0, scale(10), scale(16));
     g2.setColor((segson & HexDigit.SEG_A_MASK) != 0 ? Color.RED : Color.LIGHT_GRAY);
     g2.drawLine(scale(5), scale(3), scale(8), scale(3));

--- a/src/main/java/com/cburch/logisim/gui/icons/ShowStateIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ShowStateIcon.java
@@ -30,7 +30,7 @@ public class ShowStateIcon extends BaseIcon {
       gfx.setColor(Color.MAGENTA.brighter().brighter().brighter());
       gfx.fillRect(0, 0, getIconWidth(), getIconHeight());
     }
-    gfx.setColor(Color.BLACK);
+    gfx.setColor(gfx.getColor());
     gfx.drawRect(0, 0, getIconWidth(), getIconHeight() / 2);
     final var font = gfx.getFont().deriveFont((float) getIconWidth() / (float) 2);
     final var textLayout = new TextLayout("101", font, gfx.getFontRenderContext());
@@ -45,7 +45,7 @@ public class ShowStateIcon extends BaseIcon {
     gfx.fillOval(offset, offset + getIconHeight() / 2, wh, wh);
     gfx.setColor(Color.GREEN);
     gfx.fillOval(offset + getIconWidth() / 2, offset + getIconHeight() / 2, wh, wh);
-    gfx.setColor(Color.BLACK);
+    gfx.setColor(gfx.getColor());
     gfx.drawOval(offset, offset + getIconHeight() / 2, wh, wh);
     gfx.drawOval(offset + getIconWidth() / 2, offset + getIconHeight() / 2, wh, wh);
   }

--- a/src/main/java/com/cburch/logisim/gui/icons/TreeIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/TreeIcon.java
@@ -51,7 +51,7 @@ public class TreeIcon extends BaseIcon {
         AppPreferences.getScaled(paper.width),
         AppPreferences.getScaled(paper.height),
         true);
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     path = new GeneralPath();
     path.moveTo(AppPreferences.getScaled(shape[0]), AppPreferences.getScaled(shape[1]));
     for (int i = 2; i < shape.length; i += 2)

--- a/src/main/java/com/cburch/logisim/gui/icons/TtyIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/TtyIcon.java
@@ -23,7 +23,7 @@ public class TtyIcon extends BaseIcon {
 
     g2.setColor(Color.BLUE);
     g2.fillRoundRect(0, scale(3), scale(16), scale(10), scale(3), scale(3));
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawRoundRect(0, scale(3), scale(16), scale(10), scale(3), scale(3));
     final var f = Tty.DEFAULT_FONT.deriveFont(scale((float) 5)).deriveFont(Font.BOLD);
     final var t = new TextLayout(display.substring(0, 3), f, g2.getFontRenderContext());

--- a/src/main/java/com/cburch/logisim/gui/icons/ZoomIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ZoomIcon.java
@@ -52,7 +52,7 @@ public class ZoomIcon extends BaseIcon {
             AppPreferences.getScaled(6),
             AppPreferences.getScaled(8));
     }
-    g2.setColor(Color.BLACK);
+    g2.setColor(g2.getColor());
     g2.drawOval(scaledOne, scaledOne, scaledEleven, scaledEleven);
     final var xyPoint = AppPreferences.getScaled(6.0 + Math.sqrt(12.5));
     GeneralPath path = new GeneralPath();

--- a/src/main/java/com/cburch/logisim/gui/main/Canvas.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Canvas.java
@@ -36,6 +36,7 @@ import com.cburch.logisim.file.Options;
 import com.cburch.logisim.gui.generic.CanvasPane;
 import com.cburch.logisim.gui.generic.CanvasPaneContents;
 import com.cburch.logisim.gui.generic.GridPainter;
+import com.cburch.logisim.gui.generic.ThemeManager;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.proj.ProjectEvent;
@@ -91,15 +92,29 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
   private static final int THRESH_SIZE_UPDATE = 10;
   private static final int BUTTONS_MASK =
       InputEvent.BUTTON1_DOWN_MASK | InputEvent.BUTTON2_DOWN_MASK | InputEvent.BUTTON3_DOWN_MASK;
-  private static final Color DEFAULT_ERROR_COLOR = new Color(192, 0, 0);
-  private static final Color OSC_ERR_COLOR = DEFAULT_ERROR_COLOR;
-  private static final Color SIM_EXCEPTION_COLOR = DEFAULT_ERROR_COLOR;
+  private static final Color LIGHT_ERROR_COLOR = new Color(192, 0, 0);
+  private static final Color DARK_ERROR_COLOR = new Color(255, 80, 80);
   private static final Font ERR_MSG_FONT = new Font("Sans Serif", Font.BOLD, 18);
-  private static final Color TICK_RATE_COLOR = new Color(0, 0, 92, 92);
+  private static final Color LIGHT_TICK_RATE_COLOR = new Color(0, 0, 92, 92);
+  private static final Color DARK_TICK_RATE_COLOR = new Color(180, 180, 255, 180);
   private static final Font TICK_RATE_FONT = new Font("Monospaced", Font.PLAIN, 28);
-  private static final Color SINGLE_STEP_MSG_COLOR = Color.BLUE;
+  private static final Color LIGHT_SINGLE_STEP_MSG_COLOR = Color.BLUE;
+  private static final Color DARK_SINGLE_STEP_MSG_COLOR = new Color(100, 200, 255);
   private static final Font SINGLE_STEP_MSG_FONT = new Font("Sans Serif", Font.BOLD, 12);
   public static final Color DEFAULT_ZOOM_BUTTON_COLOR = Color.WHITE;
+
+  private static Color getTickRateColor() {
+    return ThemeManager.isDarkMode() ? DARK_TICK_RATE_COLOR : LIGHT_TICK_RATE_COLOR;
+  }
+
+  private static Color getErrorColor() {
+    return ThemeManager.isDarkMode() ? DARK_ERROR_COLOR : LIGHT_ERROR_COLOR;
+  }
+
+  private static Color getSingleStepMsgColor() {
+    return ThemeManager.isDarkMode() ? DARK_SINGLE_STEP_MSG_COLOR : LIGHT_SINGLE_STEP_MSG_COLOR;
+  }
+
   // public static BufferedImage image;
   private final Project proj;
   private final Selection selection;
@@ -146,6 +161,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
     AppPreferences.GATE_SHAPE.addPropertyChangeListener(myListener);
     AppPreferences.SHOW_TICK_RATE.addPropertyChangeListener(myListener);
     AppPreferences.CANVAS_BG_COLOR.addPropertyChangeListener(myListener);
+    ThemeManager.addPropertyChangeListener(myListener);
     loadOptions(options);
   }
 
@@ -162,7 +178,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
   public static void paintAutoZoomButton(final Graphics g,
                                          final Dimension sz, final Color zoomButtonColor) {
     final var oldColor = g.getColor();
-    g.setColor(TICK_RATE_COLOR);
+    g.setColor(getTickRateColor());
     g.fillOval(
             sz.width - ZOOM_BUTTON_SIZE - 33,
             sz.height - ZOOM_BUTTON_SIZE - 33,
@@ -960,6 +976,9 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
         setToolTipText(showTips ? "" : null);
       } else if (AppPreferences.CANVAS_BG_COLOR.isSource(event)) {
         setBackground(new Color(AppPreferences.CANVAS_BG_COLOR.get()));
+      } else if (ThemeManager.THEME_PROPERTY.equals(event.getPropertyName())) {
+        setBackground(new Color(AppPreferences.CANVAS_BG_COLOR.get()));
+        repaint();
       }
     }
 
@@ -1142,7 +1161,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
     private static final long serialVersionUID = 1L;
     StringGetter errorMessage = null;
     String widthMessage = null;
-    Color errorColor = DEFAULT_ERROR_COLOR;
+    Color errorColor = getErrorColor();
     boolean isNorth = false;
     boolean isSouth = false;
     boolean isWest = false;
@@ -1207,12 +1226,12 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
       }
 
       if (proj.getSimulator().isOscillating()) {
-        g.setColor(OSC_ERR_COLOR);
+        g.setColor(getErrorColor());
         msgY = paintString(g, msgY, S.get("canvasOscillationError"));
       }
 
       if (proj.getSimulator().isExceptionEncountered()) {
-        g.setColor(SIM_EXCEPTION_COLOR);
+        g.setColor(getErrorColor());
         final var exceptionMessage = proj.getSimulator().getExceptionMessage();
         msgY =
             paintString(
@@ -1229,7 +1248,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
       if (widthMessage != null) {
         g.setColor(Value.widthErrorColor);
         msgY = paintString(g, msgY, widthMessage);
-      } else g.setColor(TICK_RATE_COLOR);
+      } else g.setColor(getTickRateColor());
 
       if (isNorth
           || isSouth
@@ -1293,7 +1312,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
       }
 
       if (!proj.getSimulator().isAutoPropagating()) {
-        g.setColor(SINGLE_STEP_MSG_COLOR);
+        g.setColor(getSingleStepMsgColor());
         final var old = g.getFont();
         g.setFont(SINGLE_STEP_MSG_FONT);
         g.drawString(proj.getSimulator().getSingleStepMessage(), 10, 15);
@@ -1323,7 +1342,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
     void setErrorMessage(StringGetter msg, Color color) {
       if (errorMessage != msg) {
         errorMessage = msg;
-        errorColor = color == null ? DEFAULT_ERROR_COLOR : color;
+        errorColor = color == null ? getErrorColor() : color;
         paintCoordinator.requestRepaint();
       }
     }

--- a/src/main/java/com/cburch/logisim/gui/main/CanvasPainter.java
+++ b/src/main/java/com/cburch/logisim/gui/main/CanvasPainter.java
@@ -15,6 +15,7 @@ import com.cburch.logisim.comp.Component;
 import com.cburch.logisim.comp.ComponentDrawContext;
 import com.cburch.logisim.data.Value;
 import com.cburch.logisim.gui.generic.GridPainter;
+import com.cburch.logisim.gui.generic.ThemeManager;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.util.CollectionUtil;
@@ -200,9 +201,9 @@ class CanvasPainter implements PropertyChangeListener {
     ptContext.setHighlightedWires(highlightedWires);
     gfxScaled.setColor(Color.RED);
     circState.drawOscillatingPoints(ptContext);
-    gfxScaled.setColor(Color.BLUE);
+    gfxScaled.setColor(ThemeManager.isDarkMode() ? Color.CYAN : Color.BLUE);
     proj.getSimulator().drawStepPoints(ptContext);
-    gfxScaled.setColor(Color.MAGENTA); // fixme
+    gfxScaled.setColor(Color.MAGENTA);
     proj.getSimulator().drawPendingInputs(ptContext);
     gfxScaled.dispose();
   }

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -35,6 +35,7 @@ import com.cburch.logisim.gui.generic.CardPanel;
 import com.cburch.logisim.gui.generic.LFrame;
 import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.gui.generic.RegTabContent;
+import com.cburch.logisim.gui.generic.ThemeManager;
 import com.cburch.logisim.gui.generic.ZoomControl;
 import com.cburch.logisim.gui.generic.ZoomModel;
 import com.cburch.logisim.gui.menu.MainMenuListener;
@@ -145,7 +146,7 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     super(project);
     this.project = project;
 
-    setBackground(Color.white);
+    setBackground(ThemeManager.isDarkMode() ? new Color(0xFF2B2B2B) : Color.white);
     setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
     addWindowListener(new MyWindowListener());
 
@@ -262,6 +263,7 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     installFileDropTargets();
 
     LocaleManager.addLocaleListener(this);
+    ThemeManager.addPropertyChangeListener(myProjectListener);
     toolbox.updateStructure();
   }
 
@@ -1008,6 +1010,10 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
     public void propertyChange(PropertyChangeEvent event) {
       if (AppPreferences.TOOLBAR_PLACEMENT.isSource(event)) {
         placeToolbar();
+      } else if (ThemeManager.THEME_PROPERTY.equals(event.getPropertyName())) {
+        final var dark = (boolean) event.getNewValue();
+        setBackground(dark ? new Color(0xFF2B2B2B) : Color.white);
+        repaint();
       }
     }
 

--- a/src/main/java/com/cburch/logisim/gui/main/LogisimToolbarItem.java
+++ b/src/main/java/com/cburch/logisim/gui/main/LogisimToolbarItem.java
@@ -92,7 +92,7 @@ public class LogisimToolbarItem implements ToolbarItem {
       final var simple = AppPreferences.getScaled(AppPreferences.IconSize) >> 2;
       gfx.setColor(new Color(255, 128, 128));
       gfx.fillRect(simple, simple, 2 * simple, 2 * simple);
-      gfx.setColor(Color.BLACK);
+      gfx.setColor(new Color(AppPreferences.COMPONENT_ICON_COLOR.get()));
       gfx.drawLine(simple, simple, 3 * simple, 3 * simple);
       gfx.drawLine(simple, 3 * simple, 3 * simple, simple);
       gfx.drawRect(simple, simple, 2 * simple, 2 * simple);

--- a/src/main/java/com/cburch/logisim/gui/main/SimulationTreeRenderer.java
+++ b/src/main/java/com/cburch/logisim/gui/main/SimulationTreeRenderer.java
@@ -12,6 +12,7 @@ package com.cburch.logisim.gui.main;
 import com.cburch.logisim.comp.ComponentDrawContext;
 import com.cburch.logisim.comp.ComponentFactory;
 import com.cburch.logisim.gui.generic.ProjectExplorer;
+import com.cburch.logisim.prefs.AppPreferences;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics;
@@ -78,7 +79,7 @@ public class SimulationTreeRenderer extends DefaultTreeCellRenderer {
         int[] yp = {ty + 1, y + 20, y + 18, ty - 1};
         g.setColor(ProjectExplorer.MAGNIFYING_INTERIOR);
         g.fillOval(x + 5, y + 5, 10, 10);
-        g.setColor(Color.BLACK);
+        g.setColor(new Color(AppPreferences.COMPONENT_ICON_COLOR.get()));
         g.drawOval(x + 5, y + 5, 10, 10);
         g.fillPolygon(xp, yp, xp.length);
       }

--- a/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -13,6 +13,7 @@ import static com.cburch.logisim.gui.Strings.S;
 
 import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.fpga.gui.ZoomSlider;
+import com.cburch.logisim.gui.generic.ThemeManager;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Projects;
 import com.cburch.logisim.util.TableLayout;
@@ -30,6 +31,7 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JSlider;
 import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
@@ -244,21 +246,12 @@ class WindowOptions extends OptionsPanel {
 
   private void initThemePreviewer() {
     if (previewPanel != null) previewContainer.remove(previewPanel);
-    javax.swing.LookAndFeel previousLF = UIManager.getLookAndFeel();
-    try {
-      UIManager.setLookAndFeel(AppPreferences.LookAndFeel.get());
-      previewPanel = new JPanel();
-      previewPanel.add(new JButton("Preview"));
-      previewPanel.add(new JCheckBox("Preview"));
-      previewPanel.add(new JRadioButton("Preview"));
-      previewPanel.add(new JComboBox<>(new String[]{"Preview 1", "Preview 2"}));
-      previewContainer.add(previewPanel);
-      UIManager.setLookAndFeel(previousLF);
-    } catch (IllegalAccessException
-        | UnsupportedLookAndFeelException
-        | InstantiationException
-        | ClassNotFoundException ignored) {
-    }
+    previewPanel = new JPanel();
+    previewPanel.add(new JButton("Preview"));
+    previewPanel.add(new JCheckBox("Preview"));
+    previewPanel.add(new JRadioButton("Preview"));
+    previewPanel.add(new JComboBox<>(new String[]{"Preview 1", "Preview 2"}));
+    previewContainer.add(previewPanel);
     previewContainer.repaint();
     previewContainer.revalidate();
   }
@@ -319,7 +312,13 @@ class WindowOptions extends OptionsPanel {
         if (newIndex != index && newIndex >= 0 && newIndex < lookAndFeelInfos.length) {
           index = newIndex;
           AppPreferences.LookAndFeel.set(lookAndFeelInfos[index].getClassName());
-          initThemePreviewer();
+          try {
+            UIManager.setLookAndFeel(lookAndFeelInfos[index].getClassName());
+            initThemePreviewer();
+            ThemeManager.applyTheme();
+          } catch (Exception ex) {
+            ex.printStackTrace();
+          }
         }
         checkRestartWarning();
       } else if (e.getSource().equals(appFont)) {
@@ -335,9 +334,8 @@ class WindowOptions extends OptionsPanel {
           proj.getFrame().repaint();
         }
       } else if (e.getActionCommand().equals(cmdResetGridColors)) {
-        //        AppPreferences.resetWindow();
         final var nowOpen = Projects.getOpenProjects();
-        AppPreferences.setDefaultGridColors();
+        AppPreferences.applyThemeDefaults(ThemeManager.isDarkMode());
         for (final var proj : nowOpen) {
           proj.getFrame().repaint();
         }
@@ -350,8 +348,7 @@ class WindowOptions extends OptionsPanel {
     }
 
     private void checkRestartWarning() {
-      boolean show = !Objects.equals(AppPreferences.APP_FONT.get(), initialAppFont)
-          || !Objects.equals(AppPreferences.LookAndFeel.get(), initialLookAndFeel);
+      boolean show = !Objects.equals(AppPreferences.APP_FONT.get(), initialAppFont);
       restartWarning.setVisible(show);
       restartWarningSpacer.setVisible(show);
     }

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -559,7 +559,7 @@ public class AppPreferences {
   public static final PrefMonitor<String> APP_FONT =
       create(new PrefMonitorString("AppFont", ""));
 
-  // default grid colors
+  // default grid colors (light theme)
   public static final int DEFAULT_CANVAS_BG_COLOR = 0xFFFFFFFF;
   public static final int DEFAULT_GRID_BG_COLOR = 0xFFFFFFFF;
   public static final int DEFAULT_GRID_DOT_COLOR = 0xFF777777;
@@ -570,7 +570,32 @@ public class AppPreferences {
   public static final int DEFAULT_COMPONENT_ICON_COLOR = 0x00000000;
   public static final int DEFAULT_TEXT_TOOL_COLOR = 0x00000000;
 
-  // restores default grid colors
+  // default grid colors (dark theme)
+  public static final int DARK_CANVAS_BG_COLOR = 0xFF2B2B2B;
+  public static final int DARK_GRID_BG_COLOR = 0xFF2B2B2B;
+  public static final int DARK_GRID_DOT_COLOR = 0xFF555555;
+  public static final int DARK_ZOOMED_DOT_COLOR = 0xFF3A3A3A;
+  public static final int DARK_COMPONENT_COLOR = 0xFFFFFFFF;
+  public static final int DARK_COMPONENT_SECONDARY_COLOR = 0xFFAAAAAA;
+  public static final int DARK_COMPONENT_GHOST_COLOR = 0xFF888888;
+  public static final int DARK_COMPONENT_ICON_COLOR = 0xFFFFFFFF;
+  public static final int DARK_TEXT_TOOL_COLOR = 0xFFFFFFFF;
+
+  // default wire colors (dark theme)
+  public static final int DARK_TRUE_COLOR = 0xFF33FF33;
+  public static final int DARK_FALSE_COLOR = 0xFF009900;
+  public static final int DARK_UNKNOWN_COLOR = 0xFF6464FF;
+  public static final int DARK_ERROR_COLOR = 0xFFFF4040;
+  public static final int DARK_NIL_COLOR = 0xFF808080;
+  public static final int DARK_BUS_COLOR = 0xFFFFFFFF;
+  public static final int DARK_STROKE_COLOR = 0xFFFF00FF;
+  public static final int DARK_WIDTH_ERROR_COLOR = 0xFFFF7B00;
+  public static final int DARK_WIDTH_ERROR_CAPTION_COLOR = 0xFFFFAAAA;
+  public static final int DARK_WIDTH_ERROR_HIGHLIGHT_COLOR = 0xFFFFFF00;
+  public static final int DARK_WIDTH_ERROR_BACKGROUND_COLOR = 0xFF553322;
+  public static final int DARK_CLOCK_FREQUENCY_COLOR = 0xFFFF00B4;
+
+  // restores default grid colors (light theme)
   public static void setDefaultGridColors() {
     CANVAS_BG_COLOR.set(DEFAULT_CANVAS_BG_COLOR);
     GRID_BG_COLOR.set(DEFAULT_GRID_BG_COLOR);
@@ -580,6 +605,61 @@ public class AppPreferences {
     COMPONENT_SECONDARY_COLOR.set(DEFAULT_COMPONENT_SECONDARY_COLOR);
     COMPONENT_GHOST_COLOR.set(DEFAULT_COMPONENT_GHOST_COLOR);
     COMPONENT_ICON_COLOR.set(DEFAULT_COMPONENT_ICON_COLOR);
+  }
+
+  // applies theme-appropriate defaults (without overriding user customizations)
+  public static void applyThemeDefaults(boolean dark) {
+    if (dark) {
+      setIfDefault(CANVAS_BG_COLOR, DEFAULT_CANVAS_BG_COLOR, DARK_CANVAS_BG_COLOR);
+      setIfDefault(GRID_BG_COLOR, DEFAULT_GRID_BG_COLOR, DARK_GRID_BG_COLOR);
+      setIfDefault(GRID_DOT_COLOR, DEFAULT_GRID_DOT_COLOR, DARK_GRID_DOT_COLOR);
+      setIfDefault(GRID_ZOOMED_DOT_COLOR, DEFAULT_ZOOMED_DOT_COLOR, DARK_ZOOMED_DOT_COLOR);
+      setIfDefault(COMPONENT_COLOR, DEFAULT_COMPONENT_COLOR, DARK_COMPONENT_COLOR);
+      setIfDefault(COMPONENT_SECONDARY_COLOR, DEFAULT_COMPONENT_SECONDARY_COLOR, DARK_COMPONENT_SECONDARY_COLOR);
+      setIfDefault(COMPONENT_GHOST_COLOR, DEFAULT_COMPONENT_GHOST_COLOR, DARK_COMPONENT_GHOST_COLOR);
+      setIfDefault(COMPONENT_ICON_COLOR, DEFAULT_COMPONENT_ICON_COLOR, DARK_COMPONENT_ICON_COLOR);
+      setIfDefault(TEXT_TOOL_COLOR, DEFAULT_TEXT_TOOL_COLOR, DARK_TEXT_TOOL_COLOR);
+      setIfDefault(TRUE_COLOR, 0x0000D200, DARK_TRUE_COLOR);
+      setIfDefault(FALSE_COLOR, 0x00006400, DARK_FALSE_COLOR);
+      setIfDefault(UNKNOWN_COLOR, 0x002828FF, DARK_UNKNOWN_COLOR);
+      setIfDefault(ERROR_COLOR, 0x00C00000, DARK_ERROR_COLOR);
+      setIfDefault(NIL_COLOR, 0x808080, DARK_NIL_COLOR);
+      setIfDefault(BUS_COLOR, 0, DARK_BUS_COLOR);
+      setIfDefault(STROKE_COLOR, 0xff00ff, DARK_STROKE_COLOR);
+      setIfDefault(WIDTH_ERROR_COLOR, 0xFF7B00, DARK_WIDTH_ERROR_COLOR);
+      setIfDefault(WIDTH_ERROR_CAPTION_COLOR, 0x550000, DARK_WIDTH_ERROR_CAPTION_COLOR);
+      setIfDefault(WIDTH_ERROR_HIGHLIGHT_COLOR, 0xFFFF00, DARK_WIDTH_ERROR_HIGHLIGHT_COLOR);
+      setIfDefault(WIDTH_ERROR_BACKGROUND_COLOR, 0xFFE6D2, DARK_WIDTH_ERROR_BACKGROUND_COLOR);
+      setIfDefault(CLOCK_FREQUENCY_COLOR, 0xFF00B4, DARK_CLOCK_FREQUENCY_COLOR);
+    } else {
+      setIfDefault(CANVAS_BG_COLOR, DARK_CANVAS_BG_COLOR, DEFAULT_CANVAS_BG_COLOR);
+      setIfDefault(GRID_BG_COLOR, DARK_GRID_BG_COLOR, DEFAULT_GRID_BG_COLOR);
+      setIfDefault(GRID_DOT_COLOR, DARK_GRID_DOT_COLOR, DEFAULT_GRID_DOT_COLOR);
+      setIfDefault(GRID_ZOOMED_DOT_COLOR, DARK_ZOOMED_DOT_COLOR, DEFAULT_ZOOMED_DOT_COLOR);
+      setIfDefault(COMPONENT_COLOR, DARK_COMPONENT_COLOR, DEFAULT_COMPONENT_COLOR);
+      setIfDefault(COMPONENT_SECONDARY_COLOR, DARK_COMPONENT_SECONDARY_COLOR, DEFAULT_COMPONENT_SECONDARY_COLOR);
+      setIfDefault(COMPONENT_GHOST_COLOR, DARK_COMPONENT_GHOST_COLOR, DEFAULT_COMPONENT_GHOST_COLOR);
+      setIfDefault(COMPONENT_ICON_COLOR, DARK_COMPONENT_ICON_COLOR, DEFAULT_COMPONENT_ICON_COLOR);
+      setIfDefault(TEXT_TOOL_COLOR, DARK_TEXT_TOOL_COLOR, DEFAULT_TEXT_TOOL_COLOR);
+      setIfDefault(TRUE_COLOR, DARK_TRUE_COLOR, 0x0000D200);
+      setIfDefault(FALSE_COLOR, DARK_FALSE_COLOR, 0x00006400);
+      setIfDefault(UNKNOWN_COLOR, DARK_UNKNOWN_COLOR, 0x002828FF);
+      setIfDefault(ERROR_COLOR, DARK_ERROR_COLOR, 0x00C00000);
+      setIfDefault(NIL_COLOR, DARK_NIL_COLOR, 0x808080);
+      setIfDefault(BUS_COLOR, DARK_BUS_COLOR, 0);
+      setIfDefault(STROKE_COLOR, DARK_STROKE_COLOR, 0xff00ff);
+      setIfDefault(WIDTH_ERROR_COLOR, DARK_WIDTH_ERROR_COLOR, 0xFF7B00);
+      setIfDefault(WIDTH_ERROR_CAPTION_COLOR, DARK_WIDTH_ERROR_CAPTION_COLOR, 0x550000);
+      setIfDefault(WIDTH_ERROR_HIGHLIGHT_COLOR, DARK_WIDTH_ERROR_HIGHLIGHT_COLOR, 0xFFFF00);
+      setIfDefault(WIDTH_ERROR_BACKGROUND_COLOR, DARK_WIDTH_ERROR_BACKGROUND_COLOR, 0xFFE6D2);
+      setIfDefault(CLOCK_FREQUENCY_COLOR, DARK_CLOCK_FREQUENCY_COLOR, 0xFF00B4);
+    }
+  }
+
+  private static void setIfDefault(PrefMonitor<Integer> pref, int oldDefault, int newDefault) {
+    if (pref.get() == oldDefault || pref.get() == newDefault) {
+      pref.set(newDefault);
+    }
   }
 
   public static final PrefMonitor<Integer> CANVAS_BG_COLOR =


### PR DESCRIPTION
## Summary

Adds full dark mode support with theme-aware color adaptation. When switching to a dark FlatLaf theme (FlatDarkLaf, FlatDarculaLaf, FlatMacDarkLaf), all canvas, grid, wire, and component colors automatically switch to dark-appropriate defaults. No restart required.

## Key Changes

### New File
- **ThemeManager.java** - Central theme management: detects dark/light LAFs, applies theme defaults, refreshes UI instantly, fires property change events

### Core Infrastructure
- **AppPreferences.java** - Dark mode color defaults (canvas #2B2B2B, grid dots #555555, brighter wire colors, white component outlines). Smart setIfDefault() preserves user customizations.
- **Value.java** - `refreshColors()` to re-read wire/simulation colors dynamically
- **Main.java** - Initializes theme state at startup

### No-Restart LAF Switching
- **WindowOptions.java** - LAF changes apply immediately via ThemeManager.applyTheme() + SwingUtilities.updateComponentTreeUI()

### UI Components
- **Canvas.java** - Error/tick-rate/single-step colors adapt to dark mode; listens for theme changes
- **CanvasPainter.java** - Simulation annotation colors visible on dark (CYAN instead of BLUE)
- **Frame.java** - Background adapts to theme

### Icons (15 files)
- ButtonIcon, CompileIcon, DrcIcon, HdlIcon, JoystickIcon, KeyboardIcon, LedBarIcon, LedMatrixIcon, SevenSegmentIcon, ShowStateIcon, TreeIcon, TtyIcon, ZoomIcon - Replaced hardcoded Color.BLACK with theme-aware g2.getColor()
- ProjectExplorer.java, SimulationTreeRenderer.java, LogisimToolbarItem.java - Same fix

## Testing
1. Build: `./gradlew build`
2. Run: `./gradlew run`
3. Preferences -> Window -> Look and Feel -> choose any dark theme
4. Canvas, grid, wires, and all UI elements adapt instantly
5. Switch back to light -- everything resets to light defaults
