### PR TITLE
Fix TTL7447 cascading blanking.

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
@@ -19,6 +19,7 @@ import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Location;
 import com.cburch.logisim.data.Value;
 import com.cburch.logisim.instance.Instance;
+import com.cburch.logisim.instance.InstanceComponent;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.std.wiring.Pin;
 import com.cburch.logisim.std.wiring.PullResistor;
@@ -33,6 +34,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import javax.swing.SwingUtilities;
 import org.slf4j.Logger;
@@ -750,6 +752,23 @@ public class CircuitWires {
       }
       final var instance = Instance.getInstanceFor(comp);
       b.addPullValue(PullResistor.getPullValue(instance));
+    }
+    for (final var comp : components) {
+      if (comp instanceof InstanceComponent instanceComponent) {
+        final Map<Integer, Value> pullPorts = instanceComponent.getPullPorts();
+        if (pullPorts != null) {
+          for (final var portIndex : pullPorts.keySet()) {
+            final var loc = comp.getEnd(portIndex).getLocation();
+            var b = ret.getBundleAt(loc);
+            if (b == null) {
+              b = ret.createBundleAt(loc);
+              b.tempPoints.add(loc);
+              ret.setBundleAt(loc, b);
+            }
+            b.addPullValue(pullPorts.get(portIndex));
+          }
+        }
+      }
     }
   }
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceComponent.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceComponent.java
@@ -26,6 +26,7 @@ import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.data.BitWidth;
 import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Location;
+import com.cburch.logisim.data.Value;
 import com.cburch.logisim.fpga.designrulecheck.CorrectLabel;
 import com.cburch.logisim.fpga.designrulecheck.Netlist;
 import com.cburch.logisim.gui.generic.OptionPane;
@@ -40,6 +41,7 @@ import java.awt.Graphics;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 public final class InstanceComponent implements Component, AttributeListener, ToolTipMaker {
   private EventSourceWeakSupport<ComponentListener> listeners;
@@ -50,6 +52,7 @@ public final class InstanceComponent implements Component, AttributeListener, To
   private List<Port> portList;
   private EndData[] endArray;
   private List<EndData> endList;
+  private Map<Integer, Value> pullPorts = null;
   private boolean hasToolTips;
   private HashSet<Attribute<BitWidth>> widthAttrs;
   private final AttributeSet attrs;
@@ -396,6 +399,10 @@ public final class InstanceComponent implements Component, AttributeListener, To
     return portList;
   }
 
+  public Map<Integer, Value> getPullPorts() {
+    return pullPorts;
+  }
+
   @Override
   public String getToolTip(ComponentUserEvent e) {
     var i = 0;
@@ -437,6 +444,19 @@ public final class InstanceComponent implements Component, AttributeListener, To
     final var portsCopy = ports.clone();
     portList = new UnmodifiableList<>(portsCopy);
     computeEnds();
+  }
+
+  /**
+   * Sets the mapping from pull port indexes to pull value for those ports/ends that should have a pull.
+   * A null map means there is no pull for any End and is the default value.
+   * </p>This method assumes it will only be called while configuring a new InstanceComponent.
+   * If it must be called later, this method should be modified to notify CircuitWires so it
+   * can void the Connectivity.
+   *
+   * @param pullPorts the map from port indexes to pull values
+   */
+  public void setPullPorts(Map<Integer, Value> pullPorts) {
+    this.pullPorts = pullPorts == null || pullPorts.isEmpty() ? null : Map.copyOf(pullPorts);
   }
 
   void setTextField(

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7447.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7447.java
@@ -9,8 +9,10 @@
 
 package com.cburch.logisim.std.ttl;
 
+import com.cburch.logisim.data.Value;
 import com.cburch.logisim.instance.InstancePainter;
 import com.cburch.logisim.instance.InstanceState;
+import com.cburch.logisim.std.plexers.PlexersLibrary;
 
 public class Ttl7447 extends AbstractTtlGate {
   /**
@@ -40,8 +42,10 @@ public class Ttl7447 extends AbstractTtlGate {
     super(
         _ID,
         (byte) 16,
-        new byte[] {9, 10, 11, 12, 13, 14, 15},
-        new String[] {"B", "C", "LT", "BI", "RBI", "D", "A", "e", "d", "c", "b", "a", "g", "f"},
+        new byte[] {9, 10, 11, 12, 13, 14, 15}, // Inputs
+        new byte[] {}, // Unused
+        new byte[] {4}, // Input/Output
+        new String[] {"B", "C", "LT", "BI/RBO", "RBI", "D", "A", "e", "d", "c", "b", "a", "g", "f"},
         new Ttl7447HdlGenerator());
   }
 
@@ -53,9 +57,11 @@ public class Ttl7447 extends AbstractTtlGate {
 
   @Override
   public void propagateTtl(InstanceState state) {
+    var inputValue = DisplayDecoder.getdecval(state, false, 0, PORT_INDEX_A, PORT_INDEX_B, PORT_INDEX_C, PORT_INDEX_D);
+    final var blankZero = state.getPortValue(PORT_INDEX_RBI) == Value.FALSE && inputValue == 0;
     DisplayDecoder.computeDisplayDecoderOutputs(
         state,
-        DisplayDecoder.getdecval(state, false, 0, PORT_INDEX_A, PORT_INDEX_B, PORT_INDEX_C, PORT_INDEX_D),
+        inputValue,
         PORT_INDEX_QA,
         PORT_INDEX_QB,
         PORT_INDEX_QC,
@@ -66,5 +72,9 @@ public class Ttl7447 extends AbstractTtlGate {
         PORT_INDEX_LT,
         PORT_INDEX_BI,
         PORT_INDEX_RBI);
+    if (state.isPortConnected(PORT_INDEX_BI)) {
+      final var value = (blankZero && state.getPortValue(PORT_INDEX_LT) != Value.FALSE) ? Value.FALSE : Value.UNKNOWN;
+      state.setPort(PORT_INDEX_BI, value, PlexersLibrary.DELAY);
+    }
   }
 }

--- a/src/main/java/com/cburch/logisim/std/ttl/Ttl7447.java
+++ b/src/main/java/com/cburch/logisim/std/ttl/Ttl7447.java
@@ -10,9 +10,11 @@
 package com.cburch.logisim.std.ttl;
 
 import com.cburch.logisim.data.Value;
+import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.instance.InstancePainter;
 import com.cburch.logisim.instance.InstanceState;
 import com.cburch.logisim.std.plexers.PlexersLibrary;
+import java.util.Map;
 
 public class Ttl7447 extends AbstractTtlGate {
   /**
@@ -26,7 +28,7 @@ public class Ttl7447 extends AbstractTtlGate {
   public static final int PORT_INDEX_B = 0;
   public static final int PORT_INDEX_C = 1;
   public static final int PORT_INDEX_LT = 2;
-  public static final int PORT_INDEX_BI = 3;
+  public static final int PORT_INDEX_BI_RBO = 3;
   public static final int PORT_INDEX_RBI = 4;
   public static final int PORT_INDEX_D = 5;
   public static final int PORT_INDEX_A = 6;
@@ -56,6 +58,12 @@ public class Ttl7447 extends AbstractTtlGate {
   }
 
   @Override
+  protected void configureNewInstance(Instance instance) {
+    super.configureNewInstance(instance);
+    instance.getComponent().setPullPorts(Map.of(PORT_INDEX_BI_RBO, Value.TRUE));
+  }
+
+  @Override
   public void propagateTtl(InstanceState state) {
     var inputValue = DisplayDecoder.getdecval(state, false, 0, PORT_INDEX_A, PORT_INDEX_B, PORT_INDEX_C, PORT_INDEX_D);
     final var blankZero = state.getPortValue(PORT_INDEX_RBI) == Value.FALSE && inputValue == 0;
@@ -70,11 +78,9 @@ public class Ttl7447 extends AbstractTtlGate {
         PORT_INDEX_QF,
         PORT_INDEX_QG,
         PORT_INDEX_LT,
-        PORT_INDEX_BI,
+        PORT_INDEX_BI_RBO,
         PORT_INDEX_RBI);
-    if (state.isPortConnected(PORT_INDEX_BI)) {
-      final var value = (blankZero && state.getPortValue(PORT_INDEX_LT) != Value.FALSE) ? Value.FALSE : Value.UNKNOWN;
-      state.setPort(PORT_INDEX_BI, value, PlexersLibrary.DELAY);
-    }
+    final var value = (blankZero && state.getPortValue(PORT_INDEX_LT) != Value.FALSE) ? Value.FALSE : Value.UNKNOWN;
+    state.setPort(PORT_INDEX_BI_RBO, value, PlexersLibrary.DELAY);
   }
 }


### PR DESCRIPTION
This PR allows TTL7447 to cascade its blanking signal as noted in issue #2572.

Please read the discussion there so we can decide what to do before merging this.