### PR TITLE
fix(docs): translate Selection tab English guide text

### DIFF
--- a/src/main/resources/doc/en/html/guide/log/selection.html
+++ b/src/main/resources/doc/en/html/guide/log/selection.html
@@ -38,14 +38,14 @@
         The last (rightmost) vertical area lists those components that have been selected. Also, it indicates the radix (base) in which the component's multi-bit values will be logged; the radix does not have a significant effect on one-bit values.
       </p>
       <p>
-        L'horloge <var>sysclk</var> doit y figurer, elle ne sera pas affichée dans le graphe.
+        The <var>sysclk</var> clock must be included, it will not be displayed in the graph.
       </p>
       <p>
         The middle column of buttons allows the manipulation of the items within the selection.
       </p>
       <ul>
         <li>
-          <b class="button">Add&gt;&gt;</b> adds the currently selected item(s) on the left side into the selection. Il est actif seulement pour les composants éligibles.
+          <b class="button">Add&gt;&gt;</b> adds the currently selected item(s) on the left side into the selection. It is only active for eligible components.
         </li>
         <li>
           <b class="button">Change Radix</b> cycles the radix for the currently selected component in the selection between 2 (binary), 10 (decimal), and 16 (hexadecimal).


### PR DESCRIPTION
* Replace untranslated French string in src/main/resources/doc/en/html/guide/log/selection.html