### PR TITLE
gui: export non-printer canvas background

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/main/ExportImage.java
+++ b/src/main/java/com/cburch/logisim/gui/main/ExportImage.java
@@ -168,8 +168,32 @@ public class ExportImage {
     // And start a thread to actually perform the operation
     // (This is run in a thread so that Swing will update the
     // monitor.)
-    new ExportThread(frame, frame.getCanvas(), dest, filter, circuits, scale, printerView, monitor)
+    new ExportThread(
+            frame,
+            frame.getCanvas(),
+            dest,
+            filter,
+            circuits,
+            scale,
+            printerView,
+            frame.getCanvas().getBackground(),
+            monitor)
         .start();
+  }
+
+  static void paintExportBackground(
+      Graphics g,
+      int width,
+      int height,
+      int format,
+      boolean printerView,
+      Color canvasBackground) {
+    final var vectorFormat = format == FORMAT_TIKZ || format == FORMAT_SVG;
+    if (!printerView || !vectorFormat) {
+      g.setColor(printerView ? Color.WHITE : canvasBackground);
+      g.fillRect(0, 0, width, height);
+    }
+    g.setColor(Color.BLACK);
   }
 
   private static class ExportThread extends UniquelyNamedThread {
@@ -180,6 +204,7 @@ public class ExportImage {
     final List<Circuit> circuits;
     final double scale;
     final boolean printerView;
+    final Color canvasBackground;
     final ProgressMonitor monitor;
 
     ExportThread(
@@ -190,6 +215,7 @@ public class ExportImage {
         List<Circuit> circuits,
         double scale,
         boolean printerView,
+        Color canvasBackground,
         ProgressMonitor monitor) {
       super("ExportThread");
       this.frame = frame;
@@ -199,6 +225,7 @@ public class ExportImage {
       this.circuits = circuits;
       this.scale = scale;
       this.printerView = printerView;
+      this.canvasBackground = canvasBackground;
       this.monitor = monitor;
     }
 
@@ -215,10 +242,8 @@ public class ExportImage {
       } else {
         base = img.getGraphics();
         g = base.create();
-        g.setColor(Color.white);
-        g.fillRect(0, 0, width, height);
-        g.setColor(Color.black);
       }
+      paintExportBackground(g, width, height, filter.type, printerView, canvasBackground);
       if (g instanceof Graphics2D g2d) {
         g2d.scale(scale, scale);
         g.translate(-bds.getX(), -bds.getY());

--- a/src/test/java/com/cburch/logisim/gui/main/ExportImageTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/ExportImageTest.java
@@ -1,0 +1,90 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.gui.generic.TikZWriter;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ExportImageTest {
+
+  private static final Color DARK_CANVAS = new Color(0x2B2B2B);
+
+  @TempDir Path tempDir;
+
+  @Test
+  void nonPrinterRasterUsesCanvasBackground() {
+    final var image = new BufferedImage(3, 2, BufferedImage.TYPE_INT_RGB);
+    final var graphics = image.createGraphics();
+
+    ExportImage.paintExportBackground(
+        graphics, image.getWidth(), image.getHeight(), ExportImage.FORMAT_PNG, false, DARK_CANVAS);
+    graphics.dispose();
+
+    assertEquals(DARK_CANVAS.getRGB(), image.getRGB(0, 0));
+    assertEquals(DARK_CANVAS.getRGB(), image.getRGB(2, 1));
+  }
+
+  @Test
+  void nonPrinterVectorUsesCanvasBackground() throws Exception {
+    final var tikzGraphics = new TikZWriter();
+    ExportImage.paintExportBackground(
+        tikzGraphics, 3, 2, ExportImage.FORMAT_TIKZ, false, DARK_CANVAS);
+    final var tikz = tempDir.resolve("circuit.tex").toFile();
+    tikzGraphics.writeFile(tikz);
+
+    final var svgGraphics = new TikZWriter();
+    ExportImage.paintExportBackground(
+        svgGraphics, 3, 2, ExportImage.FORMAT_SVG, false, DARK_CANVAS);
+    final var svg = tempDir.resolve("circuit.svg").toFile();
+    svgGraphics.writeSvg(3, 2, svg);
+
+    final var tikzContent = Files.readString(tikz.toPath());
+    final var svgContent = Files.readString(svg.toPath());
+    assertTrue(tikzContent.contains("\\definecolor{custcol_2B2B2B}{HTML}{2B2B2B}"));
+    assertTrue(tikzContent.contains("\\fill"));
+    assertTrue(svgContent.contains("fill=\"#2B2B2B\""));
+    assertTrue(svgContent.contains("<rect"));
+  }
+
+  @Test
+  void printerViewKeepsExistingRasterAndVectorBackgrounds() throws Exception {
+    final var image = new BufferedImage(3, 2, BufferedImage.TYPE_INT_RGB);
+    final var rasterGraphics = image.createGraphics();
+    ExportImage.paintExportBackground(
+        rasterGraphics, image.getWidth(), image.getHeight(), ExportImage.FORMAT_PNG, true, DARK_CANVAS);
+    rasterGraphics.dispose();
+
+    final var tikzGraphics = new TikZWriter();
+    ExportImage.paintExportBackground(
+        tikzGraphics, 3, 2, ExportImage.FORMAT_TIKZ, true, DARK_CANVAS);
+    final var tikz = tempDir.resolve("printer-view.tex").toFile();
+    tikzGraphics.writeFile(tikz);
+
+    final var svgGraphics = new TikZWriter();
+    ExportImage.paintExportBackground(
+        svgGraphics, 3, 2, ExportImage.FORMAT_SVG, true, DARK_CANVAS);
+    final var svg = tempDir.resolve("printer-view.svg").toFile();
+    svgGraphics.writeSvg(3, 2, svg);
+
+    assertEquals(Color.WHITE.getRGB(), image.getRGB(0, 0));
+    assertEquals(Color.WHITE.getRGB(), image.getRGB(2, 1));
+    assertFalse(Files.readString(tikz.toPath()).contains("\\fill"));
+    assertFalse(Files.readString(svg.toPath()).contains("<rect"));
+  }
+}


### PR DESCRIPTION
## Summary

- snapshot the active canvas background when circuit export starts
- fill non-printer raster, TikZ, and SVG exports before applying circuit transforms
- preserve the existing printer-view background behavior
- add focused raster and vector regression coverage

## Testing

- `./gradlew test --tests com.cburch.logisim.gui.main.ExportImageTest --tests com.cburch.logisim.gui.menu.PrintHandlerTest --tests com.cburch.logisim.gui.main.CanvasPainterTest --tests com.cburch.logisim.instance.InstanceTextFieldTest`
- `./gradlew compileJava checkstyleMain compileTestJava checkstyleTest`
- `git diff --check`
- Windows GUI: dark-theme non-printer PNG and SVG exports use the canvas background

## Scope note

A separate manual check found that dark-theme printer-view raster export can render theme-colored components white on its existing white background. That behavior is also present on current `main` and spans component painting rather than export background selection, so this focused non-printer fix does not change it.

Fixes #2780