### PR TITLE
Adds component tree filtering feature.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,7 @@
   * Added and updated documentation for Telnet, FPGA Commander reports, the board editor, JAR
     libraries, wire values, transistor behavior, and unused-library save options.
   * Added a default text-tool color preference and synchronized string-option preference updates.
+  * Component tree can now be filtered. Any part of the name matches, and multiple words match in any order.
   * Many other bug fixes.
 
 * v4.1.0 (2026-02-15)

--- a/src/main/java/com/cburch/contracts/BaseTreeModelListenerContract.java
+++ b/src/main/java/com/cburch/contracts/BaseTreeModelListenerContract.java
@@ -1,0 +1,35 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.contracts;
+
+import javax.swing.event.TreeModelEvent;
+import javax.swing.event.TreeModelListener;
+
+public interface BaseTreeModelListenerContract extends TreeModelListener {
+  @Override
+  default void treeNodesChanged(TreeModelEvent event) {
+      // intentional no-op
+  }
+
+  @Override
+  default void treeNodesInserted(TreeModelEvent event) {
+      // intentional no-op
+  }
+
+  @Override
+  default void treeNodesRemoved(TreeModelEvent event) {
+      // intentional no-op
+  }
+
+  @Override
+  default void treeStructureChanged(TreeModelEvent event) {
+      // intentional no-op
+  }
+}

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
@@ -139,7 +139,9 @@ public class ProjectExplorer extends JTree implements LocaleListener {
     if (model.isFiltering()) {
       expandAllRows();
     } else if (unfilteredExpandedPaths != null) {
-      for (final var path : unfilteredExpandedPaths) expandPath(path);
+      for (final var path : unfilteredExpandedPaths) {
+        expandPath(path);
+      }
       unfilteredExpandedPaths = null;
     }
   }
@@ -153,7 +155,9 @@ public class ProjectExplorer extends JTree implements LocaleListener {
     if (isExpanded(rootPath)) result.add(rootPath);
     final var descendants = getExpandedDescendants(rootPath);
     if (descendants != null) {
-      while (descendants.hasMoreElements()) result.add(descendants.nextElement());
+      while (descendants.hasMoreElements()) {
+        result.add(descendants.nextElement());
+      }
     }
     return result;
   }
@@ -188,7 +192,9 @@ public class ProjectExplorer extends JTree implements LocaleListener {
     while (pos < name.length()) {
       final var runStart = pos;
       final var marks = marked[pos];
-      while (pos < name.length() && marked[pos] == marks) pos++;
+      while (pos < name.length() && marked[pos] == marks) {
+        pos++;
+      }
 
       final var run = escapeHtml(name.substring(runStart, pos));
       if (marks) {

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
@@ -10,6 +10,7 @@
 package com.cburch.logisim.gui.generic;
 
 import com.cburch.contracts.BaseMouseListenerContract;
+import com.cburch.contracts.BaseTreeModelListenerContract;
 import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.SubcircuitFactory;
 import com.cburch.logisim.comp.ComponentDrawContext;
@@ -24,6 +25,7 @@ import com.cburch.logisim.tools.Tool;
 import com.cburch.logisim.util.ColorUtil;
 import com.cburch.logisim.util.LocaleListener;
 import com.cburch.logisim.util.LocaleManager;
+import com.cburch.logisim.util.StringUtil;
 import com.cburch.logisim.vhdl.base.VhdlContent;
 import com.cburch.logisim.vhdl.base.VhdlEntity;
 
@@ -35,6 +37,9 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.ActionMap;
 import javax.swing.Icon;
@@ -44,8 +49,11 @@ import javax.swing.JLabel;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
 
+import javax.swing.event.TreeModelEvent;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultTreeCellRenderer;
@@ -67,11 +75,15 @@ public class ProjectExplorer extends JTree implements LocaleListener {
   private Listener listener = null;
   private Tool haloedTool = null;
 
+  /** Expansion state the tree had before filtering started, to be brought back once it is over. */
+  private List<TreePath> unfilteredExpandedPaths = null;
+
   public ProjectExplorer(Project proj, boolean showMouseTools) {
     super();
     this.proj = proj;
 
     setModel(new ProjectExplorerModel(proj, this, showMouseTools));
+    getModel().addTreeModelListener(myListener);
     setRootVisible(true);
     addMouseListener(myListener);
     ToolTipManager.sharedInstance().registerComponent(this);
@@ -109,6 +121,116 @@ public class ProjectExplorer extends JTree implements LocaleListener {
   public void updateStructure() {
     ProjectExplorerModel model = (ProjectExplorerModel) getModel();
     model.updateStructure();
+  }
+
+  /**
+   * Shows only the elements matching filter texts, Matching is done on component and library names,
+   * and is case insensitive. Filter treats each word separately so word order does not matter
+   * as long as all words are present in the subject (i.e. "foo bar" and "bar foo" would both match
+   * the "foo and bar" name). Empty text disables filtering and and brings the whole tree back
+   * along with the expansion state it had before filtering started.
+   */
+  public void setFilterText(String text) {
+    final var model = (ProjectExplorerModel) getModel();
+    if (!model.isFiltering()) unfilteredExpandedPaths = getExpandedPaths();
+
+    model.setFilter(text);
+
+    if (model.isFiltering()) {
+      expandAllRows();
+    } else if (unfilteredExpandedPaths != null) {
+      for (final var path : unfilteredExpandedPaths) expandPath(path);
+      unfilteredExpandedPaths = null;
+    }
+  }
+
+  private List<TreePath> getExpandedPaths() {
+    final var root = getModel().getRoot();
+    if (root == null) return null;
+
+    final var result = new ArrayList<TreePath>();
+    final var rootPath = new TreePath(root);
+    if (isExpanded(rootPath)) result.add(rootPath);
+    final var descendants = getExpandedDescendants(rootPath);
+    if (descendants != null) {
+      while (descendants.hasMoreElements()) result.add(descendants.nextElement());
+    }
+    return result;
+  }
+
+  private void expandAllRows() {
+    // Row count grows as rows get expanded, so this walks down the whole (filtered) tree.
+    for (var row = 0; row < getRowCount(); row++) {
+      expandRow(row);
+    }
+  }
+
+  /**
+   * Marks the parts of given name the current filter matches.
+   */
+  private String highlightFilterMatches(String name, boolean selected) {
+    final var words = ((ProjectExplorerModel) getModel()).getFilterWords();
+    if (StringUtil.isNullOrEmpty(name) || words.isEmpty()) return name;
+
+    final var marked = markMatchedCharacters(name, words);
+    if (marked == null) return name;
+    final var background =
+        UIManager.getColor(selected ? "Tree.textBackground" : "Tree.selectionBackground");
+    if (background == null) return name;
+    final var foreground = ColorUtil.getComplementaryBlackWhite(background);
+
+    final var html = new StringBuilder("<html>");
+    var pos = 0;
+    while (pos < name.length()) {
+      final var runStart = pos;
+      final var marks = marked[pos];
+      while (pos < name.length() && marked[pos] == marks) pos++;
+
+      final var run = escapeHtml(name.substring(runStart, pos));
+      if (marks) {
+        html.append("<span style=\"background-color:")
+            .append(toHtmlColor(background))
+            .append(";color:")
+            .append(toHtmlColor(foreground))
+            .append("\">")
+            .append(run)
+            .append("</span>");
+      } else {
+        html.append(run);
+      }
+    }
+    return html.append("</html>").toString();
+  }
+
+  /**
+   * Flags every character of given name covered by any of the filter words. Returns {@code null}
+   * when none of the words occurs in the name, which is the case for the elements shown only
+   * because of what their parent or their children matched.
+   */
+  private static boolean[] markMatchedCharacters(String name, List<String> words) {
+    final var lowercased = name.toLowerCase();
+    // Safety check - lowercasing grows the text in some languages (Turkish, Lithuanian),
+    // that would misalign the marks. Low impact for now, still…
+    if (lowercased.length() != name.length()) return null;
+
+    final var marked = new boolean[name.length()];
+    var anyFound = false;
+    for (final var word : words) {
+      // Stepping by one rather than by the word length, as occurrences may overlap each other.
+      for (var at = lowercased.indexOf(word); at >= 0; at = lowercased.indexOf(word, at + 1)) {
+        Arrays.fill(marked, at, at + word.length(), true);
+        anyFound = true;
+      }
+    }
+    return anyFound ? marked : null;
+  }
+
+  private static String toHtmlColor(Color color) {
+    return String.format("#%06X", color.getRGB() & 0xFFFFFF);
+  }
+
+  private static String escapeHtml(String text) {
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
   }
 
   @Override
@@ -180,7 +302,9 @@ public class ProjectExplorer extends JTree implements LocaleListener {
                     : (vhdl != null && vhdl == proj.getFrame().getHdlEditorView());
           }
           label.setFont(viewed ? boldFont : plainFont);
-          label.setText(viewed ? tool.getDisplayName() + " ●" : tool.getDisplayName());
+          label.setText(
+              highlightFilterMatches(
+                  viewed ? tool.getDisplayName() + " ●" : tool.getDisplayName(), selected));
           label.setIcon(new ToolIcon(tool));
           label.setToolTipText(tool.getDescription());
 
@@ -204,14 +328,19 @@ public class ProjectExplorer extends JTree implements LocaleListener {
             text = DIRTY_MARKER_LOCAL + baseName;
           }
 
-          ((JLabel) ret).setText(text);
+          ((JLabel) ret).setText(highlightFilterMatches(text, selected));
         }
       }
       return ret;
     }
   }
 
-  private class MyListener implements BaseMouseListenerContract, TreeSelectionListener, ProjectListener, PropertyChangeListener {
+  private class MyListener
+      implements BaseMouseListenerContract,
+          BaseTreeModelListenerContract,
+          TreeSelectionListener,
+          ProjectListener,
+          PropertyChangeListener {
     private void checkForPopup(MouseEvent e) {
       if (e.isPopupTrigger()) {
         final var path = getPathForLocation(e.getX(), e.getY());
@@ -275,6 +404,18 @@ public class ProjectExplorer extends JTree implements LocaleListener {
     public void propertyChange(PropertyChangeEvent event) {
       if (AppPreferences.GATE_SHAPE.isSource(event)) {
         ProjectExplorer.this.repaint();
+      }
+    }
+
+    //
+    // TreeModelListener methods
+    //
+    @Override
+    public void treeStructureChanged(TreeModelEvent event) {
+      // Tree struct change collapses the tree but while filtering the change
+      // is expected so we enforce tree expansion to keep all matches visible.
+      if (((ProjectExplorerModel) getModel()).isFiltering()) {
+        SwingUtilities.invokeLater(ProjectExplorer.this::expandAllRows);
       }
     }
 

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
@@ -169,8 +169,12 @@ public class ProjectExplorer extends JTree implements LocaleListener {
    * Marks the parts of given name the current filter matches.
    */
   private String highlightFilterMatches(String name, boolean selected) {
-    final var words = ((ProjectExplorerModel) getModel()).getFilterWords();
+    final var model = (ProjectExplorerModel) getModel();
+    final var words = model.getFilterWords();
     if (StringUtil.isNullOrEmpty(name) || words.isEmpty()) return name;
+
+    // Only the names matching on their own get marked.
+    if (!model.matchesFilter(name)) return name;
 
     final var marked = markMatchedCharacters(name, words);
     if (marked == null) return name;
@@ -203,9 +207,9 @@ public class ProjectExplorer extends JTree implements LocaleListener {
   }
 
   /**
-   * Flags every character of given name covered by any of the filter words. Returns {@code null}
-   * when none of the words occurs in the name, which is the case for the elements shown only
-   * because of what their parent or their children matched.
+   * Flags every character of given name covered by any of the filter words. Expects a name that
+   * matches the filter, so that each of the words is bound to be found in it. Returns {@code null}
+   * when the marks cannot be aligned with the name.
    */
   private static boolean[] markMatchedCharacters(String name, List<String> words) {
     final var lowercased = name.toLowerCase();
@@ -214,15 +218,13 @@ public class ProjectExplorer extends JTree implements LocaleListener {
     if (lowercased.length() != name.length()) return null;
 
     final var marked = new boolean[name.length()];
-    var anyFound = false;
     for (final var word : words) {
       // Stepping by one rather than by the word length, as occurrences may overlap each other.
       for (var at = lowercased.indexOf(word); at >= 0; at = lowercased.indexOf(word, at + 1)) {
         Arrays.fill(marked, at, at + word.length(), true);
-        anyFound = true;
       }
     }
-    return anyFound ? marked : null;
+    return marked;
   }
 
   private static String toHtmlColor(Color color) {

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorerModel.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorerModel.java
@@ -19,10 +19,15 @@ import com.cburch.logisim.proj.ProjectEvent;
 import com.cburch.logisim.proj.ProjectListener;
 import com.cburch.logisim.tools.Tool;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.swing.JTree;
 import javax.swing.SwingUtilities;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
 
 class ProjectExplorerModel extends DefaultTreeModel implements ProjectListener {
 
@@ -30,6 +35,16 @@ class ProjectExplorerModel extends DefaultTreeModel implements ProjectListener {
   private final JTree uiElement;
   private Project proj;
   private final boolean showMouseTools;
+  /**
+   * Lowercased words the tree is narrowed down to, all of which have to be found in a name for it
+   * to match. Empty when no filtering takes place.
+   */
+  private List<String> filterWords = List.of();
+  /**
+   * Children to be shown for each node while filtering, {@code null} when no filter is set. The
+   * node tree itself is never touched by the filter: only what the model reports gets narrowed.
+   */
+  private Map<TreeNode, List<TreeNode>> visibleChildren = null;
 
   ProjectExplorerModel(Project proj, JTree gui, boolean showMouseTools) {
     super(null);
@@ -55,8 +70,127 @@ class ProjectExplorerModel extends DefaultTreeModel implements ProjectListener {
     return null;
   }
 
+  /**
+   * Narrows the tree down to the nodes matching filter, i.e. the ones whose name contains it,
+   * together with the libraries leading to them. Text is split into words and a name has to
+   * contain all of them, in any order, to be considered a match: "foo bar" finds both
+   * "foo bar", "bar foo", "foo else bar" and "rabarbar foobar". A library matching by its own
+   * name keeps all of its content visible. Passing empty string turns the filter off.
+   */
+  void setFilter(String text) {
+    final var newWords = splitIntoWords(text);
+    if (newWords.equals(filterWords)) return;
+    filterWords = newWords;
+    rebuildVisibleNodes();
+
+    final var root = (TreeNode) getRoot();
+    if (root == null) {
+      fireStructureChanged();
+    } else {
+      nodeStructureChanged(root);
+    }
+  }
+
+  boolean isFiltering() {
+    return visibleChildren != null;
+  }
+
+  /** Returns the lowercased words currently filtered by, empty list when no filter is set. */
+  List<String> getFilterWords() {
+    return filterWords;
+  }
+
+  private static List<String> splitIntoWords(String text) {
+    final var words = new ArrayList<String>();
+    for (final var word : text.toLowerCase().split("\\s+")) {
+      if (!word.isEmpty()) words.add(word);
+    }
+    return words;
+  }
+
+  private void rebuildVisibleNodes() {
+    if (filterWords.isEmpty()) {
+      visibleChildren = null;
+      return;
+    }
+    visibleChildren = new HashMap<>();
+    final var root = (TreeNode) getRoot();
+    if (root != null) collectVisibleNodes(root, true);
+  }
+
+  /**
+   * Fills {@link #visibleChildren} for given node and tells whether the node is to be shown, which
+   * is the case when its own name matches the filter or when any of its descendants does.
+   */
+  private boolean collectVisibleNodes(TreeNode node, boolean isRoot) {
+    // Root node stands for the project file itself, so matching its
+    // name must not unfold all of it.
+    final var selfMatch = !isRoot && nameMatchesFilter(node);
+    final var visible = new ArrayList<TreeNode>();
+    for (var i = 0; i < node.getChildCount(); i++) {
+      final var child = node.getChildAt(i);
+      if (collectVisibleNodes(child, false) || selfMatch) visible.add(child);
+    }
+    visibleChildren.put(node, visible);
+
+    return selfMatch || !visible.isEmpty();
+  }
+
+  private boolean nameMatchesFilter(TreeNode node) {
+    final var name = getDisplayName(node);
+    if (name == null) return false;
+
+    final var lowercased = name.toLowerCase();
+    for (final var word : filterWords) {
+      if (!lowercased.contains(word)) return false;
+    }
+    return true;
+  }
+
+  private static String getDisplayName(TreeNode node) {
+    if (node instanceof ProjectExplorerToolNode toolNode) {
+      final var tool = toolNode.getValue();
+      return (tool == null) ? null : tool.getDisplayName();
+    }
+    if (node instanceof ProjectExplorerLibraryNode libNode) {
+      final var lib = libNode.getValue();
+      return (lib == null) ? null : lib.getDisplayName();
+    }
+    return null;
+  }
+
+  private List<TreeNode> getVisibleChildren(Object parent) {
+    return (visibleChildren == null) ? null : visibleChildren.get(parent);
+  }
+
+  @Override
+  public Object getChild(Object parent, int index) {
+    final var visible = getVisibleChildren(parent);
+    return (visible == null) ? super.getChild(parent, index) : visible.get(index);
+  }
+
+  @Override
+  public int getChildCount(Object parent) {
+    final var visible = getVisibleChildren(parent);
+    return (visible == null) ? super.getChildCount(parent) : visible.size();
+  }
+
+  @Override
+  public int getIndexOfChild(Object parent, Object child) {
+    final var visible = getVisibleChildren(parent);
+    return (visible == null) ? super.getIndexOfChild(parent, child) : visible.indexOf(child);
+  }
+
+  @Override
+  public boolean isLeaf(Object node) {
+    // While filtering, a library with no matching content must not offer an empty expand handle.
+    return isFiltering() ? (getChildCount(node) == 0) : super.isLeaf(node);
+  }
+
   void fireStructureChanged() {
     final var model = this;
+    // Nodes may have come or gone since the filter was built, so it has to be refreshed as well.
+    rebuildVisibleNodes();
     final var root = (Node<?>) getRoot();
     SwingUtilities.invokeLater(
         () -> {
@@ -133,21 +267,41 @@ class ProjectExplorerModel extends DefaultTreeModel implements ProjectListener {
       if (parent == null) {
         model.fireTreeNodesChanged(this, null, null, null);
       } else {
-        final var indices = new int[] {parent.getIndex(this)};
+        // Reading the model, not the parent node, as filtering shifts the indices.
+        final var index = model.getIndexOfChild(parent, this);
+        if (index < 0) {
+          // filtered out so nothing to repaint
+          return;
+        }
+        final var indices = new int[] {index};
         final var items = new Object[] {this.getUserObject()};
         model.fireTreeNodesChanged(this, parent.getPath(), indices, items);
       }
     }
 
     void fireNodesChanged(int[] indices, Node<?>[] children) {
+      // Indices are computed against the unfiltered children, so the whole structure
+      // has to be refreshed instead while filtering.
+      if (model.isFiltering()) {
+        model.fireStructureChanged();
+        return;
+      }
       model.fireTreeNodesChanged(model, this.getPath(), indices, children);
     }
 
     void fireNodesInserted(int[] indices, Node<?>[] children) {
+      if (model.isFiltering()) {
+        model.fireStructureChanged();
+        return;
+      }
       model.fireTreeNodesInserted(model, this.getPath(), indices, children);
     }
 
     void fireNodesRemoved(int[] indices, Node<?>[] children) {
+      if (model.isFiltering()) {
+        model.fireStructureChanged();
+        return;
+      }
       model.fireTreeNodesRemoved(model, this.getPath(), indices, children);
     }
 

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorerModel.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorerModel.java
@@ -136,8 +136,12 @@ class ProjectExplorerModel extends DefaultTreeModel implements ProjectListener {
     return selfMatch || !visible.isEmpty();
   }
 
-  private boolean nameMatchesFilter(TreeNode node) {
-    final var name = getDisplayName(node);
+  /**
+   * Tells whether given name matches the filter on its own, i.e. contains all of its words. Note
+   * that an element can well be shown while its name does not match, when what matched is its
+   * parent or any of its children (i.e. library name because its content matches).
+   */
+  boolean matchesFilter(String name) {
     if (name == null) return false;
 
     final var lowercased = name.toLowerCase();
@@ -145,6 +149,10 @@ class ProjectExplorerModel extends DefaultTreeModel implements ProjectListener {
       if (!lowercased.contains(word)) return false;
     }
     return true;
+  }
+
+  private boolean nameMatchesFilter(TreeNode node) {
+    return matchesFilter(getDisplayName(node));
   }
 
   private static String getDisplayName(TreeNode node) {

--- a/src/main/java/com/cburch/logisim/gui/icons/ClearIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ClearIcon.java
@@ -1,0 +1,60 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.icons;
+
+import com.cburch.logisim.prefs.AppPreferences;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import javax.swing.Icon;
+
+/**
+ * The "clear the content" icon.
+ */
+public class ClearIcon implements Icon {
+  // How much of the box is left empty around the mark as a fraction of its size.
+  private static final double MARGIN = 0.3;
+  private final int wh;
+
+  public ClearIcon() {
+    wh = AppPreferences.getIconSize();
+  }
+
+  @Override
+  public void paintIcon(Component comp, Graphics gfx, int x, int y) {
+    final var g2 = (Graphics2D) gfx.create();
+    g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+    g2.translate(x, y);
+    g2.setColor((comp == null) ? Color.GRAY : comp.getForeground());
+    g2.setStroke(new BasicStroke(
+        AppPreferences.getScaled(1.5f), BasicStroke.CAP_ROUND,
+        BasicStroke.JOIN_ROUND));
+
+    final var from = (int) Math.round(wh * MARGIN);
+    final var to = wh - from - 1;
+    g2.drawLine(from, from, to, to);
+    g2.drawLine(from, to, to, from);
+
+    g2.dispose();
+  }
+
+  @Override
+  public int getIconWidth() {
+    return wh;
+  }
+
+  @Override
+  public int getIconHeight() {
+    return wh;
+  }
+}

--- a/src/main/java/com/cburch/logisim/gui/main/Toolbox.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Toolbox.java
@@ -9,14 +9,33 @@
 
 package com.cburch.logisim.gui.main;
 
+import static com.cburch.logisim.gui.Strings.S;
+
+import com.cburch.contracts.BaseDocumentListenerContract;
 import com.cburch.draw.toolbar.Toolbar;
 import com.cburch.logisim.gui.generic.ProjectExplorer;
+import com.cburch.logisim.gui.icons.ClearIcon;
 import com.cburch.logisim.gui.menu.MenuListener;
+import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.tools.Tool;
+import com.cburch.logisim.util.LocaleListener;
+import com.cburch.logisim.util.LocaleManager;
 import java.awt.BorderLayout;
+import java.awt.Cursor;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.AbstractAction;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.event.DocumentEvent;
 
 class Toolbox extends JPanel {
   private static final long serialVersionUID = 1L;
@@ -32,6 +51,7 @@ class Toolbox extends JPanel {
     toolbox = new ProjectExplorer(proj, false);
     toolbox.setListener(new ToolboxManip(proj, toolbox));
     add(new JScrollPane(toolbox), BorderLayout.CENTER);
+    add(new FilterPanel(), BorderLayout.SOUTH);
 
     toolbarModel.menuEnableChanged(menu);
   }
@@ -42,5 +62,81 @@ class Toolbox extends JPanel {
 
   public void updateStructure() {
     toolbox.updateStructure();
+  }
+
+  /** Tree filter input */
+  private class FilterPanel extends JPanel implements BaseDocumentListenerContract, LocaleListener {
+    private static final long serialVersionUID = 1L;
+    private static final int GAP = 3;
+    private static final String CLEAR_FILTER_ACTION = "clearFilter";
+
+    private final JLabel label = new JLabel();
+    private final JTextField field = new JTextField();
+    private final JButton clearButton = new JButton(new ClearIcon());
+
+    FilterPanel() {
+      super(new BorderLayout(GAP, 0));
+      setBorder(BorderFactory.createEmptyBorder(GAP, GAP, GAP, GAP));
+
+      label.setFont(AppPreferences.getScaledFont(label.getFont()));
+      field.setFont(AppPreferences.getScaledFont(field.getFont()));
+      field.getDocument().addDocumentListener(this);
+
+      // Pressing ECS whike input has focus clears the content of the input filter.
+      final var clearAction = new ClearFilterAction();
+      field.getInputMap(JComponent.WHEN_FOCUSED)
+          .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), CLEAR_FILTER_ACTION);
+      field.getActionMap().put(CLEAR_FILTER_ACTION, clearAction);
+      clearButton.addActionListener(clearAction);
+      clearButton.setBorderPainted(false);
+      clearButton.setContentAreaFilled(false);
+      clearButton.setFocusable(false);
+      clearButton.setMargin(new Insets(0, 0, 0, 0));
+      clearButton.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+
+      add(label, BorderLayout.WEST);
+      add(field, BorderLayout.CENTER);
+      add(clearButton, BorderLayout.EAST);
+
+      LocaleManager.addLocaleListener(this);
+      localeChanged();
+    }
+
+    private void filterChanged() {
+      toolbox.setFilterText(field.getText());
+    }
+
+    @Override
+    public void insertUpdate(DocumentEvent event) {
+      filterChanged();
+    }
+
+    @Override
+    public void removeUpdate(DocumentEvent event) {
+      filterChanged();
+    }
+
+    @Override
+    public void changedUpdate(DocumentEvent event) {
+      filterChanged();
+    }
+
+    @Override
+    public void localeChanged() {
+      label.setText(S.get("toolboxFilterLabel"));
+      final var tip = S.get("toolboxFilterTip");
+      label.setToolTipText(tip);
+      field.setToolTipText(tip);
+      clearButton.setToolTipText(S.get("toolboxFilterClearTip"));
+    }
+
+    private class ClearFilterAction extends AbstractAction {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public void actionPerformed(ActionEvent event) {
+        field.setText("");
+      }
+    }
   }
 }

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -359,6 +359,12 @@ tickRateMHz = %s MHz
 #
 changeToolAttrAction = Change Tool Attribute
 #
+# main/Toolbox.java
+#
+toolboxFilterClearTip = Clear the filter
+toolboxFilterLabel = Filter:
+toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = Add circuit

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -360,6 +360,12 @@ tickRateMHz = %s MHz
 #
 changeToolAttrAction = Ändere Werkzeugeigenschaft
 #
+# main/Toolbox.java
+#
+# toolboxFilterClearTip =
+# toolboxFilterLabel =
+# toolboxFilterTip =
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = Schaltung hinzufügen

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -362,9 +362,9 @@ changeToolAttrAction = Ändere Werkzeugeigenschaft
 #
 # main/Toolbox.java
 #
-# toolboxFilterClearTip =
-# toolboxFilterLabel =
-# toolboxFilterTip =
+# toolboxFilterClearTip = Clear the filter
+# toolboxFilterLabel = Filter:
+# toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
 #
 # main/ToolboxToolbarModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -360,9 +360,9 @@ changeToolAttrAction = Αλλαγή Ιδιότητας Εργαλείου
 #
 # main/Toolbox.java
 #
-# toolboxFilterClearTip =
-# toolboxFilterLabel =
-# toolboxFilterTip =
+# toolboxFilterClearTip = Clear the filter
+# toolboxFilterLabel = Filter:
+# toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
 #
 # main/ToolboxToolbarModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -358,6 +358,12 @@ tickRateKHz = %s kHz
 #
 changeToolAttrAction = Αλλαγή Ιδιότητας Εργαλείου
 #
+# main/Toolbox.java
+#
+# toolboxFilterClearTip =
+# toolboxFilterLabel =
+# toolboxFilterTip =
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = Προσθήκη Κυκλώματος

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -360,6 +360,12 @@ tickRateKHz = %s kHz
 #
 changeToolAttrAction = Cambiar atributo de la herramienta
 #
+# main/Toolbox.java
+#
+# toolboxFilterClearTip =
+# toolboxFilterLabel =
+# toolboxFilterTip =
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = Añadir circuito

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -362,9 +362,9 @@ changeToolAttrAction = Cambiar atributo de la herramienta
 #
 # main/Toolbox.java
 #
-# toolboxFilterClearTip =
-# toolboxFilterLabel =
-# toolboxFilterTip =
+# toolboxFilterClearTip = Clear the filter
+# toolboxFilterLabel = Filter:
+# toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
 #
 # main/ToolboxToolbarModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -361,9 +361,9 @@ changeToolAttrAction = Outil de changement d’attribut
 #
 # main/Toolbox.java
 #
-# toolboxFilterClearTip =
-# toolboxFilterLabel =
-# toolboxFilterTip =
+# toolboxFilterClearTip = Clear the filter
+# toolboxFilterLabel = Filter:
+# toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
 #
 # main/ToolboxToolbarModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -359,6 +359,12 @@ tickRateMHz = %s MHz
 #
 changeToolAttrAction = Outil de changement d’attribut
 #
+# main/Toolbox.java
+#
+# toolboxFilterClearTip =
+# toolboxFilterLabel =
+# toolboxFilterTip =
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = Ajouter un circuit

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -359,6 +359,12 @@ tickRateKHz = %s kHz
 #
 changeToolAttrAction = Cambia gli attributi degli strumenti
 #
+# main/Toolbox.java
+#
+# toolboxFilterClearTip =
+# toolboxFilterLabel =
+# toolboxFilterTip =
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = Aggiungi circuito

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -361,9 +361,9 @@ changeToolAttrAction = Cambia gli attributi degli strumenti
 #
 # main/Toolbox.java
 #
-# toolboxFilterClearTip =
-# toolboxFilterLabel =
-# toolboxFilterTip =
+# toolboxFilterClearTip = Clear the filter
+# toolboxFilterLabel = Filter:
+# toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
 #
 # main/ToolboxToolbarModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -358,6 +358,12 @@ tickRateKHz = %s kHz
 #
 changeToolAttrAction = ツール属性の変更
 #
+# main/Toolbox.java
+#
+# toolboxFilterClearTip =
+# toolboxFilterLabel =
+# toolboxFilterTip =
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = 回路の追加

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -360,9 +360,9 @@ changeToolAttrAction = ツール属性の変更
 #
 # main/Toolbox.java
 #
-# toolboxFilterClearTip =
-# toolboxFilterLabel =
-# toolboxFilterTip =
+# toolboxFilterClearTip = Clear the filter
+# toolboxFilterLabel = Filter:
+# toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
 #
 # main/ToolboxToolbarModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -362,9 +362,9 @@ changeToolAttrAction = Wijzig gereedschap Attribuut Wijzig gereedschap Attribuut
 #
 # main/Toolbox.java
 #
-# toolboxFilterClearTip =
-# toolboxFilterLabel =
-# toolboxFilterTip =
+# toolboxFilterClearTip = Clear the filter
+# toolboxFilterLabel = Filter:
+# toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
 #
 # main/ToolboxToolbarModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -360,6 +360,12 @@ tickRateKHz = %s kHz
 #
 changeToolAttrAction = Wijzig gereedschap Attribuut Wijzig gereedschap Attribuut
 #
+# main/Toolbox.java
+#
+# toolboxFilterClearTip =
+# toolboxFilterLabel =
+# toolboxFilterTip =
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = Circuit toevoegen

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -360,6 +360,12 @@ tickRateKHz = %s kHz
 #
 changeToolAttrAction = Zmiana atrybutu narzędzia
 #
+# main/Toolbox.java
+#
+toolboxFilterClearTip = Wyczyść filtr
+toolboxFilterLabel = Filtr:
+toolboxFilterTip = Wyświetla elementy zawierające w nazwie wpisane słowa (kolejność słów dowolna).
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = Dodaj obwód

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -361,9 +361,9 @@ changeToolAttrAction = Mudar atributo da ferramenta
 #
 # main/Toolbox.java
 #
-# toolboxFilterClearTip =
-# toolboxFilterLabel =
-# toolboxFilterTip =
+# toolboxFilterClearTip = Clear the filter
+# toolboxFilterLabel = Filter:
+# toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
 #
 # main/ToolboxToolbarModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -359,6 +359,12 @@ tickRateKHz = %s kHz
 #
 changeToolAttrAction = Mudar atributo da ferramenta
 #
+# main/Toolbox.java
+#
+# toolboxFilterClearTip =
+# toolboxFilterLabel =
+# toolboxFilterTip =
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = Adicionar circuito

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -359,6 +359,12 @@ tickRateMHz = %s МГц
 #
 changeToolAttrAction = Изменить атрибут инструмента
 #
+# main/Toolbox.java
+#
+# toolboxFilterClearTip =
+# toolboxFilterLabel =
+# toolboxFilterTip =
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = Добавить схему
@@ -935,4 +941,3 @@ tveExpected = ожидается
 tveOscillating = генерация
 tveRequiresNonNull = Для вычисления тестового вектора требуются ненулевое состояние и вектор
 tveWidthMismatch = Столбец %s имеет разрядность %s, но контакт имеет разрядность %s
-

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -361,9 +361,9 @@ changeToolAttrAction = Изменить атрибут инструмента
 #
 # main/Toolbox.java
 #
-# toolboxFilterClearTip =
-# toolboxFilterLabel =
-# toolboxFilterTip =
+# toolboxFilterClearTip = Clear the filter
+# toolboxFilterLabel = Filter:
+# toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
 #
 # main/ToolboxToolbarModel.java
 #

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -358,6 +358,12 @@ tickRateMHz = %s MHz
 #
 changeToolAttrAction = 更改工具属性
 #
+# main/Toolbox.java
+#
+# toolboxFilterClearTip =
+# toolboxFilterLabel =
+# toolboxFilterTip =
+#
 # main/ToolboxToolbarModel.java
 #
 projectAddCircuitTip = 添加电路

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -360,9 +360,9 @@ changeToolAttrAction = 更改工具属性
 #
 # main/Toolbox.java
 #
-# toolboxFilterClearTip =
-# toolboxFilterLabel =
-# toolboxFilterTip =
+# toolboxFilterClearTip = Clear the filter
+# toolboxFilterLabel = Filter:
+# toolboxFilterTip = Displays items that contain the entered words in their name (word order does not matter).
 #
 # main/ToolboxToolbarModel.java
 #


### PR DESCRIPTION
This PR adds filtering feature to the component tree, which eventually (few years later…) closes #1234. I unfortunately  did not update the documentation to cover this feature but if anyone is willing to do that these are some features of the implemented filter:

- filter is not just dumb string matcher, but tries to look for all the entered words, regardless of their order,
- the term "word" in above  means any string separated from other by white-space, not just literal words. in fact real word boundaries are ignored so filter will match sub string as well, words can also overlap, 
- it matches all elements of the tree, no matter what it is (library, element, project etc),
- the library name will be shown also if any of its elements matches (to preserve the tree structure),
- pressing <kbd>ESC</kbd> while filter input has focus, clears it and restores the tree to the state it was originally in.

So if you type `foo bar` as filter phrase, then it would match items like `foo bar`, `bar foo` and `foo rabarbar` or  `bar something foofighters` as well.

<img width="527" height="435" alt="ss_20260801_205718" src="https://github.com/user-attachments/assets/7d6241b5-fdf0-4ebe-be2b-a1cee7915780" />
