### PR TITLE
fpga: keep report messages readable across themes

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/gui/ListModelCellRenderer.java
+++ b/src/main/java/com/cburch/logisim/fpga/gui/ListModelCellRenderer.java
@@ -26,9 +26,13 @@ public class ListModelCellRenderer extends JLabel implements ListCellRenderer<Ob
   private final boolean CountLines;
 
   private static final Color FATAL = Color.RED;
-  private static final Color SEVERE = Color.yellow;
-  private static final Color NORMAL = Color.LIGHT_GRAY;
-  private static final Color ADDENDUM = Color.GRAY;
+  private static final Color FATAL_FOREGROUND = Color.WHITE;
+  private static final Color SEVERE_ON_DARK = Color.YELLOW;
+  private static final Color SEVERE_ON_LIGHT = Color.ORANGE.darker().darker();
+  private static final Color NORMAL_ON_DARK = Color.LIGHT_GRAY;
+  private static final Color NORMAL_ON_LIGHT = Color.DARK_GRAY;
+  private static final Color ADDENDUM_ON_DARK = Color.GRAY.brighter();
+  private static final Color ADDENDUM_ON_LIGHT = Color.GRAY.darker();
 
   private static final DrcIcon NoDRC = new DrcIcon(false);
   private static final DrcIcon DRCError = new DrcIcon(true);
@@ -44,6 +48,7 @@ public class ListModelCellRenderer extends JLabel implements ListCellRenderer<Ob
     SimpleDrcContainer msg = null;
     setBackground(list.getBackground());
     setForeground(list.getForeground());
+    final var darkBackground = isDark(list.getBackground());
     StringBuilder Line = new StringBuilder();
     if (value instanceof SimpleDrcContainer cont) {
       msg = cont;
@@ -51,12 +56,13 @@ public class ListModelCellRenderer extends JLabel implements ListCellRenderer<Ob
     setIcon((msg != null && msg.isDrcInfoPresent()) ? DRCError : NoDRC);
     if (msg != null) {
       switch (msg.getSeverity()) {
-        case SimpleDrcContainer.LEVEL_SEVERE -> setForeground(SEVERE);
+        case SimpleDrcContainer.LEVEL_SEVERE ->
+            setForeground(darkBackground ? SEVERE_ON_DARK : SEVERE_ON_LIGHT);
         case SimpleDrcContainer.LEVEL_FATAL -> {
           setBackground(FATAL);
-          setForeground(list.getBackground());
+          setForeground(FATAL_FOREGROUND);
         }
-        default -> setForeground(NORMAL);
+        default -> setForeground(darkBackground ? NORMAL_ON_DARK : NORMAL_ON_LIGHT);
       }
     }
     if (value.toString().contains("BUG")) {
@@ -66,7 +72,7 @@ public class ListModelCellRenderer extends JLabel implements ListCellRenderer<Ob
     if (CountLines) {
       if (msg != null) {
         if (msg.getSuppressCount()) {
-          setForeground(ADDENDUM);
+          setForeground(darkBackground ? ADDENDUM_ON_DARK : ADDENDUM_ON_LIGHT);
           Line.append("       ");
         } else {
           int line = msg.getListNumber();
@@ -108,5 +114,12 @@ public class ListModelCellRenderer extends JLabel implements ListCellRenderer<Ob
     setEnabled(list.isEnabled());
     setFont(list.getFont());
     return this;
+  }
+
+  private static boolean isDark(Color color) {
+    if (color == null) return false;
+    final var brightness =
+        color.getRed() * 299 + color.getGreen() * 587 + color.getBlue() * 114;
+    return brightness < 128_000;
   }
 }

--- a/src/test/java/com/cburch/logisim/fpga/gui/ListModelCellRendererTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/gui/ListModelCellRendererTest.java
@@ -1,0 +1,111 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.fpga.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.fpga.designrulecheck.SimpleDrcContainer;
+import java.awt.Color;
+import java.awt.Component;
+import javax.swing.JList;
+import org.junit.jupiter.api.Test;
+
+class ListModelCellRendererTest {
+  private static final double MINIMUM_CONTRAST_RATIO = 4.5;
+
+  @Test
+  void messageColorsRemainReadableOnLightBackground() {
+    assertMessageColorsReadable(Color.WHITE, Color.BLACK);
+  }
+
+  @Test
+  void messageColorsRemainReadableOnDarkBackground() {
+    assertMessageColorsReadable(new Color(0x3C3F41), Color.WHITE);
+  }
+
+  @Test
+  void fatalErrorsUseWhiteTextAcrossThemes() {
+    assertFatalColors(Color.WHITE, Color.BLACK);
+    assertFatalColors(new Color(0x3C3F41), Color.WHITE);
+  }
+
+  private static void assertMessageColorsReadable(Color background, Color foreground) {
+    final var list = new JList<>();
+    list.setBackground(background);
+    list.setForeground(foreground);
+    final var renderer = new ListModelCellRenderer(true);
+
+    assertReadable(
+        renderer.getListCellRendererComponent(
+            list,
+            new SimpleDrcContainer("normal", SimpleDrcContainer.LEVEL_NORMAL),
+            0,
+            false,
+            false));
+    assertReadable(
+        renderer.getListCellRendererComponent(
+            list,
+            new SimpleDrcContainer("severe", SimpleDrcContainer.LEVEL_SEVERE),
+            1,
+            false,
+            false));
+    assertReadable(
+        renderer.getListCellRendererComponent(
+            list,
+            new SimpleDrcContainer("addendum", SimpleDrcContainer.LEVEL_NORMAL, true),
+            2,
+            false,
+            false));
+  }
+
+  private static void assertReadable(Component component) {
+    final var contrast = contrastRatio(component.getForeground(), component.getBackground());
+    assertTrue(
+        contrast >= MINIMUM_CONTRAST_RATIO,
+        () -> String.format("Expected readable message colors, but contrast ratio was %.2f", contrast));
+  }
+
+  private static void assertFatalColors(Color listBackground, Color listForeground) {
+    final var list = new JList<>();
+    list.setBackground(listBackground);
+    list.setForeground(listForeground);
+    final var component =
+        new ListModelCellRenderer(true)
+            .getListCellRendererComponent(
+                list,
+                new SimpleDrcContainer("fatal", SimpleDrcContainer.LEVEL_FATAL),
+                0,
+                false,
+                false);
+
+    assertEquals(Color.RED, component.getBackground());
+    assertEquals(Color.WHITE, component.getForeground());
+  }
+
+  private static double contrastRatio(Color first, Color second) {
+    final var firstLuminance = relativeLuminance(first);
+    final var secondLuminance = relativeLuminance(second);
+    final var lighter = Math.max(firstLuminance, secondLuminance);
+    final var darker = Math.min(firstLuminance, secondLuminance);
+    return (lighter + 0.05) / (darker + 0.05);
+  }
+
+  private static double relativeLuminance(Color color) {
+    return 0.2126 * linearChannel(color.getRed())
+        + 0.7152 * linearChannel(color.getGreen())
+        + 0.0722 * linearChannel(color.getBlue());
+  }
+
+  private static double linearChannel(int channel) {
+    final var value = channel / 255.0;
+    return value <= 0.04045 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4);
+  }
+}


### PR DESCRIPTION
Fixes #2748.

Summary
- adapt FPGA Commander normal, severe, and addendum message colors to the active list background
- keep fatal messages readable as white text on a red background across themes
- add renderer regression tests for light and dark backgrounds

Root cause

The recent theme update changed FPGA Commander report lists from a fixed black background to look-and-feel colors, while the cell renderer retained its old hard-coded foreground palette. Fatal messages also reused the list background as their foreground, which became unreadable in dark themes.

Verification
- `.\gradlew.bat test --tests com.cburch.logisim.fpga.gui.ListModelCellRendererTest --tests com.cburch.logisim.fpga.gui.FpgaCommanderTest`
- `.\gradlew.bat compileJava checkstyleMain compileTestJava checkstyleTest`
- `git diff --check`
- manually verified severe warnings and fatal errors on Windows with both light and dark themes
