### PR TITLE
Fix constant value mapping window not popping up

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/data/ConstantButton.java
+++ b/src/main/java/com/cburch/logisim/fpga/data/ConstantButton.java
@@ -49,17 +49,17 @@ public class ConstantButton extends FpgaIoInformationContainer {
       case CONSTANT_ZERO -> map.tryConstantMap(selComp.getPin(), 0L);
       case CONSTANT_ONE  -> map.tryConstantMap(selComp.getPin(), -1L);
       case LEAVE_OPEN    -> map.tryOpenMap(selComp.getPin());
-      case CONSTANT_VALUE ->  getConstant(selComp.getPin(), map);
+      case CONSTANT_VALUE ->  getConstant(parent, selComp.getPin(), map);
       default -> false;
     };
   }
 
-  private boolean getConstant(int pin, MapComponent map) {
+  private boolean getConstant(JPanel parent, int pin, MapComponent map) {
     var v = 0L;
     boolean correct;
     do {
       correct = true;
-      final var value = OptionPane.showInputDialog(S.get("FpgaMapSpecConst"));
+      final var value = OptionPane.showInputDialog(parent, S.get("FpgaMapSpecConst"));
       if (value == null) return false;
       if (value.startsWith("0x")) {
         try {
@@ -74,7 +74,7 @@ public class ConstantButton extends FpgaIoInformationContainer {
           correct = false;
         }
       }
-      if (!correct) OptionPane.showMessageDialog(null, S.get("FpgaMapSpecErr"));
+      if (!correct) OptionPane.showMessageDialog(parent, S.get("FpgaMapSpecErr"));
     } while (!correct);
     return map.tryConstantMap(pin, v);
   }

--- a/src/main/java/com/cburch/logisim/fpga/gui/BoardManipulator.java
+++ b/src/main/java/com/cburch/logisim/fpga/gui/BoardManipulator.java
@@ -38,7 +38,6 @@ import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
-import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;

--- a/src/main/java/com/cburch/logisim/gui/generic/OptionPane.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/OptionPane.java
@@ -115,13 +115,14 @@ public class OptionPane {
   /**
    * Displays an input dialog with the specified message.
    *
+   * @param parentComponent The parent component of the dialog.
    * @param message The message to be displayed.
    *
    * @return The input provided by the user, or null if the GUI is not available.
    */
-  public static String showInputDialog(Object message) {
+  public static String showInputDialog(Component parentComponent, Object message) {
     return Main.hasGui()
-            ? JOptionPane.showInputDialog(message)
+            ? JOptionPane.showInputDialog(parentComponent, message)
             : null;
   }
 


### PR DESCRIPTION
When mapping a custom constant value to an input in the board mapping window, the window where you should be able to enter the custom value doesn't show up and Logisim becomes no longer responsive (at least this is what happens on my system: Windows 11, latest commit). This PR fixes that.

---

Additionally, remove unused import that I forgot to remove in #2686.