### PR TITLE
docs: validate JavaHelp structure and fall back to English

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/menu/MenuHelp.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuHelp.java
@@ -22,6 +22,7 @@ import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.URI;
+import java.net.URL;
 import java.util.Locale;
 import javax.help.HelpSet;
 import javax.help.JHelp;
@@ -31,6 +32,7 @@ import javax.swing.JMenuItem;
 class MenuHelp extends JMenu implements ActionListener {
 
   private static final long serialVersionUID = 1L;
+  private static final String ENGLISH_HELP_SET = "doc/doc_en.hs";
   private final LogisimMenuBar menubar;
   private final JMenuItem tutorial = new JMenuItem();
   private final JMenuItem guide = new JMenuItem();
@@ -88,21 +90,16 @@ class MenuHelp extends JMenu implements ActionListener {
   }
 
   private void loadBroker() {
-    var helpUrl = S.get("helpsetUrl");
-    if (helpUrl == null) {
-      helpUrl = "doc/doc_en.hs";
+    final var resolved = resolveHelpSet(MenuHelp.class.getClassLoader(), S.get("helpsetUrl"));
+    if (resolved == null) {
+      disableHelp();
+      OptionPane.showMessageDialog(menubar.getParentFrame(), S.get("helpNotFoundError"));
+      return;
     }
-    if (helpSet == null || helpFrame == null || !helpUrl.equals(helpSetUrl)) {
-      final var loader = MenuHelp.class.getClassLoader();
+    if (helpSet == null || helpFrame == null || !resolved.path().equals(helpSetUrl)) {
       try {
-        final var hsUrl = HelpSet.findHelpSet(loader, helpUrl);
-        if (hsUrl == null) {
-          disableHelp();
-          OptionPane.showMessageDialog(menubar.getParentFrame(), S.get("helpNotFoundError"));
-          return;
-        }
-        helpSetUrl = helpUrl;
-        helpSet = new HelpSet(null, hsUrl);
+        helpSetUrl = resolved.path();
+        helpSet = new HelpSet(null, resolved.url());
         helpComponent = new JHelp(helpSet);
         if (helpFrame == null) {
           helpFrame = new LFrame.Dialog(null);
@@ -125,6 +122,26 @@ class MenuHelp extends JMenu implements ActionListener {
       }
     }
   }
+
+  static ResolvedHelpSet resolveHelpSet(ClassLoader loader, String localizedHelpSet) {
+    final var requested =
+        localizedHelpSet == null || localizedHelpSet.isBlank()
+            ? ENGLISH_HELP_SET
+            : localizedHelpSet;
+    var url = HelpSet.findHelpSet(loader, requested);
+    if (url != null) {
+      return new ResolvedHelpSet(requested, url);
+    }
+    if (!ENGLISH_HELP_SET.equals(requested)) {
+      url = HelpSet.findHelpSet(loader, ENGLISH_HELP_SET);
+      if (url != null) {
+        return new ResolvedHelpSet(ENGLISH_HELP_SET, url);
+      }
+    }
+    return null;
+  }
+
+  record ResolvedHelpSet(String path, URL url) {}
 
   // On Linux this feature depends on Gnome, so may not be
   // working on all distros (i.e. KDE).

--- a/src/test/java/com/cburch/logisim/docs/DocumentationStructureTest.java
+++ b/src/test/java/com/cburch/logisim/docs/DocumentationStructureTest.java
@@ -1,0 +1,318 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.docs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+class DocumentationStructureTest {
+
+  private static final String BASELINE_RESOURCE = "/documentation-known-issues.txt";
+  private static final Path DOC_ROOT = Path.of("src", "main", "resources", "doc");
+  private static final Set<String> REQUIRED_TARGETS =
+      Set.of("top", "guide", "tutorial", "libs");
+  private static final Pattern HELP_SET_NAME = Pattern.compile("doc_([a-z]{2})\\.hs");
+  private static final Pattern HELP_SET_MAP =
+      Pattern.compile(
+          "<mapref\\s+[^>]*location=[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+  private static final Pattern HELP_SET_VIEW =
+      Pattern.compile("<view\\b[^>]*>(.*?)</view>", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+  private static final Pattern HTML_ANCHOR =
+      Pattern.compile("\\b(?:id|name)=[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+
+  @Test
+  void javaHelpStructureMatchesKnownIssueBaseline() throws Exception {
+    final var expected = readKnownIssues();
+    final var actual = validateJavaHelp(DOC_ROOT);
+
+    assertEquals(
+        expected,
+        actual,
+        () ->
+            "JavaHelp structure changed. Fix new issues or intentionally update "
+                + BASELINE_RESOURCE
+                + ".\nCurrent issues:\n"
+                + String.join("\n", actual));
+  }
+
+  private static List<String> readKnownIssues() throws Exception {
+    try (var input = DocumentationStructureTest.class.getResourceAsStream(BASELINE_RESOURCE)) {
+      if (input == null) {
+        throw new IllegalStateException("Missing test resource " + BASELINE_RESOURCE);
+      }
+      try (var reader =
+          new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+        return reader
+            .lines()
+            .map(String::trim)
+            .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+            .sorted()
+            .toList();
+      }
+    }
+  }
+
+  private static List<String> validateJavaHelp(Path docRoot) throws Exception {
+    final var issues = new ArrayList<String>();
+    try (var paths = Files.list(docRoot)) {
+      for (final var helpSet : paths.filter(Files::isRegularFile).sorted().toList()) {
+        final var matcher = HELP_SET_NAME.matcher(helpSet.getFileName().toString());
+        if (matcher.matches()) {
+          validateHelpSet(docRoot, helpSet, issues);
+        }
+      }
+    }
+    issues.sort(String::compareTo);
+    return issues;
+  }
+
+  private static void validateHelpSet(Path docRoot, Path helpSetPath, List<String> issues)
+      throws Exception {
+    final var helpSetLabel = relativeLabel(docRoot, helpSetPath);
+    final var helpSetText = Files.readString(helpSetPath, StandardCharsets.UTF_8);
+    try {
+      parseXml(helpSetPath);
+    } catch (Exception exception) {
+      issues.add(helpSetLabel + ": XML is not well-formed");
+    }
+    final var mapReference = firstMatch(HELP_SET_MAP, helpSetText);
+    final var contentsReference = viewData(helpSetText, "TOC");
+    final var searchReference = viewData(helpSetText, "Search");
+
+    if (mapReference == null) {
+      issues.add(helpSetLabel + ": missing mapref");
+      return;
+    }
+    if (contentsReference == null) {
+      issues.add(helpSetLabel + ": missing TOC data");
+      return;
+    }
+
+    final var mapPath = docRoot.resolve(mapReference).normalize();
+    final var contentsPath = docRoot.resolve(contentsReference).normalize();
+    validateReferencedPath(docRoot, helpSetLabel, "mapref", mapReference, mapPath, issues);
+    validateReferencedPath(
+        docRoot, helpSetLabel, "TOC data", contentsReference, contentsPath, issues);
+    if (searchReference != null) {
+      validateReferencedPath(
+          docRoot,
+          helpSetLabel,
+          "Search data",
+          searchReference,
+          docRoot.resolve(searchReference).normalize(),
+          issues);
+    }
+    if (!Files.isRegularFile(mapPath) || !Files.isRegularFile(contentsPath)) {
+      return;
+    }
+
+    validateMapAndContents(docRoot, mapPath, contentsPath, issues);
+  }
+
+  private static void validateMapAndContents(
+      Path docRoot, Path mapPath, Path contentsPath, List<String> issues) throws Exception {
+    final var mapDocument = parseXml(mapPath);
+    final var mapEntries = new TreeMap<String, String>();
+    final var mapIds = mapDocument.getElementsByTagName("mapID");
+    for (var i = 0; i < mapIds.getLength(); i++) {
+      final var element = (Element) mapIds.item(i);
+      final var target = element.getAttribute("target");
+      final var url = element.getAttribute("url");
+      if (target.isBlank() || url.isBlank()) {
+        issues.add(relativeLabel(docRoot, mapPath) + ": mapID missing target or url");
+      } else if (mapEntries.putIfAbsent(target, url) != null) {
+        issues.add(relativeLabel(docRoot, mapPath) + ": duplicate mapID '" + target + "'");
+      }
+    }
+
+    final var targets = new TreeSet<>(REQUIRED_TARGETS);
+    final var imageTargets = new TreeSet<String>();
+    final var contentsDocument = parseXml(contentsPath);
+    final var tocItems = contentsDocument.getElementsByTagName("tocitem");
+    for (var i = 0; i < tocItems.getLength(); i++) {
+      final var element = (Element) tocItems.item(i);
+      final var target = element.getAttribute("target");
+      final var image = element.getAttribute("image");
+      if (!target.isBlank()) {
+        targets.add(target);
+      }
+      if (!image.isBlank()) {
+        imageTargets.add(image);
+      }
+    }
+
+    for (final var target : targets) {
+      validateMappedTarget(
+          docRoot, mapPath, contentsPath, mapEntries, "target", target, issues);
+    }
+    for (final var target : imageTargets) {
+      validateMappedTarget(
+          docRoot, mapPath, contentsPath, mapEntries, "image target", target, issues);
+    }
+  }
+
+  private static void validateMappedTarget(
+      Path docRoot,
+      Path mapPath,
+      Path contentsPath,
+      Map<String, String> mapEntries,
+      String kind,
+      String target,
+      List<String> issues)
+      throws Exception {
+    final var url = mapEntries.get(target);
+    if (url == null) {
+      issues.add(
+          relativeLabel(docRoot, contentsPath)
+              + ": "
+              + kind
+              + " '"
+              + target
+              + "' has no mapID in "
+              + mapPath.getFileName());
+      return;
+    }
+
+    final var hash = url.indexOf('#');
+    final var pathPart = hash < 0 ? url : url.substring(0, hash);
+    final var fragment = hash < 0 ? "" : url.substring(hash + 1);
+    final var targetPath = docRoot.resolve(pathPart).normalize();
+    final var mapLabel =
+        relativeLabel(docRoot, mapPath) + ": mapID '" + target + "'";
+    if (!targetPath.startsWith(docRoot.normalize())) {
+      issues.add(mapLabel + " points outside the documentation root " + url);
+    } else if (!Files.exists(targetPath)) {
+      issues.add(mapLabel + " points to missing file " + url);
+    } else if (!pathExistsWithExactCase(docRoot, targetPath)) {
+      issues.add(mapLabel + " has path case mismatch " + url);
+    } else if (!fragment.isEmpty()
+        && (pathPart.endsWith(".html") || pathPart.endsWith(".htm"))
+        && !htmlAnchors(targetPath).contains(fragment)) {
+      issues.add(mapLabel + " points to missing anchor " + url);
+    }
+  }
+
+  private static void validateReferencedPath(
+      Path docRoot,
+      String sourceLabel,
+      String kind,
+      String reference,
+      Path target,
+      List<String> issues) {
+    if (!target.startsWith(docRoot.normalize())) {
+      issues.add(sourceLabel + ": " + kind + " points outside documentation root " + reference);
+    } else if (!Files.exists(target)) {
+      issues.add(sourceLabel + ": " + kind + " points to missing path " + reference);
+    } else if (!pathExistsWithExactCase(docRoot, target)) {
+      issues.add(sourceLabel + ": " + kind + " has path case mismatch " + reference);
+    }
+  }
+
+  private static Document parseXml(Path path) throws Exception {
+    final var factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    final var builder = factory.newDocumentBuilder();
+    builder.setErrorHandler(
+        new DefaultHandler() {
+          @Override
+          public void error(SAXParseException exception) throws SAXException {
+            throw exception;
+          }
+
+          @Override
+          public void fatalError(SAXParseException exception) throws SAXException {
+            throw exception;
+          }
+        });
+    return builder.parse(path.toFile());
+  }
+
+  private static String firstMatch(Pattern pattern, String input) {
+    final var matcher = pattern.matcher(input);
+    return matcher.find() ? matcher.group(1).trim() : null;
+  }
+
+  private static String viewData(String helpSet, String viewName) {
+    final var views = HELP_SET_VIEW.matcher(helpSet);
+    while (views.find()) {
+      final var view = views.group(1);
+      if (viewName.equals(elementText(view, "name"))) {
+        return elementText(view, "data");
+      }
+    }
+    return null;
+  }
+
+  private static String elementText(String input, String tag) {
+    final var pattern =
+        Pattern.compile(
+            "<" + tag + "\\b[^>]*>(.*?)</" + tag + ">",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    final var matcher = pattern.matcher(input);
+    return matcher.find() ? matcher.group(1).trim() : null;
+  }
+
+  private static Set<String> htmlAnchors(Path path) throws Exception {
+    final var anchors = new TreeSet<String>();
+    final var matcher = HTML_ANCHOR.matcher(Files.readString(path, StandardCharsets.UTF_8));
+    while (matcher.find()) {
+      anchors.add(matcher.group(1));
+    }
+    return anchors;
+  }
+
+  private static boolean pathExistsWithExactCase(Path root, Path target) {
+    if (!Files.exists(target)) {
+      return false;
+    }
+    var current = root.normalize();
+    for (final var part : root.normalize().relativize(target.normalize())) {
+      try (var children = Files.list(current)) {
+        if (children.noneMatch(child -> child.getFileName().equals(part))) {
+          return false;
+        }
+      } catch (Exception exception) {
+        return false;
+      }
+      current = current.resolve(part);
+    }
+    return true;
+  }
+
+  private static String relativeLabel(Path root, Path path) {
+    return root.normalize().relativize(path.normalize()).toString().replace('\\', '/');
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/menu/MenuHelpTest.java
+++ b/src/test/java/com/cburch/logisim/gui/menu/MenuHelpTest.java
@@ -1,0 +1,59 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.menu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+class MenuHelpTest {
+
+  private static final ClassLoader RESOURCE_LOADER = MenuHelp.class.getClassLoader();
+
+  @Test
+  void keepsAvailableLocalizedHelpSet() {
+    final var resolved = MenuHelp.resolveHelpSet(RESOURCE_LOADER, "doc/doc_de.hs");
+
+    assertNotNull(resolved);
+    assertEquals("doc/doc_de.hs", resolved.path());
+  }
+
+  @Test
+  void fallsBackToEnglishWhenLocalizedHelpSetIsMissing() {
+    final var resolved = MenuHelp.resolveHelpSet(RESOURCE_LOADER, "doc/doc_es.hs");
+
+    assertNotNull(resolved);
+    assertEquals("doc/doc_en.hs", resolved.path());
+  }
+
+  @Test
+  void blankHelpSetConfigurationUsesEnglish() {
+    final var resolved = MenuHelp.resolveHelpSet(RESOURCE_LOADER, " ");
+
+    assertNotNull(resolved);
+    assertEquals("doc/doc_en.hs", resolved.path());
+  }
+
+  @Test
+  void missingEnglishHelpSetCannotBeResolved() {
+    final var emptyLoader =
+        new ClassLoader(null) {
+          @Override
+          public URL getResource(String name) {
+            return null;
+          }
+        };
+
+    assertNull(MenuHelp.resolveHelpSet(emptyLoader, "doc/doc_es.hs"));
+  }
+}

--- a/src/test/resources/documentation-known-issues.txt
+++ b/src/test/resources/documentation-known-issues.txt
@@ -1,0 +1,99 @@
+# Existing JavaHelp structure issues on 2026-07-30.
+# Keep this list explicit so new documentation regressions fail CI while existing debt can be
+# removed incrementally.
+de/contents.xml: image target 'icon_DIP' has no mapID in map_de.jhm
+de/contents.xml: image target 'icon_ledRGB' has no mapID in map_de.jhm
+de/contents.xml: target 'Tests_for_doc' has no mapID in map_de.jhm
+de/contents.xml: target 'hdl' has no mapID in map_de.jhm
+de/contents.xml: target 'hdl_vhdlentity' has no mapID in map_de.jhm
+de/contents.xml: target 'io_DIP' has no mapID in map_de.jhm
+de/contents.xml: target 'io_ledRGB' has no mapID in map_de.jhm
+de/contents.xml: target 'io_videorgb' has no mapID in map_de.jhm
+doc_de.hs: XML is not well-formed
+doc_en.hs: XML is not well-formed
+doc_fr.hs: XML is not well-formed
+doc_pt.hs: XML is not well-formed
+doc_ru.hs: XML is not well-formed
+doc_zh.hs: XML is not well-formed
+en/contents.xml: target 'Tests_for_doc' has no mapID in map_en.jhm
+en/contents.xml: target 'Tests_for_doc' has no mapID in map_pt.jhm
+en/contents.xml: target 'Translation_status' has no mapID in map_pt.jhm
+en/contents.xml: target 'dynamic_components' has no mapID in map_pt.jhm
+en/contents.xml: target 'io_DIP' has no mapID in map_en.jhm
+en/contents.xml: target 'io_DIP' has no mapID in map_pt.jhm
+en/contents.xml: target 'io_ledRGB' has no mapID in map_en.jhm
+en/contents.xml: target 'io_ledRGB' has no mapID in map_pt.jhm
+en/contents.xml: target 'test_hmlcss' has no mapID in map_pt.jhm
+fr/contents.xml: image target 'icon_DIP' has no mapID in map_fr.jhm
+fr/contents.xml: image target 'icon_led RGB' has no mapID in map_fr.jhm
+fr/contents.xml: target 'Tests_for_doc' has no mapID in map_fr.jhm
+fr/contents.xml: target 'hdl' has no mapID in map_fr.jhm
+fr/contents.xml: target 'hdl_vhdlentity' has no mapID in map_fr.jhm
+fr/contents.xml: target 'io_DIP' has no mapID in map_fr.jhm
+fr/contents.xml: target 'io_ledRGB' has no mapID in map_fr.jhm
+fr/contents.xml: target 'io_videorgb' has no mapID in map_fr.jhm
+map_de.jhm: duplicate mapID 'icon_controlled'
+map_de.jhm: duplicate mapID 'socbus_icon'
+map_de.jhm: duplicate mapID 'up_icon'
+map_de.jhm: mapID 'analyze_expimp' points to missing file de/html/guide/analyze/ana-expimp.html
+map_de.jhm: mapID 'gates_PLA' points to missing file de/html/libs/gates/pla.html
+map_de.jhm: mapID 'io_Port_IO' points to missing file de/html/libs/io/Port_io.html
+map_de.jhm: mapID 'io_Repetar' points to missing file de/html/libs/io/repetar.html
+map_de.jhm: mapID 'log_timetable' points to missing file de/html/guide/log/timetable.html
+map_de.jhm: mapID 'mem_ascii' points to missing file de/html/guide/mem/mem-vascii.html
+map_de.jhm: mapID 'mem_binary' points to missing file de/html/guide/mem/mem-vbinary.html
+map_de.jhm: mapID 'mem_filetabel' points to missing file de/html/guide/mem/mem-filepanel.html
+map_de.jhm: mapID 'mem_v2raw' points to missing file de/html/guide/mem/mem-v2raw.html
+map_de.jhm: mapID 'mem_v3byte' points to missing file de/html/guide/mem/mem-v3byte.html
+map_de.jhm: mapID 'mem_v3word' points to missing file de/html/guide/mem/mem-v3word.html
+map_de.jhm: mapID 'nios2_sim' points to missing file de/html/libs/soc/nios2.html
+map_de.jhm: mapID 'prefs_intl' points to missing file de/html/guide/prefs/pref-intl.html
+map_de.jhm: mapID 'soc' points to missing file de/html/libs/soc/index.html
+map_de.jhm: mapID 'socbus' points to missing file de/html/libs/soc/socbus.html
+map_de.jhm: mapID 'tcl' points to missing file de/html/libs/tcl/index.html
+map_de.jhm: mapID 'tcl_generic' points to missing file de/html/libs/tcl/generic.html
+map_de.jhm: mapID 'tcl_reds_console' points to missing file de/html/libs/tcl/reds_console.html
+map_de.jhm: mapID 'test_hmlcss' points to missing file de/testhtml/index.html
+map_de.jhm: mapID 'wiring' points to missing file de/html/libs/wiring/index.html
+map_de.jhm: mapID 'wiring_const01' points to missing file de/html/libs/wiring/const01.html
+map_de.jhm: mapID 'wiring_notconnect' points to missing file de/html/libs/wiring/notconnect.html
+map_de.jhm: mapID 'wiring_por' points to missing file de/html/libs/wiring/poweronreset.html
+map_de.jhm: mapID 'wiring_transist' points to missing file de/html/libs/wiring/transist.html
+map_de.jhm: mapID 'wiring_transmis' points to missing file de/html/libs/wiring/transmis.html
+map_en.jhm: duplicate mapID 'icon_controlled'
+map_en.jhm: duplicate mapID 'socbus_icon'
+map_en.jhm: duplicate mapID 'up_icon'
+map_fr.jhm: duplicate mapID 'icon_controlled'
+map_fr.jhm: duplicate mapID 'socbus_icon'
+map_fr.jhm: duplicate mapID 'up_icon'
+map_fr.jhm: mapID 'nios2_sim' points to missing file en/html/libs/soc/nios2.html
+map_fr.jhm: mapID 'tcl_generic' points to missing file en/html/libs/tcl/generic.html
+map_fr.jhm: mapID 'tcl_reds_console' points to missing file en/html/libs/tcl/reds_console.html
+map_pt.jhm: duplicate mapID 'icon_controlled'
+map_pt.jhm: duplicate mapID 'socbus_icon'
+map_pt.jhm: duplicate mapID 'up_icon'
+map_pt.jhm: mapID 'about' points to missing file pt/html/guide/about/index.html
+map_pt.jhm: mapID 'analyze_expimp' points to missing file pt/html/guide/analyze/ana-expimp.html
+map_pt.jhm: mapID 'gates_PLA' points to missing file pt/html/libs/gates/pla.html
+map_pt.jhm: mapID 'log_timetable' points to missing file pt/html/guide/log/timetable.html
+map_pt.jhm: mapID 'mem_ascii' points to missing file pt/html/guide/mem/mem-vascii.html
+map_pt.jhm: mapID 'mem_binary' points to missing file pt/html/guide/mem/mem-vbinary.html
+map_pt.jhm: mapID 'mem_filetabel' points to missing file pt/html/guide/mem/mem-filepanel.html
+map_pt.jhm: mapID 'mem_v2raw' points to missing file pt/html/guide/mem/mem-v2raw.html
+map_pt.jhm: mapID 'mem_v3byte' points to missing file pt/html/guide/mem/mem-v3byte.html
+map_pt.jhm: mapID 'mem_v3word' points to missing file pt/html/guide/mem/mem-v3word.html
+map_pt.jhm: mapID 'wiring_const01' points to missing file pt/html/libs/wiring/const01.html
+map_pt.jhm: mapID 'wiring_notconnect' points to missing file pt/html/libs/wiring/notconnect.html
+map_pt.jhm: mapID 'wiring_transist' points to missing file pt/html/libs/wiring/transist.html
+map_pt.jhm: mapID 'wiring_transmis' points to missing file pt/html/libs/wiring/transmis.html
+map_ru.jhm: duplicate mapID 'icon_controlled'
+map_ru.jhm: duplicate mapID 'socbus_icon'
+map_ru.jhm: duplicate mapID 'up_icon'
+map_zh.jhm: duplicate mapID 'icon_controlled'
+map_zh.jhm: duplicate mapID 'socbus_icon'
+map_zh.jhm: duplicate mapID 'up_icon'
+map_zh.jhm: mapID 'io_Port_IO' points to missing file zh/html/libs/io/Port_io.html
+map_zh.jhm: mapID 'io_Repetar' points to missing file zh/html/libs/io/repetar.html
+ru/contents.xml: target 'Tests_for_doc' has no mapID in map_ru.jhm
+zh/contents.xml: target 'Tests_for_doc' has no mapID in map_zh.jhm
+zh/contents.xml: target 'io_videorgb' has no mapID in map_zh.jhm


### PR DESCRIPTION
## Summary

- fall back to the English JavaHelp HelpSet when the configured localized HelpSet is absent
- validate HelpSet map, table-of-contents, and search paths; duplicate or missing targets; exact-case paths; target files; and HTML anchors
- record the 96 existing structure findings as an explicit baseline so new regressions fail without folding the historical documentation cleanup into this PR

## Motivation

The Spanish GUI currently selects `doc/doc_es.hs`, which is not packaged. The previous behavior disabled integrated help even though the English HelpSet was available.

The independently maintained HelpSets, maps, TOCs, and search data also contain existing drift. A baseline-backed validator gives later migration work a safety net while keeping this first slice reviewable.

This is the first implementation step discussed in #2762. It intentionally does not close the issue, migrate documentation content, or introduce the later canonical manifest and generated locale overlays.

## Validation

- `.\gradlew.bat test --tests com.cburch.logisim.docs.DocumentationStructureTest --tests com.cburch.logisim.gui.menu.MenuHelpTest --rerun-tasks`
- `.\gradlew.bat test --rerun-tasks` (with Git's bundled `xxd` added to the command's `PATH` for the existing Windows `HexFileTest` dependency)
- `.\gradlew.bat compileJava checkstyleMain compileTestJava checkstyleTest`
- `git diff --check`
- Windows GUI: Spanish opens the English guide; German and Simplified Chinese continue opening their localized guides
