### PR TITLE
Follow-up #2792: Improve combo box scrolling and fix value skipping

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/generic/AttrTable.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/AttrTable.java
@@ -104,6 +104,8 @@ public class AttrTable extends JPanel implements LocaleListener {
   private String scrollFinalValue = null;
   private AttrTableModelRow scrollRow = null;
   private Timer scrollTimer = null;
+  private long lastWheelTime = 0;
+  private static final long WHEEL_THROTTLE_MS = 100;
 
   private void handleMouseWheel(MouseWheelEvent e) {
     final var rowIdx = table.rowAtPoint(e.getPoint());
@@ -115,11 +117,15 @@ public class AttrTable extends JPanel implements LocaleListener {
     final var row = attrModel.getRow(rowIdx);
     if (row == null || !row.isValueEditable()) return;
 
+    final var now = System.currentTimeMillis();
+    if (now - lastWheelTime < WHEEL_THROTTLE_MS) return;
+    lastWheelTime = now;
+
     final var editorComp = row.getEditor(parent);
-    if (editorComp instanceof JComboBox<?> box) {
+    if (editorComp instanceof JComboBox<?> box && !box.isEditable()) {
       final var count = box.getItemCount();
       if (count <= 1) return;
-      final var rotation = e.getWheelRotation();
+      final var rotation = Integer.signum(e.getWheelRotation());
       if (rotation == 0) return;
 
       int currentIdx = box.getSelectedIndex();
@@ -155,7 +161,7 @@ public class AttrTable extends JPanel implements LocaleListener {
       return;
     }
 
-    final var rotation = e.getWheelRotation();
+    final var rotation = Integer.signum(e.getWheelRotation());
     if (rotation == 0) return;
 
     final var label = row.getLabel().toLowerCase();


### PR DESCRIPTION
### Summary
This is a follow-up to #2792, addressing a reviewer's suggestion and fixing a newly discovered scrolling bug.

* **Numeric Increment/Decrement:** As suggested in [this review comment](https://github.com/logisim-evolution/logisim-evolution/pull/2792#pullrequestreview-4815215830), editable combo boxes (like `BitWidth.Attribute`) now correctly increment or decrement their value by exactly 1 on mouse wheel scroll, rather than just cycling through the predefined dropdown items. Non-editable combo boxes retain the previous list-cycling behavior.
* **Scroll Skipping Fix:** While testing the interface with a different mouse (Logitech), I discovered a bug where scroll wheel events caused values to skip or jump multiple steps at once. To fix this, I added a ±1 step normalization and a 100ms throttle to prevent rapid, uncontrollable multi-step jumps during continuous scrolling.