### PR TITLE
fix: ignore probes during DRC width validation

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/designrulecheck/Netlist.java
+++ b/src/main/java/com/cburch/logisim/fpga/designrulecheck/Netlist.java
@@ -660,6 +660,9 @@ public class Netlist {
             SimpleDrcContainer.MARK_INSTANCE));
     final var points = new HashMap<Location, Integer>();
     for (final var comp : components) {
+      // Probes are intentionally omitted from the generated netlist. Do not
+      // let their one-bit endpoint participate in width validation either.
+      if (comp.getFactory() instanceof Probe) continue;
       for (final var end : comp.getEnds()) {
         final var loc = end.getLocation();
         if (points.containsKey(loc)) {


### PR DESCRIPTION
## Summary

- exclude Probe endpoints from the CMake-style DRC width validation pass
- keep probes transparent to the generated FPGA netlist, matching the existing probe omission in netlist construction
- avoid treating a one-bit probe attached to a wider output as a fatal component-width mismatch

Fixes #2795

## Validation

- `./gradlew.bat test --tests com.cburch.logisim.fpga.designrulecheck.NetlistDrcTest` passes
- replayed the attached `fpgatesting31.circ` circuit locally: the DRC now returns `DRC_PASSED`; without this guard it returned `DRC_ERROR`
- `git diff --check` passes