### PR TITLE
gui: honor component label color at creation

### DIFF
--- a/src/main/java/com/cburch/logisim/instance/InstanceTextField.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceTextField.java
@@ -145,6 +145,8 @@ public class InstanceTextField implements AttributeListener, TextFieldListener, 
     this.valign = valign;
     final var shouldReg = shouldRegister();
     var attrs = comp.getAttributeSet();
+    if (attrs.containsAttribute(StdAttr.LABEL_COLOR))
+      fontColor = attrs.getValue(StdAttr.LABEL_COLOR);
     if (attrs.containsAttribute(StdAttr.LABEL_VISIBILITY))
       isLabelVisible = attrs.getValue(StdAttr.LABEL_VISIBILITY);
     if (!wasReg && shouldReg) attrs.addAttributeListener(this);

--- a/src/test/java/com/cburch/logisim/instance/InstanceTextFieldTest.java
+++ b/src/test/java/com/cburch/logisim/instance/InstanceTextFieldTest.java
@@ -12,14 +12,22 @@ package com.cburch.logisim.instance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.comp.ComponentDrawContext;
 import com.cburch.logisim.data.Location;
 import com.cburch.logisim.file.Loader;
 import com.cburch.logisim.file.LogisimFile;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.base.Text;
+import com.cburch.logisim.std.io.Led;
 import com.cburch.logisim.tools.TextEditable;
+import java.awt.Color;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
 import org.junit.jupiter.api.Test;
 
 public class InstanceTextFieldTest {
@@ -54,6 +62,27 @@ public class InstanceTextFieldTest {
     assertEquals("new", comp.getAttributeSet().getValue(Text.ATTR_TEXT));
     project.undoAction();
     assertEquals("old", comp.getAttributeSet().getValue(Text.ATTR_TEXT));
+  }
+
+  @Test
+  public void componentCreationHonorsConfiguredLabelColor() {
+    final var led = new Led();
+    final var attrs = led.createAttributeSet();
+    attrs.setValue(StdAttr.LABEL, "label");
+    attrs.setValue(StdAttr.LABEL_COLOR, Color.RED);
+    final var comp = led.createComponent(Location.create(100, 100, false), attrs);
+    final var textField = (InstanceTextField) comp.getFeature(TextEditable.class);
+    final var sourceGraphics = mock(Graphics.class);
+    final var labelGraphics = mock(Graphics.class);
+    final var context = mock(ComponentDrawContext.class);
+
+    assertNotNull(textField);
+    when(sourceGraphics.create()).thenReturn(labelGraphics);
+    when(labelGraphics.getFontMetrics()).thenReturn(mock(FontMetrics.class));
+    when(context.getGraphics()).thenReturn(sourceGraphics);
+    textField.draw(comp, context);
+
+    verify(labelGraphics).setColor(Color.RED);
   }
 
   private static TextEditable newTextEditable() {


### PR DESCRIPTION
## Summary

- initialize `InstanceTextField` label color from the component attribute set
- preserve explicit label colors immediately when components are created or loaded
- add regression coverage for attributes populated before `createComponent()`

This is intentionally separate from the theme-aware default-color design discussed in #2757.

## Testing

- `./gradlew test --tests com.cburch.logisim.instance.InstanceTextFieldTest`
- `./gradlew compileJava checkstyleMain compileTestJava checkstyleTest test --tests "com.cburch.logisim.instance.*"`
- Windows GUI: set a LED label color to red, saved and closed the circuit, then reopened it; the label remained red immediately after loading
- `git diff --check`

Fixes #2773