### PR TITLE
fix(gui): update table values dynamically on mouse wheel scroll in ap…

### DIFF
--- a/src/main/java/com/cburch/draw/gui/SelectionAttributes.java
+++ b/src/main/java/com/cburch/draw/gui/SelectionAttributes.java
@@ -135,6 +135,7 @@ public class SelectionAttributes extends AbstractAttributeSet {
         for (var i = 0; i < attrs.length; i++) {
           if (attrs[i] == attr) {
             values[i] = getSelectionValue(attr, selected.keySet());
+            fireAttributeValueChanged(attr, values[i], null);
           }
         }
       }

--- a/src/main/java/com/cburch/logisim/gui/generic/AttrTable.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/AttrTable.java
@@ -141,6 +141,7 @@ public class AttrTable extends JPanel implements LocaleListener {
         row.setValue(parent, newItem);
       } catch (Exception ignored) {
       }
+      table.repaint();
       return;
     }
 
@@ -190,6 +191,7 @@ public class AttrTable extends JPanel implements LocaleListener {
     } catch (Exception ignored) {
     }
 
+    table.repaint();
     scrollTimer.restart();
   }
 


### PR DESCRIPTION
### Summary
Follow-up to **#2792** and **#2800**. I didn't thoroughly test the mouse wheel scrolling across all editor views in my previous PRs. Since the scrolling worked perfectly in the main circuit editing mode, this minor bug slipped through, and I only noticed it now while developing a new feature.

When scrolling the mouse wheel over properties in the Subcircuit Appearance Editor, the target shape on the canvas updated correctly, but the displayed numerical value in the `AttrTable` did not visually update until the cell selection changed.

### Cause & Changes
It was just a missing UI repaint trigger (a 3-line fix):
- **`SelectionAttributes.java`:** Added `fireAttributeValueChanged` event dispatching.
- **`AttrTable.java`:** Added explicit `table.repaint()` to update the UI instantly during scrolling.

### How to Test
1. Create or open a subcircuit and enter the **Subcircuit Appearance Editor**.
2. Select a shape on the canvas (e.g., a Line or Rectangle).
3. Hover over the **Stroke Width** (line thickness) property in the Attribute Table and scroll the mouse wheel **UP** or **DOWN**.
4. Verify that both the shape on the canvas AND the displayed number in the Attribute Table update dynamically and instantly in real-time.