### PR TITLE
Improve circuit deletion notification & navigation panel toolbar

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/menu/MainMenuListener.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MainMenuListener.java
@@ -25,6 +25,7 @@ import com.cburch.logisim.gui.main.StatisticsDialog;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.proj.ProjectEvent;
 import com.cburch.logisim.proj.ProjectListener;
+import com.cburch.logisim.vhdl.base.VhdlContent;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
@@ -92,7 +93,11 @@ public class MainMenuListener extends MenuListener {
       } else if (src == LogisimMenuBar.SET_MAIN_CIRCUIT) {
         ProjectCircuitActions.doSetAsMainCircuit(proj, cur);
       } else if (src == LogisimMenuBar.REMOVE_CIRCUIT) {
-        ProjectCircuitActions.doRemoveCircuit(proj, cur);
+        if (cur != null) {
+          ProjectCircuitActions.doRemoveCircuit(proj, cur);
+        } else if (proj.getCurrentHdl() != null) {
+          ProjectCircuitActions.doRemoveVhdl(proj, (VhdlContent) proj.getCurrentHdl());
+        }
       } else if (src == LogisimMenuBar.EDIT_LAYOUT) {
         frame.setEditorView(Frame.EDIT_LAYOUT);
       } else if (src == LogisimMenuBar.EDIT_APPEARANCE) {
@@ -123,16 +128,18 @@ public class MainMenuListener extends MenuListener {
       var canMoveDown = false;
       var canRemove = false;
       var canRevert = false;
+      var canToggleAppearance = true;
 
       // is project circuit?
       if (curIndex >= 0) {
-        List<?> tools = proj.getLogisimFile().getTools();
-
-        canSetMain = proj.getLogisimFile().getMainCircuit() != cur;
+        canSetMain = file.getMainCircuit() != cur;
         canMoveUp = curIndex > 0;
-        canMoveDown = curIndex < tools.size() - 1;
-        canRemove = tools.size() > 1;
+        canMoveDown = curIndex < file.getTools().size() - 1;
+        canRemove = file.getCircuits().size() > 1 && proj.getDependencies().canRemove(cur);
         canRevert = viewAppearance && !cur.getAppearance().isDefaultAppearance();
+      } else if (proj.getCurrentHdl() != null) {
+        canRemove = true;
+        canToggleAppearance = false;
       }
 
       menubar.setEnabled(LogisimMenuBar.ADD_CIRCUIT, true);
@@ -144,7 +151,7 @@ public class MainMenuListener extends MenuListener {
       menubar.setEnabled(LogisimMenuBar.REMOVE_CIRCUIT, canRemove);
       menubar.setEnabled(LogisimMenuBar.EDIT_LAYOUT, viewAppearance);
       menubar.setEnabled(LogisimMenuBar.EDIT_APPEARANCE, viewLayout);
-      menubar.setEnabled(LogisimMenuBar.TOGGLE_APPEARANCE, true);
+      menubar.setEnabled(LogisimMenuBar.TOGGLE_APPEARANCE, canToggleAppearance);
       menubar.setEnabled(LogisimMenuBar.REVERT_APPEARANCE, canRevert);
       menubar.setEnabled(LogisimMenuBar.ANALYZE_CIRCUIT, true);
       menubar.setEnabled(LogisimMenuBar.CIRCUIT_STATS, true);

--- a/src/main/java/com/cburch/logisim/gui/menu/ProjectCircuitActions.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/ProjectCircuitActions.java
@@ -245,13 +245,13 @@ public class ProjectCircuitActions {
     } else if (!proj.getDependencies().canRemove(circuit)) {
       OptionPane.showMessageDialog(
           proj.getFrame(),
-          S.get("circuitRemoveUsedError"),
+          S.get("circuitRemoveUsedError", circuit.getName()),
           S.get("circuitRemoveErrorTitle"),
           OptionPane.ERROR_MESSAGE);
     } else {
       int result = OptionPane.showConfirmDialog(
           proj.getFrame(),
-          S.get("circuitRemoveConfirm"),
+          S.get("circuitRemoveConfirm", circuit.getName()),
           S.get("circuitRemoveConfirmTitle"),
           OptionPane.YES_NO_OPTION);
       if (result == OptionPane.YES_OPTION) {
@@ -264,14 +264,14 @@ public class ProjectCircuitActions {
     if (!proj.getDependencies().canRemove(vhdl)) {
       OptionPane.showMessageDialog(
           proj.getFrame(),
-          S.get("circuitRemoveUsedError"),
-          S.get("circuitRemoveErrorTitle"),
+          S.get("vhdlRemoveUsedError", vhdl.getName()),
+          S.get("vhdlRemoveErrorTitle"),
           OptionPane.ERROR_MESSAGE);
     } else {
       int result = OptionPane.showConfirmDialog(
           proj.getFrame(),
-          S.get("circuitRemoveConfirm"),
-          S.get("circuitRemoveConfirmTitle"),
+          S.get("vhdlRemoveConfirm", vhdl.getName()),
+          S.get("vhdlRemoveConfirmTitle"),
           OptionPane.YES_NO_OPTION);
       if (result == OptionPane.YES_OPTION) {
         proj.doAction(LogisimFileActions.removeVhdl(vhdl));

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -531,13 +531,17 @@ circuitNameInvalidName = The name is invalid (it must follow the rule ([a-zA-Z]+
 circuitNameKeyword = This name is a keyword and can therefore not be used.
 circuitNameMissingError = Every circuit requires a name.
 circuitNamePrompt = Circuit Name:
-circuitRemoveConfirm = Are you sure you want to remove this circuit?
-circuitRemoveConfirmTitle = Confirm Circuit removal
+circuitRemoveConfirm = Are you sure you want to remove circuit '%s'?
+circuitRemoveConfirmTitle = Confirm Circuit Removal
 circuitRemoveErrorTitle = Cannot Remove Circuit
 circuitRemoveLastError = Library must contain at least one circuit.
-circuitRemoveUsedError = Circuit used in other circuits cannot be removed.
+circuitRemoveUsedError = Circuit '%s' is used in other circuits and therefore cannot be removed.
 vhdlNameDialogTitle = Input VHDL Entity Name
 vhdlNamePrompt = VHDL Entity Name:
+vhdlRemoveConfirm = Are you sure you want to remove VHDL entity '%s'?
+vhdlRemoveConfirmTitle = Confirm VHDL Entity Removal
+vhdlRemoveErrorTitle = Cannot Remove VHDL Entity
+vhdlRemoveUsedError = VHDL entity '%s' is used in other circuits and therefore cannot be removed.
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -471,7 +471,7 @@ simulateTickItem = Weiterschalten aktivieren
 simulateTickFreqMenu = Schaltfrequenz
 simulateTickKFreqItem = %s kHz
 simulateUpStateMenu = Absteigen
-simulateVhdlEnableItem = VHDL Simulation aktiviert
+simulateVhdlEnableItem = VHDL-Simulation aktiviert
 #
 # menu/OpenRecent.java
 #
@@ -501,7 +501,7 @@ projectRemoveVhdlItem = VHDL-Einheit entfernen
 projectSetAsMainItem = Als Hauptschaltung festlegen
 projectUnloadLibraryItem = Bibliothek entfernen
 projMenu = Projekt
-vhdlMenu = VHDL Einheit
+vhdlMenu = VHDL-Einheit
 # ==> exportSubcircuitTitle = Export Circuit: %s
 # ==> exportSubcircuitDependenciesHeader = The following dependencies were found:
 # ==> exportSubcircuitAutoPrefix = Add main circuit prefix to dependent circuits
@@ -536,9 +536,9 @@ circuitRemoveConfirm = Sind Sie sicher, dass Sie die Schaltung '%s' entfernen m�
 circuitRemoveConfirmTitle = Entfernung der Schaltung bestätigen
 circuitRemoveErrorTitle = Kann Schaltung nicht entfernen
 circuitRemoveLastError = Bibliothek muß mindestens eine Schaltung enthalten.
-vhdlNameDialogTitle = Eingang VHDL Entitätsname
-vhdlNamePrompt = VHDL Körpername:
 circuitRemoveUsedError = Schaltung '%s' wird in anderen Schaltungen benutzt und kann deshalb nicht entfernt werden.
+vhdlNameDialogTitle = Eingang VHDL-Entitätsname
+vhdlNamePrompt = VHDL-Körpername:
 vhdlRemoveConfirm = Sind Sie sicher, dass Sie die VHDL-Entität '%s' entfernen möchten?
 vhdlRemoveConfirmTitle = Entfernung der VHDL-Entität bestätigen
 vhdlRemoveErrorTitle = Kann VHDL-Entität nicht entfernen

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -532,13 +532,17 @@ circuitNameInvalidName = Der Name ist ungültig (er muss der Regel folgen ([a-zA
 circuitNameKeyword = Dieser Name ist ein Schlüsselwort und kann daher nicht verwendet werden.
 circuitNameMissingError = Jede Schaltung benötigt einen Namen.
 circuitNamePrompt = Schaltungsname:
-# ==> circuitRemoveConfirm =
-# ==> circuitRemoveConfirmTitle =
+circuitRemoveConfirm = Sind Sie sicher, dass Sie die Schaltung '%s' entfernen möchten?
+circuitRemoveConfirmTitle = Entfernung der Schaltung bestätigen
 circuitRemoveErrorTitle = Kann Schaltung nicht entfernen
 circuitRemoveLastError = Bibliothek muß mindestens eine Schaltung enthalten.
-circuitRemoveUsedError = Schaltungen, die in anderen Schaltungen benutzt werden, können nicht entfernt werden.
 vhdlNameDialogTitle = Eingang VHDL Entitätsname
 vhdlNamePrompt = VHDL Körpername:
+circuitRemoveUsedError = Schaltung '%s' wird in anderen Schaltungen benutzt und kann deshalb nicht entfernt werden.
+vhdlRemoveConfirm = Sind Sie sicher, dass Sie die VHDL-Entität '%s' entfernen möchten?
+vhdlRemoveConfirmTitle = Entfernung der VHDL-Entität bestätigen
+vhdlRemoveErrorTitle = Kann VHDL-Entität nicht entfernen
+vhdlRemoveUsedError = VHDL-Entität '%s' wird in anderen Schaltungen benutzt und kann deshalb nicht entfernt werden.
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -534,9 +534,13 @@ circuitNamePrompt = Όνομα Κυκλώματος:
 # ==> circuitRemoveConfirmTitle =
 circuitRemoveErrorTitle = Δεν είναι δυνατή η κατάργηση του κυκλώματος
 circuitRemoveLastError = Η βιβλιοθήκη θα πρέπει να περιέχει τουλάχιστον ένα κύκλωμα.
-circuitRemoveUsedError = Το κύκλωμα που χρησιμοποιείται σε άλλα κυκλώματα δεν μπορεί να αφαιρεθεί.
+# ==> circuitRemoveUsedError
 # ==> vhdlNameDialogTitle =
 # ==> vhdlNamePrompt =
+# ==> vhdlRemoveConfirm =
+# ==> vhdlRemoveConfirmTitle =
+# ==> vhdlRemoveErrorTitle =
+# ==> vhdlRemoveUsedError =
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -536,9 +536,13 @@ circuitNamePrompt = Nombre del circuito:
 # ==> circuitRemoveConfirmTitle =
 circuitRemoveErrorTitle = El circuito no se puede eliminar
 circuitRemoveLastError = La librería debe contener al menos un circuito.
-circuitRemoveUsedError = El circuito está siendo utilizado en otros circuitos, no se puede eliminar.
+# ==> circuitRemoveUsedError
 # ==> vhdlNameDialogTitle =
 vhdlNamePrompt = Nombre de la entidad VHDL:
+# ==> vhdlRemoveConfirm =
+# ==> vhdlRemoveConfirmTitle =
+# ==> vhdlRemoveErrorTitle =
+# ==> vhdlRemoveUsedError =
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -531,13 +531,17 @@ circuitNameInvalidName = Ce nom est invalide (il doit respecter la règle ([a-zA
 circuitNameKeyword = Ce nom est un mot-clé et ne peut pas donc être utilisé.
 circuitNameMissingError = Un circuit a besoin d’un nom.
 circuitNamePrompt = Nom du circuit :
-# ==> circuitRemoveConfirm =
-# ==> circuitRemoveConfirmTitle =
+circuitRemoveConfirm = Êtes-vous sûr de vouloir supprimer le circuit « %s » ?
+circuitRemoveConfirmTitle = Confirmer la suppression de circuit
 circuitRemoveErrorTitle = Impossible de supprimer le circuit
 circuitRemoveLastError = La librairie doit contenir au moins un circuit.
-circuitRemoveUsedError = Les circuits contenus dans d’autres circuits ne peuvent pas être supprimés.
+circuitRemoveUsedError = Le circuit « %s » est contenu dans d’autres circuits et ne peut donc pas être supprimé.
 vhdlNameDialogTitle = Nom d’entité VHDL en entrée
 vhdlNamePrompt = Nom de l’entité VHDL :
+vhdlRemoveConfirm = Êtes-vous sûr de vouloir supprimer l’entité VHDL « %s » ?
+vhdlRemoveConfirmTitle = Confirmer la suppression d’entité VHDL
+vhdlRemoveErrorTitle = Impossible de supprimer l’entité VHDL
+vhdlRemoveUsedError = L’entité VHDL « %s » est contenue dans d’autres circuits et ne peut donc pas être supprimée.
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -535,9 +535,13 @@ circuitNamePrompt = Nome Circuito:
 # ==> circuitRemoveConfirmTitle =
 circuitRemoveErrorTitle = Impossibile Rimuovere Circuito
 circuitRemoveLastError = La libreria deve contenere almeno un circuito.
-circuitRemoveUsedError = I circuiti usati in altri circuiti non possono essere rimossi.
+# ==> circuitRemoveUsedError
 vhdlNameDialogTitle = Ingresso VHDL Nome entità
 vhdlNamePrompt = VHDL Nome dell’entità:
+# ==> vhdlRemoveConfirm =
+# ==> vhdlRemoveConfirmTitle =
+# ==> vhdlRemoveErrorTitle =
+# ==> vhdlRemoveUsedError =
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -534,9 +534,13 @@ circuitNamePrompt = 回路名:
 # ==> circuitRemoveConfirmTitle =
 circuitRemoveErrorTitle = 回路を削除できません。
 circuitRemoveLastError = ライブラリには少なくとも 1 つの回路が含まれている必要があります。
-circuitRemoveUsedError = 他の回路で使用されている回路は削除できません。
+# ==> circuitRemoveUsedError
 vhdlNameDialogTitle = 入力VHDLエンティティ名
 vhdlNamePrompt = VHDLエンティティ名:
+# ==> vhdlRemoveConfirm =
+# ==> vhdlRemoveConfirmTitle =
+# ==> vhdlRemoveErrorTitle =
+# ==> vhdlRemoveUsedError =
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -536,9 +536,13 @@ circuitNamePrompt = Naam van het circuit:
 # ==> circuitRemoveConfirmTitle =
 circuitRemoveErrorTitle = Kan de schakeling niet verwijderen
 circuitRemoveLastError = De bibliotheek moet ten minste één circuit bevatten.
-circuitRemoveUsedError = Het circuit dat in andere circuits wordt gebruikt, kan niet worden verwijderd.
+# ==> circuitRemoveUsedError
 vhdlNameDialogTitle = Invoer VHDL Naam van de entiteit
 vhdlNamePrompt = VHDL Naam van de entiteit:
+# ==> vhdlRemoveConfirm =
+# ==> vhdlRemoveConfirmTitle =
+# ==> vhdlRemoveErrorTitle =
+# ==> vhdlRemoveUsedError =
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -536,9 +536,13 @@ circuitNamePrompt = Nazwa obwodu:
 # ==> circuitRemoveConfirmTitle =
 circuitRemoveErrorTitle = Nie można usunąć obwodu
 circuitRemoveLastError = Biblioteka musi zawierać co najmniej jeden obwód.
-circuitRemoveUsedError = Obwód jest używany w innych obwodach i nie może być usunięty.
+# ==> circuitRemoveUsedError
 vhdlNameDialogTitle = Podaj nazwę elementu VHDL
 vhdlNamePrompt = Nazwa elementu VHDL:
+# ==> vhdlRemoveConfirm =
+# ==> vhdlRemoveConfirmTitle =
+# ==> vhdlRemoveErrorTitle =
+# ==> vhdlRemoveUsedError =
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -535,9 +535,13 @@ circuitNamePrompt = Nome do circuito:
 # ==> circuitRemoveConfirmTitle =
 circuitRemoveErrorTitle = Impossível remover circuito
 circuitRemoveLastError = Biblioteca deve conter pelo menos um circuito.
-circuitRemoveUsedError = Impossível remover circuito usado por outro(s).
+# ==> circuitRemoveUsedError
 vhdlNameDialogTitle = Nome da entidade VHDL de entrada
 vhdlNamePrompt = Nome da entidade VHDL:
+# ==> vhdlRemoveConfirm =
+# ==> vhdlRemoveConfirmTitle =
+# ==> vhdlRemoveErrorTitle =
+# ==> vhdlRemoveUsedError =
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -531,13 +531,17 @@ circuitNameInvalidName = Недопустимое имя (оно должно с
 circuitNameKeyword = Это имя является ключевым словом и поэтому не может быть использовано.
 circuitNameMissingError = У каждой схемы должно быть имя.
 circuitNamePrompt = Название схемы:
-circuitRemoveConfirm = Вы уверены, что хотите удалить эту схему?
+# ==> circuitRemoveConfirm =
 circuitRemoveConfirmTitle = Подтверждение удаления
 circuitRemoveErrorTitle = Невозможно удалить схему
 circuitRemoveLastError = Библиотека должна содержать хотя бы одну схему.
-circuitRemoveUsedError = Схема, используемая в других схемах, не может быть удалена.
+# ==> circuitRemoveUsedError
 vhdlNameDialogTitle = Ввод имени сущности VHDL
 vhdlNamePrompt = Имя сущности VHDL:
+# ==> vhdlRemoveConfirm =
+# ==> vhdlRemoveConfirmTitle =
+# ==> vhdlRemoveErrorTitle =
+# ==> vhdlRemoveUsedError =
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -535,9 +535,13 @@ circuitNamePrompt = 电路名称：
 # ==> circuitRemoveConfirmTitle =
 circuitRemoveErrorTitle = 无法删除电路
 circuitRemoveLastError = 库中至少需要包含一个电路。
-circuitRemoveUsedError = 该电路被其他电路使用，无法删除。
+# ==> circuitRemoveUsedError
 vhdlNameDialogTitle = 输入 VHDL 实体名称
 vhdlNamePrompt = VHDL 实体名称：
+# ==> vhdlRemoveConfirm =
+# ==> vhdlRemoveConfirmTitle =
+# ==> vhdlRemoveErrorTitle =
+# ==> vhdlRemoveUsedError =
 #
 # menu/ProjectLibraryActions.java
 #

--- a/src/main/resources/resources/logisim/strings/hdl/hdl_de.properties
+++ b/src/main/resources/resources/logisim/strings/hdl/hdl_de.properties
@@ -1,9 +1,9 @@
 #
 # base/VhdlContent.java
 #
-vhdlDuplicateNameError = Ungültiger VHDL Entitätsname. Namen müssen eindeutig sein.
-vhdlInvalidNameError = Ungültiger VHDL Entitätsname. Namen müssen:\n mit einem Buchstaben beginnen,\n dürfen nur Buchstaben [a-z,A-Z],\n Zahlen [0-9] und Unterstriche [_] enthalten,\n nicht mit einem Unterstrich „_“ enden,\n nicht zwei aufeinanderfolgende Unterstriche „__“ enthalten.
-vhdlKeywordNameError = Ungültiger VHDL Entitätsname. Das ist ein reserviertes Schlüsselwort.
+vhdlDuplicateNameError = Ungültiger VHDL-Entitätsname. Namen müssen eindeutig sein.
+vhdlInvalidNameError = Ungültiger VHDL-Entitätsname. Namen müssen:\n mit einem Buchstaben beginnen,\n dürfen nur Buchstaben [a-z,A-Z],\n Zahlen [0-9] und Unterstriche [_] enthalten,\n nicht mit einem Unterstrich „_“ enden,\n nicht zwei aufeinanderfolgende Unterstriche „__“ enthalten.
+vhdlKeywordNameError = Ungültiger VHDL-Entitätsname. Das ist ein reserviertes Schlüsselwort.
 #
 # base/VhdlEntity.java
 #


### PR DESCRIPTION
- Add the circuit's/VHDL entity's name to the deletion popup. The reason is because the navigation panel toolbar's deletion tool deletes the circuit that is currently opened and not the one that is highlighted in the navigation panel. For me at least, there is room for confusion, so by adding the name people can see and confirm which circuit/VHDL entity they are deleting.
- Improved the navigation panel toolbar itself:
  - Remove the ability to toggle the appearance when having a VHDL entity open. If you opened the appearance of a VHDL entity it would result in buggy behavior.
  - Added the ability to remove VHDL entities with the `x` tool.
  - Added some extra checks for circuit removal: at least one circuit must remain and no other circuits depend on it.
- Made German VHDL compound nouns use a dash, just to be consistent within Logisim.