### PR TITLE
gui: adapt default component labels to dark theme

### DIFF
--- a/src/main/java/com/cburch/logisim/instance/InstanceTextField.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceTextField.java
@@ -51,7 +51,7 @@ public class InstanceTextField implements AttributeListener, TextFieldListener, 
     this.field = null;
     this.labelAttr = null;
     this.fontAttr = null;
-    fontColor = StdAttr.DEFAULT_LABEL_COLOR;
+    fontColor = null;
   }
 
   @Override
@@ -79,7 +79,8 @@ public class InstanceTextField implements AttributeListener, TextFieldListener, 
     if (field != null && isLabelVisible) {
       final var gfx = context.getGraphics().create();
       final var currentColor = gfx.getColor();
-      if (!context.isPrintView()) gfx.setColor(fontColor);
+      if (!context.isPrintView())
+        gfx.setColor(fontColor == null ? StdAttr.getDefaultLabelColor() : fontColor);
       field.draw(gfx);
       gfx.setColor(currentColor);
       gfx.dispose();
@@ -145,8 +146,10 @@ public class InstanceTextField implements AttributeListener, TextFieldListener, 
     this.valign = valign;
     final var shouldReg = shouldRegister();
     var attrs = comp.getAttributeSet();
-    if (attrs.containsAttribute(StdAttr.LABEL_COLOR))
-      fontColor = attrs.getValue(StdAttr.LABEL_COLOR);
+    fontColor =
+        attrs.containsAttribute(StdAttr.LABEL_COLOR)
+            ? attrs.getValue(StdAttr.LABEL_COLOR)
+            : null;
     if (attrs.containsAttribute(StdAttr.LABEL_VISIBILITY))
       isLabelVisible = attrs.getValue(StdAttr.LABEL_VISIBILITY);
     if (!wasReg && shouldReg) attrs.addAttributeListener(this);

--- a/src/main/java/com/cburch/logisim/instance/StdAttr.java
+++ b/src/main/java/com/cburch/logisim/instance/StdAttr.java
@@ -17,6 +17,7 @@ import com.cburch.logisim.data.Attributes;
 import com.cburch.logisim.data.BitWidth;
 import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.fpga.data.ComponentMapInformationContainer;
+import com.cburch.logisim.prefs.AppPreferences;
 import java.awt.Color;
 import java.awt.Font;
 
@@ -45,6 +46,14 @@ public interface StdAttr {
   Font DEFAULT_LABEL_FONT = new Font("SansSerif", Font.BOLD, 16);
   Attribute<Color> LABEL_COLOR = Attributes.forColor("labelcolor", S.getter("ioLabelColorAttr"));
   Color DEFAULT_LABEL_COLOR = Color.BLUE;
+  Color DARK_DEFAULT_LABEL_COLOR = new Color(0x6C, 0xB6, 0xFF);
+
+  static Color getDefaultLabelColor() {
+    return AppPreferences.isDarkTheme(AppPreferences.LookAndFeel.get())
+        ? DARK_DEFAULT_LABEL_COLOR
+        : DEFAULT_LABEL_COLOR;
+  }
+
   AttributeOption LABEL_CENTER =
       new AttributeOption("center", "center", S.getter("stdLabelCenter"));
   Attribute<Object> LABEL_LOC =

--- a/src/test/java/com/cburch/logisim/instance/InstanceTextFieldTest.java
+++ b/src/test/java/com/cburch/logisim/instance/InstanceTextFieldTest.java
@@ -18,13 +18,16 @@ import static org.mockito.Mockito.when;
 
 import com.cburch.logisim.circuit.CircuitMutation;
 import com.cburch.logisim.comp.ComponentDrawContext;
+import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.data.Location;
 import com.cburch.logisim.file.Loader;
 import com.cburch.logisim.file.LogisimFile;
+import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.base.Text;
 import com.cburch.logisim.std.io.Led;
 import com.cburch.logisim.tools.TextEditable;
+import com.cburch.logisim.util.GraphicsUtil;
 import java.awt.Color;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
@@ -83,6 +86,51 @@ public class InstanceTextFieldTest {
     textField.draw(comp, context);
 
     verify(labelGraphics).setColor(Color.RED);
+  }
+
+  @Test
+  public void componentWithoutLabelColorTracksThemeChanges() {
+    final var originalLookAndFeel = AppPreferences.LookAndFeel.get();
+    final var comp = mock(InstanceComponent.class);
+    final var attrs = mock(AttributeSet.class);
+    final var textField = new InstanceTextField(comp);
+
+    when(comp.getAttributeSet()).thenReturn(attrs);
+    when(attrs.containsAttribute(StdAttr.LABEL_COLOR)).thenReturn(false);
+    when(attrs.containsAttribute(StdAttr.LABEL_VISIBILITY)).thenReturn(false);
+    when(attrs.getValue(StdAttr.LABEL)).thenReturn("label");
+    when(attrs.getValue(StdAttr.LABEL_FONT)).thenReturn(StdAttr.DEFAULT_LABEL_FONT);
+    textField.update(
+        StdAttr.LABEL,
+        StdAttr.LABEL_FONT,
+        0,
+        0,
+        GraphicsUtil.H_CENTER,
+        GraphicsUtil.V_CENTER);
+
+    try {
+      AppPreferences.LookAndFeel.set("TestLight");
+      final var lightGraphics = draw(textField, comp);
+      verify(lightGraphics).setColor(Color.BLUE);
+
+      AppPreferences.LookAndFeel.set("TestDark");
+      final var darkGraphics = draw(textField, comp);
+      verify(darkGraphics).setColor(new Color(0x6C, 0xB6, 0xFF));
+    } finally {
+      AppPreferences.LookAndFeel.set(originalLookAndFeel);
+    }
+  }
+
+  private static Graphics draw(InstanceTextField textField, InstanceComponent comp) {
+    final var sourceGraphics = mock(Graphics.class);
+    final var labelGraphics = mock(Graphics.class);
+    final var context = mock(ComponentDrawContext.class);
+
+    when(sourceGraphics.create()).thenReturn(labelGraphics);
+    when(labelGraphics.getFontMetrics()).thenReturn(mock(FontMetrics.class));
+    when(context.getGraphics()).thenReturn(sourceGraphics);
+    textField.draw(comp, context);
+    return labelGraphics;
   }
 
   private static TextEditable newTextEditable() {


### PR DESCRIPTION
## Summary

- resolve component labels without a `LABEL_COLOR` attribute to a theme-aware default at draw time
- keep explicitly configured component label colors unchanged across theme switches
- cover live light-to-dark redraws without recreating the component

The light-theme default remains the existing blue. Dark themes use the existing readable light-blue palette value `#6CB6FF`. No circuit attributes or serialized values are added or rewritten.

This is limited to component labels. Canvas Text Tool labels from #2661 and the single-step status-message color remain out of scope.

## Testing

- `.\gradlew.bat test --tests com.cburch.logisim.instance.InstanceTextFieldTest`
- `.\gradlew.bat test --tests 'com.cburch.logisim.instance.*' compileJava checkstyleMain compileTestJava checkstyleTest`
- `git diff --check`
- Windows GUI: an existing AND-gate label changed from blue to light blue when switching to a dark theme and changed back on return to a light theme
- Windows GUI: an LED label explicitly set to red remained red in both themes

Fixes #2757