### PR TITLE
fix: use print-friendly colors in printer view

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/Circuit.java
+++ b/src/main/java/com/cburch/logisim/circuit/Circuit.java
@@ -526,6 +526,14 @@ public class Circuit {
   // Graphics methods
   //
   public void draw(ComponentDrawContext context, Collection<Component> hidden) {
+    if (context.isPrintView()) {
+      AppPreferences.runWithPrintViewColors(() -> drawComponents(context, hidden));
+    } else {
+      drawComponents(context, hidden);
+    }
+  }
+
+  private void drawComponents(ComponentDrawContext context, Collection<Component> hidden) {
     final var g = context.getGraphics();
     var gCopy = g.create();
     context.setGraphics(gCopy);

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -54,6 +54,23 @@ import javax.swing.JMenuItem;
 import javax.swing.KeyStroke;
 
 public class AppPreferences {
+  // Export and print jobs may run off the EDT, so keep their palette override thread-local.
+  private static final ThreadLocal<Boolean> PRINT_VIEW_COLORS = new ThreadLocal<>();
+
+  private static final class PrintViewColorPreference extends PrefMonitorInt {
+    private final int printValue;
+
+    private PrintViewColorPreference(String name, int printValue) {
+      super(name, printValue);
+      this.printValue = printValue;
+    }
+
+    @Override
+    public Integer get() {
+      return Boolean.TRUE.equals(PRINT_VIEW_COLORS.get()) ? printValue : super.get();
+    }
+  }
+
   //
   // LocalePreference
   //
@@ -168,6 +185,20 @@ public class AppPreferences {
 
   private static <E> PrefMonitor<E> create(PrefMonitor<E> monitor) {
     return monitor;
+  }
+
+  public static void runWithPrintViewColors(Runnable action) {
+    final var previous = PRINT_VIEW_COLORS.get();
+    PRINT_VIEW_COLORS.set(true);
+    try {
+      action.run();
+    } finally {
+      if (previous == null) {
+        PRINT_VIEW_COLORS.remove();
+      } else {
+        PRINT_VIEW_COLORS.set(previous);
+      }
+    }
   }
 
   static void firePropertyChange(String property, boolean oldVal, boolean newVal) {
@@ -712,13 +743,15 @@ public class AppPreferences {
   public static final PrefMonitor<Integer> GRID_ZOOMED_DOT_COLOR =
       create(new PrefMonitorInt("gridZoomedDotColor", DEFAULT_ZOOMED_DOT_COLOR));
   public static final PrefMonitor<Integer> COMPONENT_COLOR =
-      create(new PrefMonitorInt("componentColor", DEFAULT_COMPONENT_COLOR));
+      create(new PrintViewColorPreference("componentColor", DEFAULT_COMPONENT_COLOR));
   public static final PrefMonitor<Integer> COMPONENT_SECONDARY_COLOR =
-      create(new PrefMonitorInt("componentSecondaryColor", DEFAULT_COMPONENT_SECONDARY_COLOR));
+      create(
+          new PrintViewColorPreference(
+              "componentSecondaryColor", DEFAULT_COMPONENT_SECONDARY_COLOR));
   public static final PrefMonitor<Integer> COMPONENT_GHOST_COLOR =
-      create(new PrefMonitorInt("componentGhostColor", DEFAULT_COMPONENT_GHOST_COLOR));
+      create(new PrintViewColorPreference("componentGhostColor", DEFAULT_COMPONENT_GHOST_COLOR));
   public static final PrefMonitor<Integer> COMPONENT_ICON_COLOR =
-      create(new PrefMonitorInt("componentIconColor", DEFAULT_COMPONENT_ICON_COLOR));
+      create(new PrintViewColorPreference("componentIconColor", DEFAULT_COMPONENT_ICON_COLOR));
   public static final PrefMonitor<Integer> TEXT_TOOL_COLOR =
       create(new PrefMonitorInt("textToolColor", DEFAULT_TEXT_TOOL_COLOR));
 

--- a/src/test/java/com/cburch/logisim/gui/main/ExportImageTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/ExportImageTest.java
@@ -13,11 +13,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.comp.ComponentDrawContext;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.file.Loader;
+import com.cburch.logisim.file.LogisimFile;
 import com.cburch.logisim.gui.generic.TikZWriter;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.prefs.PrefMonitor;
+import com.cburch.logisim.std.gates.GatesLibrary;
+import com.cburch.logisim.tools.AddTool;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.prefs.PreferenceChangeEvent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -86,5 +97,64 @@ class ExportImageTest {
     assertEquals(Color.WHITE.getRGB(), image.getRGB(2, 1));
     assertFalse(Files.readString(tikz.toPath()).contains("\\fill"));
     assertFalse(Files.readString(svg.toPath()).contains("<rect"));
+  }
+
+  @Test
+  void darkThemePrinterViewDrawsComponentsOnWhiteBackground() {
+    final var originalComponentColor = AppPreferences.COMPONENT_COLOR.get();
+    setPreference(AppPreferences.COMPONENT_COLOR, AppPreferences.DARK_COMPONENT_COLOR);
+    try {
+      final var file = LogisimFile.createNew(new Loader(null), null);
+      final var circuit = file.getMainCircuit();
+      final var andFactory = ((AddTool) new GatesLibrary().getTool("AND Gate")).getFactory();
+      final var attributes = andFactory.createAttributeSet();
+      attributes.setValue(StdAttr.LABEL, "auto_test");
+      final var gate = andFactory.createComponent(Location.create(60, 50, false), attributes);
+      final var mutation = new CircuitMutation(circuit);
+      mutation.add(gate);
+      mutation.execute();
+
+      final var image = new BufferedImage(120, 100, BufferedImage.TYPE_INT_RGB);
+      final var graphics = image.createGraphics();
+      ExportImage.paintExportBackground(
+          graphics,
+          image.getWidth(),
+          image.getHeight(),
+          ExportImage.FORMAT_PNG,
+          true,
+          DARK_CANVAS);
+      final var context =
+          new ComponentDrawContext(null, circuit, null, graphics, graphics, true) {
+            @Override
+            public Object getGateShape() {
+              return AppPreferences.SHAPE_SHAPED;
+            }
+          };
+
+      circuit.draw(context, null);
+      graphics.dispose();
+
+      assertTrue(hasNonWhitePixel(image));
+      assertEquals(AppPreferences.DARK_COMPONENT_COLOR, AppPreferences.COMPONENT_COLOR.get());
+    } finally {
+      setPreference(AppPreferences.COMPONENT_COLOR, originalComponentColor);
+    }
+  }
+
+  private static boolean hasNonWhitePixel(BufferedImage image) {
+    for (var y = 0; y < image.getHeight(); y++) {
+      for (var x = 0; x < image.getWidth(); x++) {
+        if (image.getRGB(x, y) != Color.WHITE.getRGB()) return true;
+      }
+    }
+    return false;
+  }
+
+  private static void setPreference(PrefMonitor<Integer> monitor, int value) {
+    final var preferences = AppPreferences.getPrefs();
+    preferences.putInt(monitor.getIdentifier(), value);
+    monitor.preferenceChange(
+        new PreferenceChangeEvent(
+            preferences, monitor.getIdentifier(), Integer.toString(value)));
   }
 }


### PR DESCRIPTION
Fixes #2785

Reason: In dark mode, component colors are white. Printer view reused these theme colors while rendering on a white background, causing components and labels to become invisible.

Now: Printer view uses light-theme component colors regardless of the active application theme. This keeps components and labels visible when exporting images, printing

The color override is scoped to the rendering thread and does not affect the canvas or non-printer exports.

## Testing

Full test suite and Checkstyle pass.