### PR TITLE
docs: prototype sparse locale overlay generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -206,6 +206,38 @@ java {
   }
 }
 
+val docgen = sourceSets.create("docgen") {
+  java.srcDir("src/docgen/java")
+}
+
+dependencies {
+  testImplementation(docgen.output)
+}
+
+tasks.register<JavaExec>("generateDocumentationPrototype") {
+  group = "documentation"
+  description = "Generates the prototype English and German JavaHelp memory trees."
+  dependsOn(docgen.classesTaskName)
+
+  val manifest = layout.projectDirectory.file("src/main/doc/guide-memory.xml")
+  val germanOverlay = layout.projectDirectory.file("src/main/doc/locales/de-guide-memory.xml")
+  val docRoot = layout.projectDirectory.dir("src/main/resources/doc")
+  val outputRoot = layout.buildDirectory.dir("generated/documentation-prototype")
+
+  classpath = docgen.runtimeClasspath
+  mainClass.set("com.cburch.logisim.docs.DocumentationGenerator")
+  args(
+      manifest.asFile.absolutePath,
+      docRoot.asFile.absolutePath,
+      outputRoot.get().asFile.absolutePath,
+      germanOverlay.asFile.absolutePath,
+  )
+
+  inputs.files(manifest, germanOverlay)
+  inputs.dir(docRoot)
+  outputs.dir(outputRoot)
+}
+
 tasks.register<Jar>("sourcesJar") {
   group = "build"
   description = "Creates a JAR archive with project sources."

--- a/src/docgen/java/com/cburch/logisim/docs/DocumentationGenerator.java
+++ b/src/docgen/java/com/cburch/logisim/docs/DocumentationGenerator.java
@@ -1,0 +1,317 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.docs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public final class DocumentationGenerator {
+
+  private static final String ENGLISH = "en";
+  private static final Pattern LANGUAGE = Pattern.compile("[a-z]{2}");
+  private static final String MAP_PUBLIC_ID =
+      "-//Sun Microsystems Inc.//DTD JavaHelp Map Version 2.0//EN";
+  private static final String MAP_SYSTEM_ID =
+      "http://java.sun.com/products/javahelp/map_2_0.dtd";
+  private static final String TOC_PUBLIC_ID =
+      "-//Sun Microsystems Inc.//DTD JavaHelp TOC Version 2.0//EN";
+  private static final String TOC_SYSTEM_ID =
+      "http://java.sun.com/products/javahelp/toc_2_0.dtd";
+
+  private DocumentationGenerator() {}
+
+  public static void main(String[] args) throws Exception {
+    if (args.length < 3) {
+      throw new IllegalArgumentException(
+          "Usage: DocumentationGenerator <manifest> <doc-root> <output-root> [overlay ...]");
+    }
+
+    final var overlays = new ArrayList<Path>();
+    for (var i = 3; i < args.length; i++) {
+      overlays.add(Path.of(args[i]));
+    }
+    generate(Path.of(args[0]), Path.of(args[1]), Path.of(args[2]), overlays);
+  }
+
+  public static void generate(
+      Path manifestPath, Path docRoot, Path outputRoot, List<Path> overlayPaths)
+      throws Exception {
+    final var topics = readManifest(manifestPath, docRoot);
+    writeLocale(outputRoot, ENGLISH, resolveTopics(topics, Map.of()));
+
+    final var languages = new HashSet<String>();
+    languages.add(ENGLISH);
+    for (final var overlayPath : overlayPaths) {
+      final var overlay = readOverlay(overlayPath, topics, docRoot);
+      if (!languages.add(overlay.language())) {
+        throw new IllegalArgumentException(
+            "Duplicate locale overlay for " + overlay.language());
+      }
+      writeLocale(outputRoot, overlay.language(), resolveTopics(topics, overlay.entries()));
+    }
+  }
+
+  private static List<Topic> readManifest(Path path, Path docRoot) throws Exception {
+    final var document = parseXml(path);
+    final var root = document.getDocumentElement();
+    if (!"documentation".equals(root.getTagName())) {
+      throw new IllegalArgumentException("Expected <documentation> in " + path);
+    }
+    if (!ENGLISH.equals(requiredAttribute(root, "language", path))) {
+      throw new IllegalArgumentException("The canonical manifest language must be English");
+    }
+
+    final var ids = new HashSet<String>();
+    final var topics = new ArrayList<Topic>();
+    for (final var element : childElements(root, "topic")) {
+      topics.add(readTopic(element, path, docRoot, ids));
+    }
+    if (topics.isEmpty()) {
+      throw new IllegalArgumentException("The documentation manifest has no topics");
+    }
+    return List.copyOf(topics);
+  }
+
+  private static Topic readTopic(
+      Element element, Path source, Path docRoot, Set<String> ids) throws IOException {
+    final var id = requiredAttribute(element, "id", source);
+    if (!ids.add(id)) {
+      throw new IllegalArgumentException("Duplicate topic id '" + id + "' in " + source);
+    }
+    final var path = requiredAttribute(element, "path", source);
+    validateDocumentPath(docRoot, path, source);
+
+    final var children = new ArrayList<Topic>();
+    for (final var child : childElements(element, "topic")) {
+      children.add(readTopic(child, source, docRoot, ids));
+    }
+    return new Topic(
+        id,
+        requiredAttribute(element, "title", source),
+        path,
+        List.copyOf(children));
+  }
+
+  private static LocaleOverlay readOverlay(Path path, List<Topic> topics, Path docRoot)
+      throws Exception {
+    final var document = parseXml(path);
+    final var root = document.getDocumentElement();
+    if (!"locale".equals(root.getTagName())) {
+      throw new IllegalArgumentException("Expected <locale> in " + path);
+    }
+    final var language = requiredAttribute(root, "language", path);
+    if (!LANGUAGE.matcher(language).matches() || ENGLISH.equals(language)) {
+      throw new IllegalArgumentException("Invalid overlay language '" + language + "'");
+    }
+
+    final var knownIds = new HashSet<String>();
+    collectIds(topics, knownIds);
+    final var entries = new HashMap<String, LocalizedTopic>();
+    for (final var element : childElements(root, "topic")) {
+      final var id = requiredAttribute(element, "id", path);
+      if (!knownIds.contains(id)) {
+        throw new IllegalArgumentException("Unknown topic id '" + id + "' in " + path);
+      }
+      final var localizedPath = optionalAttribute(element, "path");
+      if (localizedPath != null) {
+        validateDocumentPath(docRoot, localizedPath, path);
+      }
+      final var entry =
+          new LocalizedTopic(requiredAttribute(element, "title", path), localizedPath);
+      if (entries.putIfAbsent(id, entry) != null) {
+        throw new IllegalArgumentException("Duplicate topic id '" + id + "' in " + path);
+      }
+    }
+    return new LocaleOverlay(language, Map.copyOf(entries));
+  }
+
+  private static List<ResolvedTopic> resolveTopics(
+      List<Topic> topics, Map<String, LocalizedTopic> overlay) {
+    return topics.stream().map(topic -> resolveTopic(topic, overlay)).toList();
+  }
+
+  private static ResolvedTopic resolveTopic(
+      Topic topic, Map<String, LocalizedTopic> overlay) {
+    final var localized = overlay.get(topic.id());
+    final var title = localized == null ? topic.title() : localized.title();
+    final var path =
+        localized == null || localized.path() == null ? topic.path() : localized.path();
+    final var children =
+        topic.children().stream().map(child -> resolveTopic(child, overlay)).toList();
+    return new ResolvedTopic(topic.id(), title, path, children);
+  }
+
+  private static void writeLocale(Path outputRoot, String language, List<ResolvedTopic> topics)
+      throws Exception {
+    writeMap(outputRoot.resolve("map_" + language + ".jhm"), topics);
+    writeToc(outputRoot.resolve(language).resolve("contents.xml"), topics);
+  }
+
+  private static void writeMap(Path output, List<ResolvedTopic> topics) throws Exception {
+    final var document = newDocument();
+    final var root = document.createElement("map");
+    root.setAttribute("version", "2.0");
+    document.appendChild(root);
+    appendMapEntries(document, root, topics);
+    writeXml(document, output, MAP_PUBLIC_ID, MAP_SYSTEM_ID);
+  }
+
+  private static void appendMapEntries(
+      Document document, Element root, List<ResolvedTopic> topics) {
+    for (final var topic : topics) {
+      final var entry = document.createElement("mapID");
+      entry.setAttribute("target", topic.id());
+      entry.setAttribute("url", topic.path());
+      root.appendChild(entry);
+      appendMapEntries(document, root, topic.children());
+    }
+  }
+
+  private static void writeToc(Path output, List<ResolvedTopic> topics) throws Exception {
+    final var document = newDocument();
+    final var root = document.createElement("toc");
+    root.setAttribute("version", "2.0");
+    document.appendChild(root);
+    for (final var topic : topics) {
+      root.appendChild(createTocItem(document, topic));
+    }
+    writeXml(document, output, TOC_PUBLIC_ID, TOC_SYSTEM_ID);
+  }
+
+  private static Element createTocItem(Document document, ResolvedTopic topic) {
+    final var item = document.createElement("tocitem");
+    item.setAttribute("target", topic.id());
+    item.setAttribute("text", topic.title());
+    for (final var child : topic.children()) {
+      item.appendChild(createTocItem(document, child));
+    }
+    return item;
+  }
+
+  private static Document parseXml(Path path) throws Exception {
+    final var factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    return factory.newDocumentBuilder().parse(path.toFile());
+  }
+
+  private static Document newDocument() throws Exception {
+    return DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+  }
+
+  private static void writeXml(
+      Document document, Path output, String publicId, String systemId) throws Exception {
+    Files.createDirectories(output.getParent());
+    final var factory = TransformerFactory.newInstance();
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+    final var transformer = factory.newTransformer();
+    transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+    transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+    transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, publicId);
+    transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, systemId);
+    transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+    transformer.transform(new DOMSource(document), new StreamResult(output.toFile()));
+  }
+
+  private static List<Element> childElements(Element parent, String tagName) {
+    final var elements = new ArrayList<Element>();
+    for (var child = parent.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element element && tagName.equals(element.getTagName())) {
+        elements.add(element);
+      }
+    }
+    return elements;
+  }
+
+  private static String requiredAttribute(Element element, String name, Path source) {
+    final var value = optionalAttribute(element, name);
+    if (value == null) {
+      throw new IllegalArgumentException(
+          "Missing attribute '" + name + "' on <" + element.getTagName() + "> in " + source);
+    }
+    return value;
+  }
+
+  private static String optionalAttribute(Element element, String name) {
+    final var value = element.getAttribute(name).trim();
+    return value.isEmpty() ? null : value;
+  }
+
+  private static void validateDocumentPath(Path docRoot, String value, Path source)
+      throws IOException {
+    final var relative = Path.of(value).normalize();
+    final var normalizedRoot = docRoot.toAbsolutePath().normalize();
+    final var resolved = normalizedRoot.resolve(relative).normalize();
+    if (relative.isAbsolute() || !resolved.startsWith(normalizedRoot)) {
+      throw new IllegalArgumentException(
+          "Documentation path points outside the documentation root in " + source + ": " + value);
+    }
+    if (!Files.isRegularFile(resolved)) {
+      throw new IllegalArgumentException(
+          "Documentation path does not exist in " + source + ": " + value);
+    }
+    if (!pathExistsWithExactCase(normalizedRoot, resolved)) {
+      throw new IllegalArgumentException(
+          "Documentation path has a case mismatch in " + source + ": " + value);
+    }
+  }
+
+  private static boolean pathExistsWithExactCase(Path root, Path target) throws IOException {
+    var current = root;
+    for (final var part : root.relativize(target)) {
+      try (var children = Files.list(current)) {
+        if (children.noneMatch(child -> child.getFileName().equals(part))) {
+          return false;
+        }
+      }
+      current = current.resolve(part);
+    }
+    return true;
+  }
+
+  private static void collectIds(List<Topic> topics, Set<String> ids) {
+    for (final var topic : topics) {
+      ids.add(topic.id());
+      collectIds(topic.children(), ids);
+    }
+  }
+
+  private record Topic(String id, String title, String path, List<Topic> children) {}
+
+  private record LocalizedTopic(String title, String path) {}
+
+  private record LocaleOverlay(String language, Map<String, LocalizedTopic> entries) {}
+
+  private record ResolvedTopic(
+      String id, String title, String path, List<ResolvedTopic> children) {}
+}

--- a/src/main/doc/README.md
+++ b/src/main/doc/README.md
@@ -1,0 +1,13 @@
+# Documentation generation prototype
+
+This directory contains authored metadata for the incremental multilingual JavaHelp migration. It
+is not packaged as application help content.
+
+`guide-memory.xml` is the canonical English topic tree for the bounded Memory guide prototype.
+Locale overlays provide translated titles and may explicitly select a reviewed localized page. If
+an overlay omits a topic or its `path`, the generator inherits the corresponding English value;
+the presence of a similarly named file does not select it automatically.
+
+Run `./gradlew generateDocumentationPrototype` to write standalone English and German map and TOC
+artifacts under `build/generated/documentation-prototype`. These prototype artifacts do not yet
+replace the complete hand-maintained JavaHelp files packaged by the application.

--- a/src/main/doc/guide-memory.xml
+++ b/src/main/doc/guide-memory.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<documentation language="en">
+  <topic id="mem_guide" title="Memory components" path="en/html/guide/mem/index.html">
+    <topic id="mem_poke" title="Memory poke" path="en/html/guide/mem/mem-poke.html" />
+    <topic id="mem_hex" title="Editeur hexadécimal" path="en/html/guide/mem/mem-hex.html" />
+    <topic id="mem_menu" title="Pop-up menus and files" path="en/html/guide/mem/mem-menu.html" />
+    <topic
+        id="mem_filetabel"
+        title="Memory file panel"
+        path="en/html/guide/mem/mem-filepanel.html" />
+    <topic id="mem_v2raw" title="File v2raw" path="en/html/guide/mem/mem-v2raw.html" />
+    <topic id="mem_v3word" title="File v3word" path="en/html/guide/mem/mem-v3word.html" />
+    <topic id="mem_v3byte" title="File v3byte" path="en/html/guide/mem/mem-v3byte.html" />
+    <topic id="mem_binary" title="File binary" path="en/html/guide/mem/mem-vbinary.html" />
+    <topic id="mem_ascii" title="File ASCII" path="en/html/guide/mem/mem-vascii.html" />
+  </topic>
+</documentation>

--- a/src/main/doc/locales/de-guide-memory.xml
+++ b/src/main/doc/locales/de-guide-memory.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<locale language="de">
+  <topic
+      id="mem_guide"
+      title="Speicherbauelemente"
+      path="de/html/guide/mem/index.html" />
+  <topic
+      id="mem_poke"
+      title="Speicherinhalte bearbeiten"
+      path="de/html/guide/mem/mem-poke.html" />
+  <topic id="mem_hex" title="Hex-Editor" path="de/html/guide/mem/mem-hex.html" />
+  <topic
+      id="mem_menu"
+      title="Kontextmenüs und Dateien"
+      path="de/html/guide/mem/mem-menu.html" />
+  <topic id="mem_filetabel" title="Speicherdatei-Panel" />
+  <topic id="mem_v2raw" title="v2raw-Date" />
+  <topic id="mem_v3word" title="v3word-Date" />
+  <topic id="mem_v3byte" title="v3byte-Date" />
+  <topic id="mem_binary" title="Binärdatei" />
+  <topic id="mem_ascii" title="ascii-Datei" />
+</locale>

--- a/src/main/resources/doc/map_de.jhm
+++ b/src/main/resources/doc/map_de.jhm
@@ -41,13 +41,13 @@
     <mapID target="mem_guide"           url="de/html/guide/mem/index.html"/>
     <mapID target="mem_poke"            url="de/html/guide/mem/mem-poke.html" />
     <mapID target="mem_menu"            url="de/html/guide/mem/mem-menu.html"/>
-    <mapID target="mem_filetabel"       url="de/html/guide/mem/mem-filepanel.html"/>
+    <mapID target="mem_filetabel"       url="en/html/guide/mem/mem-filepanel.html"/>
     <mapID target="mem_hex"             url="de/html/guide/mem/mem-hex.html"/>  
-    <mapID target="mem_v2raw"           url="de/html/guide/mem/mem-v2raw.html"/>  
-    <mapID target="mem_v3word"          url="de/html/guide/mem/mem-v3word.html"/> 
-    <mapID target="mem_v3byte"          url="de/html/guide/mem/mem-v3byte.html"/> 
-    <mapID target="mem_binary"          url="de/html/guide/mem/mem-vbinary.html"/>
-    <mapID target="mem_ascii"           url="de/html/guide/mem/mem-vascii.html"/>
+    <mapID target="mem_v2raw"           url="en/html/guide/mem/mem-v2raw.html"/>
+    <mapID target="mem_v3word"          url="en/html/guide/mem/mem-v3word.html"/>
+    <mapID target="mem_v3byte"          url="en/html/guide/mem/mem-v3byte.html"/>
+    <mapID target="mem_binary"          url="en/html/guide/mem/mem-vbinary.html"/>
+    <mapID target="mem_ascii"           url="en/html/guide/mem/mem-vascii.html"/>
 	<mapID target="test_vector"         url="de/html/guide/test_vector/index.html" />
 	<mapID target="test_vector_window"  url="de/html/guide/test_vector/test_vector_window.html" />
 	<mapID target="test_vector_file_format" url="de/html/guide/test_vector/test_vector_file_format.html" />

--- a/src/test/java/com/cburch/logisim/docs/DocumentationGeneratorTest.java
+++ b/src/test/java/com/cburch/logisim/docs/DocumentationGeneratorTest.java
@@ -1,0 +1,178 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.docs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+class DocumentationGeneratorTest {
+
+  private static final Path DOC_ROOT = Path.of("src", "main", "resources", "doc");
+  private static final Path MANIFEST = Path.of("src", "main", "doc", "guide-memory.xml");
+  private static final Path GERMAN_OVERLAY =
+      Path.of("src", "main", "doc", "locales", "de-guide-memory.xml");
+
+  @TempDir Path temporaryDirectory;
+
+  @Test
+  void generatesLegacyCompatibleEnglishAndGermanMemoryTrees() throws Exception {
+    DocumentationGenerator.generate(
+        MANIFEST, DOC_ROOT, temporaryDirectory, List.of(GERMAN_OVERLAY));
+
+    assertGeneratedMapMatchesLegacy("en");
+    assertGeneratedMapMatchesLegacy("de");
+    assertGeneratedTocMatchesLegacy("en");
+    assertGeneratedTocMatchesLegacy("de");
+
+    final var germanMap = mapEntries(parseXml(temporaryDirectory.resolve("map_de.jhm")));
+    assertEquals(
+        4, germanMap.values().stream().filter(path -> path.startsWith("de/")).count());
+    assertEquals(
+        6, germanMap.values().stream().filter(path -> path.startsWith("en/")).count());
+  }
+
+  @Test
+  void sparseOverlayFallsBackToEnglishFields() throws Exception {
+    final var sparseOverlay = temporaryDirectory.resolve("sparse-de.xml");
+    Files.writeString(
+        sparseOverlay,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <locale language="de">
+          <topic
+              id="mem_guide"
+              title="Speicherbauelemente"
+              path="de/html/guide/mem/index.html" />
+        </locale>
+        """,
+        StandardCharsets.UTF_8);
+    final var output = temporaryDirectory.resolve("sparse-output");
+
+    DocumentationGenerator.generate(MANIFEST, DOC_ROOT, output, List.of(sparseOverlay));
+
+    final var germanMap = mapEntries(parseXml(output.resolve("map_de.jhm")));
+    assertEquals("de/html/guide/mem/index.html", germanMap.get("mem_guide"));
+    assertEquals("en/html/guide/mem/mem-poke.html", germanMap.get("mem_poke"));
+
+    final var germanToc = parseXml(output.resolve("de").resolve("contents.xml"));
+    assertEquals("Speicherbauelemente", findTocItem(germanToc, "mem_guide").getAttribute("text"));
+    assertEquals("Memory poke", findTocItem(germanToc, "mem_poke").getAttribute("text"));
+  }
+
+  @Test
+  void rejectsExplicitLocalizedPathThatDoesNotExist() throws Exception {
+    final var invalidOverlay = temporaryDirectory.resolve("invalid-de.xml");
+    Files.writeString(
+        invalidOverlay,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <locale language="de">
+          <topic
+              id="mem_guide"
+              title="Speicherbauelemente"
+              path="de/html/guide/mem/missing.html" />
+        </locale>
+        """,
+        StandardCharsets.UTF_8);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            DocumentationGenerator.generate(
+                MANIFEST,
+                DOC_ROOT,
+                temporaryDirectory.resolve("invalid-output"),
+                List.of(invalidOverlay)));
+  }
+
+  private void assertGeneratedMapMatchesLegacy(String language) throws Exception {
+    final var generated =
+        mapEntries(parseXml(temporaryDirectory.resolve("map_" + language + ".jhm")));
+    final var legacy = mapEntries(parseXml(DOC_ROOT.resolve("map_" + language + ".jhm")));
+    final var legacySubset = new LinkedHashMap<String, String>();
+    for (final var target : generated.keySet()) {
+      legacySubset.put(target, legacy.get(target));
+    }
+    assertEquals(generated, legacySubset);
+  }
+
+  private void assertGeneratedTocMatchesLegacy(String language) throws Exception {
+    final var generated =
+        parseXml(temporaryDirectory.resolve(language).resolve("contents.xml"));
+    final var legacy = parseXml(DOC_ROOT.resolve(language).resolve("contents.xml"));
+    final var generatedRoot = findTocItem(generated, "mem_guide");
+    final var legacyRoot = findTocItem(legacy, "mem_guide");
+    assertEquals(tocEntries(generatedRoot), tocEntries(legacyRoot));
+  }
+
+  private static Document parseXml(Path path) throws Exception {
+    final var factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    return factory.newDocumentBuilder().parse(path.toFile());
+  }
+
+  private static Map<String, String> mapEntries(Document document) {
+    final var entries = new LinkedHashMap<String, String>();
+    final var mapIds = document.getElementsByTagName("mapID");
+    for (var i = 0; i < mapIds.getLength(); i++) {
+      final var element = (Element) mapIds.item(i);
+      entries.putIfAbsent(element.getAttribute("target"), element.getAttribute("url"));
+    }
+    return entries;
+  }
+
+  private static Element findTocItem(Document document, String target) {
+    final var items = document.getElementsByTagName("tocitem");
+    for (var i = 0; i < items.getLength(); i++) {
+      final var element = (Element) items.item(i);
+      if (target.equals(element.getAttribute("target"))) {
+        return element;
+      }
+    }
+    return fail("Missing TOC target " + target);
+  }
+
+  private static List<String> tocEntries(Element root) {
+    final var entries = new ArrayList<String>();
+    collectTocEntries(root, 0, entries);
+    return entries;
+  }
+
+  private static void collectTocEntries(Element item, int depth, List<String> entries) {
+    entries.add(
+        depth + "|" + item.getAttribute("target") + "|" + item.getAttribute("text"));
+    for (var child = item.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element element && "tocitem".equals(element.getTagName())) {
+        collectTocEntries(element, depth + 1, entries);
+      }
+    }
+  }
+}

--- a/src/test/resources/documentation-known-issues.txt
+++ b/src/test/resources/documentation-known-issues.txt
@@ -40,12 +40,6 @@ map_de.jhm: mapID 'gates_PLA' points to missing file de/html/libs/gates/pla.html
 map_de.jhm: mapID 'io_Port_IO' points to missing file de/html/libs/io/Port_io.html
 map_de.jhm: mapID 'io_Repetar' points to missing file de/html/libs/io/repetar.html
 map_de.jhm: mapID 'log_timetable' points to missing file de/html/guide/log/timetable.html
-map_de.jhm: mapID 'mem_ascii' points to missing file de/html/guide/mem/mem-vascii.html
-map_de.jhm: mapID 'mem_binary' points to missing file de/html/guide/mem/mem-vbinary.html
-map_de.jhm: mapID 'mem_filetabel' points to missing file de/html/guide/mem/mem-filepanel.html
-map_de.jhm: mapID 'mem_v2raw' points to missing file de/html/guide/mem/mem-v2raw.html
-map_de.jhm: mapID 'mem_v3byte' points to missing file de/html/guide/mem/mem-v3byte.html
-map_de.jhm: mapID 'mem_v3word' points to missing file de/html/guide/mem/mem-v3word.html
 map_de.jhm: mapID 'nios2_sim' points to missing file de/html/libs/soc/nios2.html
 map_de.jhm: mapID 'prefs_intl' points to missing file de/html/guide/prefs/pref-intl.html
 map_de.jhm: mapID 'soc' points to missing file de/html/libs/soc/index.html


### PR DESCRIPTION
## Summary

- add a separate documentation-generator source set and a Gradle task that produces standalone JavaHelp map and TOC prototype artifacts
- model the ten-topic English Memory guide as a canonical tree and German as a sparse overlay with explicit localized paths
- inherit English titles and paths when an overlay omits them, while rejecting unknown or duplicate IDs, unsafe paths, missing files, and path case mismatches
- replace six broken German Memory map paths with their existing English pages and remove those findings from the known-debt baseline

## Motivation

This is the second review-sized implementation step for #2762, following the merged validator and whole-HelpSet fallback in #2793. The Memory guide is a bounded prototype with both relevant cases: four reviewed German pages exist, while six topics have German TOC titles but only English pages.

The overlay therefore selects German content only for the four existing pages. The other six paths inherit English explicitly through the manifest model rather than inferring translation status from similarly named files.

The generated artifacts are currently standalone prototypes under `build/generated/documentation-prototype`. They do not replace the complete JavaHelp files packaged by the application. This PR does not close #2762, migrate other documentation trees or languages, generate search databases, or change the historical #2579 branch.

## Validation

- `./gradlew generateDocumentationPrototype check` (with Git's bundled `xxd` added only to the command's `PATH` for the existing Windows `HexFileTest` dependency)
- focused generator and JavaHelp structure tests after the final edits
- `git diff --check`
- Windows GUI: all ten German Memory TOC titles remain; four topics open German pages and six inherited topics open English pages without blank or unavailable-help states
