### PR TITLE
simulator: update pending markers after circuit edits

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitState.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitState.java
@@ -127,6 +127,7 @@ public class CircuitState implements InstanceData {
       } else if (action == CircuitEvent.TRANSACTION_DONE) {
         final var map = event.getResult().getReplacementMap(circuit);
         if (map == null) return;
+        proj.getSimulator().updatePendingInputs(CircuitState.this, map);
         for (final var comp : map.getRemovals()) {
           final var compState = componentData.remove(comp);
           if (compState == null) continue;

--- a/src/main/java/com/cburch/logisim/circuit/PropagationPoints.java
+++ b/src/main/java/com/cburch/logisim/circuit/PropagationPoints.java
@@ -52,6 +52,23 @@ class PropagationPoints {
     pendingInputs.add(new Entry<>(state, comp));
   }
 
+  void updatePendingInputs(CircuitState state, ReplacementMap replacements) {
+    if (pendingInputs.isEmpty() || replacements.isEmpty()) return;
+
+    final var updated = new HashSet<Entry<Component>>(pendingInputs.size());
+    for (final var entry : pendingInputs) {
+      if (entry.state != state || !replacements.getRemovals().contains(entry.item)) {
+        updated.add(entry);
+      } else {
+        for (final var replacement : replacements.getReplacementsFor(entry.item)) {
+          updated.add(new Entry<>(state, replacement));
+        }
+      }
+    }
+    pendingInputs.clear();
+    pendingInputs.addAll(updated);
+  }
+
   void add(CircuitState state, Location loc) {
     data.add(new Entry<>(state, loc));
   }

--- a/src/main/java/com/cburch/logisim/circuit/Simulator.java
+++ b/src/main/java/com/cburch/logisim/circuit/Simulator.java
@@ -206,6 +206,10 @@ public class Simulator {
       }
     }
 
+    void updatePendingInputs(CircuitState state, ReplacementMap replacements) {
+      stepPoints.updatePendingInputs(state, replacements);
+    }
+
     synchronized String getSingleStepMessage() {
       return autoPropagatingUnsynchronized ? "" : stepPoints.getSingleStepMessage();
     }
@@ -728,6 +732,10 @@ public class Simulator {
 
   public void addPendingInput(CircuitState state, Component comp) {
     simThread.addPendingInput(state, comp);
+  }
+
+  void updatePendingInputs(CircuitState state, ReplacementMap replacements) {
+    simThread.updatePendingInputs(state, replacements);
   }
 
   private ArrayList<StatusListener> copyStatusListeners() {

--- a/src/test/java/com/cburch/logisim/circuit/SimulatorTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/SimulatorTest.java
@@ -11,8 +11,13 @@ package com.cburch.logisim.circuit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.comp.ComponentDrawContext;
 import com.cburch.logisim.data.Location;
 import com.cburch.logisim.file.Loader;
 import com.cburch.logisim.file.LogisimFile;
@@ -20,6 +25,8 @@ import com.cburch.logisim.instance.InstanceFactory;
 import com.cburch.logisim.instance.InstancePainter;
 import com.cburch.logisim.instance.InstanceState;
 import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.wiring.Pin;
+import java.awt.Graphics2D;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -66,10 +73,89 @@ class SimulatorTest {
     }
   }
 
+  @Test
+  void movesPendingInputMarkerWithReplacedComponent() {
+    final var fixture = new PendingInputFixture();
+    try {
+      final var pin =
+          Pin.FACTORY.createComponent(
+              Location.create(100, 100, true), Pin.FACTORY.createAttributeSet());
+      add(fixture.circuit, pin);
+      fixture.simulator.addPendingInput(fixture.state, pin);
+
+      final var movedPin =
+          Pin.FACTORY.createComponent(Location.create(140, 100, true), pin.getAttributeSet());
+      replace(fixture.circuit, pin, movedPin);
+
+      final var graphics = mock(Graphics2D.class);
+      fixture.simulator.drawPendingInputs(
+          new ComponentDrawContext(
+              null, fixture.circuit, fixture.state, graphics, graphics));
+
+      final var bounds = movedPin.getBounds();
+      verify(graphics)
+          .drawRect(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
+    } finally {
+      fixture.simulator.shutDown();
+    }
+  }
+
+  @Test
+  void dropsPendingInputMarkerWithRemovedComponent() {
+    final var fixture = new PendingInputFixture();
+    try {
+      final var pin =
+          Pin.FACTORY.createComponent(
+              Location.create(100, 100, true), Pin.FACTORY.createAttributeSet());
+      add(fixture.circuit, pin);
+      fixture.simulator.addPendingInput(fixture.state, pin);
+
+      remove(fixture.circuit, pin);
+
+      final var graphics = mock(Graphics2D.class);
+      fixture.simulator.drawPendingInputs(
+          new ComponentDrawContext(
+              null, fixture.circuit, fixture.state, graphics, graphics));
+
+      verify(graphics, never()).drawRect(anyInt(), anyInt(), anyInt(), anyInt());
+    } finally {
+      fixture.simulator.shutDown();
+    }
+  }
+
   private static void add(Circuit circuit, Component component) {
     final var mutation = new CircuitMutation(circuit);
     mutation.add(component);
     mutation.execute();
+  }
+
+  private static void remove(Circuit circuit, Component component) {
+    final var mutation = new CircuitMutation(circuit);
+    mutation.remove(component);
+    mutation.execute();
+  }
+
+  private static void replace(Circuit circuit, Component oldComponent, Component newComponent) {
+    final var mutation = new CircuitMutation(circuit);
+    mutation.replace(oldComponent, newComponent);
+    mutation.execute();
+  }
+
+  private static final class PendingInputFixture {
+    private final Circuit circuit;
+    private final CircuitState state;
+    private final Simulator simulator;
+
+    private PendingInputFixture() {
+      final var file = LogisimFile.createNew(new Loader(null), null);
+      final var project = new Project(file);
+      circuit = file.getMainCircuit();
+      circuit.setProject(project);
+      state = CircuitState.createRootState(project, circuit);
+      simulator = project.getSimulator();
+      simulator.setCircuitState(state);
+      simulator.setAutoPropagation(false);
+    }
   }
 
   private static final class ThrowingFactory extends InstanceFactory {


### PR DESCRIPTION
## Summary

- remap pending-input markers when circuit transactions replace components
- remove markers when components are deleted without replacements
- add simulator-level regression coverage for both cases

## Root cause

With auto-propagation disabled, pending-input highlights store the current `Component` object. Moving a component replaces that object with a translated copy, but the pending-input set kept the removed instance and continued drawing its old bounds until the simulation was reset.

The transaction-completion path now updates pending markers from the transaction's `ReplacementMap`. Markers follow replacement components and disappear for pure removals, while entries for other circuit states remain unchanged.

## Validation

- `./gradlew test --tests 'com.cburch.logisim.circuit.*Test'`
- `./gradlew compileJava checkstyleMain compileTestJava checkstyleTest`
- forced rerun of `SimulatorTest`
- `git diff --check`
- manual Windows GUI verification with auto-propagation disabled: after moving and dropping an input pin, its magenta pending marker follows the pin and no stale marker remains at the old location

Fixes #1706
