### PR TITLE
Feature/editor theme preference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
       bit-range labels to be visible on dark backgrounds.
     * Replaced hard-coded hex color literals with named `DEFAULT_*`/`DARK_*` constants
       in class `AppPreferences`.
+  * Added separate light and dark code editor theme preferences for HDL and assembly editors.
   * Improved Timing Diagram recording and exports:
     * Corrected vector and GIF exports.
     * Corrected reset offsets, non-50% duty-cycle clocks, real-time traces, and RAM memory traces.

--- a/src/main/java/com/cburch/logisim/gui/generic/EditorTheme.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/EditorTheme.java
@@ -1,0 +1,54 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.generic;
+
+import com.cburch.logisim.prefs.AppPreferences;
+import java.beans.PropertyChangeListener;
+import java.io.IOException;
+import javax.swing.SwingUtilities;
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
+import org.fife.ui.rsyntaxtextarea.Theme;
+
+public final class EditorTheme {
+  private static final String LISTENER_KEY = EditorTheme.class.getName() + ".listener";
+  private static final String THEME_ROOT = "/org/fife/ui/rsyntaxtextarea/themes/";
+
+  private EditorTheme() {}
+
+  public static void install(RSyntaxTextArea editor) {
+    apply(editor);
+
+    final PropertyChangeListener listener =
+        event -> {
+          if (AppPreferences.LookAndFeel.isSource(event)) {
+            SwingUtilities.invokeLater(() -> apply(editor));
+          } else if (AppPreferences.LIGHT_EDITOR_THEME.isSource(event)
+              || AppPreferences.DARK_EDITOR_THEME.isSource(event)) {
+            apply(editor);
+          }
+        };
+    editor.putClientProperty(LISTENER_KEY, listener);
+    AppPreferences.addPropertyChangeListener(listener);
+  }
+
+  private static void apply(RSyntaxTextArea editor) {
+    final var preference =
+        AppPreferences.isDarkTheme(AppPreferences.LookAndFeel.get())
+            ? AppPreferences.DARK_EDITOR_THEME
+            : AppPreferences.LIGHT_EDITOR_THEME;
+    final var themePath = THEME_ROOT + preference.get() + ".xml";
+    try (final var input = EditorTheme.class.getResourceAsStream(themePath)) {
+      if (input != null) {
+        Theme.load(input).apply(editor);
+      }
+    } catch (IOException ignored) {
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/gui/generic/ZoomControl.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ZoomControl.java
@@ -97,6 +97,7 @@ public class ZoomControl extends JPanel {
   }
 
   private int nearestZoomOption() {
+    if (model == null) return 0;
     final var choices = model.getZoomOptions();
     final var factor = model.getZoomFactor() * 100.0;
     var closest = 0;

--- a/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -70,6 +70,8 @@ class WindowOptions extends OptionsPanel {
   private final JLabel zoomLabel;
   private final JTextArea zoomFactorImportant;
   private final JComboBox<String> lookAndFeel;
+  private final JLabel editorThemeLabel;
+  private final JComboBox<String> editorTheme;
   private final JComboBox<String> appFont;
   private final LookAndFeelInfo[] lookAndFeelInfos;
   private int index = 0;
@@ -191,6 +193,17 @@ class WindowOptions extends OptionsPanel {
         lookAndFeel.setSelectedIndex(index = i);
       }
     }
+
+    editorTheme = new JComboBox<>();
+    editorTheme.addItem("Default");
+    editorTheme.addItem("Dark");
+    editorTheme.addItem("Monokai");
+    editorTheme.addItem("Eclipse");
+    editorTheme.addItem("IDEA");
+    editorTheme.addItem("Visual Studio");
+    editorTheme.addItem("Druid");
+    updateEditorThemeSelection();
+    editorThemeLabel = new JLabel(S.get("windowEditorTheme"));
     
     appFont = new JComboBox<>();
     appFont.addItem(S.get("windowAppFontDefault"));
@@ -208,6 +221,10 @@ class WindowOptions extends OptionsPanel {
     panel.add(lookfeelLabel);
     panel.add(lookAndFeel);
     lookAndFeel.addActionListener(listener);
+
+    panel.add(editorThemeLabel);
+    panel.add(editorTheme);
+    editorTheme.addActionListener(listener);
 
     panel.add(appFontLabel);
     panel.add(appFont);
@@ -258,6 +275,20 @@ class WindowOptions extends OptionsPanel {
     }
   }
 
+  private void updateEditorThemeSelection() {
+    final var preference =
+        AppPreferences.isDarkTheme(AppPreferences.LookAndFeel.get())
+            ? AppPreferences.DARK_EDITOR_THEME
+            : AppPreferences.LIGHT_EDITOR_THEME;
+    final var selectedTheme = preference.get();
+    for (var i = 0; i < AppPreferences.EDITOR_THEMES.length; i++) {
+      if (AppPreferences.EDITOR_THEMES[i].equals(selectedTheme)) {
+        editorTheme.setSelectedIndex(i);
+        return;
+      }
+    }
+  }
+
   @Override
   public String getHelpText() {
     return S.get("windowHelp");
@@ -276,6 +307,7 @@ class WindowOptions extends OptionsPanel {
     toolbarPlacement.localeChanged();
     zoomLabel.setText(S.get("windowToolbarZoomfactor"));
     lookfeelLabel.setText(S.get("windowToolbarLookandfeel"));
+    editorThemeLabel.setText(S.get("windowEditorTheme"));
     appFontLabel.setText(S.get("windowAppFont"));
     restartWarning.setText(S.get("windowRestartWarning"));
     zoomFactorImportant.setText(S.get("windowToolbarImportant"));
@@ -316,8 +348,18 @@ class WindowOptions extends OptionsPanel {
           AppPreferences.LookAndFeel.set(lookAndFeelInfos[index].getClassName());
           AppPreferences.applyThemeColors();
           applyLookAndFeelGlobally(lookAndFeelInfos[index].getClassName());
+          updateEditorThemeSelection();
         }
         checkRestartWarning();
+      } else if (e.getSource().equals(editorTheme)) {
+        final var selectedIndex = editorTheme.getSelectedIndex();
+        if (selectedIndex >= 0 && selectedIndex < AppPreferences.EDITOR_THEMES.length) {
+          final var preference =
+              AppPreferences.isDarkTheme(AppPreferences.LookAndFeel.get())
+                  ? AppPreferences.DARK_EDITOR_THEME
+                  : AppPreferences.LIGHT_EDITOR_THEME;
+          preference.set(AppPreferences.EDITOR_THEMES[selectedIndex]);
+        }
       } else if (e.getSource().equals(appFont)) {
         String val = (String) appFont.getSelectedItem();
         AppPreferences.APP_FONT.set(S.get("windowAppFontDefault").equals(val) ? "" : val);

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -560,6 +560,19 @@ public class AppPreferences {
   public static final PrefMonitor<String> LookAndFeel =
       create(new PrefMonitorString("LookAndFeel", FlatIntelliJLaf.class.getName()));
 
+  public static final String EDITOR_THEME_DEFAULT = "default";
+  public static final String EDITOR_THEME_DARK = "dark";
+  public static final String[] EDITOR_THEMES = {
+    EDITOR_THEME_DEFAULT, EDITOR_THEME_DARK, "monokai", "eclipse", "idea", "vs", "druid"
+  };
+  public static final PrefMonitor<String> LIGHT_EDITOR_THEME =
+      create(
+          new PrefMonitorStringOpts(
+              "lightEditorTheme", EDITOR_THEMES, EDITOR_THEME_DEFAULT));
+  public static final PrefMonitor<String> DARK_EDITOR_THEME =
+      create(
+          new PrefMonitorStringOpts("darkEditorTheme", EDITOR_THEMES, EDITOR_THEME_DARK));
+
   public static final PrefMonitor<String> APP_FONT =
       create(new PrefMonitorString("AppFont", ""));
 

--- a/src/main/java/com/cburch/logisim/prefs/PrefMonitorString.java
+++ b/src/main/java/com/cburch/logisim/prefs/PrefMonitorString.java
@@ -75,6 +75,7 @@ class PrefMonitorString extends AbstractPrefMonitor<String> {
     if (!isSame(oldValue, newValue)) {
       value = newValue;
       AppPreferences.getPrefs().put(getIdentifier(), newValue);
+      AppPreferences.firePropertyChange(getIdentifier(), oldValue, newValue);
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/soc/gui/AssemblerPanel.java
+++ b/src/main/java/com/cburch/logisim/soc/gui/AssemblerPanel.java
@@ -29,7 +29,6 @@ import com.cburch.logisim.soc.util.Assembler;
 import com.cburch.logisim.soc.util.AssemblerInterface;
 import com.cburch.logisim.util.LocaleListener;
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -153,7 +152,6 @@ public class AssemblerPanel extends JPanel
     info.add(Box.createHorizontalStrut(5));
     info.add(helpLabel);
     info.add(Box.createHorizontalGlue());
-    lineLabel.setOpaque(true);
     info.add(lineLabel);
     info.setPreferredSize(new Dimension(40, AppPreferences.getScaled(20)));
     setLayout(new BorderLayout());
@@ -264,7 +262,6 @@ public class AssemblerPanel extends JPanel
   }
 
   private void updateLineNumber() {
-    lineLabel.setBackground(documentChanged ? Color.YELLOW : Color.WHITE);
     lineLabel.setText(S.get("RV32imAsmLineIndicator", lineNumber, numberOfLines));
     lineLabel.repaint();
   }

--- a/src/main/java/com/cburch/logisim/soc/gui/AssemblerPanel.java
+++ b/src/main/java/com/cburch/logisim/soc/gui/AssemblerPanel.java
@@ -16,6 +16,7 @@ import com.cburch.contracts.BaseKeyListenerContract;
 import com.cburch.contracts.BaseMouseListenerContract;
 import com.cburch.contracts.BaseWindowListenerContract;
 import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.gui.generic.EditorTheme;
 import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.gui.icons.CompileIcon;
 import com.cburch.logisim.gui.icons.ErrorIcon;
@@ -162,6 +163,7 @@ public class AssemblerPanel extends JPanel
     this.assembler = new Assembler(assembler, debugScrollPane);
     asmWindow.addParser(this.assembler);
     localeChanged();
+    EditorTheme.install(asmWindow);
   }
 
   private void openFile() {

--- a/src/main/java/com/cburch/logisim/soc/gui/BreakpointPanel.java
+++ b/src/main/java/com/cburch/logisim/soc/gui/BreakpointPanel.java
@@ -13,6 +13,7 @@ import static com.cburch.logisim.soc.Strings.S;
 
 import com.cburch.contracts.BaseKeyListenerContract;
 import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.gui.generic.EditorTheme;
 import com.cburch.logisim.gui.icons.BreakpointIcon;
 import com.cburch.logisim.soc.data.SocProcessorInterface;
 import com.cburch.logisim.soc.file.ElfProgramHeader;
@@ -82,6 +83,7 @@ public class BreakpointPanel extends JPanel
     debugLines = new HashMap<>();
     localeChanged();
     LocaleManager.addLocaleListener(this);
+    EditorTheme.install(asmWindow);
   }
 
   public void loadProgram(

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlContentEditor.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlContentEditor.java
@@ -231,10 +231,10 @@ public class HdlContentEditor extends JDialog implements JInputDialog {
     editor.setCodeFoldingEnabled(true);
     editor.setAntiAliasingEnabled(true);
     editor.getDocument().addDocumentListener(editorListener);
-    EditorTheme.install(editor);
 
     final var sp = new RTextScrollPane(editor);
     sp.setFoldIndicatorEnabled(true);
+    EditorTheme.install(editor);
 
     add(sp, BorderLayout.CENTER);
     add(buttonsPanel, BorderLayout.SOUTH);

--- a/src/main/java/com/cburch/logisim/std/hdl/HdlContentEditor.java
+++ b/src/main/java/com/cburch/logisim/std/hdl/HdlContentEditor.java
@@ -15,6 +15,7 @@ import com.cburch.contracts.BaseDocumentListenerContract;
 import com.cburch.hdl.HdlFile;
 import com.cburch.hdl.HdlModel;
 import com.cburch.hdl.HdlModelListener;
+import com.cburch.logisim.gui.generic.EditorTheme;
 import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.util.FileUtil;
@@ -230,6 +231,7 @@ public class HdlContentEditor extends JDialog implements JInputDialog {
     editor.setCodeFoldingEnabled(true);
     editor.setAntiAliasingEnabled(true);
     editor.getDocument().addDocumentListener(editorListener);
+    EditorTheme.install(editor);
 
     final var sp = new RTextScrollPane(editor);
     sp.setFoldIndicatorEnabled(true);

--- a/src/main/java/com/cburch/logisim/vhdl/gui/HdlContentEditor.java
+++ b/src/main/java/com/cburch/logisim/vhdl/gui/HdlContentEditor.java
@@ -12,6 +12,7 @@ package com.cburch.logisim.vhdl.gui;
 import static com.cburch.logisim.vhdl.Strings.S;
 
 import com.cburch.contracts.BaseDocumentListenerContract;
+import com.cburch.logisim.gui.generic.EditorTheme;
 import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.util.FileUtil;
@@ -221,6 +222,7 @@ public class HdlContentEditor extends JDialog implements JInputDialog {
     editor.setCodeFoldingEnabled(true);
     editor.setAntiAliasingEnabled(true);
     editor.getDocument().addDocumentListener(editorListener);
+    EditorTheme.install(editor);
 
     RTextScrollPane sp = new RTextScrollPane(editor);
     sp.setFoldIndicatorEnabled(true);

--- a/src/main/java/com/cburch/logisim/vhdl/gui/HdlContentEditor.java
+++ b/src/main/java/com/cburch/logisim/vhdl/gui/HdlContentEditor.java
@@ -222,10 +222,10 @@ public class HdlContentEditor extends JDialog implements JInputDialog {
     editor.setCodeFoldingEnabled(true);
     editor.setAntiAliasingEnabled(true);
     editor.getDocument().addDocumentListener(editorListener);
-    EditorTheme.install(editor);
 
     RTextScrollPane sp = new RTextScrollPane(editor);
     sp.setFoldIndicatorEnabled(true);
+    EditorTheme.install(editor);
 
     add(sp, BorderLayout.CENTER);
     add(buttonsPanel, BorderLayout.SOUTH);

--- a/src/main/java/com/cburch/logisim/vhdl/gui/HdlContentView.java
+++ b/src/main/java/com/cburch/logisim/vhdl/gui/HdlContentView.java
@@ -13,6 +13,7 @@ import static com.cburch.logisim.vhdl.Strings.S;
 
 import com.cburch.contracts.BaseDocumentListenerContract;
 import com.cburch.draw.toolbar.ToolbarModel;
+import com.cburch.logisim.gui.generic.EditorTheme;
 import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.proj.Action;
 import com.cburch.logisim.proj.Project;
@@ -166,6 +167,7 @@ public class HdlContentView extends JPanel
     this.model = null;
     this.toolbar = new HdlToolbarModel(proj, this);
     configure("vhdl");
+    EditorTheme.install(editor);
   }
 
   private void configure(String lang) {

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -723,6 +723,7 @@ windowToolbarHidden = Hidden
 windowToolbarImportant = Important: changing the zoom factor manually may have unpredictable results\nand requires a restart of Logisim for the changes to take effect.
 windowToolbarLocation = Toolbar location:
 windowToolbarLookandfeel = Look and feel:
+windowEditorTheme = Editor theme:
 windowToolbarPreview = Preview
 windowToolbarReset = Reset window layout to Logisim’s defaults
 windowToolbarZoomfactor = Zoom factor

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -724,6 +724,7 @@ windowToolbarHidden = Versteckt
 windowToolbarImportant = Wichtig: Das manuelle Ändern des Zoomfaktors kann zu unvorhersehbaren Ergebnissen führen\nund erfordert einen Neustart von Logisim, damit die Änderungen wirksam werden.
 windowToolbarLocation = Position der Werkzeugleiste
 windowToolbarLookandfeel = Sehen und Fühlen:
+# ==> windowEditorTheme =
 windowToolbarPreview = Preview
 windowToolbarReset = Fensterlayout auf Logisim-evolutions Standardeinstellungen zurücksetzen
 windowToolbarZoomfactor = Zoom-Faktor

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -722,6 +722,7 @@ windowToolbarHidden = Κρυφό
 # ==> windowToolbarImportant =
 windowToolbarLocation = Θέση Εργαλειοθήκης
 # ==> windowToolbarLookandfeel =
+# ==> windowEditorTheme =
 # ==> windowToolbarPreview =
 # ==> windowToolbarReset =
 # ==> windowToolbarZoomfactor =

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -724,6 +724,7 @@ windowToolbarHidden = Oculto
 # ==> windowToolbarImportant =
 windowToolbarLocation = Posición de la barra de herramientas:
 windowToolbarLookandfeel = Apariencia:
+# ==> windowEditorTheme =
 # ==> windowToolbarPreview =
 # ==> windowToolbarReset =
 windowToolbarZoomfactor = Factor de zoom

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -723,6 +723,7 @@ windowToolbarHidden = Caché
 windowToolbarImportant = Important : modifier le facteur de zoom manuellement peut avoir des résultats imprévisibles\net nécessite un redémarrage de Logisim pour que les modifications soient prises en compte.
 windowToolbarLocation = Position de la barre d’outils :
 windowToolbarLookandfeel = Apparence :
+# ==> windowEditorTheme =
 windowToolbarPreview = Prévisualisation
 windowToolbarReset = Réinitialiser la disposition de la fenêtre aux valeurs par défaut
 windowToolbarZoomfactor = Facteur de zoom

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -723,6 +723,7 @@ windowToolbarHidden = Nascosta
 # ==> windowToolbarImportant =
 windowToolbarLocation = Posizione barra strumenti:
 windowToolbarLookandfeel = Guarda e senti:
+# ==> windowEditorTheme =
 # ==> windowToolbarPreview =
 # ==> windowToolbarReset =
 windowToolbarZoomfactor = Fattore di zoom

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -722,6 +722,7 @@ windowToolbarHidden = 隠す
 # ==> windowToolbarImportant =
 windowToolbarLocation = ツールバーの位置:
 windowToolbarLookandfeel = 外観および操作感:
+# ==> windowEditorTheme =
 # ==> windowToolbarPreview =
 windowToolbarReset = ウィンドウレイアウトをlogisimsのデフォルト設定にリセットします。
 windowToolbarZoomfactor = ズームファクタ

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -724,6 +724,7 @@ windowToolbarHidden = Verborgen
 # ==> windowToolbarImportant =
 windowToolbarLocation = Locatie van de werkbalk:
 windowToolbarLookandfeel = User interface thema:
+# ==> windowEditorTheme =
 windowToolbarPreview = Voorbeeld
 windowToolbarReset = Reset de vensterlay-out naar de standaard lay-out.
 windowToolbarZoomfactor = Uitvergrotingsfactor

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -724,6 +724,7 @@ windowToolbarHidden = Ukryty
 # ==> windowToolbarImportant =
 windowToolbarLocation = Lokalizacja paska narzędzi:
 windowToolbarLookandfeel = Wygląd:
+# ==> windowEditorTheme =
 windowToolbarPreview = Podgląd
 windowToolbarReset = Przywróć ustawienia domyślne
 windowToolbarZoomfactor = Skalowanie

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -723,6 +723,7 @@ windowToolbarHidden = Ocultar a barra de ferramentas
 # ==> windowToolbarImportant =
 windowToolbarLocation = Posição da barra de ferramentas:
 windowToolbarLookandfeel = Temas:
+# ==> windowEditorTheme =
 windowToolbarPreview = Preview
 windowToolbarReset = Resetar o layout da janela para os padrões do Logisim
 windowToolbarZoomfactor = Fator Zoom

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -723,6 +723,7 @@ windowToolbarHidden = Скрыта
 windowToolbarImportant = Важно: изменение указанных ниже значений может привести к\nнепредсказуемым результатам!
 windowToolbarLocation = Расположение панели инструментов:
 windowToolbarLookandfeel = Стиль интерфейса:
+# ==> windowEditorTheme =
 windowToolbarPleaserestart = Пожалуйста, перезапустите Logisim.
 windowToolbarPreview = Предпросмотр
 windowToolbarReset = Сбросить расположение окон к настройкам по умолчанию Logisim

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -723,6 +723,7 @@ windowToolbarHidden = 隐藏
 # ==> windowToolbarImportant =
 windowToolbarLocation = 工具栏位置：
 windowToolbarLookandfeel = 外观样式：
+windowEditorTheme = 代码编辑器主题：
 windowToolbarPreview = 预览
 windowToolbarReset = 将窗口布局重置为 Logisim 的默认值
 windowToolbarZoomfactor = 缩放系数
@@ -735,8 +736,9 @@ windowGridDotColor = 栅格点颜色：
 windowGridZoomedDotColor = 栅格缩放点颜色：
 windowGridColorsReset = 将网格颜色重置为 Logisim 的默认值
 windowSetAutoScaleFactor = 将缩放比例重置为 Logisim 的默认值
-# ==> windowAppFont =
-# ==> windowAppFontDefault =
+# TODO: Consider shortening “应用程序字体” to “字体”.
+windowAppFont = 应用程序字体：
+windowAppFontDefault = 默认
 # ==> windowRestartWarning =
 windowCanvasLocation = 主画布位置：
 #


### PR DESCRIPTION
Completed the theme settings for the HDL and assembly code editing page of #2662. 

It can be set in `preferencea` -> `window` -> `Editor theme`.