### PR TITLE
docs(ru): fix JavaHelp validation issues in Russian documentation

### DIFF
--- a/src/main/resources/doc/doc_ru.hs
+++ b/src/main/resources/doc/doc_ru.hs
@@ -41,7 +41,7 @@
      *  The toolbar has a back arrow, a forward arrow, and
      *  a home button that has a user-defined image.
    -->
-   <presentation default=true>
+    <presentation default="true">
        <name>main window</name>
        <location x="200" y="10" />
        <toolbar>

--- a/src/main/resources/doc/map_ru.jhm
+++ b/src/main/resources/doc/map_ru.jhm
@@ -113,8 +113,9 @@
 	<mapID target="about_gpl_tr"        url="ru/html/guide/about/gpl-ru.html" />
 	
 <!-- for testing and validation -->
-	<mapID target="test_hml_css"        url="en/testhtml/index.html" />
-	<mapID target="Translation_status"  url="index.html" />
+ 	<mapID target="Tests_for_doc"       url="index.html" />
+ 	<mapID target="test_hml_css"        url="en/testhtml/index.html" />
+ 	<mapID target="Translation_status"  url="index.html" />
 <!-- Librairie -->
 	<mapID target="libs"                url="ru/html/libs/index.html" />
 	<mapID target="wiring"              url="ru/html/libs/wiring/index.html" />
@@ -231,7 +232,6 @@
 	<mapID target="icon_basic"       url="icons/1616/ansandgate.png" />
 	<mapID target="icon_xor"         url="icons/1616/ansxorgate.png" />
 	<mapID target="icon_controlled"  url="icons/1616/anscontrolledbuffer.png" />
-	<mapID target="icon_controlled"  url="icons/1616/anscontrolledbuffer.png" />
 	<mapID target="icon_pla"         url="icons/1616/pla0.png" />
 	
 	<mapID target="icon_mux"         url="icons/1616/multiplexer.png" />
@@ -291,10 +291,7 @@
 	<mapID target="icon_buzzer"      url="icons/1616/buzzer.png" />	
 	<mapID target="icon_slider"      url="icons/1616/slider.png" />	
 	<mapID target="icon_digitalscope"    url="icons/1616/digitalscope.png" />	
-	<mapID target="icon_pla2"        url="icons/1616/pla2.png" />	
-	<mapID target="up_icon"          url="icons/1616/rgbvideo.png" />	
-	<mapID target="socbus_icon"      url="icons/1616/rgbvideo.png" />		
-
+	<mapID target="icon_pla2"        url="icons/1616/pla2.png" />
 	<mapID target="icon_vhdl"        url="icons/1616/vhdl.png" />
     <mapID target="up_icon"          url="icons/1616/up.png"/>
     <mapID target="socbus_icon"      url="icons/1616/socbus.png"/>

--- a/src/test/resources/documentation-known-issues.txt
+++ b/src/test/resources/documentation-known-issues.txt
@@ -13,7 +13,6 @@ doc_de.hs: XML is not well-formed
 doc_en.hs: XML is not well-formed
 doc_fr.hs: XML is not well-formed
 doc_pt.hs: XML is not well-formed
-doc_ru.hs: XML is not well-formed
 doc_zh.hs: XML is not well-formed
 en/contents.xml: target 'Tests_for_doc' has no mapID in map_en.jhm
 en/contents.xml: target 'Tests_for_doc' has no mapID in map_pt.jhm
@@ -86,14 +85,10 @@ map_pt.jhm: mapID 'wiring_const01' points to missing file pt/html/libs/wiring/co
 map_pt.jhm: mapID 'wiring_notconnect' points to missing file pt/html/libs/wiring/notconnect.html
 map_pt.jhm: mapID 'wiring_transist' points to missing file pt/html/libs/wiring/transist.html
 map_pt.jhm: mapID 'wiring_transmis' points to missing file pt/html/libs/wiring/transmis.html
-map_ru.jhm: duplicate mapID 'icon_controlled'
-map_ru.jhm: duplicate mapID 'socbus_icon'
-map_ru.jhm: duplicate mapID 'up_icon'
 map_zh.jhm: duplicate mapID 'icon_controlled'
 map_zh.jhm: duplicate mapID 'socbus_icon'
 map_zh.jhm: duplicate mapID 'up_icon'
 map_zh.jhm: mapID 'io_Port_IO' points to missing file zh/html/libs/io/Port_io.html
 map_zh.jhm: mapID 'io_Repetar' points to missing file zh/html/libs/io/repetar.html
-ru/contents.xml: target 'Tests_for_doc' has no mapID in map_ru.jhm
 zh/contents.xml: target 'Tests_for_doc' has no mapID in map_zh.jhm
 zh/contents.xml: target 'io_videorgb' has no mapID in map_zh.jhm


### PR DESCRIPTION
### Summary
This PR resolves the 5 JavaHelp structural issues in the Russian documentation (`ru/`) that were flagged by the `DocumentationStructureTest` (introduced in commit e9154de). 

### Changes
* **`doc_ru.hs`**: Fixed malformed XML syntax (`default="true"`).
* **`map_ru.jhm`**: Removed duplicate `mapID` entries (`icon_controlled`, `socbus_icon`, `up_icon`) correcting erroneous icon paths, and added the missing `Tests_for_doc` mapping.
* **`documentation-known-issues.txt`**: Removed all 5 resolved Russian entries from the baseline file.