### PR TITLE
fix(gui): add copy error button and refine file error dialog scroll l…

### DIFF
--- a/src/main/java/com/cburch/logisim/file/Loader.java
+++ b/src/main/java/com/cburch/logisim/file/Loader.java
@@ -18,6 +18,8 @@ import com.cburch.logisim.util.ZipClassLoader;
 import com.cburch.logisim.vhdl.file.HdlFile;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -34,6 +36,7 @@ import java.util.Stack;
 import com.cburch.logisim.util.LineBuffer;
 import java.util.zip.ZipOutputStream;
 
+import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
@@ -576,6 +579,12 @@ public class Loader implements LibraryLoader {
       description = init + sep + description;
     }
 
+    final var copyButtonText = S.get("fileErrorCopyButton");
+    final var okButtonText = javax.swing.UIManager.getString("OptionPane.okButtonText") != null
+        ? javax.swing.UIManager.getString("OptionPane.okButtonText")
+        : "OK";
+    final Object[] options = new Object[] {copyButtonText, okButtonText};
+
     if (description.contains("\n") || description.length() > 60) {
       var lines = 1;
       for (var pos = description.indexOf('\n');
@@ -583,20 +592,44 @@ public class Loader implements LibraryLoader {
           pos = description.indexOf('\n', pos + 1)) {
         lines++;
       }
-      lines = Math.max(4, Math.min(lines, 7));
+      lines = Math.max(3, Math.min(lines, 8));
 
-      final var textArea = new JTextArea(lines, 60);
+      final var textArea = new JTextArea(lines, 45);
       textArea.setEditable(false);
       textArea.setText(description);
       textArea.setCaretPosition(0);
 
       final var scrollPane = new JScrollPane(textArea);
-      scrollPane.setPreferredSize(new Dimension(350, 150));
-      OptionPane.showMessageDialog(
-          parent, scrollPane, S.get("fileErrorTitle"), OptionPane.ERROR_MESSAGE);
+      
+      final var result = OptionPane.showOptionDialog(
+          parent,
+          scrollPane,
+          S.get("fileErrorTitle"),
+          JOptionPane.DEFAULT_OPTION,
+          OptionPane.ERROR_MESSAGE,
+          null,
+          options,
+          okButtonText);
+
+      if (result == 0) {
+        final var selection = new StringSelection(description);
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(selection, null);
+      }
     } else {
-      OptionPane.showMessageDialog(
-          parent, description, S.get("fileErrorTitle"), OptionPane.ERROR_MESSAGE);
+      final var result = OptionPane.showOptionDialog(
+          parent,
+          description,
+          S.get("fileErrorTitle"),
+          JOptionPane.DEFAULT_OPTION,
+          OptionPane.ERROR_MESSAGE,
+          null,
+          options,
+          okButtonText);
+
+      if (result == 0) {
+        final var selection = new StringSelection(description);
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(selection, null);
+      }
     }
   }
 

--- a/src/main/resources/resources/logisim/strings/file/file.properties
+++ b/src/main/resources/resources/logisim/strings/file/file.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = No file known corresponding to %s.
 # Loader.java
 #
 fileCircularError = Cannot create circular reference. (The file is used by the %s library.)
+fileErrorCopyButton = Copy error
 fileErrorTitle = File Error
 fileLibraryMissingButton = Select
 fileLibraryMissingError = The required library file ‘%s’ is missing. Please select the file from the following dialog.

--- a/src/main/resources/resources/logisim/strings/file/file_de.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_de.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = Keine Datei bekannt, die %s entspricht.
 # Loader.java
 #
 fileCircularError = Zirkelbezug kann nicht hergestellt werden. (Die Datei wird von der Bibliothek „%s“ benutzt.)
+# ==> fileErrorCopyButton = Copy error
 fileErrorTitle = Dateifehler
 fileLibraryMissingButton = Auswählen
 fileLibraryMissingError = Die erforderliche Bibliotheksdatei „%s“ fehlt. Bitte wählen Sie die Datei im folgenden Dialogfenster aus.

--- a/src/main/resources/resources/logisim/strings/file/file_el.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_el.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = Κανένα γνωστό αρχείο δεν αντι
 # Loader.java
 #
 fileCircularError = Δεν μπορεί να δημιουργηθεί κυκλική αναφορά. (Το αρχείο χρησιμοποιείται από την βιβλιοθήκη %s .)
+# ==> fileErrorCopyButton = Copy error
 fileErrorTitle = Σφάλμα Αρχείου
 fileLibraryMissingButton = Επιλογή
 fileLibraryMissingError = Το απαιτούμενο αρχείο βιβλιοθήκης “%s” λείπει. Παρακαλώ επιλέξτε το αρχείο από τον ακόλουθο διάλογο.

--- a/src/main/resources/resources/logisim/strings/file/file_es.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_es.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = No existe un archivo que se corresponda con %s.
 # Loader.java
 #
 fileCircularError = No se puede crear una referencia circular (el archivo está siendo utilizado por la librería %s).
+# ==> fileErrorCopyButton = Copy error
 fileErrorTitle = Error de archivo
 fileLibraryMissingButton = Seleccionar
 fileLibraryMissingError = Falta el archivo “%s” requerido por la librería. Por favor, selecciona el archivo desde la siguiente ventana.

--- a/src/main/resources/resources/logisim/strings/file/file_fr.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_fr.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = Aucun fichier connu ne correspond à %s.
 # Loader.java
 #
 fileCircularError = Impossible de créer une référence circulaire. (Le fichier est utilisé dans la librairie %s.)
+# ==> fileErrorCopyButton = Copy error
 fileErrorTitle = Erreur de fichier
 fileLibraryMissingButton = Sélectionner
 fileLibraryMissingError = Le fichier de librarie ‹ %s › est manquant. Merci de sélectionner le fichier dans la fenêtre de dialogue.

--- a/src/main/resources/resources/logisim/strings/file/file_it.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_it.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = Nessun file conosciuto corrispondente a %s.
 # Loader.java
 #
 fileCircularError = Impossibile creare rinvio incrociato. (Il file è usato dalla libreria %s.)
+# ==> fileErrorCopyButton = Copy error
 fileErrorTitle = Errore File
 fileLibraryMissingButton = Seleziona
 fileLibraryMissingError = Il file libreria richiesto “%s” è mancante. Si prega di selezionare il file dalla seguente finestra di dialogo.

--- a/src/main/resources/resources/logisim/strings/file/file_ja.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_ja.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = %s に対応する既知のファイルがありませ
 # Loader.java
 #
 fileCircularError = 循環参照を作成できません。(このファイルは %s ライブラリで使用されています)。
+# ==> fileErrorCopyButton = Copy error
 fileErrorTitle = ファイル・エラー
 fileLibraryMissingButton = 選択
 fileLibraryMissingError = 必要なライブラリファイル ‘%s’ がありません。以下のダイアログからファイルを選択してください。

--- a/src/main/resources/resources/logisim/strings/file/file_nl.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_nl.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = Geen bestand bekend dat overeenkomt met %s.
 # Loader.java
 #
 fileCircularError = Kan geen cirkelvormige referentie maken. (Het bestand wordt gebruikt door de %s bibliotheek.)
+# ==> fileErrorCopyButton = Copy error
 fileErrorTitle = Bestandsfout
 fileLibraryMissingButton = Selecteer
 fileLibraryMissingError = Het vereiste bibliotheekbestand ‚%s’ ontbreekt. Selecteer het bestand uit het volgende dialoogvenster.

--- a/src/main/resources/resources/logisim/strings/file/file_pl.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_pl.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = Nie znaleziono pliku który odpowiada %s.
 # Loader.java
 #
 fileCircularError = Nie można utwożyć pętli odniesień (plik jest używany przez bibliotekę %s).
+# ==> fileErrorCopyButton = Copy error
 fileErrorTitle = Błąd pliku
 fileLibraryMissingButton = Wybierz
 fileLibraryMissingError = Nie odnaleziono wymaganego pliku biblioteki „%s”. Proszę wybrać jeden z następujących plików.

--- a/src/main/resources/resources/logisim/strings/file/file_pt.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_pt.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = Nenhum arquivo conhecido corresponde a %s.
 # Loader.java
 #
 fileCircularError = Impossível criar referência circular. (O arquivo está em uso pela biblioteca %s.)
+# ==> fileErrorCopyButton = Copy error
 fileErrorTitle = Arquivo de erros
 fileLibraryMissingButton = Selecionar
 fileLibraryMissingError = Falta o arquivo requerido da biblioteca “%s”. Favor selecionar o arquivo do diálogo a seguir.

--- a/src/main/resources/resources/logisim/strings/file/file_ru.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_ru.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = Неизвестен файл, соответству�
 # Loader.java
 #
 fileCircularError = Невозможно создать циклическую ссылку (файл используется библиотекой «%s»).
+fileErrorCopyButton = Скопировать ошибку
 fileErrorTitle = Ошибка файла
 fileLibraryMissingButton = Выбрать
 fileLibraryMissingError = Требуемый файл библиотеки «%s» отсутствует. Пожалуйста, выберите файл в открывшемся диалоге.

--- a/src/main/resources/resources/logisim/strings/file/file_zh.properties
+++ b/src/main/resources/resources/logisim/strings/file/file_zh.properties
@@ -10,6 +10,7 @@ unknownLibraryFileError = 没有与 %s 对应的已知文件。
 # Loader.java
 #
 fileCircularError = 无法创建循环引用。（该文件已被 %s 库使用。）
+# ==> fileErrorCopyButton = Copy error
 fileErrorTitle = 文件错误
 fileLibraryMissingButton = 选择
 fileLibraryMissingError = 缺少所需的库文件“%s”。请在下方对话框中选择该文件。


### PR DESCRIPTION
### Summary of Changes
- **Copy to Clipboard support**: Replaced `OptionPane.showMessageDialog` with `OptionPane.showOptionDialog` in `Loader.java` to provide a dedicated **Copy error** button. Clicking it instantly copies the full error description to the system clipboard.
- **Scrollpane Layout Refinement**: Removed hardcoded `scrollPane.setPreferredSize` constraints so that `JScrollPane` naturally renders vertical and horizontal scrollbars as needed for long file paths or multi-line error traces.
- **Localization**: Added `fileErrorCopyButton` key in `file.properties` and `file_ru.properties`, along with `# ==>` translation stubs across all other language property files.

### Verification
- Tested with short single-line file error messages (compact display).
- Tested with multi-line error messages and long file paths to verify horizontal and vertical scrolling behavior.
- Verified clipboard copy functionality via the **Copy error** button.
- Verified that other application dialogs and the Preferences window remain unaffected.
<img width="674" height="233" alt="Снимок экрана — 2026-07-25 в 14 01 55" src="https://github.com/user-attachments/assets/d086cf9c-674c-4b3d-9a0b-df26736a6325" />
