### PR TITLE
docs: fix typos in timetable window documentation

### DIFF
--- a/src/main/resources/doc/en/html/guide/log/timetable.html
+++ b/src/main/resources/doc/en/html/guide/log/timetable.html
@@ -88,7 +88,7 @@
         </table>
       </blockquote>
       <p>
-        <b>The display area</b>On the right three columns: the first presents an icon of the type of signal (bus or singlle) then we have the name and finally the signal value under the cursor (the red line in the graph). It is possible to move the cursor with the mouse, just click and move. <b class="tkeybd">Right-clicking</b> on the row of a bus-type signal displays a pop-up menu with two options:
+        <b>The display area</b> On the right three columns: the first presents an icon of the type of signal (bus or single) then we have the name and finally the signal value under the cursor (the red line in the graph). It is possible to move the cursor with the mouse, just click and move. <b class="tkeybd">Right-clicking</b> on the row of a bus-type signal displays a pop-up menu with two options:
       </p>
       <ul>
         <li>


### PR DESCRIPTION
Fixes minor typos 'areaOn' and 'singlle' in the Timetable window documentation

### Changes
- Fixed missing space: `areaOn` → `area on`
- Fixed spelling: `singlle` → `single`

### Context
*Note regarding #2765:* Testing on a local runtime build confirms that the toolbar icons render perfectly inside the application. The broken images were isolated to static browser previews, meaning this PR fully resolves the documentation issue.


<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/0c8cccc1-a677-471d-af94-45f043c9257c" />

