### PR TITLE
gui: apply Text Tool color preference

### DIFF
--- a/src/main/java/com/cburch/logisim/tools/TextTool.java
+++ b/src/main/java/com/cburch/logisim/tools/TextTool.java
@@ -24,16 +24,20 @@ import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.data.Location;
 import com.cburch.logisim.gui.main.Canvas;
 import com.cburch.logisim.gui.main.SelectionActions;
+import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Action;
 import com.cburch.logisim.proj.JoinedAction;
 import com.cburch.logisim.std.base.Text;
 import com.cburch.logisim.util.StringUtil;
+import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Graphics;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 
-public class TextTool extends Tool {
+public class TextTool extends Tool implements PropertyChangeListener {
   /**
    * Unique identifier of the tool, used as reference in project files. Do NOT change as it will
    * prevent project files from loading.
@@ -147,6 +151,8 @@ public class TextTool extends Tool {
 
   public TextTool() {
     attrs = Text.FACTORY.createAttributeSet();
+    AppPreferences.TEXT_TOOL_COLOR.addPropertyChangeListener(this);
+    attrs.setValue(Text.ATTR_COLOR, new Color(AppPreferences.TEXT_TOOL_COLOR.get()));
   }
 
   @Override
@@ -358,6 +364,13 @@ public class TextTool extends Tool {
   @Override
   public void paintIcon(ComponentDrawContext c, int x, int y) {
     Text.FACTORY.paintIcon(c, x, y, null);
+  }
+
+  @Override
+  public void propertyChange(PropertyChangeEvent event) {
+    if (AppPreferences.TEXT_TOOL_COLOR.isSource(event)) {
+      attrs.setValue(Text.ATTR_COLOR, new Color(AppPreferences.TEXT_TOOL_COLOR.get()));
+    }
   }
 
   private void refreshEditMenu(Canvas canvas) {

--- a/src/test/java/com/cburch/logisim/tools/TextToolTest.java
+++ b/src/test/java/com/cburch/logisim/tools/TextToolTest.java
@@ -9,15 +9,47 @@
 
 package com.cburch.logisim.tools;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.cburch.logisim.data.Bounds;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.std.base.Text;
+import java.awt.Color;
 import java.awt.Graphics;
 import java.lang.reflect.Field;
+import java.util.Objects;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class TextToolTest {
+  private final int originalTextToolColor = AppPreferences.TEXT_TOOL_COLOR.get();
+
+  @AfterEach
+  void restoreTextToolColor() throws InterruptedException {
+    AppPreferences.TEXT_TOOL_COLOR.set(originalTextToolColor);
+    waitForTextToolPreference(originalTextToolColor);
+  }
+
+  @Test
+  void usesConfiguredDefaultColor() throws InterruptedException {
+    setTextToolPreference(Color.BLUE);
+
+    final var tool = new TextTool();
+
+    assertEquals(Color.BLUE, tool.getAttributeSet().getValue(Text.ATTR_COLOR));
+  }
+
+  @Test
+  void colorFollowsPreferenceChanges() throws InterruptedException {
+    final var tool = new TextTool();
+
+    setTextToolPreference(Color.RED);
+
+    waitForToolColor(tool, Color.RED);
+  }
+
   @Test
   void returnsNoTextEditActionsWhenNoCaretIsActive() {
     final var tool = new TextTool();
@@ -39,6 +71,32 @@ class TextToolTest {
     final Field field = TextTool.class.getDeclaredField("caret");
     field.setAccessible(true);
     field.set(tool, caret);
+  }
+
+  private static void setTextToolPreference(Color color) throws InterruptedException {
+    final var rgb = color.getRGB();
+    AppPreferences.TEXT_TOOL_COLOR.set(rgb);
+    waitForTextToolPreference(rgb);
+  }
+
+  private static void waitForTextToolPreference(int rgb) throws InterruptedException {
+    for (var i = 0; i < 100; i++) {
+      if (Objects.equals(AppPreferences.TEXT_TOOL_COLOR.get(), rgb)) {
+        return;
+      }
+      Thread.sleep(10);
+    }
+    assertEquals(rgb, AppPreferences.TEXT_TOOL_COLOR.get());
+  }
+
+  private static void waitForToolColor(TextTool tool, Color color) throws InterruptedException {
+    for (var i = 0; i < 100; i++) {
+      if (color.equals(tool.getAttributeSet().getValue(Text.ATTR_COLOR))) {
+        return;
+      }
+      Thread.sleep(10);
+    }
+    assertEquals(color, tool.getAttributeSet().getValue(Text.ATTR_COLOR));
   }
 
   private static class TestCaret implements Caret, TextEditActions {


### PR DESCRIPTION
## Summary

- initialize the toolbar `TextTool` color from `TEXT_TOOL_COLOR`
- update the tool default when the preference changes while the application is running
- add regressions for both constructor-time and live preference updates

The tool attributes are cloned when new text is created, so existing canvas text keeps its explicit color. Theme-aware updates for existing labels remain the separate design discussed in #2661.

## Testing

- `./gradlew test --tests com.cburch.logisim.tools.TextToolTest`
- `./gradlew compileJava checkstyleMain compileTestJava checkstyleTest test --tests "com.cburch.logisim.tools.*"`
- Windows GUI: created red text from a red default, changed the preference to blue without restarting, then created blue text; the earlier red text remained red
- `git diff --check`

Fixes #2774