### PR TITLE
feat(gui): introduce Image component for embedding pictures into circuits and custom appearances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Added Image component to insert custom bitmap images into circuits and subcircuit appearances.
   * Added contributor guidance and an online component overview for the TTL library.
   * Added "Find Action" omni-search, letting menu actions be found and run by typing part of their
     name, with fuzzy and acronym matching (e.g. "expim" or "ei" find "Export Image"). It opens from

--- a/src/main/java/com/cburch/draw/gui/SelectionAttributes.java
+++ b/src/main/java/com/cburch/draw/gui/SelectionAttributes.java
@@ -115,6 +115,26 @@ public class SelectionAttributes extends AbstractAttributeSet {
     }
   }
 
+  @Override
+  public boolean isReadOnly(Attribute<?> attr) {
+    for (final var objAttrs : selected.keySet()) {
+      if (objAttrs.isReadOnly(attr)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isToSave(Attribute<?> attr) {
+    for (final var objAttrs : selected.keySet()) {
+      if (!objAttrs.isToSave(attr)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   private class Listener implements SelectionListener, AttributeListener {
     //
     // AttributeSet listener
@@ -128,14 +148,15 @@ public class SelectionAttributes extends AbstractAttributeSet {
     @Override
     public void attributeValueChanged(AttributeEvent e) {
       if (selected.containsKey(e.getSource())) {
-        @SuppressWarnings("unchecked")
-        Attribute<Object> attr = (Attribute<Object>) e.getAttribute();
         final var attrs = SelectionAttributes.this.selAttrs;
         final var values = SelectionAttributes.this.selValues;
         for (var i = 0; i < attrs.length; i++) {
-          if (attrs[i] == attr) {
-            values[i] = getSelectionValue(attr, selected.keySet());
-            fireAttributeValueChanged(attr, values[i], null);
+          @SuppressWarnings("unchecked")
+          final var a = (Attribute<Object>) attrs[i];
+          final var newValue = getSelectionValue(a, selected.keySet());
+          if (!Objects.equals(values[i], newValue)) {
+            values[i] = newValue;
+            fireAttributeValueChanged(a, newValue, null);
           }
         }
       }

--- a/src/main/java/com/cburch/draw/shapes/ImageShape.java
+++ b/src/main/java/com/cburch/draw/shapes/ImageShape.java
@@ -72,12 +72,22 @@ public class ImageShape extends Rectangular {
     }
 
     if (cachedImage != null) {
+      var drawImg = cachedImage;
+      if (g.getClass().getName().contains("ComponentDrawContext")) {
+        try {
+          final var m = g.getClass().getMethod("isPrintView");
+          if ((Boolean) m.invoke(g)) {
+            drawImg = ImageUtil.toGrayscale(cachedImage);
+          }
+        } catch (Exception ignored) {
+        }
+      }
       final var scaleOpt = scale == null ? "fit" : (String) scale.getValue();
       if ("stretch".equals(scaleOpt)) {
-        g.drawImage(cachedImage, x, y, w, h, null);
+        g.drawImage(drawImg, x, y, w, h, null);
       } else if ("cover".equals(scaleOpt)) {
-        final var imgW = cachedImage.getWidth();
-        final var imgH = cachedImage.getHeight();
+        final var imgW = drawImg.getWidth();
+        final var imgH = drawImg.getHeight();
         final var scaleFactor = Math.max((double) w / imgW, (double) h / imgH);
         final var targetW = Math.max(1, (int) (imgW * scaleFactor));
         final var targetH = Math.max(1, (int) (imgH * scaleFactor));
@@ -85,17 +95,17 @@ public class ImageShape extends Rectangular {
         final var targetY = y + (h - targetH) / 2;
         final var oldClip = g.getClip();
         g.clipRect(x, y, w, h);
-        g.drawImage(cachedImage, targetX, targetY, targetW, targetH, null);
+        g.drawImage(drawImg, targetX, targetY, targetW, targetH, null);
         g.setClip(oldClip);
       } else { // fit — preserve aspect ratio
-        final var imgW = cachedImage.getWidth();
-        final var imgH = cachedImage.getHeight();
+        final var imgW = drawImg.getWidth();
+        final var imgH = drawImg.getHeight();
         final var scaleFactor = Math.min((double) w / imgW, (double) h / imgH);
         final var targetW = Math.max(1, (int) (imgW * scaleFactor));
         final var targetH = Math.max(1, (int) (imgH * scaleFactor));
         final var targetX = x + (w - targetW) / 2;
         final var targetY = y + (h - targetH) / 2;
-        g.drawImage(cachedImage, targetX, targetY, targetW, targetH, null);
+        g.drawImage(drawImg, targetX, targetY, targetW, targetH, null);
       }
     } else {
       g.setColor(Color.LIGHT_GRAY);

--- a/src/main/java/com/cburch/draw/shapes/ImageShape.java
+++ b/src/main/java/com/cburch/draw/shapes/ImageShape.java
@@ -1,0 +1,180 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.draw.shapes;
+
+import static com.cburch.draw.Strings.S;
+
+import com.cburch.draw.model.CanvasObject;
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.data.AttributeOption;
+import com.cburch.logisim.data.Attributes;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.std.Strings;
+import com.cburch.logisim.std.base.Image;
+import com.cburch.logisim.util.ImageUtil;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.util.List;
+import java.util.Objects;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class ImageShape extends Rectangular {
+  public static final Attribute<String> IMAGE_ATTR = Image.ATTR_IMAGE;
+  public static final Attribute<Integer> ATTR_X = Attributes.forInteger("x", Strings.S.getter("imageLocationXAttr"));
+  public static final Attribute<Integer> ATTR_Y = Attributes.forInteger("y", Strings.S.getter("imageLocationYAttr"));
+  public static final Attribute<Integer> WIDTH_ATTR = Image.ATTR_WIDTH;
+  public static final Attribute<Integer> HEIGHT_ATTR = Image.ATTR_HEIGHT;
+  public static final Attribute<AttributeOption> SCALE_ATTR = Image.ATTR_SCALE;
+
+  private String imageSource = "";
+  private BufferedImage cachedImage = null;
+  private AttributeOption scale = SCALE_ATTR.parse("fit");
+
+  public ImageShape(int x, int y, int w, int h) {
+    super(x, y, w, h);
+  }
+
+  public String getImageSource() {
+    return imageSource;
+  }
+
+  public void setImageSource(String source) {
+    this.imageSource = source;
+    this.cachedImage = ImageUtil.loadBufferedImage(source);
+  }
+
+  @Override
+  protected boolean contains(int x, int y, int w, int h, Location q) {
+    return isInRect(q.getX(), q.getY(), x, y, w, h);
+  }
+
+  @Override
+  public void draw(Graphics g, int x, int y, int w, int h) {
+    if (cachedImage == null && imageSource != null && !imageSource.isBlank()) {
+      cachedImage = ImageUtil.loadBufferedImage(imageSource);
+    }
+
+    if (cachedImage != null) {
+      final var scaleOpt = scale == null ? "fit" : (String) scale.getValue();
+      if ("stretch".equals(scaleOpt)) {
+        g.drawImage(cachedImage, x, y, w, h, null);
+      } else if ("cover".equals(scaleOpt)) {
+        final var imgW = cachedImage.getWidth();
+        final var imgH = cachedImage.getHeight();
+        final var scaleFactor = Math.max((double) w / imgW, (double) h / imgH);
+        final var targetW = Math.max(1, (int) (imgW * scaleFactor));
+        final var targetH = Math.max(1, (int) (imgH * scaleFactor));
+        final var targetX = x + (w - targetW) / 2;
+        final var targetY = y + (h - targetH) / 2;
+        final var oldClip = g.getClip();
+        g.clipRect(x, y, w, h);
+        g.drawImage(cachedImage, targetX, targetY, targetW, targetH, null);
+        g.setClip(oldClip);
+      } else { // fit — preserve aspect ratio
+        final var imgW = cachedImage.getWidth();
+        final var imgH = cachedImage.getHeight();
+        final var scaleFactor = Math.min((double) w / imgW, (double) h / imgH);
+        final var targetW = Math.max(1, (int) (imgW * scaleFactor));
+        final var targetH = Math.max(1, (int) (imgH * scaleFactor));
+        final var targetX = x + (w - targetW) / 2;
+        final var targetY = y + (h - targetH) / 2;
+        g.drawImage(cachedImage, targetX, targetY, targetW, targetH, null);
+      }
+    } else {
+      g.setColor(Color.LIGHT_GRAY);
+      g.fillRect(x, y, w, h);
+      g.setColor(Color.DARK_GRAY);
+      g.drawRect(x, y, w, h);
+      g.drawLine(x, y, x + w, y + h);
+      g.drawLine(x, y + h, x + w, y);
+    }
+  }
+
+  @Override
+  public List<Attribute<?>> getAttributes() {
+    return List.of(IMAGE_ATTR, ATTR_X, ATTR_Y, WIDTH_ATTR, HEIGHT_ATTR, SCALE_ATTR);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <V> V getValue(Attribute<V> attr) {
+    if (attr == IMAGE_ATTR) return (V) imageSource;
+    if (attr == ATTR_X) return (V) Integer.valueOf(getX());
+    if (attr == ATTR_Y) return (V) Integer.valueOf(getY());
+    if (attr == WIDTH_ATTR) return (V) Integer.valueOf(getWidth());
+    if (attr == HEIGHT_ATTR) return (V) Integer.valueOf(getHeight());
+    if (attr == SCALE_ATTR) return (V) scale;
+    return super.getValue(attr);
+  }
+
+  @Override
+  public void updateValue(Attribute<?> attr, Object value) {
+    if (attr == IMAGE_ATTR) {
+      setImageSource((String) value);
+    } else if (attr == ATTR_X) {
+      final var newX = (Integer) value;
+      setBounds(newX, getY(), getWidth(), getHeight());
+    } else if (attr == ATTR_Y) {
+      final var newY = (Integer) value;
+      setBounds(getX(), newY, getWidth(), getHeight());
+    } else if (attr == WIDTH_ATTR) {
+      final var val = (Integer) value;
+      if (val <= 0 && cachedImage != null) {
+        setBounds(getX(), getY(), cachedImage.getWidth(), cachedImage.getHeight());
+      } else {
+        setBounds(getX(), getY(), Math.max(1, val), getHeight());
+      }
+    } else if (attr == HEIGHT_ATTR) {
+      final var val = (Integer) value;
+      if (val <= 0 && cachedImage != null) {
+        setBounds(getX(), getY(), cachedImage.getWidth(), cachedImage.getHeight());
+      } else {
+        setBounds(getX(), getY(), getWidth(), Math.max(1, val));
+      }
+    } else if (attr == SCALE_ATTR) {
+      scale = (AttributeOption) value;
+    } else {
+      super.updateValue(attr, value);
+    }
+  }
+
+  @Override
+  public String getDisplayName() {
+    return S.get("shapeImage");
+  }
+
+  @Override
+  public ImageShape clone() {
+    final var ret = (ImageShape) super.clone();
+    ret.imageSource = this.imageSource;
+    ret.cachedImage = this.cachedImage;
+    return ret;
+  }
+
+  @Override
+  public boolean matches(CanvasObject other) {
+    if (other instanceof ImageShape that) {
+      return super.matches(other) && Objects.equals(this.imageSource, that.imageSource);
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "ImageShape:" + getBounds();
+  }
+
+  @Override
+  public Element toSvgElement(Document doc) {
+    return SvgCreator.createImage(doc, this);
+  }
+}

--- a/src/main/java/com/cburch/draw/shapes/ImageShape.java
+++ b/src/main/java/com/cburch/draw/shapes/ImageShape.java
@@ -34,6 +34,7 @@ public class ImageShape extends Rectangular {
   public static final Attribute<Integer> WIDTH_ATTR = Image.ATTR_WIDTH;
   public static final Attribute<Integer> HEIGHT_ATTR = Image.ATTR_HEIGHT;
   public static final Attribute<AttributeOption> SCALE_ATTR = Image.ATTR_SCALE;
+  public static final Attribute<String> DATA_SIZE_ATTR = Image.ATTR_DATA_SIZE;
   public static final Attribute<AttributeOption> LICENSE_ATTR = Image.ATTR_LICENSE;
   public static final Attribute<String> ATTRIBUTION_ATTR = Image.ATTR_ATTRIBUTION;
 
@@ -57,6 +58,7 @@ public class ImageShape extends Rectangular {
   }
 
   public String getAttribution() {
+
     return attribution;
   }
 
@@ -119,7 +121,23 @@ public class ImageShape extends Rectangular {
 
   @Override
   public List<Attribute<?>> getAttributes() {
-    return List.of(IMAGE_ATTR, ATTR_X, ATTR_Y, WIDTH_ATTR, HEIGHT_ATTR, SCALE_ATTR, LICENSE_ATTR, ATTRIBUTION_ATTR);
+    return List.of(IMAGE_ATTR, ATTR_X, ATTR_Y, WIDTH_ATTR, HEIGHT_ATTR, SCALE_ATTR, DATA_SIZE_ATTR, LICENSE_ATTR, ATTRIBUTION_ATTR);
+  }
+
+  @Override
+  public boolean isReadOnly(Attribute<?> attr) {
+    if (attr == DATA_SIZE_ATTR) return true;
+    return super.isReadOnly(attr);
+  }
+
+  @Override
+  public boolean isToSave(Attribute<?> attr) {
+    if (attr == DATA_SIZE_ATTR) return false;
+    return super.isToSave(attr);
+  }
+
+  public String getDataSizeFormatted() {
+    return ImageUtil.formatDataSize(imageSource);
   }
 
   @Override
@@ -131,6 +149,7 @@ public class ImageShape extends Rectangular {
     if (attr == WIDTH_ATTR) return (V) Integer.valueOf(getWidth());
     if (attr == HEIGHT_ATTR) return (V) Integer.valueOf(getHeight());
     if (attr == SCALE_ATTR) return (V) scale;
+    if (attr == DATA_SIZE_ATTR) return (V) getDataSizeFormatted();
     if (attr == LICENSE_ATTR) return (V) license;
     if (attr == ATTRIBUTION_ATTR) return (V) attribution;
     return super.getValue(attr);

--- a/src/main/java/com/cburch/draw/shapes/ImageShape.java
+++ b/src/main/java/com/cburch/draw/shapes/ImageShape.java
@@ -34,10 +34,14 @@ public class ImageShape extends Rectangular {
   public static final Attribute<Integer> WIDTH_ATTR = Image.ATTR_WIDTH;
   public static final Attribute<Integer> HEIGHT_ATTR = Image.ATTR_HEIGHT;
   public static final Attribute<AttributeOption> SCALE_ATTR = Image.ATTR_SCALE;
+  public static final Attribute<AttributeOption> LICENSE_ATTR = Image.ATTR_LICENSE;
+  public static final Attribute<String> ATTRIBUTION_ATTR = Image.ATTR_ATTRIBUTION;
 
   private String imageSource = "";
   private BufferedImage cachedImage = null;
   private AttributeOption scale = SCALE_ATTR.parse("fit");
+  private AttributeOption license = Image.LICENSE_UNSPECIFIED;
+  private String attribution = "";
 
   public ImageShape(int x, int y, int w, int h) {
     super(x, y, w, h);
@@ -50,6 +54,10 @@ public class ImageShape extends Rectangular {
   public void setImageSource(String source) {
     this.imageSource = source;
     this.cachedImage = ImageUtil.loadBufferedImage(source);
+  }
+
+  public String getAttribution() {
+    return attribution;
   }
 
   @Override
@@ -101,7 +109,7 @@ public class ImageShape extends Rectangular {
 
   @Override
   public List<Attribute<?>> getAttributes() {
-    return List.of(IMAGE_ATTR, ATTR_X, ATTR_Y, WIDTH_ATTR, HEIGHT_ATTR, SCALE_ATTR);
+    return List.of(IMAGE_ATTR, ATTR_X, ATTR_Y, WIDTH_ATTR, HEIGHT_ATTR, SCALE_ATTR, LICENSE_ATTR, ATTRIBUTION_ATTR);
   }
 
   @Override
@@ -113,6 +121,8 @@ public class ImageShape extends Rectangular {
     if (attr == WIDTH_ATTR) return (V) Integer.valueOf(getWidth());
     if (attr == HEIGHT_ATTR) return (V) Integer.valueOf(getHeight());
     if (attr == SCALE_ATTR) return (V) scale;
+    if (attr == LICENSE_ATTR) return (V) license;
+    if (attr == ATTRIBUTION_ATTR) return (V) attribution;
     return super.getValue(attr);
   }
 
@@ -142,6 +152,10 @@ public class ImageShape extends Rectangular {
       }
     } else if (attr == SCALE_ATTR) {
       scale = (AttributeOption) value;
+    } else if (attr == LICENSE_ATTR) {
+      license = (AttributeOption) value;
+    } else if (attr == ATTRIBUTION_ATTR) {
+      attribution = value == null ? "" : (String) value;
     } else {
       super.updateValue(attr, value);
     }
@@ -157,6 +171,8 @@ public class ImageShape extends Rectangular {
     final var ret = (ImageShape) super.clone();
     ret.imageSource = this.imageSource;
     ret.cachedImage = this.cachedImage;
+    ret.license = this.license;
+    ret.attribution = this.attribution;
     return ret;
   }
 

--- a/src/main/java/com/cburch/draw/shapes/Rectangular.java
+++ b/src/main/java/com/cburch/draw/shapes/Rectangular.java
@@ -25,6 +25,10 @@ abstract class Rectangular extends FillableCanvasObject {
     bounds = Bounds.create(x, y, w, h);
   }
 
+  protected void setBounds(int x, int y, int w, int h) {
+    bounds = Bounds.create(x, y, Math.max(1, w), Math.max(1, h));
+  }
+
   @Override
   public boolean canMoveHandle(Handle handle) {
     return true;

--- a/src/main/java/com/cburch/draw/shapes/SvgCreator.java
+++ b/src/main/java/com/cburch/draw/shapes/SvgCreator.java
@@ -104,6 +104,14 @@ public final class SvgCreator {
 
   public static Element createImage(Document doc, ImageShape image) {
     final var elt = doc.createElement("image");
+    final var attr = image.getAttribution();
+    if (attr != null && !attr.isBlank()) {
+      elt.setAttribute("attribution", attr);
+    }
+    final var license = image.getValue(ImageShape.LICENSE_ATTR);
+    if (license != null) {
+      elt.setAttribute("license", license.getValue().toString());
+    }
     elt.setAttribute("x", "" + image.getX());
     elt.setAttribute("y", "" + image.getY());
     elt.setAttribute("width", "" + Math.max(1, image.getWidth()));
@@ -116,8 +124,6 @@ public final class SvgCreator {
     if (src != null && !src.isBlank()) {
       src = src.replaceAll("[\\r\\n]+", "");
       elt.setAttribute("href", src);
-      elt.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
-      elt.setAttribute("xlink:href", src);
     }
     return elt;
   }

--- a/src/main/java/com/cburch/draw/shapes/SvgCreator.java
+++ b/src/main/java/com/cburch/draw/shapes/SvgCreator.java
@@ -102,6 +102,26 @@ public final class SvgCreator {
     return elt;
   }
 
+  public static Element createImage(Document doc, ImageShape image) {
+    final var elt = doc.createElement("image");
+    elt.setAttribute("x", "" + image.getX());
+    elt.setAttribute("y", "" + image.getY());
+    elt.setAttribute("width", "" + Math.max(1, image.getWidth()));
+    elt.setAttribute("height", "" + Math.max(1, image.getHeight()));
+    final var scale = image.getValue(ImageShape.SCALE_ATTR);
+    if (scale != null) {
+      elt.setAttribute("scale", scale.getValue().toString());
+    }
+    var src = image.getImageSource();
+    if (src != null && !src.isBlank()) {
+      src = src.replaceAll("[\\r\\n]+", "");
+      elt.setAttribute("href", src);
+      elt.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
+      elt.setAttribute("xlink:href", src);
+    }
+    return elt;
+  }
+
   public static Element createText(Document doc, Text text) {
     final var elt = doc.createElement("text");
     final var loc = text.getLocation();

--- a/src/main/java/com/cburch/draw/shapes/SvgReader.java
+++ b/src/main/java/com/cburch/draw/shapes/SvgReader.java
@@ -168,9 +168,35 @@ public final class SvgReader {
     return ret;
   }
 
+  private static AbstractCanvasObject createImage(Element elt) {
+    final var x = Integer.parseInt(elt.getAttribute("x"));
+    final var y = Integer.parseInt(elt.getAttribute("y"));
+    final var w = Integer.parseInt(elt.getAttribute("width"));
+    final var h = Integer.parseInt(elt.getAttribute("height"));
+    final var ret = new ImageShape(x, y, w, h);
+    if (elt.hasAttribute("scale")) {
+      final var scaleStr = elt.getAttribute("scale");
+      if (!scaleStr.isBlank()) {
+        try {
+          ret.updateValue(ImageShape.SCALE_ATTR, ImageShape.SCALE_ATTR.parse(scaleStr));
+        } catch (Exception ignored) {
+        }
+      }
+    }
+    var href = elt.getAttribute("xlink:href");
+    if (href.isBlank()) {
+      href = elt.getAttribute("href");
+    }
+    if (!href.isBlank()) {
+      ret.setImageSource(href);
+    }
+    return ret;
+  }
+
   private static AbstractCanvasObject createShapeObject(Element elt, String name) {
     return switch (name) {
       case "ellipse" -> createOval(elt);
+      case "image" -> createImage(elt);
       case "line" -> createLine(elt);
       case "path" -> createPath(elt);
       case "polyline" -> createPolyline(elt);

--- a/src/main/java/com/cburch/draw/shapes/SvgReader.java
+++ b/src/main/java/com/cburch/draw/shapes/SvgReader.java
@@ -183,6 +183,18 @@ public final class SvgReader {
         }
       }
     }
+    if (elt.hasAttribute("license")) {
+      final var licenseStr = elt.getAttribute("license");
+      if (!licenseStr.isBlank()) {
+        try {
+          ret.updateValue(ImageShape.LICENSE_ATTR, ImageShape.LICENSE_ATTR.parse(licenseStr));
+        } catch (Exception ignored) {
+        }
+      }
+    }
+    if (elt.hasAttribute("attribution")) {
+      ret.updateValue(ImageShape.ATTRIBUTION_ATTR, elt.getAttribute("attribution"));
+    }
     var href = elt.getAttribute("xlink:href");
     if (href.isBlank()) {
       href = elt.getAttribute("href");

--- a/src/main/java/com/cburch/draw/tools/ImageTool.java
+++ b/src/main/java/com/cburch/draw/tools/ImageTool.java
@@ -17,7 +17,6 @@ import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.gui.icons.ImageIcon;
 
 import java.awt.Graphics;
-import java.util.Collections;
 import java.util.List;
 import javax.swing.Icon;
 
@@ -48,7 +47,7 @@ public class ImageTool extends RectangularTool {
 
   @Override
   public List<Attribute<?>> getAttributes() {
-    return List.of(ImageShape.SCALE_ATTR);
+    return List.of(ImageShape.SCALE_ATTR, ImageShape.LICENSE_ATTR, ImageShape.ATTRIBUTION_ATTR);
   }
 
   @Override

--- a/src/main/java/com/cburch/draw/tools/ImageTool.java
+++ b/src/main/java/com/cburch/draw/tools/ImageTool.java
@@ -1,0 +1,63 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.draw.tools;
+
+import static com.cburch.draw.Strings.S;
+
+import com.cburch.draw.model.CanvasObject;
+import com.cburch.draw.shapes.ImageShape;
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.gui.icons.ImageIcon;
+
+import java.awt.Graphics;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.Icon;
+
+public class ImageTool extends RectangularTool {
+  private static final ImageIcon ICON = new ImageIcon();
+  private final DrawingAttributeSet attrs;
+
+  public ImageTool(DrawingAttributeSet attrs) {
+    this.attrs = attrs;
+  }
+
+  @Override
+  public CanvasObject createShape(int x, int y, int w, int h) {
+    return attrs.applyTo(new ImageShape(x, y, w, h));
+  }
+
+  @Override
+  public void drawShape(Graphics g, int x, int y, int w, int h) {
+    g.drawRect(x, y, w, h);
+    g.drawLine(x, y, x + w, y + h);
+    g.drawLine(x, y + h, x + w, y);
+  }
+
+  @Override
+  public void fillShape(Graphics g, int x, int y, int w, int h) {
+    g.fillRect(x, y, w, h);
+  }
+
+  @Override
+  public List<Attribute<?>> getAttributes() {
+    return List.of(ImageShape.SCALE_ATTR);
+  }
+
+  @Override
+  public String getDescription() {
+    return S.get("shapeImage");
+  }
+
+  @Override
+  public Icon getIcon() {
+    return ICON;
+  }
+}

--- a/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearance.java
+++ b/src/main/java/com/cburch/logisim/circuit/appear/CircuitAppearance.java
@@ -25,9 +25,11 @@ import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.data.Location;
 import com.cburch.logisim.gui.appear.CanvasActionAdapter;
+import com.cburch.draw.shapes.ImageShape;
 import com.cburch.logisim.instance.Instance;
 import com.cburch.logisim.instance.InstanceComponent;
 import com.cburch.logisim.instance.InstancePainter;
+import com.cburch.logisim.util.ImageUtil;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.util.EventSourceWeakSupport;
 import java.awt.Graphics;
@@ -312,10 +314,21 @@ public class CircuitAppearance extends Drawing implements AttributeListener {
         // Do nothing.
       }
     }
+    final var isPrintView = painter.isPrintView();
     for (final var shape : getObjectsFromBottom()) {
       if (!(shape instanceof AppearanceElement)) {
         final var dup = g.create();
-        if (shape instanceof DynamicElement dynEl) {
+        if (shape instanceof ImageShape imgShape && isPrintView) {
+          final var grayImg = ImageUtil.toGrayscale(ImageUtil.loadBufferedImage(imgShape.getImageSource()));
+          if (grayImg != null) {
+            final var origSrc = imgShape.getImageSource();
+            imgShape.setImageSource(ImageUtil.bufferedImageToBase64(grayImg));
+            shape.paint(dup, null);
+            imgShape.setImageSource(origSrc);
+          } else {
+            shape.paint(dup, null);
+          }
+        } else if (shape instanceof DynamicElement dynEl) {
           dynEl.paintDynamic(dup, state);
           if (shape instanceof DynamicElementWithPoker dynElWithPoker)
             dynElWithPoker.setAnchor(offset);

--- a/src/main/java/com/cburch/logisim/file/LogisimFile.java
+++ b/src/main/java/com/cburch/logisim/file/LogisimFile.java
@@ -704,9 +704,10 @@ public class LogisimFile extends Library implements LibraryEventSource, CircuitL
     } catch (ParserConfigurationException e) {
       loader.showError("internal error configuring parser");
     } catch (TransformerException e) {
+      org.slf4j.LoggerFactory.getLogger(LogisimFile.class).error("XML Transformation Exception during save", e);
       final var msg = e.getMessage();
       var err = S.get("xmlConversionError");
-      if (msg == null) err += ": " + msg;
+      if (msg != null) err += ": " + msg;
       loader.showError(err);
     } catch (IOException e) {
       loader.showError("Unable to create zip file");

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -218,6 +218,7 @@ final class XmlWriter {
     Source src = new DOMSource(doc);
     Result dest = new StreamResult(out);
     tf.transform(src, dest);
+    out.flush();
   }
 
   void addAttributeSetContent(Element elt, AttributeSet attrs, AttributeDefaultProvider source, boolean userModifiedOnly) {

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -217,6 +217,7 @@ final class XmlWriter {
     Source src = new DOMSource(doc);
     Result dest = new StreamResult(out);
     tf.transform(src, dest);
+    out.flush();
   }
 
   void addAttributeSetContent(Element elt, AttributeSet attrs, AttributeDefaultProvider source, boolean userModifiedOnly) {

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -22,6 +22,7 @@ import com.cburch.logisim.fpga.data.MapComponent;
 import com.cburch.logisim.generated.BuildInfo;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.std.base.Image;
 import com.cburch.logisim.std.base.Text;
 import com.cburch.logisim.std.wiring.ProbeAttributes;
 import com.cburch.logisim.tools.Library;
@@ -235,6 +236,7 @@ final class XmlWriter {
         var newValue = attr.toStandardString(val);
         if (dflt == null || (!dflt.equals(val) && !defaultValue.equals(newValue))
             || (attr.equals(StdAttr.APPEARANCE) && !userModifiedOnly)
+            || (attr.equals(Image.ATTR_LICENSE) && !userModifiedOnly)
             || (attr.equals(ProbeAttributes.PROBEAPPEARANCE) && !userModifiedOnly && val.equals(ProbeAttributes.APPEAR_EVOLUTION_NEW))) {
           final var a = doc.createElement("a");
           a.setAttribute("name", attr.getName());

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -22,6 +22,7 @@ import com.cburch.logisim.fpga.data.MapComponent;
 import com.cburch.logisim.generated.BuildInfo;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.std.base.Image;
 import com.cburch.logisim.std.base.Text;
 import com.cburch.logisim.std.wiring.ProbeAttributes;
 import com.cburch.logisim.tools.Library;
@@ -234,6 +235,7 @@ final class XmlWriter {
         var newValue = attr.toStandardString(val);
         if (dflt == null || (!dflt.equals(val) && !defaultValue.equals(newValue))
             || (attr.equals(StdAttr.APPEARANCE) && !userModifiedOnly)
+            || (attr.equals(Image.ATTR_LICENSE) && !userModifiedOnly)
             || (attr.equals(ProbeAttributes.PROBEAPPEARANCE) && !userModifiedOnly && val.equals(ProbeAttributes.APPEAR_EVOLUTION_NEW))) {
           final var a = doc.createElement("a");
           a.setAttribute("name", attr.getName());

--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditHandler.java
@@ -292,7 +292,6 @@ public class AppearanceEditHandler extends EditHandler implements SelectionListe
                       add,
                       null,
                       null));
-          ImageUtil.checkAndShowCopyrightDisclaimer(canvas.getProject().getFrame());
           return true;
         }
       }

--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditHandler.java
@@ -27,11 +27,18 @@ import com.cburch.logisim.circuit.appear.AppearanceAnchor;
 import com.cburch.logisim.circuit.appear.AppearanceElement;
 import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.data.Location;
+import com.cburch.draw.shapes.ImageShape;
 import com.cburch.logisim.gui.menu.EditHandler;
 import com.cburch.logisim.gui.menu.LogisimMenuBar;
+import com.cburch.logisim.util.ImageUtil;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class AppearanceEditHandler extends EditHandler implements SelectionListener, PropertyChangeListener, CanvasModelListener {
   private final AppearanceCanvas canvas;
@@ -58,7 +65,6 @@ public class AppearanceEditHandler extends EditHandler implements SelectionListe
     final var sel = canvas.getSelection();
     final var selEmpty = sel.isEmpty();
     final var canChange = proj.getLogisimFile().contains(circ);
-    final var clipExists = !Clipboard.isEmpty();
     var selHasRemovable = false;
     for (final var o : sel.getSelected()) {
       if (!(o instanceof AppearanceElement)) {
@@ -104,7 +110,7 @@ public class AppearanceEditHandler extends EditHandler implements SelectionListe
 
     setEnabled(LogisimMenuBar.CUT, selHasRemovable && canChange);
     setEnabled(LogisimMenuBar.COPY, !selEmpty);
-    setEnabled(LogisimMenuBar.PASTE, canChange && clipExists);
+    setEnabled(LogisimMenuBar.PASTE, canChange);
     setEnabled(LogisimMenuBar.DELETE, selHasRemovable && canChange);
     setEnabled(LogisimMenuBar.DUPLICATE, !selEmpty && canChange);
     setEnabled(LogisimMenuBar.SELECT_ALL, true);
@@ -214,8 +220,16 @@ public class AppearanceEditHandler extends EditHandler implements SelectionListe
 
   @Override
   public void paste() {
+    if (pasteSystemClipboardImage()) {
+      return;
+    }
+
+    if (Clipboard.isEmpty()) return;
+
     final var clip = Clipboard.get();
     final var contents = clip.getElements();
+    if (contents.isEmpty()) return;
+
     final var add = new ArrayList<CanvasObject>(contents.size());
     for (final var obj : contents) {
       add.add(obj.clone());
@@ -261,6 +275,36 @@ public class AppearanceEditHandler extends EditHandler implements SelectionListe
                 add,
                 anchorLocation,
                 clip.getAnchorFacing()));
+  }
+
+  private boolean pasteSystemClipboardImage() {
+    try {
+      final var img = ImageUtil.getSystemClipboardImage();
+      if (img != null) {
+        final var base64 = ImageUtil.bufferedImageToBase64(img);
+        if (base64 != null && !base64.isBlank()) {
+          final var shape = new ImageShape(-img.getWidth() / 2, -img.getHeight() / 2, img.getWidth(), img.getHeight());
+          shape.setImageSource(base64);
+          final var add = Collections.<CanvasObject>singletonList(shape);
+          canvas
+              .getProject()
+              .doAction(
+                  new SelectionAction(
+                      canvas,
+                      S.getter("pasteClipboardAction"),
+                      null,
+                      add,
+                      add,
+                      null,
+                      null));
+          return true;
+        }
+      }
+    } catch (Exception e) {
+      org.slf4j.LoggerFactory.getLogger(AppearanceEditHandler.class)
+          .error("Failed to paste image from system clipboard", e);
+    }
+    return false;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditHandler.java
@@ -220,9 +220,7 @@ public class AppearanceEditHandler extends EditHandler implements SelectionListe
 
   @Override
   public void paste() {
-    if (pasteSystemClipboardImage()) {
-      return;
-    }
+    if (pasteSystemClipboardImage()) return;
 
     if (Clipboard.isEmpty()) return;
 
@@ -302,7 +300,7 @@ public class AppearanceEditHandler extends EditHandler implements SelectionListe
       }
     } catch (Exception e) {
       org.slf4j.LoggerFactory.getLogger(AppearanceEditHandler.class)
-          .error("Failed to paste image from system clipboard", e);
+          .error("Failed to paste image from clipboard", e);
     }
     return false;
   }

--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditHandler.java
@@ -31,11 +31,8 @@ import com.cburch.draw.shapes.ImageShape;
 import com.cburch.logisim.gui.menu.EditHandler;
 import com.cburch.logisim.gui.menu.LogisimMenuBar;
 import com.cburch.logisim.util.ImageUtil;
-import java.awt.Toolkit;
-import java.awt.datatransfer.DataFlavor;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -295,6 +292,7 @@ public class AppearanceEditHandler extends EditHandler implements SelectionListe
                       add,
                       null,
                       null));
+          ImageUtil.checkAndShowCopyrightDisclaimer(canvas.getProject().getFrame());
           return true;
         }
       }

--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditPopup.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditPopup.java
@@ -9,12 +9,19 @@
 
 package com.cburch.logisim.gui.appear;
 
+import com.cburch.draw.actions.ModelChangeAttributeAction;
+import com.cburch.draw.model.AttributeMapKey;
+import com.cburch.draw.shapes.ImageShape;
 import com.cburch.logisim.gui.menu.EditHandler;
 import com.cburch.logisim.gui.menu.EditPopup;
 import com.cburch.logisim.gui.menu.LogisimMenuBar;
 import com.cburch.logisim.gui.menu.LogisimMenuItem;
+import com.cburch.logisim.std.Strings;
+import com.cburch.logisim.util.ImageUtil;
 import java.util.HashMap;
 import java.util.Map;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
 
 public class AppearanceEditPopup extends EditPopup implements EditHandler.Listener {
   private static final long serialVersionUID = 1L;
@@ -30,6 +37,104 @@ public class AppearanceEditPopup extends EditPopup implements EditHandler.Listen
     enabled = new HashMap<>();
     handler.computeEnabled();
     initialize();
+    for (final var obj : canvas.getSelection().getSelected()) {
+      if (obj instanceof ImageShape) {
+        addSeparator();
+
+        // ── Reset to Original Size ──────────────────────────────────────────
+        final var resetItem = new JMenuItem(Strings.S.get("imageResetSizeItem"));
+        resetItem.addActionListener(e -> {
+          for (final var selObj : canvas.getSelection().getSelected()) {
+            if (selObj instanceof ImageShape shape) {
+              final var img = ImageUtil.loadBufferedImage(shape.getImageSource());
+              if (img == null) continue;
+              final var origW = img.getWidth();
+              final var origH = img.getHeight();
+              final var oldVals = Map.<AttributeMapKey, Object>of(
+                  new AttributeMapKey(ImageShape.WIDTH_ATTR, shape), shape.getWidth(),
+                  new AttributeMapKey(ImageShape.HEIGHT_ATTR, shape), shape.getHeight());
+              final var newVals = Map.<AttributeMapKey, Object>of(
+                  new AttributeMapKey(ImageShape.WIDTH_ATTR, shape), origW,
+                  new AttributeMapKey(ImageShape.HEIGHT_ATTR, shape), origH);
+              canvas.doAction(new ModelChangeAttributeAction(canvas.getModel(), oldVals, newVals));
+            }
+          }
+        });
+        add(resetItem);
+
+        // ── Optimize Image Size ─────────────────────────────────────────────
+        final var optimizeItem = new JMenuItem(Strings.S.get("imageOptimizeItem"));
+        optimizeItem.addActionListener(e -> {
+          for (final var selObj : canvas.getSelection().getSelected()) {
+            if (selObj instanceof ImageShape shape) {
+              final var frameW = shape.getWidth();
+              final var frameH = shape.getHeight();
+              final var scaleOptAttr = shape.getValue(ImageShape.SCALE_ATTR);
+              final var scaleOpt = scaleOptAttr == null ? "fit" : (String) scaleOptAttr.getValue();
+              final var cachedImg = ImageUtil.loadBufferedImage(shape.getImageSource());
+              if (cachedImg == null) continue;
+              final var targetDims = ImageUtil.getOptimizedTargetDimensions(cachedImg, frameW, frameH, scaleOpt);
+              final var targetW = targetDims[0];
+              final var targetH = targetDims[1];
+              final var origW = cachedImg.getWidth();
+              final var origH = cachedImg.getHeight();
+
+              if (origW == targetW && origH == targetH) {
+                JOptionPane.showMessageDialog(null,
+                    String.format(Strings.S.get("imageAlreadyOptimizedMessage"), origW, origH),
+                    Strings.S.get("imageOptimizeConfirmTitle"),
+                    JOptionPane.INFORMATION_MESSAGE);
+                return;
+              }
+              final var choice = JOptionPane.showConfirmDialog(null,
+                  String.format(Strings.S.get("imageOptimizeConfirmMessage"), origW, origH, targetW, targetH),
+                  Strings.S.get("imageOptimizeConfirmTitle"),
+                  JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+              if (choice == JOptionPane.YES_OPTION) {
+                final var scaled = ImageUtil.optimizeImage(cachedImg, frameW, frameH, scaleOpt);
+                final var base64 = ImageUtil.bufferedImageToBase64(scaled);
+                if (!base64.isBlank()) {
+                  final var oldValsBuilder = new HashMap<AttributeMapKey, Object>();
+                  final var newValsBuilder = new HashMap<AttributeMapKey, Object>();
+                  oldValsBuilder.put(new AttributeMapKey(ImageShape.IMAGE_ATTR, shape), shape.getImageSource());
+                  newValsBuilder.put(new AttributeMapKey(ImageShape.IMAGE_ATTR, shape), base64);
+                  if ("fit".equalsIgnoreCase(scaleOpt) && (origW != targetW || origH != targetH)) {
+                    oldValsBuilder.put(new AttributeMapKey(ImageShape.WIDTH_ATTR, shape), shape.getWidth());
+                    oldValsBuilder.put(new AttributeMapKey(ImageShape.HEIGHT_ATTR, shape), shape.getHeight());
+                    newValsBuilder.put(new AttributeMapKey(ImageShape.WIDTH_ATTR, shape), targetW);
+                    newValsBuilder.put(new AttributeMapKey(ImageShape.HEIGHT_ATTR, shape), targetH);
+                  }
+                  canvas.doAction(new ModelChangeAttributeAction(canvas.getModel(), oldValsBuilder, newValsBuilder));
+                }
+              }
+            }
+          }
+        });
+        add(optimizeItem);
+
+        // ── Make White Background Transparent ──────────────────────────────
+        final var transparentItem = new JMenuItem(Strings.S.get("imageMakeWhiteTransparentItem"));
+        transparentItem.addActionListener(e -> {
+          for (final var selObj : canvas.getSelection().getSelected()) {
+            if (selObj instanceof ImageShape shape) {
+              final var img = ImageUtil.loadBufferedImage(shape.getImageSource());
+              if (img == null) continue;
+              final var transImg = ImageUtil.makeWhiteTransparent(img);
+              final var base64 = ImageUtil.bufferedImageToBase64(transImg);
+              if (!base64.isBlank()) {
+                final var oldVals = Map.<AttributeMapKey, Object>of(
+                    new AttributeMapKey(ImageShape.IMAGE_ATTR, shape), shape.getImageSource());
+                final var newVals = Map.<AttributeMapKey, Object>of(
+                    new AttributeMapKey(ImageShape.IMAGE_ATTR, shape), base64);
+                canvas.doAction(new ModelChangeAttributeAction(canvas.getModel(), oldVals, newVals));
+              }
+            }
+          }
+        });
+        add(transparentItem);
+        break;
+      }
+    }
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceToolbarModel.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceToolbarModel.java
@@ -15,6 +15,7 @@ import com.cburch.draw.toolbar.ToolbarItem;
 import com.cburch.draw.tools.AbstractTool;
 import com.cburch.draw.tools.CurveTool;
 import com.cburch.draw.tools.DrawingAttributeSet;
+import com.cburch.draw.tools.ImageTool;
 import com.cburch.draw.tools.LineTool;
 import com.cburch.draw.tools.OvalTool;
 import com.cburch.draw.tools.PolyTool;
@@ -38,6 +39,7 @@ class AppearanceToolbarModel extends AbstractToolbarModel implements PropertyCha
     AbstractTool[] tools = {
       selectTool,
       new TextTool(attrs),
+      new ImageTool(attrs),
       new LineTool(attrs),
       new CurveTool(attrs),
       new PolyTool(false, attrs),

--- a/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
@@ -10,11 +10,13 @@
 package com.cburch.logisim.gui.generic;
 
 import com.cburch.draw.shapes.DrawAttr;
+import com.cburch.logisim.util.ImageUtil;
 import com.cburch.logisim.util.XmlUtil;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Font;
+import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Shape;
@@ -51,6 +53,7 @@ public class TikZInfo implements Cloneable {
   private static final String PNG_DATA_URI_PREFIX = "data:image/png;base64,";
   private static final String XLINK_NAMESPACE = "http://www.w3.org/1999/xlink";
 
+  private boolean svgMode = false;
   private AffineTransform myTransformer = new AffineTransform();
   private Color drawColor;
   private Color backColor;
@@ -98,9 +101,18 @@ public class TikZInfo implements Cloneable {
     return " (" + getBarePoint(p) + ") ";
   }
 
+  public boolean isSvgMode() {
+    return svgMode;
+  }
+
+  public void setSvgMode(boolean mode) {
+    this.svgMode = mode;
+  }
+
   @Override
   public TikZInfo clone() {
     var newInst = new TikZInfo();
+    newInst.svgMode = svgMode;
     newInst.myTransformer = (AffineTransform) myTransformer.clone();
     newInst.drawColor = drawColor;
     newInst.backColor = backColor;
@@ -1271,7 +1283,19 @@ public class TikZInfo implements Cloneable {
 
     @Override
     public String getTikZCommand() {
-      return "% Raster image omitted: TikZ image export is not supported.";
+      final var pt = new Point2D.Double(0, 0);
+      transform.transform(pt, pt);
+      final var sb = new StringBuilder();
+      sb.append("% Raster image omitted: TikZ image export is not supported.\n");
+      sb.append("\\draw [line width=").append(rounded(getStrokeWidth() * BASIC_STROKE_WIDTH))
+        .append("pt, ").append(getDrawColorString()).append("]");
+      sb.append(getPoint(pt)).append("rectangle");
+      sb.append(getPoint(new Point2D.Double(pt.x + width, pt.y + height)));
+      sb.append(";");
+      sb.append("\\node[anchor=north west, font=\\small] at (").append(rounded(pt.x))
+        .append(",").append(rounded(pt.y)).append(") {[Image: ").append(width).append("x")
+        .append(height).append("]};");
+      return sb.toString();
     }
 
     @Override
@@ -1516,3 +1540,4 @@ public class TikZInfo implements Cloneable {
     }
   }
 }
+

--- a/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
@@ -10,11 +10,13 @@
 package com.cburch.logisim.gui.generic;
 
 import com.cburch.draw.shapes.DrawAttr;
+import com.cburch.logisim.util.ImageUtil;
 import com.cburch.logisim.util.XmlUtil;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Font;
+import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Shape;
@@ -24,6 +26,7 @@ import java.awt.font.TextAttribute;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -44,6 +47,7 @@ public class TikZInfo implements Cloneable {
 
   private static final double BASIC_STROKE_WIDTH = 1;
 
+  private boolean svgMode = false;
   private AffineTransform myTransformer = new AffineTransform();
   private Color drawColor;
   private Color backColor;
@@ -91,9 +95,18 @@ public class TikZInfo implements Cloneable {
     return " (" + getBarePoint(p) + ") ";
   }
 
+  public boolean isSvgMode() {
+    return svgMode;
+  }
+
+  public void setSvgMode(boolean mode) {
+    this.svgMode = mode;
+  }
+
   @Override
   public TikZInfo clone() {
     var newInst = new TikZInfo();
+    newInst.svgMode = svgMode;
     newInst.myTransformer = (AffineTransform) myTransformer.clone();
     newInst.drawColor = drawColor;
     newInst.backColor = backColor;
@@ -231,6 +244,15 @@ public class TikZInfo implements Cloneable {
 
   public void addString(AttributedCharacterIterator str, int x, int y) {
     contents.add(new TikZString(str, x, y));
+  }
+
+  public void addImage(Image img, int x, int y, int width, int height, Color bgcolor) {
+    if (img == null) return;
+    final var bufImg = ImageUtil.toBufferedImage(img);
+    if (bufImg == null) return;
+    final var pos = new Point(x, y);
+    transform(pos, pos);
+    contents.add(new TikZImage(bufImg, pos, width, height, bgcolor));
   }
 
   public void rotate(double theta) {
@@ -1408,6 +1430,72 @@ public class TikZInfo implements Cloneable {
     @Override
     public void move(int dx, int dy) {
       location = new Point(location.x + dx, location.y + dy);
+    }
+  }
+
+  private class TikZImage implements DrawObject {
+    private final BufferedImage image;
+    private final Point pos;
+    private final int width;
+    private final int height;
+    private final Color bgcolor;
+    private final String color;
+    private final float strokeWidth;
+
+    public TikZImage(BufferedImage img, Point pos, int w, int h, Color bg) {
+      this.image = img;
+      this.pos = pos;
+      this.width = Math.max(1, w);
+      this.height = Math.max(1, h);
+      this.bgcolor = bg;
+      this.color = getDrawColorString();
+      this.strokeWidth = getStrokeWidth();
+    }
+
+    @Override
+    public void getSvgCommand(Document root, Element e) {
+      final var ne = root.createElement("image");
+      e.appendChild(ne);
+      ne.setAttribute("x", rounded(pos.x));
+      ne.setAttribute("y", rounded(pos.y));
+      ne.setAttribute("width", Integer.toString(width));
+      ne.setAttribute("height", Integer.toString(height));
+      final var base64 = ImageUtil.bufferedImageToBase64(image);
+      ne.setAttribute("href", base64);
+    }
+
+    @Override
+    public String getTikZCommand() {
+      final var sb = new StringBuilder();
+      sb.append("\\draw [line width=").append(rounded(strokeWidth * BASIC_STROKE_WIDTH))
+        .append("pt, ").append(color).append("]");
+      sb.append(getPoint(new Point2D.Double(pos.x, pos.y))).append("rectangle");
+      sb.append(getPoint(new Point2D.Double(pos.x + width, pos.y + height)));
+      sb.append(";");
+      sb.append("\\node[anchor=north west, font=\\small] at (").append(rounded(pos.x))
+        .append(",").append(rounded(pos.y)).append(") {[Image: ").append(width).append("x")
+        .append(height).append("]};");
+      return sb.toString();
+    }
+
+    @Override
+    public boolean insideArea(int x, int y, int width, int height) {
+      return (pos.x >= x && pos.x <= x + width)
+          && (pos.y >= y && pos.y <= y + height)
+          && (pos.x + this.width >= x && pos.x + this.width <= x + width)
+          && (pos.y + this.height >= y && pos.y + this.height <= y + height);
+    }
+
+    @Override
+    public DrawObject clone() {
+      return new TikZImage(image, (Point) pos.clone(), width, height, bgcolor);
+    }
+
+    @Override
+    public void move(int dx, int dy) {
+      final var move = new Point(dx, dy);
+      transform(move, move);
+      pos.setLocation(pos.x + move.x, pos.y + move.y);
     }
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/generic/TikZWriter.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/TikZWriter.java
@@ -53,6 +53,10 @@ public class TikZWriter extends Graphics2D {
     MyInfo = info;
   }
 
+  public void setSvgMode(boolean mode) {
+    MyInfo.setSvgMode(mode);
+  }
+
   @Override
   public void draw(Shape s) {
     MyInfo.addBezier(s, false);

--- a/src/main/java/com/cburch/logisim/gui/generic/TikZWriter.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/TikZWriter.java
@@ -53,6 +53,10 @@ public class TikZWriter extends Graphics2D {
     MyInfo = info;
   }
 
+  public void setSvgMode(boolean mode) {
+    MyInfo.setSvgMode(mode);
+  }
+
   @Override
   public void draw(Shape s) {
     MyInfo.addBezier(s, false);
@@ -404,9 +408,7 @@ public class TikZWriter extends Graphics2D {
 
   @Override
   public boolean drawImage(Image img, int x, int y, int width, int height, ImageObserver observer) {
-    System.out.println(
-        "TikZ not yet supported : drawImage(Image img, int x, int y, int width, int height, ImageObserver observer)");
-    return false;
+    return drawImage(img, x, y, width, height, null, observer);
   }
 
   @Override
@@ -419,9 +421,8 @@ public class TikZWriter extends Graphics2D {
   @Override
   public boolean drawImage(
       Image img, int x, int y, int width, int height, Color bgcolor, ImageObserver observer) {
-    System.out.println(
-        "TikZ not yet supported : drawImage(Image img, int x, int y, int width, int height, Color bgcolor, ImageObserver observer)");
-    return false;
+    MyInfo.addImage(img, x, y, width, height, bgcolor);
+    return true;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/icons/ImageIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ImageIcon.java
@@ -1,0 +1,30 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.icons;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+
+public class ImageIcon extends BaseIcon {
+
+  @Override
+  protected void paintIcon(Graphics2D g2) {
+    g2.drawRect(scale(1), scale(1), scale(13), scale(13));
+
+    // Enlarged yellow sun
+    g2.setColor(new Color(0xFA, 0xCC, 0x15));
+    g2.fillOval(scale(3), scale(3), scale(4), scale(4));
+
+    g2.setColor(new Color(0x22, 0xC5, 0x5E));
+    final int[] xPoints = {scale(2), scale(7), scale(10), scale(13), scale(13), scale(2)};
+    final int[] yPoints = {scale(13), scale(7), scale(10), scale(7), scale(13), scale(13)};
+    g2.fillPolygon(xPoints, yPoints, 6);
+  }
+}

--- a/src/main/java/com/cburch/logisim/gui/main/ExportImage.java
+++ b/src/main/java/com/cburch/logisim/gui/main/ExportImage.java
@@ -237,7 +237,9 @@ public class ExportImage {
       Graphics base;
       final var img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
       if (filter.type == FORMAT_TIKZ || filter.type == FORMAT_SVG) {
-        base = new TikZWriter();
+        final var tz = new TikZWriter();
+        tz.setSvgMode(filter.type == FORMAT_SVG);
+        base = tz;
         g = base.create();
       } else {
         base = img.getGraphics();

--- a/src/main/java/com/cburch/logisim/gui/main/LayoutEditHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/main/LayoutEditHandler.java
@@ -199,7 +199,6 @@ public class LayoutEditHandler extends EditHandler
           final var xn = new CircuitMutation(circuit);
           xn.add(comp);
           proj.doAction(xn.toAction(S.getter("addComponentAction", Image.FACTORY.getDisplayGetter())));
-          ImageUtil.checkAndShowCopyrightDisclaimer(proj.getFrame());
           return true;
         }
       }

--- a/src/main/java/com/cburch/logisim/gui/main/LayoutEditHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/main/LayoutEditHandler.java
@@ -9,6 +9,10 @@
 
 package com.cburch.logisim.gui.main;
 
+import static com.cburch.logisim.gui.Strings.S;
+
+import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.data.Location;
 import com.cburch.logisim.file.LibraryEvent;
 import com.cburch.logisim.file.LibraryListener;
 import com.cburch.logisim.gui.menu.EditHandler;
@@ -17,11 +21,17 @@ import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.proj.ProjectEvent;
 import com.cburch.logisim.proj.ProjectListener;
 import com.cburch.logisim.std.base.BaseLibrary;
+import com.cburch.logisim.std.base.Image;
 import com.cburch.logisim.tools.EditTool;
 import com.cburch.logisim.tools.TextEditActions;
 import com.cburch.logisim.tools.TextTool;
+import com.cburch.logisim.util.ImageUtil;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.util.List;
 
 public class LayoutEditHandler extends EditHandler
     implements ProjectListener, LibraryListener, PropertyChangeListener {
@@ -75,7 +85,7 @@ public class LayoutEditHandler extends EditHandler
 
     setEnabled(LogisimMenuBar.CUT, !selEmpty && selectAvailable && canChange);
     setEnabled(LogisimMenuBar.COPY, !selEmpty && selectAvailable);
-    setEnabled(LogisimMenuBar.PASTE, selectAvailable && canChange && !Clipboard.isEmpty());
+    setEnabled(LogisimMenuBar.PASTE, selectAvailable && canChange);
     setEnabled(LogisimMenuBar.DELETE, !selEmpty && selectAvailable && canChange);
     setEnabled(LogisimMenuBar.DUPLICATE, !selEmpty && selectAvailable && canChange);
     setEnabled(LogisimMenuBar.SELECT_ALL, selectAvailable);
@@ -161,10 +171,44 @@ public class LayoutEditHandler extends EditHandler
     final var proj = frame.getProject();
     final var sel = frame.getCanvas().getSelection();
     selectSelectTool(proj);
-    final var action = SelectionActions.pasteMaybe(proj, sel);
-    if (action != null) {
-      proj.doAction(action);
+
+    if (pasteSystemClipboardImage(proj)) {
+      return;
     }
+
+    if (!Clipboard.isEmpty()) {
+      final var action = SelectionActions.pasteMaybe(proj, sel);
+      if (action != null) {
+        proj.doAction(action);
+        return;
+      }
+    }
+  }
+
+  private boolean pasteSystemClipboardImage(Project proj) {
+    try {
+      final var img = ImageUtil.getSystemClipboardImage();
+      if (img != null) {
+        final var base64 = ImageUtil.bufferedImageToBase64(img);
+        if (base64 != null && !base64.isBlank()) {
+          final var circuit = proj.getCurrentCircuit();
+          final var attrs = Image.FACTORY.createAttributeSet();
+          attrs.setValue(Image.ATTR_IMAGE, base64);
+          attrs.setValue(Image.ATTR_WIDTH, img.getWidth());
+          attrs.setValue(Image.ATTR_HEIGHT, img.getHeight());
+
+          final var comp = Image.FACTORY.createComponent(Location.create(100, 100, false), attrs);
+          final var xn = new CircuitMutation(circuit);
+          xn.add(comp);
+          proj.doAction(xn.toAction(S.getter("addComponentAction", Image.FACTORY.getDisplayGetter())));
+          return true;
+        }
+      }
+    } catch (Exception e) {
+      org.slf4j.LoggerFactory.getLogger(LayoutEditHandler.class)
+          .error("Failed to paste image onto layout canvas from system clipboard", e);
+    }
+    return false;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/main/LayoutEditHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/main/LayoutEditHandler.java
@@ -26,8 +26,6 @@ import com.cburch.logisim.tools.EditTool;
 import com.cburch.logisim.tools.TextEditActions;
 import com.cburch.logisim.tools.TextTool;
 import com.cburch.logisim.util.ImageUtil;
-import java.awt.Toolkit;
-import java.awt.datatransfer.DataFlavor;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
@@ -201,6 +199,7 @@ public class LayoutEditHandler extends EditHandler
           final var xn = new CircuitMutation(circuit);
           xn.add(comp);
           proj.doAction(xn.toAction(S.getter("addComponentAction", Image.FACTORY.getDisplayGetter())));
+          ImageUtil.checkAndShowCopyrightDisclaimer(proj.getFrame());
           return true;
         }
       }

--- a/src/main/java/com/cburch/logisim/gui/main/SelectionActions.java
+++ b/src/main/java/com/cburch/logisim/gui/main/SelectionActions.java
@@ -130,6 +130,7 @@ public class SelectionActions {
 
     ArrayList<String> dropped = null;
     final var clip = Clipboard.get();
+    if (clip == null) return null;
     final var comps = clip.getComponents();
     final var factoryReplacements = new HashMap<ComponentFactory, ComponentFactory>();
     for (final var comp : comps) {

--- a/src/main/java/com/cburch/logisim/gui/main/SelectionAttributes.java
+++ b/src/main/java/com/cburch/logisim/gui/main/SelectionAttributes.java
@@ -340,6 +340,7 @@ class SelectionAttributes extends AbstractAttributeSet {
     public void attributeValueChanged(AttributeEvent e) {
       if (listening) {
         updateList(false);
+        selection.fireSelectionChanged();
       }
     }
 

--- a/src/main/java/com/cburch/logisim/gui/menu/PrintHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/PrintHandler.java
@@ -146,6 +146,9 @@ public abstract class PrintHandler implements Printable {
     }
     final var img = new BufferedImage(d.width, d.height, BufferedImage.TYPE_INT_RGB);
     final var base = (fmt == ExportImage.FORMAT_TIKZ || fmt == ExportImage.FORMAT_SVG) ? new TikZWriter() : img.getGraphics();
+    if (base instanceof TikZWriter tz) {
+      tz.setSvgMode(fmt == ExportImage.FORMAT_SVG);
+    }
     final var gr = base.create();
 
     try {

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -557,6 +557,8 @@ public class AppPreferences {
       create(new PrefMonitorBoolean("NoGatedClockWarnings", false));
   public static final PrefMonitor<Boolean> SuppressOpenPinWarnings =
       create(new PrefMonitorBoolean("NoOpenPinWarnings", false));
+  public static final PrefMonitor<Boolean> IMAGE_COPYRIGHT_WARNED =
+      create(new PrefMonitorBoolean("imageCopyrightWarned", false));
   public static final PrefMonitor<Boolean> VhdlKeywordsUpperCase =
       create(new PrefMonitorBoolean("VhdlKeywordsUpperCase", true));
   //file preferences

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -557,8 +557,6 @@ public class AppPreferences {
       create(new PrefMonitorBoolean("NoGatedClockWarnings", false));
   public static final PrefMonitor<Boolean> SuppressOpenPinWarnings =
       create(new PrefMonitorBoolean("NoOpenPinWarnings", false));
-  public static final PrefMonitor<Boolean> IMAGE_COPYRIGHT_WARNED =
-      create(new PrefMonitorBoolean("imageCopyrightWarned", false));
   public static final PrefMonitor<Boolean> VhdlKeywordsUpperCase =
       create(new PrefMonitorBoolean("VhdlKeywordsUpperCase", true));
   //file preferences

--- a/src/main/java/com/cburch/logisim/std/base/BaseLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/base/BaseLibrary.java
@@ -35,24 +35,25 @@ public class BaseLibrary extends Library {
 
   private final List<Tool> tools;
   private final AddTool textAdder = new AddTool(Text.FACTORY);
+  private final AddTool imageAdder = new AddTool(Image.FACTORY);
   private final SelectTool selectTool = new SelectTool();
 
   public BaseLibrary() {
     setHidden();
     WiringTool wiring = new WiringTool();
 
-    tools =
-        Arrays.asList(
-            new PokeTool(),
-            new EditTool(selectTool, wiring),
-            wiring,
-            new TextTool(),
-            new MenuTool());
+    tools = Arrays.asList(
+        new PokeTool(),
+        new EditTool(selectTool, wiring),
+        wiring,
+        new TextTool(),
+        imageAdder,
+        new MenuTool());
   }
 
   @Override
   public boolean contains(ComponentFactory querry) {
-    return super.contains(querry) || (querry instanceof Text);
+    return super.contains(querry) || (querry instanceof Text) || (querry instanceof Image);
   }
 
   @Override
@@ -60,6 +61,9 @@ public class BaseLibrary extends Library {
     final var t = super.getTool(name);
     if (t == null && name.equals(Text._ID)) {
       return textAdder; // needed by XmlCircuitReader
+    }
+    if (t == null && name.equals(Image._ID)) {
+      return imageAdder;
     }
     return t;
   }

--- a/src/main/java/com/cburch/logisim/std/base/Image.java
+++ b/src/main/java/com/cburch/logisim/std/base/Image.java
@@ -22,12 +22,12 @@ import com.cburch.logisim.instance.InstanceFactory;
 import com.cburch.logisim.instance.InstancePainter;
 import com.cburch.logisim.instance.InstanceState;
 import java.awt.Color;
-import java.awt.Graphics;
 import java.awt.Graphics2D;
 
 import com.cburch.logisim.circuit.CircuitMutation;
 import com.cburch.logisim.tools.MenuExtender;
 import com.cburch.logisim.util.ImageUtil;
+import com.cburch.logisim.util.StringUtil;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
@@ -45,6 +45,40 @@ public class Image extends InstanceFactory {
           new AttributeOption("stretch", "stretch", S.getter("imageScaleStretchOpt")),
           new AttributeOption("cover", "cover", S.getter("imageScaleCoverOpt")),
       });
+
+  public static final AttributeOption LICENSE_UNSPECIFIED = new AttributeOption("Unspecified", S.getter("imageLicenseUnspecifiedOpt"));
+  public static final AttributeOption LICENSE_PUBLIC_DOMAIN = new AttributeOption("Public Domain / CC0", StringUtil.constantGetter("Public Domain / CC0"));
+  public static final AttributeOption LICENSE_CC_BY = new AttributeOption("CC BY (Attribution)", StringUtil.constantGetter("CC BY (Attribution)"));
+  public static final AttributeOption LICENSE_CC_BY_SA = new AttributeOption("CC BY-SA (Attribution-ShareAlike)", StringUtil.constantGetter("CC BY-SA (Attribution-ShareAlike)"));
+  public static final AttributeOption LICENSE_CC_BY_NC = new AttributeOption("CC BY-NC (NonCommercial)", StringUtil.constantGetter("CC BY-NC (NonCommercial)"));
+  public static final AttributeOption LICENSE_CC_BY_ND = new AttributeOption("CC BY-ND (NoDerivatives)", StringUtil.constantGetter("CC BY-ND (NoDerivatives)"));
+  public static final AttributeOption LICENSE_FAIR_USE = new AttributeOption("Fair Use / Educational", StringUtil.constantGetter("Fair Use / Educational"));
+  public static final AttributeOption LICENSE_PROPRIETARY = new AttributeOption("Proprietary / Copyrighted", StringUtil.constantGetter("Proprietary / Copyrighted"));
+  public static final AttributeOption LICENSE_OTHER = new AttributeOption("Other", S.getter("imageLicenseOtherOpt"));
+
+
+
+  public static final Attribute<AttributeOption> ATTR_LICENSE = Attributes.forOption(
+      "license",
+      S.getter("imageLicenseAttr"),
+      new AttributeOption[] {
+          LICENSE_UNSPECIFIED,
+          LICENSE_PUBLIC_DOMAIN,
+          LICENSE_CC_BY,
+          LICENSE_CC_BY_SA,
+          LICENSE_CC_BY_NC,
+          LICENSE_CC_BY_ND,
+          LICENSE_FAIR_USE,
+          LICENSE_PROPRIETARY,
+          LICENSE_OTHER
+      });
+
+  public static final Attribute<String> ATTR_ATTRIBUTION = Attributes.forString(
+      "attribution",
+      S.getter("imageAttributionAttr"));
+
+
+
 
   public static final Image FACTORY = new Image();
 

--- a/src/main/java/com/cburch/logisim/std/base/Image.java
+++ b/src/main/java/com/cburch/logisim/std/base/Image.java
@@ -212,12 +212,13 @@ public class Image extends InstanceFactory {
     final var img = attrs.getCachedImage();
 
     if (img != null) {
+      final var drawImg = painter.isPrintView() ? ImageUtil.toGrayscale(img) : img;
       final var scaleOpt = attrs.getScale() == null ? "fit" : (String) attrs.getScale().getValue();
       if ("stretch".equals(scaleOpt)) {
-        g.drawImage(img, 0, 0, w, h, null);
+        g.drawImage(drawImg, 0, 0, w, h, null);
       } else if ("cover".equals(scaleOpt)) {
-        final var imgW = img.getWidth();
-        final var imgH = img.getHeight();
+        final var imgW = drawImg.getWidth();
+        final var imgH = drawImg.getHeight();
         final var scale = Math.max((double) w / imgW, (double) h / imgH);
         final var targetW = Math.max(1, (int) (imgW * scale));
         final var targetH = Math.max(1, (int) (imgH * scale));
@@ -225,17 +226,17 @@ public class Image extends InstanceFactory {
         final var targetY = (h - targetH) / 2;
         final var oldClip = g.getClip();
         g.clipRect(0, 0, w, h);
-        g.drawImage(img, targetX, targetY, targetW, targetH, null);
+        g.drawImage(drawImg, targetX, targetY, targetW, targetH, null);
         g.setClip(oldClip);
       } else { // fit — preserve aspect ratio
-        final var imgW = img.getWidth();
-        final var imgH = img.getHeight();
+        final var imgW = drawImg.getWidth();
+        final var imgH = drawImg.getHeight();
         final var scale = Math.min((double) w / imgW, (double) h / imgH);
         final var targetW = Math.max(1, (int) (imgW * scale));
         final var targetH = Math.max(1, (int) (imgH * scale));
         final var targetX = (w - targetW) / 2;
         final var targetY = (h - targetH) / 2;
-        g.drawImage(img, targetX, targetY, targetW, targetH, null);
+        g.drawImage(drawImg, targetX, targetY, targetW, targetH, null);
       }
     } else {
       g.setColor(Color.LIGHT_GRAY);

--- a/src/main/java/com/cburch/logisim/std/base/Image.java
+++ b/src/main/java/com/cburch/logisim/std/base/Image.java
@@ -1,0 +1,238 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.base;
+
+import static com.cburch.logisim.std.Strings.S;
+
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.data.AttributeOption;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.data.Attributes;
+import com.cburch.logisim.data.Bounds;
+import com.cburch.logisim.gui.icons.ImageIcon;
+import com.cburch.logisim.instance.Instance;
+import com.cburch.logisim.instance.InstanceFactory;
+import com.cburch.logisim.instance.InstancePainter;
+import com.cburch.logisim.instance.InstanceState;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+
+import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.tools.MenuExtender;
+import com.cburch.logisim.util.ImageUtil;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
+
+public class Image extends InstanceFactory {
+  public static final String _ID = "Image";
+
+  public static final Attribute<String> ATTR_IMAGE = new ImageSourceAttribute("image");
+  public static final Attribute<Integer> ATTR_WIDTH = Attributes.forInteger("width", S.getter("imageWidthAttr"));
+  public static final Attribute<Integer> ATTR_HEIGHT = Attributes.forInteger("height", S.getter("imageHeightAttr"));
+  public static final Attribute<AttributeOption> ATTR_SCALE = Attributes.forOption(
+      "scale",
+      S.getter("imageScaleAttr"),
+      new AttributeOption[] {
+          new AttributeOption("fit", "fit", S.getter("imageScaleFitOpt")),
+          new AttributeOption("stretch", "stretch", S.getter("imageScaleStretchOpt")),
+          new AttributeOption("cover", "cover", S.getter("imageScaleCoverOpt")),
+      });
+
+  public static final Image FACTORY = new Image();
+
+  private Image() {
+    super(_ID, S.getter("imageComponent"));
+    setShouldSnap(false);
+  }
+
+  @Override
+  protected void configureNewInstance(Instance instance) {
+    instance.addAttributeListener();
+  }
+
+  @Override
+  protected Object getInstanceFeature(Instance instance, Object key) {
+    if (key == MenuExtender.class) {
+      return (MenuExtender) (menu, proj) -> {
+        final var resetItem = new JMenuItem(S.get("imageResetSizeItem"));
+        resetItem.addActionListener(e -> {
+          final var attrs = (ImageAttributes) instance.getAttributeSet();
+          final var img = attrs.getCachedImage();
+          if (img != null) {
+            final var circuit = proj.getCurrentCircuit();
+            if (circuit != null) {
+              final var mutation = new CircuitMutation(circuit);
+              mutation.set(instance.getComponent(), ATTR_WIDTH, img.getWidth());
+              mutation.set(instance.getComponent(), ATTR_HEIGHT, img.getHeight());
+              proj.doAction(mutation.toAction(S.getter("imageResetSizeItem")));
+            }
+          }
+        });
+        menu.add(resetItem);
+
+        final var optimizeItem = new JMenuItem(S.get("imageOptimizeItem"));
+        optimizeItem.addActionListener(e -> {
+          final var attrs = (ImageAttributes) instance.getAttributeSet();
+          final var img = attrs.getCachedImage();
+          if (img != null) {
+            final var frameW = attrs.getWidth();
+            final var frameH = attrs.getHeight();
+            final var scaleOpt = attrs.getScale() == null ? "fit" : (String) attrs.getScale().getValue();
+            final var targetDims = ImageUtil.getOptimizedTargetDimensions(img, frameW, frameH, scaleOpt);
+            final var targetW = targetDims[0];
+            final var targetH = targetDims[1];
+            final var origW = img.getWidth();
+            final var origH = img.getHeight();
+
+            if (origW == targetW && origH == targetH) {
+              JOptionPane.showMessageDialog(
+                  null,
+                  String.format(S.get("imageAlreadyOptimizedMessage"), origW, origH),
+                  S.get("imageOptimizeConfirmTitle"),
+                  JOptionPane.INFORMATION_MESSAGE);
+              return;
+            }
+            final var choice = JOptionPane.showConfirmDialog(
+                null,
+                String.format(S.get("imageOptimizeConfirmMessage"), origW, origH, targetW, targetH),
+                S.get("imageOptimizeConfirmTitle"),
+                JOptionPane.YES_NO_OPTION,
+                JOptionPane.QUESTION_MESSAGE);
+            if (choice == JOptionPane.YES_OPTION) {
+              final var scaled = ImageUtil.optimizeImage(img, frameW, frameH, scaleOpt);
+              final var base64 = ImageUtil.bufferedImageToBase64(scaled);
+              final var circuit = proj.getCurrentCircuit();
+              if (circuit != null && !base64.isBlank()) {
+                final var mutation = new CircuitMutation(circuit);
+                mutation.set(instance.getComponent(), ATTR_IMAGE, base64);
+                if ("fit".equalsIgnoreCase(scaleOpt) && (origW != targetW || origH != targetH)) {
+                  mutation.set(instance.getComponent(), ATTR_WIDTH, targetW);
+                  mutation.set(instance.getComponent(), ATTR_HEIGHT, targetH);
+                }
+                proj.doAction(mutation.toAction(S.getter("imageOptimizeItem")));
+              }
+            }
+          }
+        });
+        menu.add(optimizeItem);
+
+        final var transparentItem = new JMenuItem(S.get("imageMakeWhiteTransparentItem"));
+        transparentItem.addActionListener(e -> {
+          final var attrs = (ImageAttributes) instance.getAttributeSet();
+          final var img = attrs.getCachedImage();
+          if (img != null) {
+            final var transImg = ImageUtil.makeWhiteTransparent(img);
+            final var base64 = ImageUtil.bufferedImageToBase64(transImg);
+            final var circuit = proj.getCurrentCircuit();
+            if (circuit != null && !base64.isBlank()) {
+              final var mutation = new CircuitMutation(circuit);
+              mutation.set(instance.getComponent(), ATTR_IMAGE, base64);
+              proj.doAction(mutation.toAction(S.getter("imageMakeWhiteTransparentItem")));
+            }
+          }
+        });
+        menu.add(transparentItem);
+      };
+    }
+    return super.getInstanceFeature(instance, key);
+  }
+
+  @Override
+  protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
+    if (attr == ATTR_WIDTH || attr == ATTR_HEIGHT || attr == ATTR_IMAGE || attr == ATTR_SCALE) {
+      instance.recomputeBounds();
+      instance.fireInvalidated();
+    }
+  }
+
+  @Override
+  public AttributeSet createAttributeSet() {
+    return new ImageAttributes();
+  }
+
+  @Override
+  public Bounds getOffsetBounds(AttributeSet attrsBase) {
+    ImageAttributes attrs = (ImageAttributes) attrsBase;
+    return attrs.getOffsetBounds();
+  }
+
+  @Override
+  public boolean isHDLSupportedComponent(AttributeSet attrs) {
+    return false;
+  }
+
+  @Override
+  public void paintGhost(InstancePainter painter) {
+    final var attrs = (ImageAttributes) painter.getAttributeSet();
+    final var g = painter.getGraphics();
+    final var w = attrs.getWidth();
+    final var h = attrs.getHeight();
+    final var img = attrs.getCachedImage();
+
+    if (img != null) {
+      final var scaleOpt = attrs.getScale() == null ? "fit" : (String) attrs.getScale().getValue();
+      if ("stretch".equals(scaleOpt)) {
+        g.drawImage(img, 0, 0, w, h, null);
+      } else if ("cover".equals(scaleOpt)) {
+        final var imgW = img.getWidth();
+        final var imgH = img.getHeight();
+        final var scale = Math.max((double) w / imgW, (double) h / imgH);
+        final var targetW = Math.max(1, (int) (imgW * scale));
+        final var targetH = Math.max(1, (int) (imgH * scale));
+        final var targetX = (w - targetW) / 2;
+        final var targetY = (h - targetH) / 2;
+        final var oldClip = g.getClip();
+        g.clipRect(0, 0, w, h);
+        g.drawImage(img, targetX, targetY, targetW, targetH, null);
+        g.setClip(oldClip);
+      } else { // fit — preserve aspect ratio
+        final var imgW = img.getWidth();
+        final var imgH = img.getHeight();
+        final var scale = Math.min((double) w / imgW, (double) h / imgH);
+        final var targetW = Math.max(1, (int) (imgW * scale));
+        final var targetH = Math.max(1, (int) (imgH * scale));
+        final var targetX = (w - targetW) / 2;
+        final var targetY = (h - targetH) / 2;
+        g.drawImage(img, targetX, targetY, targetW, targetH, null);
+      }
+    } else {
+      g.setColor(Color.LIGHT_GRAY);
+      g.fillRect(0, 0, w, h);
+      g.setColor(Color.GRAY);
+      g.drawRect(0, 0, w - 1, h - 1);
+      g.drawLine(0, 0, w - 1, h - 1);
+      g.drawLine(0, h - 1, w - 1, 0);
+    }
+  }
+
+  @Override
+  public void paintIcon(InstancePainter painter) {
+    Graphics2D g2 = (Graphics2D) painter.getGraphics().create();
+    ImageIcon icon = new ImageIcon();
+    icon.paintIcon(null, g2, 0, 0);
+    g2.dispose();
+  }
+
+  @Override
+  public void paintInstance(InstancePainter painter) {
+    final var loc = painter.getLocation();
+    final var x = loc.getX();
+    final var y = loc.getY();
+    final var g = painter.getGraphics();
+    g.translate(x, y);
+    paintGhost(painter);
+    g.translate(-x, -y);
+  }
+
+  @Override
+  public void propagate(InstanceState state) {
+  }
+}

--- a/src/main/java/com/cburch/logisim/std/base/Image.java
+++ b/src/main/java/com/cburch/logisim/std/base/Image.java
@@ -56,8 +56,6 @@ public class Image extends InstanceFactory {
   public static final AttributeOption LICENSE_PROPRIETARY = new AttributeOption("Proprietary / Copyrighted", StringUtil.constantGetter("Proprietary / Copyrighted"));
   public static final AttributeOption LICENSE_OTHER = new AttributeOption("Other", S.getter("imageLicenseOtherOpt"));
 
-
-
   public static final Attribute<AttributeOption> ATTR_LICENSE = Attributes.forOption(
       "license",
       S.getter("imageLicenseAttr"),
@@ -77,8 +75,9 @@ public class Image extends InstanceFactory {
       "attribution",
       S.getter("imageAttributionAttr"));
 
-
-
+  public static final Attribute<String> ATTR_DATA_SIZE = Attributes.forString(
+      "dataSize",
+      S.getter("imageDataSizeAttr"));
 
   public static final Image FACTORY = new Image();
 

--- a/src/main/java/com/cburch/logisim/std/base/ImageAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/base/ImageAttributes.java
@@ -22,12 +22,17 @@ import java.util.Objects;
 
 public class ImageAttributes extends AbstractAttributeSet {
   private static final List<Attribute<?>> ATTRIBUTES = Arrays.asList(
-      Image.ATTR_IMAGE, Image.ATTR_WIDTH, Image.ATTR_HEIGHT, Image.ATTR_SCALE);
+      Image.ATTR_IMAGE, Image.ATTR_WIDTH, Image.ATTR_HEIGHT, Image.ATTR_SCALE, Image.ATTR_LICENSE, Image.ATTR_ATTRIBUTION);
+
+
+
 
   private String imageSource;
   private Integer width;
   private Integer height;
   private AttributeOption scale;
+  private AttributeOption license;
+  private String attribution;
   private Bounds offsetBounds;
   private BufferedImage cachedImage;
   private boolean userSetDimensions;
@@ -37,6 +42,8 @@ public class ImageAttributes extends AbstractAttributeSet {
     width = 64;
     height = 64;
     scale = Image.ATTR_SCALE.parse("fit");
+    license = Image.LICENSE_UNSPECIFIED;
+    attribution = "";
     offsetBounds = Bounds.create(0, 0, width, height);
     cachedImage = null;
     userSetDimensions = false;
@@ -49,6 +56,8 @@ public class ImageAttributes extends AbstractAttributeSet {
     dest.width = this.width;
     dest.height = this.height;
     dest.scale = this.scale;
+    dest.license = this.license;
+    dest.attribution = this.attribution;
     dest.offsetBounds = this.offsetBounds;
     dest.cachedImage = this.cachedImage;
     dest.userSetDimensions = this.userSetDimensions;
@@ -107,6 +116,10 @@ public class ImageAttributes extends AbstractAttributeSet {
       return (V) height;
     if (attr == Image.ATTR_SCALE)
       return (V) scale;
+    if (attr == Image.ATTR_LICENSE)
+      return (V) license;
+    if (attr == Image.ATTR_ATTRIBUTION)
+      return (V) attribution;
     return null;
   }
 
@@ -142,6 +155,10 @@ public class ImageAttributes extends AbstractAttributeSet {
       offsetBounds = Bounds.create(0, 0, getWidth(), getHeight());
     } else if (attr == Image.ATTR_SCALE) {
       scale = (AttributeOption) value;
+    } else if (attr == Image.ATTR_LICENSE) {
+      license = (AttributeOption) value;
+    } else if (attr == Image.ATTR_ATTRIBUTION) {
+      attribution = value == null ? "" : (String) value;
     } else {
       return;
     }

--- a/src/main/java/com/cburch/logisim/std/base/ImageAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/base/ImageAttributes.java
@@ -22,10 +22,7 @@ import java.util.Objects;
 
 public class ImageAttributes extends AbstractAttributeSet {
   private static final List<Attribute<?>> ATTRIBUTES = Arrays.asList(
-      Image.ATTR_IMAGE, Image.ATTR_WIDTH, Image.ATTR_HEIGHT, Image.ATTR_SCALE, Image.ATTR_LICENSE, Image.ATTR_ATTRIBUTION);
-
-
-
+      Image.ATTR_IMAGE, Image.ATTR_WIDTH, Image.ATTR_HEIGHT, Image.ATTR_SCALE, Image.ATTR_DATA_SIZE, Image.ATTR_LICENSE, Image.ATTR_ATTRIBUTION);
 
   private String imageSource;
   private Integer width;
@@ -68,6 +65,18 @@ public class ImageAttributes extends AbstractAttributeSet {
     return ATTRIBUTES;
   }
 
+  @Override
+  public boolean isReadOnly(Attribute<?> attr) {
+    if (attr == Image.ATTR_DATA_SIZE) return true;
+    return super.isReadOnly(attr);
+  }
+
+  @Override
+  public boolean isToSave(Attribute<?> attr) {
+    if (attr == Image.ATTR_DATA_SIZE) return false;
+    return super.isToSave(attr);
+  }
+
   public String getImageSource() {
     return imageSource;
   }
@@ -105,6 +114,10 @@ public class ImageAttributes extends AbstractAttributeSet {
     this.cachedImage = img;
   }
 
+  public String getDataSizeFormatted() {
+    return ImageUtil.formatDataSize(imageSource);
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public <V> V getValue(Attribute<V> attr) {
@@ -116,6 +129,8 @@ public class ImageAttributes extends AbstractAttributeSet {
       return (V) height;
     if (attr == Image.ATTR_SCALE)
       return (V) scale;
+    if (attr == Image.ATTR_DATA_SIZE)
+      return (V) getDataSizeFormatted();
     if (attr == Image.ATTR_LICENSE)
       return (V) license;
     if (attr == Image.ATTR_ATTRIBUTION)
@@ -163,5 +178,8 @@ public class ImageAttributes extends AbstractAttributeSet {
       return;
     }
     fireAttributeValueChanged(attr, value, null);
+    if (attr == Image.ATTR_IMAGE) {
+      fireAttributeValueChanged(Image.ATTR_DATA_SIZE, getDataSizeFormatted(), null);
+    }
   }
 }

--- a/src/main/java/com/cburch/logisim/std/base/ImageAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/base/ImageAttributes.java
@@ -1,0 +1,150 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.base;
+
+import com.cburch.logisim.data.AbstractAttributeSet;
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.data.AttributeOption;
+import com.cburch.logisim.data.Bounds;
+import com.cburch.logisim.util.ImageUtil;
+
+import java.awt.image.BufferedImage;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class ImageAttributes extends AbstractAttributeSet {
+  private static final List<Attribute<?>> ATTRIBUTES = Arrays.asList(
+      Image.ATTR_IMAGE, Image.ATTR_WIDTH, Image.ATTR_HEIGHT, Image.ATTR_SCALE);
+
+  private String imageSource;
+  private Integer width;
+  private Integer height;
+  private AttributeOption scale;
+  private Bounds offsetBounds;
+  private BufferedImage cachedImage;
+  private boolean userSetDimensions;
+
+  public ImageAttributes() {
+    imageSource = "";
+    width = 64;
+    height = 64;
+    scale = Image.ATTR_SCALE.parse("fit");
+    offsetBounds = Bounds.create(0, 0, width, height);
+    cachedImage = null;
+    userSetDimensions = false;
+  }
+
+  @Override
+  protected void copyInto(AbstractAttributeSet destObj) {
+    final var dest = (ImageAttributes) destObj;
+    dest.imageSource = this.imageSource;
+    dest.width = this.width;
+    dest.height = this.height;
+    dest.scale = this.scale;
+    dest.offsetBounds = this.offsetBounds;
+    dest.cachedImage = this.cachedImage;
+    dest.userSetDimensions = this.userSetDimensions;
+  }
+
+  @Override
+  public List<Attribute<?>> getAttributes() {
+    return ATTRIBUTES;
+  }
+
+  public String getImageSource() {
+    return imageSource;
+  }
+
+  public int getWidth() {
+    return width == null ? 64 : width;
+  }
+
+  public int getHeight() {
+    return height == null ? 64 : height;
+  }
+
+  public AttributeOption getScale() {
+    return scale;
+  }
+
+  public Bounds getOffsetBounds() {
+    return offsetBounds;
+  }
+
+  public boolean setOffsetBounds(Bounds value) {
+    Bounds old = offsetBounds;
+    boolean same = Objects.equals(old, value);
+    if (!same) {
+      offsetBounds = value;
+    }
+    return !same;
+  }
+
+  public BufferedImage getCachedImage() {
+    return cachedImage;
+  }
+
+  public void setCachedImage(BufferedImage img) {
+    this.cachedImage = img;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <V> V getValue(Attribute<V> attr) {
+    if (attr == Image.ATTR_IMAGE)
+      return (V) imageSource;
+    if (attr == Image.ATTR_WIDTH)
+      return (V) width;
+    if (attr == Image.ATTR_HEIGHT)
+      return (V) height;
+    if (attr == Image.ATTR_SCALE)
+      return (V) scale;
+    return null;
+  }
+
+  @Override
+  public <V> void setValue(Attribute<V> attr, V value) {
+    if (attr == Image.ATTR_IMAGE) {
+      imageSource = (String) value;
+      cachedImage = ImageUtil.loadBufferedImage(imageSource);
+      if (cachedImage != null && !userSetDimensions) {
+        width = cachedImage.getWidth();
+        height = cachedImage.getHeight();
+        offsetBounds = Bounds.create(0, 0, getWidth(), getHeight());
+      }
+    } else if (attr == Image.ATTR_WIDTH) {
+      final var val = (Integer) value;
+      if (val <= 0 && cachedImage != null) {
+        width = cachedImage.getWidth();
+        height = cachedImage.getHeight();
+      } else {
+        width = Math.max(1, val);
+      }
+      userSetDimensions = true;
+      offsetBounds = Bounds.create(0, 0, getWidth(), getHeight());
+    } else if (attr == Image.ATTR_HEIGHT) {
+      final var val = (Integer) value;
+      if (val <= 0 && cachedImage != null) {
+        width = cachedImage.getWidth();
+        height = cachedImage.getHeight();
+      } else {
+        height = Math.max(1, val);
+      }
+      userSetDimensions = true;
+      offsetBounds = Bounds.create(0, 0, getWidth(), getHeight());
+    } else if (attr == Image.ATTR_SCALE) {
+      scale = (AttributeOption) value;
+    } else {
+      return;
+    }
+    fireAttributeValueChanged(attr, value, null);
+  }
+}

--- a/src/main/java/com/cburch/logisim/std/base/ImageSourceAttribute.java
+++ b/src/main/java/com/cburch/logisim/std/base/ImageSourceAttribute.java
@@ -40,7 +40,7 @@ public class ImageSourceAttribute extends Attribute<String> {
   @Override
   public String toDisplayString(String value) {
     if (value == null || value.isBlank()) {
-      return "...";
+      return S.get("imageSourceNone");
     }
     if (value.startsWith("data:image/")) {
       final var semicolon = value.indexOf(';');

--- a/src/main/java/com/cburch/logisim/std/base/ImageSourceAttribute.java
+++ b/src/main/java/com/cburch/logisim/std/base/ImageSourceAttribute.java
@@ -97,7 +97,6 @@ public class ImageSourceAttribute extends Attribute<String> {
         } catch (Exception e) {
           resultValue = selected.getAbsolutePath();
         }
-        ImageUtil.checkAndShowCopyrightDisclaimer(parent);
       } else {
         resultValue = currentValue;
       }

--- a/src/main/java/com/cburch/logisim/std/base/ImageSourceAttribute.java
+++ b/src/main/java/com/cburch/logisim/std/base/ImageSourceAttribute.java
@@ -1,0 +1,115 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.base;
+
+import static com.cburch.logisim.std.Strings.S;
+
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.util.ImageUtil;
+import com.cburch.logisim.util.JFileChoosers;
+import com.cburch.logisim.util.JInputDialog;
+import java.awt.Component;
+import java.awt.Window;
+import java.io.File;
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileFilter;
+
+public class ImageSourceAttribute extends Attribute<String> {
+
+  public ImageSourceAttribute(String name) {
+    super(name, S.getter("imageSourceAttr"));
+  }
+
+  @Override
+  public Component getCellEditor(Window source, String value) {
+    return new ImageFileChooserDialog(source, value);
+  }
+
+  @Override
+  public String parse(String value) {
+    return value == null ? "" : value;
+  }
+
+  @Override
+  public String toDisplayString(String value) {
+    if (value == null || value.isBlank()) {
+      return "...";
+    }
+    if (value.startsWith("data:image/")) {
+      final var semicolon = value.indexOf(';');
+      final var type = semicolon > 11 ? value.substring(11, semicolon) : "image";
+      return "[" + type.toUpperCase() + " Data]";
+    }
+    return new File(value).getName();
+  }
+
+  @Override
+  public String toStandardString(String value) {
+    return value == null ? "" : value.replaceAll("[\\r\\n]+", "");
+  }
+
+  private static class ImageFileChooserDialog extends JFileChooser implements JInputDialog {
+    private final Window parent;
+    private final String currentValue;
+    private String resultValue;
+
+    public ImageFileChooserDialog(Window parent, String currentValue) {
+      this.parent = parent;
+      this.currentValue = currentValue;
+      this.resultValue = currentValue;
+    }
+
+    @Override
+    public void setVisible(boolean b) {
+      if (!b) return;
+      final var chooser = JFileChoosers.create();
+      chooser.setDialogTitle(S.get("imageChooseDialogTitle"));
+      chooser.setFileFilter(new FileFilter() {
+        @Override
+        public boolean accept(File f) {
+          if (f.isDirectory()) return true;
+          final var name = f.getName().toLowerCase();
+          return name.endsWith(".png")
+              || name.endsWith(".jpg")
+              || name.endsWith(".jpeg")
+              || name.endsWith(".gif");
+          // SVG and WebP intentionally excluded — Java standard ImageIO cannot render SVG or WebP without extra plugins.
+        }
+
+        @Override
+        public String getDescription() {
+          return S.get("imageFileFilterDescription");
+        }
+      });
+
+      final var returnVal = chooser.showOpenDialog(parent);
+      if (returnVal == JFileChooser.APPROVE_OPTION) {
+        final var selected = chooser.getSelectedFile();
+        try {
+          resultValue = ImageUtil.fileToBase64(selected);
+        } catch (Exception e) {
+          resultValue = selected.getAbsolutePath();
+        }
+      } else {
+        resultValue = currentValue;
+      }
+    }
+
+    @Override
+    public Object getValue() {
+      return resultValue;
+    }
+
+    @Override
+    public void setValue(Object value) {
+      this.resultValue = (String) value;
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/std/base/ImageSourceAttribute.java
+++ b/src/main/java/com/cburch/logisim/std/base/ImageSourceAttribute.java
@@ -97,6 +97,7 @@ public class ImageSourceAttribute extends Attribute<String> {
         } catch (Exception e) {
           resultValue = selected.getAbsolutePath();
         }
+        ImageUtil.checkAndShowCopyrightDisclaimer(parent);
       } else {
         resultValue = currentValue;
       }

--- a/src/main/java/com/cburch/logisim/util/ImageUtil.java
+++ b/src/main/java/com/cburch/logisim/util/ImageUtil.java
@@ -299,6 +299,26 @@ public class ImageUtil {
     return out;
   }
 
+  public static BufferedImage toGrayscale(BufferedImage src) {
+    if (src == null) return null;
+    final var w = src.getWidth();
+    final var h = src.getHeight();
+    final var out = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+    for (var y = 0; y < h; y++) {
+      for (var x = 0; x < w; x++) {
+        final var rgb = src.getRGB(x, y);
+        final var a = (rgb >> 24) & 0xFF;
+        final var r = (rgb >> 16) & 0xFF;
+        final var g = (rgb >> 8) & 0xFF;
+        final var b = rgb & 0xFF;
+        final var gray = (int) (0.2126 * r + 0.7152 * g + 0.0722 * b);
+        final var newRgb = (a << 24) | (gray << 16) | (gray << 8) | gray;
+        out.setRGB(x, y, newRgb);
+      }
+    }
+    return out;
+  }
+
   public static BufferedImage toBufferedImage(java.awt.Image img) {
     if (img == null) return null;
     if (img instanceof BufferedImage b) return enforceMaxDimensions(b);

--- a/src/main/java/com/cburch/logisim/util/ImageUtil.java
+++ b/src/main/java/com/cburch/logisim/util/ImageUtil.java
@@ -9,6 +9,9 @@
 
 package com.cburch.logisim.util;
 
+import com.cburch.logisim.prefs.AppPreferences;
+import static com.cburch.logisim.std.Strings.S;
+import java.awt.Component;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.image.BufferedImage;
@@ -34,6 +37,37 @@ public class ImageUtil {
 
   private ImageUtil() {
     // static
+  }
+
+  public static void checkAndShowCopyrightDisclaimer(Component parent) {
+    if (AppPreferences.IMAGE_COPYRIGHT_WARNED.getBoolean()) {
+      return;
+    }
+
+    final var parts = S.get("imageCopyrightDialogMessage").split("\n\n");
+    final var msgLabel = new javax.swing.JLabel(
+        "<html><center>"
+        + "<b>" + parts[0] + "</b>"
+        + "<br><br>"
+        + "<span style='font-weight: normal;'>" + (parts.length > 1 ? parts[1] : "") + "</span>"
+        + "<br><br>"
+        + "</center></html>");
+
+    final var dontShowCheckBox = new javax.swing.JCheckBox(S.get("imageCopyrightDontShowAgain"));
+    dontShowCheckBox.setFont(dontShowCheckBox.getFont().deriveFont(java.awt.Font.PLAIN));
+
+    final var checkPanel = new javax.swing.JPanel(new java.awt.FlowLayout(java.awt.FlowLayout.CENTER, 0, 10));
+    checkPanel.add(dontShowCheckBox);
+
+    com.cburch.logisim.gui.generic.OptionPane.showMessageDialog(
+        parent,
+        new Object[] { msgLabel, checkPanel },
+        S.get("imageCopyrightDialogTitle"),
+        com.cburch.logisim.gui.generic.OptionPane.INFORMATION_MESSAGE);
+
+    if (dontShowCheckBox.isSelected()) {
+      AppPreferences.IMAGE_COPYRIGHT_WARNED.set(true);
+    }
   }
 
   /**

--- a/src/main/java/com/cburch/logisim/util/ImageUtil.java
+++ b/src/main/java/com/cburch/logisim/util/ImageUtil.java
@@ -1,0 +1,336 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.util;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.lang.ref.SoftReference;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+import javax.imageio.ImageIO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ImageUtil {
+  private static final Logger logger = LoggerFactory.getLogger(ImageUtil.class);
+
+  private static final Map<String, SoftReference<BufferedImage>> IMAGE_CACHE = Collections
+      .synchronizedMap(new WeakHashMap<>());
+
+  private ImageUtil() {
+    // static
+  }
+
+  /**
+   * Reads an image file and converts it into a Base64 data URI string
+   * ("data:image/png;base64,...").
+   */
+  public static String fileToBase64(File file) throws IOException {
+    if (file == null || !file.exists()) {
+      return "";
+    }
+    byte[] fileContent = Files.readAllBytes(file.toPath());
+    String mimeType = Files.probeContentType(file.toPath());
+    if (mimeType == null || !mimeType.startsWith("image/")) {
+      String name = file.getName().toLowerCase();
+      if (name.endsWith(".png"))
+        mimeType = "image/png";
+      else if (name.endsWith(".jpg") || name.endsWith(".jpeg"))
+        mimeType = "image/jpeg";
+      else if (name.endsWith(".gif"))
+        mimeType = "image/gif";
+      else
+        mimeType = "image/png";
+    }
+    String encoded = Base64.getEncoder().encodeToString(fileContent);
+    return "data:" + mimeType + ";base64," + encoded;
+  }
+
+  /**
+   * Decodes a Base64 data URI or reads a file path, returning a BufferedImage.
+   */
+  public static BufferedImage loadBufferedImage(String source) {
+    if (source == null || source.isBlank()) {
+      return null;
+    }
+    final var ref = IMAGE_CACHE.get(source);
+    if (ref != null) {
+      final var cached = ref.get();
+      if (cached != null) {
+        return cached;
+      }
+    }
+    final var img = loadBufferedImageInternal(source);
+    if (img != null) {
+      IMAGE_CACHE.put(source, new SoftReference<>(img));
+    }
+    return img;
+  }
+
+  public static final int MAX_IMAGE_DIMENSION = 2048;
+
+  public static BufferedImage enforceMaxDimensions(BufferedImage img) {
+    if (img == null) return null;
+    final var width = img.getWidth();
+    final var height = img.getHeight();
+    if (width <= MAX_IMAGE_DIMENSION && height <= MAX_IMAGE_DIMENSION) {
+      return img;
+    }
+    final var scale = Math.min((double) MAX_IMAGE_DIMENSION / width, (double) MAX_IMAGE_DIMENSION / height);
+    final var targetWidth = Math.max(1, (int) (width * scale));
+    final var targetHeight = Math.max(1, (int) (height * scale));
+    final var imageType = img.getType() == 0 ? BufferedImage.TYPE_INT_ARGB : img.getType();
+    final var scaled = new BufferedImage(targetWidth, targetHeight, imageType);
+    final var g2 = scaled.createGraphics();
+    g2.setRenderingHint(java.awt.RenderingHints.KEY_INTERPOLATION, java.awt.RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+    g2.setRenderingHint(java.awt.RenderingHints.KEY_RENDERING, java.awt.RenderingHints.VALUE_RENDER_QUALITY);
+    g2.setRenderingHint(java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
+    g2.drawImage(img, 0, 0, targetWidth, targetHeight, null);
+    g2.dispose();
+    logger.info("Downscaled large image from {}x{} to {}x{}", width, height, targetWidth, targetHeight);
+    return scaled;
+  }
+
+  public static int[] getOptimizedTargetDimensions(BufferedImage img, int frameW, int frameH, String scaleOpt) {
+    if (img == null || frameW <= 0 || frameH <= 0) return new int[] {0, 0};
+    final var w = img.getWidth();
+    final var h = img.getHeight();
+    if ("stretch".equalsIgnoreCase(scaleOpt) || "cover".equalsIgnoreCase(scaleOpt)) {
+      return new int[] {frameW, frameH};
+    }
+    final var scale = Math.min((double) frameW / w, (double) frameH / h);
+    if (scale >= 1.0) {
+      return new int[] {w, h};
+    }
+    final var targetW = Math.max(1, (int) (w * scale));
+    final var targetH = Math.max(1, (int) (h * scale));
+    return new int[] {targetW, targetH};
+  }
+
+  public static BufferedImage optimizeImage(BufferedImage img, int frameW, int frameH, String scaleOpt) {
+    if (img == null || frameW <= 0 || frameH <= 0) return img;
+    final var targetDims = getOptimizedTargetDimensions(img, frameW, frameH, scaleOpt);
+    final var targetW = targetDims[0];
+    final var targetH = targetDims[1];
+    if (targetW <= 0 || targetH <= 0) return img;
+    if (img.getWidth() == targetW && img.getHeight() == targetH) return img;
+
+    final var imageType = img.getType() == 0 ? BufferedImage.TYPE_INT_ARGB : img.getType();
+    final var scaled = new BufferedImage(targetW, targetH, imageType);
+    final var g2 = scaled.createGraphics();
+    g2.setRenderingHint(java.awt.RenderingHints.KEY_INTERPOLATION, java.awt.RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+    g2.setRenderingHint(java.awt.RenderingHints.KEY_RENDERING, java.awt.RenderingHints.VALUE_RENDER_QUALITY);
+    g2.setRenderingHint(java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
+
+    if ("cover".equalsIgnoreCase(scaleOpt)) {
+      final var imgW = img.getWidth();
+      final var imgH = img.getHeight();
+      final var scaleFactor = Math.max((double) targetW / imgW, (double) targetH / imgH);
+      final var coveredW = Math.max(1, (int) (imgW * scaleFactor));
+      final var coveredH = Math.max(1, (int) (imgH * scaleFactor));
+      final var coveredX = (targetW - coveredW) / 2;
+      final var coveredY = (targetH - coveredH) / 2;
+      g2.drawImage(img, coveredX, coveredY, coveredW, coveredH, null);
+    } else {
+      g2.drawImage(img, 0, 0, targetW, targetH, null);
+    }
+    g2.dispose();
+    logger.info("Optimized image (mode={}) from {}x{} to {}x{}", scaleOpt, img.getWidth(), img.getHeight(), targetW, targetH);
+    return scaled;
+  }
+
+  private static BufferedImage loadBufferedImageInternal(String source) {
+    try {
+      BufferedImage img = null;
+      if (source.startsWith("data:image/")) {
+        final var commaIdx = source.indexOf(',');
+        if (commaIdx >= 0) {
+          final var base64Data = source.substring(commaIdx + 1).replaceAll("\\s+", "");
+          final var imageBytes = Base64.getDecoder().decode(base64Data);
+          img = ImageIO.read(new ByteArrayInputStream(imageBytes));
+        }
+      } else {
+        final var file = new File(source);
+        if (file.exists() && file.isFile()) {
+          img = ImageIO.read(file);
+        }
+      }
+      return enforceMaxDimensions(img);
+    } catch (Exception e) {
+      logger.error(
+          "Failed to load image from source: {}",
+          source.length() > 50 ? source.substring(0, 50) + "..." : source,
+          e);
+    }
+    return null;
+  }
+
+  public static String bufferedImageToBase64(BufferedImage img) {
+    if (img == null) return "";
+    try (final var baos = new java.io.ByteArrayOutputStream()) {
+      ImageIO.write(img, "png", baos);
+      final var bytes = baos.toByteArray();
+      final var encoded = Base64.getEncoder().encodeToString(bytes);
+      return "data:image/png;base64," + encoded;
+    } catch (Exception e) {
+      logger.error("Failed to convert BufferedImage to Base64", e);
+      return "";
+    }
+  }
+
+  // Flood fill from image borders to make outer white background transparent
+  public static BufferedImage makeWhiteTransparent(BufferedImage src) {
+    if (src == null) return null;
+    final var w = src.getWidth();
+    final var h = src.getHeight();
+    final var out = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+    final var visited = new boolean[w][h];
+    final var queue = new java.util.ArrayDeque<int[]>();
+
+    for (var y = 0; y < h; y++) {
+      for (var x = 0; x < w; x++) {
+        out.setRGB(x, y, src.getRGB(x, y));
+      }
+    }
+
+    java.util.function.BiPredicate<Integer, Integer> isWhite = (x, y) -> {
+      final var rgb = src.getRGB(x, y);
+      final var a = (rgb >> 24) & 0xFF;
+      final var r = (rgb >> 16) & 0xFF;
+      final var g = (rgb >> 8) & 0xFF;
+      final var b = rgb & 0xFF;
+      return a > 0 && r > 235 && g > 235 && b > 235;
+    };
+
+    // Start flood fill from all four outer borders
+    for (var x = 0; x < w; x++) {
+      if (isWhite.test(x, 0)) { visited[x][0] = true; queue.add(new int[]{x, 0}); }
+      if (isWhite.test(x, h - 1)) { visited[x][h - 1] = true; queue.add(new int[]{x, h - 1}); }
+    }
+    for (var y = 0; y < h; y++) {
+      if (isWhite.test(0, y) && !visited[0][y]) { visited[0][y] = true; queue.add(new int[]{0, y}); }
+      if (isWhite.test(w - 1, y) && !visited[w - 1][y]) { visited[w - 1][y] = true; queue.add(new int[]{w - 1, y}); }
+    }
+
+    final int[] dx = {0, 0, 1, -1};
+    final int[] dy = {1, -1, 0, 0};
+
+    while (!queue.isEmpty()) {
+      final var curr = queue.poll();
+      final var cx = curr[0];
+      final var cy = curr[1];
+
+      final var rgb = src.getRGB(cx, cy);
+      out.setRGB(cx, cy, 0x00FFFFFF & rgb);
+
+      for (var i = 0; i < 4; i++) {
+        final var nx = cx + dx[i];
+        final var ny = cy + dy[i];
+        if (nx >= 0 && nx < w && ny >= 0 && ny < h && !visited[nx][ny]) {
+          if (isWhite.test(nx, ny)) {
+            visited[nx][ny] = true;
+            queue.add(new int[]{nx, ny});
+          }
+        }
+      }
+    }
+
+    return out;
+  }
+
+  public static BufferedImage toBufferedImage(java.awt.Image img) {
+    if (img == null) return null;
+    if (img instanceof BufferedImage b) return enforceMaxDimensions(b);
+    final var w = img.getWidth(null);
+    final var h = img.getHeight(null);
+    if (w <= 0 || h <= 0) return null;
+    final var bimg = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+    final var g2 = bimg.createGraphics();
+    g2.drawImage(img, 0, 0, null);
+    g2.dispose();
+    return enforceMaxDimensions(bimg);
+  }
+
+  public static BufferedImage getSystemClipboardImage() {
+    try {
+      final var sysClip = Toolkit.getDefaultToolkit().getSystemClipboard();
+      if (sysClip == null) return null;
+
+      // Prefer javaFileListFlavor first to get actual image files copied in file explorer
+      if (sysClip.isDataFlavorAvailable(DataFlavor.javaFileListFlavor)) {
+        @SuppressWarnings("unchecked")
+        final var files = (List<File>) sysClip.getData(DataFlavor.javaFileListFlavor);
+        if (files != null) {
+          for (final var file : files) {
+            final var name = file.getName().toLowerCase();
+            if (name.endsWith(".png") || name.endsWith(".jpg") || name.endsWith(".jpeg")
+                || name.endsWith(".gif") || name.endsWith(".bmp") || name.endsWith(".wbmp")) {
+              final var buf = loadBufferedImageInternal(file.getAbsolutePath());
+              if (buf != null) {
+                return buf;
+              }
+            }
+          }
+        }
+      }
+
+      if (sysClip.isDataFlavorAvailable(DataFlavor.imageFlavor)) {
+        final var obj = sysClip.getData(DataFlavor.imageFlavor);
+        if (obj instanceof java.awt.Image img) {
+          final var buf = toBufferedImage(img);
+          if (buf != null) {
+            return buf;
+          }
+        }
+      }
+
+      final var flavors = sysClip.getAvailableDataFlavors();
+      if (flavors != null) {
+        for (final var flavor : flavors) {
+          try {
+            if (flavor.isMimeTypeEqual("image/png")
+                || flavor.isMimeTypeEqual("image/jpeg")
+                || flavor.isMimeTypeEqual("image/gif")
+                || flavor.isMimeTypeEqual("image/bmp")
+                || (flavor.getPrimaryType() != null && flavor.getPrimaryType().equalsIgnoreCase("image"))) {
+              final var obj = sysClip.getData(flavor);
+              if (obj instanceof java.awt.Image img) {
+                final var buf = toBufferedImage(img);
+                if (buf != null) return buf;
+              } else if (obj instanceof java.io.InputStream stream) {
+                final var buf = ImageIO.read(stream);
+                if (buf != null) return buf;
+              } else if (obj instanceof byte[] bytes) {
+                final var buf = ImageIO.read(new ByteArrayInputStream(bytes));
+                if (buf != null) return buf;
+              }
+            }
+          } catch (Exception ignored) {
+          }
+        }
+      }
+    } catch (Exception e) {
+      logger.debug("Failed to get image from system clipboard", e);
+    }
+    return null;
+  }
+
+  public static boolean hasSystemClipboardImage() {
+    return getSystemClipboardImage() != null;
+  }
+}

--- a/src/main/java/com/cburch/logisim/util/ImageUtil.java
+++ b/src/main/java/com/cburch/logisim/util/ImageUtil.java
@@ -9,9 +9,6 @@
 
 package com.cburch.logisim.util;
 
-import com.cburch.logisim.prefs.AppPreferences;
-import static com.cburch.logisim.std.Strings.S;
-import java.awt.Component;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.image.BufferedImage;
@@ -37,37 +34,6 @@ public class ImageUtil {
 
   private ImageUtil() {
     // static
-  }
-
-  public static void checkAndShowCopyrightDisclaimer(Component parent) {
-    if (AppPreferences.IMAGE_COPYRIGHT_WARNED.getBoolean()) {
-      return;
-    }
-
-    final var parts = S.get("imageCopyrightDialogMessage").split("\n\n");
-    final var msgLabel = new javax.swing.JLabel(
-        "<html><center>"
-        + "<b>" + parts[0] + "</b>"
-        + "<br><br>"
-        + "<span style='font-weight: normal;'>" + (parts.length > 1 ? parts[1] : "") + "</span>"
-        + "<br><br>"
-        + "</center></html>");
-
-    final var dontShowCheckBox = new javax.swing.JCheckBox(S.get("imageCopyrightDontShowAgain"));
-    dontShowCheckBox.setFont(dontShowCheckBox.getFont().deriveFont(java.awt.Font.PLAIN));
-
-    final var checkPanel = new javax.swing.JPanel(new java.awt.FlowLayout(java.awt.FlowLayout.CENTER, 0, 10));
-    checkPanel.add(dontShowCheckBox);
-
-    com.cburch.logisim.gui.generic.OptionPane.showMessageDialog(
-        parent,
-        new Object[] { msgLabel, checkPanel },
-        S.get("imageCopyrightDialogTitle"),
-        com.cburch.logisim.gui.generic.OptionPane.INFORMATION_MESSAGE);
-
-    if (dontShowCheckBox.isSelected()) {
-      AppPreferences.IMAGE_COPYRIGHT_WARNED.set(true);
-    }
   }
 
   /**

--- a/src/main/java/com/cburch/logisim/util/ImageUtil.java
+++ b/src/main/java/com/cburch/logisim/util/ImageUtil.java
@@ -219,12 +219,24 @@ public class ImageUtil {
 
     // Start flood fill from all four outer borders
     for (var x = 0; x < w; x++) {
-      if (isWhite.test(x, 0)) { visited[x][0] = true; queue.add(new int[]{x, 0}); }
-      if (isWhite.test(x, h - 1)) { visited[x][h - 1] = true; queue.add(new int[]{x, h - 1}); }
+      if (isWhite.test(x, 0)) {
+        visited[x][0] = true;
+        queue.add(new int[]{x, 0});
+      }
+      if (isWhite.test(x, h - 1)) {
+        visited[x][h - 1] = true;
+        queue.add(new int[]{x, h - 1});
+      }
     }
     for (var y = 0; y < h; y++) {
-      if (isWhite.test(0, y) && !visited[0][y]) { visited[0][y] = true; queue.add(new int[]{0, y}); }
-      if (isWhite.test(w - 1, y) && !visited[w - 1][y]) { visited[w - 1][y] = true; queue.add(new int[]{w - 1, y}); }
+      if (isWhite.test(0, y) && !visited[0][y]) {
+        visited[0][y] = true;
+        queue.add(new int[]{0, y});
+      }
+      if (isWhite.test(w - 1, y) && !visited[w - 1][y]) {
+        visited[w - 1][y] = true;
+        queue.add(new int[]{w - 1, y});
+      }
     }
 
     final int[] dx = {0, 0, 1, -1};

--- a/src/main/java/com/cburch/logisim/util/ImageUtil.java
+++ b/src/main/java/com/cburch/logisim/util/ImageUtil.java
@@ -10,6 +10,7 @@
 package com.cburch.logisim.util;
 
 import java.awt.Toolkit;
+
 import java.awt.datatransfer.DataFlavor;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -31,6 +32,26 @@ public class ImageUtil {
 
   private static final Map<String, SoftReference<BufferedImage>> IMAGE_CACHE = Collections
       .synchronizedMap(new WeakHashMap<>());
+
+  private static final String[] BYTE_UNITS = new String[] {"B", "KB", "MB", "GB", "TB"};
+
+  public static String formatBytes(long bytes) {
+    if (bytes <= 0) return "0 B";
+    int digitGroups = (int) (Math.log10(bytes) / Math.log10(1024));
+    digitGroups = Math.min(digitGroups, BYTE_UNITS.length - 1);
+    if (digitGroups == 0) {
+      return bytes + " B";
+    }
+    return String.format(java.util.Locale.US, "%.1f %s", bytes / Math.pow(1024, digitGroups), BYTE_UNITS[digitGroups]);
+  }
+
+  public static String formatDataSize(String base64Source) {
+    if (base64Source == null || base64Source.isEmpty()) {
+      return formatBytes(0);
+    }
+    final var bytes = base64Source.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+    return formatBytes(bytes);
+  }
 
   private ImageUtil() {
     // static

--- a/src/main/resources/resources/logisim/default.templ
+++ b/src/main/resources/resources/logisim/default.templ
@@ -33,6 +33,7 @@
   <tool lib="8" name="Edit Tool" />
   <tool lib="8" name="Wiring Tool" />
   <tool lib="8" name="Text Tool"/>
+  <tool lib="8" name="Image"/>
   <sep />
   <tool lib="0" name="Pin">
    <a name="tristate" val="false" />

--- a/src/main/resources/resources/logisim/strings/draw/draw.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw.properties
@@ -98,4 +98,8 @@ shapeRoundRect = Rounded Rectangle
 # shapes/Text.java
 #
 shapeText = Text
+#
+# shapes/ImageShape.java
+#
+shapeImage = Image
 

--- a/src/main/resources/resources/logisim/strings/draw/draw_de.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_de.properties
@@ -98,3 +98,7 @@ shapeRoundRect = Abgerundetes Rechteck
 # shapes/Text.java
 #
 shapeText = Text
+#
+# shapes/ImageShape.java
+#
+# ==> shapeImage = Image

--- a/src/main/resources/resources/logisim/strings/draw/draw_el.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_el.properties
@@ -98,3 +98,7 @@ shapeRoundRect = Στρογγυλεμένο Ορθογώνιο
 # shapes/Text.java
 #
 shapeText = Κείμενο
+#
+# shapes/ImageShape.java
+#
+# ==> shapeImage = Image

--- a/src/main/resources/resources/logisim/strings/draw/draw_es.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_es.properties
@@ -98,3 +98,7 @@ shapeRoundRect = Rectángulo redondeado
 # shapes/Text.java
 #
 shapeText = Texto
+#
+# shapes/ImageShape.java
+#
+# ==> shapeImage = Image

--- a/src/main/resources/resources/logisim/strings/draw/draw_fr.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_fr.properties
@@ -98,3 +98,7 @@ shapeRoundRect = Rectangle arrondi
 # shapes/Text.java
 #
 shapeText = Texte
+#
+# shapes/ImageShape.java
+#
+# ==> shapeImage = Image

--- a/src/main/resources/resources/logisim/strings/draw/draw_it.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_it.properties
@@ -98,3 +98,7 @@ shapeRoundRect = Rettangolo Arrotondato
 # shapes/Text.java
 #
 shapeText = Testo
+#
+# shapes/ImageShape.java
+#
+# ==> shapeImage = Image

--- a/src/main/resources/resources/logisim/strings/draw/draw_ja.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_ja.properties
@@ -96,3 +96,7 @@ shapeRoundRect = 丸みのある長方形
 # shapes/Text.java
 #
 shapeText = テキスト
+#
+# shapes/ImageShape.java
+#
+# ==> shapeImage = Image

--- a/src/main/resources/resources/logisim/strings/draw/draw_nl.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_nl.properties
@@ -96,3 +96,7 @@ shapeRoundRect = Afgeronde rechthoek
 # shapes/Text.java
 #
 shapeText = Tekst
+#
+# shapes/ImageShape.java
+#
+# ==> shapeImage = Image

--- a/src/main/resources/resources/logisim/strings/draw/draw_pl.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_pl.properties
@@ -102,4 +102,5 @@ shapeText = Tekst
 #
 # shapes/ImageShape.java
 #
-# ==> shapeImage = Image
+shapeImage = Obraz
+

--- a/src/main/resources/resources/logisim/strings/draw/draw_pl.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_pl.properties
@@ -99,3 +99,7 @@ shapeRoundRect = Zaokrąglony prostokąt
 # shapes/Text.java
 #
 shapeText = Tekst
+#
+# shapes/ImageShape.java
+#
+# ==> shapeImage = Image

--- a/src/main/resources/resources/logisim/strings/draw/draw_pt.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_pt.properties
@@ -98,3 +98,7 @@ shapeRoundRect = Retângulo com bordas arredondadas
 # shapes/Text.java
 #
 shapeText = Texto
+#
+# shapes/ImageShape.java
+#
+# ==> shapeImage = Image

--- a/src/main/resources/resources/logisim/strings/draw/draw_ru.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_ru.properties
@@ -98,3 +98,8 @@ shapeRoundRect = Скруглённый прямоугольник
 # shapes/Text.java
 #
 shapeText = Текст
+#
+# shapes/ImageShape.java
+#
+shapeImage = Изображение
+

--- a/src/main/resources/resources/logisim/strings/draw/draw_zh.properties
+++ b/src/main/resources/resources/logisim/strings/draw/draw_zh.properties
@@ -98,3 +98,7 @@ shapeRoundRect = 圆角矩形
 # shapes/Text.java
 #
 shapeText = 文本
+#
+# shapes/ImageShape.java
+#
+# ==> shapeImage = Image

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -302,9 +302,7 @@ imageLicenseAttr = License
 imageLicenseUnspecifiedOpt = Unspecified
 imageLicenseOtherOpt = Other
 imageAttributionAttr = Source / Author
-
-
-
+imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -272,6 +272,28 @@ textVertAlignBottomOpt = Bottom
 textVertAlignCenterOpt = Center
 textVertAlignTopOpt = Top
 #
+# base/Image.java
+#
+imageComponent = Image
+imageSourceAttr = Image Source
+imageLocationXAttr = Location X
+imageLocationYAttr = Location Y
+imageWidthAttr = Width
+imageHeightAttr = Height
+imageScaleAttr = Scale Mode
+imageScaleFitOpt = Fit (Aspect Ratio)
+imageScaleStretchOpt = Stretch
+imageScaleCoverOpt = Crop / Fill
+imageResetSizeItem = Reset to Original Size
+imageOptimizeItem = Optimize Image Size
+imageOptimizeConfirmTitle = Optimize Image Size
+imageOptimizeConfirmMessage = The image resolution will be reduced from %dx%d to %dx%d pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+imageAlreadyOptimizedMessage = The image is already optimized for its current frame size (%dx%d).
+imageMakeWhiteTransparentItem = Make Outer Background Transparent
+imageChooseDialogTitle = Select Image File
+imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = The entity declaration cannot be found

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -292,6 +292,8 @@ imageAlreadyOptimizedMessage = The image is already optimized for its current fr
 imageMakeWhiteTransparentItem = Make Outer Background Transparent
 imageChooseDialogTitle = Select Image File
 imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+imageSourceNone = (none)
+
 
 #
 # base/VhdlParser.java

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -297,6 +297,8 @@ imageAlreadyOptimizedMessage = The image is already optimized for its current fr
 imageMakeWhiteTransparentItem = Make Outer Background Transparent
 imageChooseDialogTitle = Select Image File
 imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+imageSourceNone = (none)
+
 
 #
 # base/VhdlParser.java

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -298,6 +298,14 @@ imageMakeWhiteTransparentItem = Make Outer Background Transparent
 imageChooseDialogTitle = Select Image File
 imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
 imageSourceNone = (none)
+imageLicenseAttr = License
+imageLicenseUnspecifiedOpt = Unspecified
+imageLicenseOtherOpt = Other
+imageAttributionAttr = Source / Author
+imageCopyrightDialogTitle = Image Copyright Notice
+imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+imageCopyrightDontShowAgain = I understand, don't show this message again
+
 
 
 #

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -293,6 +293,14 @@ imageMakeWhiteTransparentItem = Make Outer Background Transparent
 imageChooseDialogTitle = Select Image File
 imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
 imageSourceNone = (none)
+imageLicenseAttr = License
+imageLicenseUnspecifiedOpt = Unspecified
+imageLicenseOtherOpt = Other
+imageAttributionAttr = Source / Author
+imageCopyrightDialogTitle = Image Copyright Notice
+imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+imageCopyrightDontShowAgain = I understand, don't show this message again
+
 
 
 #

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -277,6 +277,28 @@ textVertAlignBottomOpt = Bottom
 textVertAlignCenterOpt = Center
 textVertAlignTopOpt = Top
 #
+# base/Image.java
+#
+imageComponent = Image
+imageSourceAttr = Image Source
+imageLocationXAttr = Location X
+imageLocationYAttr = Location Y
+imageWidthAttr = Width
+imageHeightAttr = Height
+imageScaleAttr = Scale Mode
+imageScaleFitOpt = Fit (Aspect Ratio)
+imageScaleStretchOpt = Stretch
+imageScaleCoverOpt = Crop / Fill
+imageResetSizeItem = Reset to Original Size
+imageOptimizeItem = Optimize Image Size
+imageOptimizeConfirmTitle = Optimize Image Size
+imageOptimizeConfirmMessage = The image resolution will be reduced from %dx%d to %dx%d pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+imageAlreadyOptimizedMessage = The image is already optimized for its current frame size (%dx%d).
+imageMakeWhiteTransparentItem = Make Outer Background Transparent
+imageChooseDialogTitle = Select Image File
+imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = The entity declaration cannot be found

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -302,9 +302,6 @@ imageLicenseAttr = License
 imageLicenseUnspecifiedOpt = Unspecified
 imageLicenseOtherOpt = Other
 imageAttributionAttr = Source / Author
-imageCopyrightDialogTitle = Image Copyright Notice
-imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-imageCopyrightDontShowAgain = I understand, don't show this message again
 
 
 

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -299,6 +299,7 @@ textVertAlignTopOpt = Oben
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
+# ==> imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -294,6 +294,14 @@ textVertAlignTopOpt = Oben
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -289,6 +289,14 @@ textVertAlignTopOpt = Oben
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -269,6 +269,27 @@ textVertAlignBottomOpt = Unten
 textVertAlignCenterOpt = Zentriert
 textVertAlignTopOpt = Oben
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = Die Entitätserklärung kann nicht gefunden werden.

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -299,9 +299,6 @@ textVertAlignTopOpt = Oben
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
-# ==> imageCopyrightDialogTitle = Image Copyright Notice
-# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -274,6 +274,27 @@ textVertAlignBottomOpt = Unten
 textVertAlignCenterOpt = Zentriert
 textVertAlignTopOpt = Oben
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = Die Entitätserklärung kann nicht gefunden werden.

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -269,6 +269,27 @@ textVertAlignBottomOpt = Κάτω
 textVertAlignCenterOpt = Κέντρο
 textVertAlignTopOpt = Επάνω
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 # ==> CannotFindEntityException =

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -294,6 +294,14 @@ textVertAlignTopOpt = Επάνω
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -274,6 +274,27 @@ textVertAlignBottomOpt = Κάτω
 textVertAlignCenterOpt = Κέντρο
 textVertAlignTopOpt = Επάνω
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 # ==> CannotFindEntityException =

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -299,9 +299,6 @@ textVertAlignTopOpt = Επάνω
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
-# ==> imageCopyrightDialogTitle = Image Copyright Notice
-# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -299,6 +299,7 @@ textVertAlignTopOpt = Επάνω
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
+# ==> imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -289,6 +289,14 @@ textVertAlignTopOpt = Επάνω
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -294,6 +294,14 @@ textVertAlignTopOpt = Arriba
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -299,9 +299,6 @@ textVertAlignTopOpt = Arriba
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
-# ==> imageCopyrightDialogTitle = Image Copyright Notice
-# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -269,6 +269,27 @@ textVertAlignBottomOpt = Abajo
 textVertAlignCenterOpt = Centro
 textVertAlignTopOpt = Arriba
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = No se puede encontrar la declaración de la entidad

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -289,6 +289,14 @@ textVertAlignTopOpt = Arriba
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -274,6 +274,27 @@ textVertAlignBottomOpt = Abajo
 textVertAlignCenterOpt = Centro
 textVertAlignTopOpt = Arriba
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = No se puede encontrar la declaración de la entidad

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -299,6 +299,7 @@ textVertAlignTopOpt = Arriba
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
+# ==> imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -299,6 +299,7 @@ textVertAlignTopOpt = Sommet
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
+# ==> imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -274,6 +274,27 @@ textVertAlignBottomOpt = Fond
 textVertAlignCenterOpt = Centre
 textVertAlignTopOpt = Sommet
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = Impossible de trouver la déclaration d’entité

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -299,9 +299,6 @@ textVertAlignTopOpt = Sommet
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
-# ==> imageCopyrightDialogTitle = Image Copyright Notice
-# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -289,6 +289,14 @@ textVertAlignTopOpt = Sommet
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -269,6 +269,27 @@ textVertAlignBottomOpt = Fond
 textVertAlignCenterOpt = Centre
 textVertAlignTopOpt = Sommet
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = Impossible de trouver la déclaration d’entité

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -294,6 +294,14 @@ textVertAlignTopOpt = Sommet
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -294,6 +294,14 @@ textVertAlignTopOpt = Sopra
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -299,6 +299,7 @@ textVertAlignTopOpt = Sopra
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
+# ==> imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -289,6 +289,14 @@ textVertAlignTopOpt = Sopra
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -269,6 +269,27 @@ textVertAlignBottomOpt = Sotto
 textVertAlignCenterOpt = Centro
 textVertAlignTopOpt = Sopra
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = La dichiarazione dell’entità non può essere trovata

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -299,9 +299,6 @@ textVertAlignTopOpt = Sopra
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
-# ==> imageCopyrightDialogTitle = Image Copyright Notice
-# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -274,6 +274,27 @@ textVertAlignBottomOpt = Sotto
 textVertAlignCenterOpt = Centro
 textVertAlignTopOpt = Sopra
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = La dichiarazione dell’entità non può essere trovata

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -294,6 +294,14 @@ textVertAlignTopOpt = 上
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -269,6 +269,27 @@ textVertAlignBottomOpt = 下
 textVertAlignCenterOpt = 中央
 textVertAlignTopOpt = 上
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = エンティティ宣言が見つかりません。

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -299,9 +299,6 @@ textVertAlignTopOpt = 上
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
-# ==> imageCopyrightDialogTitle = Image Copyright Notice
-# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -299,6 +299,7 @@ textVertAlignTopOpt = 上
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
+# ==> imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -289,6 +289,14 @@ textVertAlignTopOpt = 上
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -274,6 +274,27 @@ textVertAlignBottomOpt = 下
 textVertAlignCenterOpt = 中央
 textVertAlignTopOpt = 上
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = エンティティ宣言が見つかりません。

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -269,6 +269,27 @@ textVertAlignBottomOpt = Onderkant
 textVertAlignCenterOpt = Midden
 textVertAlignTopOpt = Bovenkant
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = De entiteitsdeclaratie kan niet worden gevonden

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -289,6 +289,14 @@ textVertAlignTopOpt = Bovenkant
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -274,6 +274,27 @@ textVertAlignBottomOpt = Onderkant
 textVertAlignCenterOpt = Midden
 textVertAlignTopOpt = Bovenkant
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = De entiteitsdeclaratie kan niet worden gevonden

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -294,6 +294,14 @@ textVertAlignTopOpt = Bovenkant
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -299,6 +299,7 @@ textVertAlignTopOpt = Bovenkant
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
+# ==> imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -299,9 +299,6 @@ textVertAlignTopOpt = Bovenkant
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
-# ==> imageCopyrightDialogTitle = Image Copyright Notice
-# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -276,24 +276,27 @@ textVertAlignTopOpt = Góra
 #
 # base/Image.java
 #
-# ==> imageComponent = Image
-# ==> imageSourceAttr = Image Source
-# ==> imageLocationXAttr = Location X
-# ==> imageLocationYAttr = Location Y
-# ==> imageWidthAttr = Width
-# ==> imageHeightAttr = Height
-# ==> imageScaleAttr = Scale Mode
-# ==> imageScaleCoverOpt = Crop / Fill
-# ==> imageResetSizeItem = Reset to Original Size
-# ==> imageOptimizeItem = Optimize Image Size
-# ==> imageOptimizeConfirmTitle = Optimize Image Size
-# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
-# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
-# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
-# ==> imageScaleFitOpt = Fit (Aspect Ratio)
-# ==> imageScaleStretchOpt = Stretch
-# ==> imageChooseDialogTitle = Select Image File
-# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+imageComponent = Obraz
+imageSourceAttr = Źródło obrazu
+imageLocationXAttr = Położenie X
+imageLocationYAttr = Położenie Y
+imageWidthAttr = Szerokość
+imageHeightAttr = Wysokość
+imageScaleAttr = Tryb skalowania
+imageScaleFitOpt = Dopasuj (zachowaj proporcje)
+imageScaleStretchOpt = Rozciągnij
+imageScaleCoverOpt = Przytnij / Wypełnij
+imageResetSizeItem = Przywróć oryginalny rozmiar
+imageOptimizeItem = Optymalizuj rozmiar obrazu
+imageOptimizeConfirmTitle = Optymalizacja rozmiaru obrazu
+imageOptimizeConfirmMessage = Rozdzielczość obrazu zostanie zmniejszona z %dx%d do %dx%d pikseli. Znacząco zmniejszy to rozmiar pliku układu oraz zużycie pamięci.\n\nCzy chcesz kontynuować?
+imageAlreadyOptimizedMessage = Obraz jest już zoptymalizowany dla bieżącego rozmiaru ramki (%dx%d).
+imageMakeWhiteTransparentItem = Ustaw zewnętrzne tło jako przezroczyste
+imageChooseDialogTitle = Wybierz plik obrazu
+imageFileFilterDescription = Pliki obrazów (*.png, *.jpg, *.jpeg, *.gif)
+imageSourceNone = (brak)
+
+
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -299,9 +299,7 @@ imageLicenseAttr = Licencja
 imageLicenseUnspecifiedOpt = Nieokreślona
 imageLicenseOtherOpt = Inna
 imageAttributionAttr = Źródło / Autor
-
-
-
+# ==> imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -295,6 +295,14 @@ imageMakeWhiteTransparentItem = Ustaw zewnętrzne tło jako przezroczyste
 imageChooseDialogTitle = Wybierz plik obrazu
 imageFileFilterDescription = Pliki obrazów (*.png, *.jpg, *.jpeg, *.gif)
 imageSourceNone = (brak)
+imageLicenseAttr = Licencja
+imageLicenseUnspecifiedOpt = Nieokreślona
+imageLicenseOtherOpt = Inna
+imageAttributionAttr = Źródło / Autor
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
+
 
 
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -269,6 +269,27 @@ textVertAlignBottomOpt = Dół
 textVertAlignCenterOpt = Środek
 textVertAlignTopOpt = Góra
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = Nie można znaleźć deklaracji elementu

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -290,6 +290,14 @@ imageMakeWhiteTransparentItem = Ustaw zewnętrzne tło jako przezroczyste
 imageChooseDialogTitle = Wybierz plik obrazu
 imageFileFilterDescription = Pliki obrazów (*.png, *.jpg, *.jpeg, *.gif)
 imageSourceNone = (brak)
+imageLicenseAttr = Licencja
+imageLicenseUnspecifiedOpt = Nieokreślona
+imageLicenseOtherOpt = Inna
+imageAttributionAttr = Źródło / Autor
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
+
 
 
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -271,24 +271,27 @@ textVertAlignTopOpt = Góra
 #
 # base/Image.java
 #
-# ==> imageComponent = Image
-# ==> imageSourceAttr = Image Source
-# ==> imageLocationXAttr = Location X
-# ==> imageLocationYAttr = Location Y
-# ==> imageWidthAttr = Width
-# ==> imageHeightAttr = Height
-# ==> imageScaleAttr = Scale Mode
-# ==> imageScaleCoverOpt = Crop / Fill
-# ==> imageResetSizeItem = Reset to Original Size
-# ==> imageOptimizeItem = Optimize Image Size
-# ==> imageOptimizeConfirmTitle = Optimize Image Size
-# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
-# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
-# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
-# ==> imageScaleFitOpt = Fit (Aspect Ratio)
-# ==> imageScaleStretchOpt = Stretch
-# ==> imageChooseDialogTitle = Select Image File
-# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+imageComponent = Obraz
+imageSourceAttr = Źródło obrazu
+imageLocationXAttr = Położenie X
+imageLocationYAttr = Położenie Y
+imageWidthAttr = Szerokość
+imageHeightAttr = Wysokość
+imageScaleAttr = Tryb skalowania
+imageScaleFitOpt = Dopasuj (zachowaj proporcje)
+imageScaleStretchOpt = Rozciągnij
+imageScaleCoverOpt = Przytnij / Wypełnij
+imageResetSizeItem = Przywróć oryginalny rozmiar
+imageOptimizeItem = Optymalizuj rozmiar obrazu
+imageOptimizeConfirmTitle = Optymalizacja rozmiaru obrazu
+imageOptimizeConfirmMessage = Rozdzielczość obrazu zostanie zmniejszona z %dx%d do %dx%d pikseli. Znacząco zmniejszy to rozmiar pliku układu oraz zużycie pamięci.\n\nCzy chcesz kontynuować?
+imageAlreadyOptimizedMessage = Obraz jest już zoptymalizowany dla bieżącego rozmiaru ramki (%dx%d).
+imageMakeWhiteTransparentItem = Ustaw zewnętrzne tło jako przezroczyste
+imageChooseDialogTitle = Wybierz plik obrazu
+imageFileFilterDescription = Pliki obrazów (*.png, *.jpg, *.jpeg, *.gif)
+imageSourceNone = (brak)
+
+
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -299,9 +299,6 @@ imageLicenseAttr = Licencja
 imageLicenseUnspecifiedOpt = Nieokreślona
 imageLicenseOtherOpt = Inna
 imageAttributionAttr = Źródło / Autor
-# ==> imageCopyrightDialogTitle = Image Copyright Notice
-# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 
 
 

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -274,6 +274,27 @@ textVertAlignBottomOpt = Dół
 textVertAlignCenterOpt = Środek
 textVertAlignTopOpt = Góra
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = Nie można znaleźć deklaracji elementu

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -274,6 +274,27 @@ textVertAlignBottomOpt = Embaixo
 textVertAlignCenterOpt = Centro
 textVertAlignTopOpt = Em cima
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = Impossível encontrar definição de entidade

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -299,9 +299,6 @@ textVertAlignTopOpt = Em cima
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
-# ==> imageCopyrightDialogTitle = Image Copyright Notice
-# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -269,6 +269,27 @@ textVertAlignBottomOpt = Embaixo
 textVertAlignCenterOpt = Centro
 textVertAlignTopOpt = Em cima
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = Impossível encontrar definição de entidade

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -299,6 +299,7 @@ textVertAlignTopOpt = Em cima
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
+# ==> imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -289,6 +289,14 @@ textVertAlignTopOpt = Em cima
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -294,6 +294,14 @@ textVertAlignTopOpt = Em cima
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -294,6 +294,8 @@ imageAlreadyOptimizedMessage = Изображение уже оптимизир�
 imageMakeWhiteTransparentItem = Сделать внешний фон прозрачным
 imageChooseDialogTitle = Выбор файла изображения
 imageFileFilterDescription = Файлы изображений (*.png, *.jpg, *.jpeg, *.gif)
+imageSourceNone = (нет)
+
 
 #
 # base/VhdlParser.java

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -269,6 +269,28 @@ textVertAlignBottomOpt = По низу
 textVertAlignCenterOpt = По центру
 textVertAlignTopOpt = По верху
 #
+# base/Image.java
+#
+imageComponent = Изображение
+imageSourceAttr = Источник изображения
+imageLocationXAttr = Координата X
+imageLocationYAttr = Координата Y
+imageWidthAttr = Ширина
+imageHeightAttr = Высота
+imageScaleAttr = Масштабирование
+imageScaleFitOpt = Вписать (с сохранением пропорций)
+imageScaleStretchOpt = Растянуть
+imageScaleCoverOpt = Заполнить (с обрезкой)
+imageResetSizeItem = Сбросить к исходному размеру
+imageOptimizeItem = Оптимизировать размер
+imageOptimizeConfirmTitle = Оптимизация размера изображения
+imageOptimizeConfirmMessage = Разрешение изображения будет уменьшено с %dx%d до %dx%d пикселей. Это существенно уменьшит размер файла схемы и потребление памяти.\n\nПродолжить?
+imageAlreadyOptimizedMessage = Изображение уже оптимизировано под текущий размер рамки (%dx%d).
+imageMakeWhiteTransparentItem = Сделать внешний фон прозрачным
+imageChooseDialogTitle = Выбор файла изображения
+imageFileFilterDescription = Файлы изображений (*.png, *.jpg, *.jpeg, *.gif)
+
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = Не найдено объявление сущности (Entity)

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -290,6 +290,14 @@ imageMakeWhiteTransparentItem = Сделать внешний фон прозр�
 imageChooseDialogTitle = Выбор файла изображения
 imageFileFilterDescription = Файлы изображений (*.png, *.jpg, *.jpeg, *.gif)
 imageSourceNone = (нет)
+imageLicenseAttr = Лицензия
+imageLicenseUnspecifiedOpt = Не определено
+imageLicenseOtherOpt = Другое
+imageAttributionAttr = Источник / Автор
+imageCopyrightDialogTitle = Уведомление об авторских правах
+imageCopyrightDialogMessage = При вставке внешних изображений, пожалуйста, соблюдайте авторские права.\n\nВы можете указать автора и выбрать соответствующую лицензию в таблице атрибутов.
+imageCopyrightDontShowAgain = Я понял, больше не показывать это сообщение
+
 
 
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -299,9 +299,6 @@ imageLicenseAttr = Лицензия
 imageLicenseUnspecifiedOpt = Не определено
 imageLicenseOtherOpt = Другое
 imageAttributionAttr = Источник / Автор
-imageCopyrightDialogTitle = Уведомление об авторских правах
-imageCopyrightDialogMessage = При вставке внешних изображений, пожалуйста, соблюдайте авторские права.\n\nВы можете указать автора и выбрать соответствующую лицензию в таблице атрибутов.
-imageCopyrightDontShowAgain = Я понял, больше не показывать это сообщение
 
 
 

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -299,9 +299,7 @@ imageLicenseAttr = Лицензия
 imageLicenseUnspecifiedOpt = Не определено
 imageLicenseOtherOpt = Другое
 imageAttributionAttr = Источник / Автор
-
-
-
+imageDataSizeAttr = Размер данных
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -295,6 +295,14 @@ imageMakeWhiteTransparentItem = Сделать внешний фон прозр�
 imageChooseDialogTitle = Выбор файла изображения
 imageFileFilterDescription = Файлы изображений (*.png, *.jpg, *.jpeg, *.gif)
 imageSourceNone = (нет)
+imageLicenseAttr = Лицензия
+imageLicenseUnspecifiedOpt = Не определено
+imageLicenseOtherOpt = Другое
+imageAttributionAttr = Источник / Автор
+imageCopyrightDialogTitle = Уведомление об авторских правах
+imageCopyrightDialogMessage = При вставке внешних изображений, пожалуйста, соблюдайте авторские права.\n\nВы можете указать автора и выбрать соответствующую лицензию в таблице атрибутов.
+imageCopyrightDontShowAgain = Я понял, больше не показывать это сообщение
+
 
 
 #

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -274,6 +274,28 @@ textVertAlignBottomOpt = По низу
 textVertAlignCenterOpt = По центру
 textVertAlignTopOpt = По верху
 #
+# base/Image.java
+#
+imageComponent = Изображение
+imageSourceAttr = Источник изображения
+imageLocationXAttr = Координата X
+imageLocationYAttr = Координата Y
+imageWidthAttr = Ширина
+imageHeightAttr = Высота
+imageScaleAttr = Масштабирование
+imageScaleFitOpt = Вписать (с сохранением пропорций)
+imageScaleStretchOpt = Растянуть
+imageScaleCoverOpt = Заполнить (с обрезкой)
+imageResetSizeItem = Сбросить к исходному размеру
+imageOptimizeItem = Оптимизировать размер
+imageOptimizeConfirmTitle = Оптимизация размера изображения
+imageOptimizeConfirmMessage = Разрешение изображения будет уменьшено с %dx%d до %dx%d пикселей. Это существенно уменьшит размер файла схемы и потребление памяти.\n\nПродолжить?
+imageAlreadyOptimizedMessage = Изображение уже оптимизировано под текущий размер рамки (%dx%d).
+imageMakeWhiteTransparentItem = Сделать внешний фон прозрачным
+imageChooseDialogTitle = Выбор файла изображения
+imageFileFilterDescription = Файлы изображений (*.png, *.jpg, *.jpeg, *.gif)
+
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = Не найдено объявление сущности (Entity)

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -289,6 +289,8 @@ imageAlreadyOptimizedMessage = Изображение уже оптимизир�
 imageMakeWhiteTransparentItem = Сделать внешний фон прозрачным
 imageChooseDialogTitle = Выбор файла изображения
 imageFileFilterDescription = Файлы изображений (*.png, *.jpg, *.jpeg, *.gif)
+imageSourceNone = (нет)
+
 
 #
 # base/VhdlParser.java

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -294,6 +294,14 @@ textVertAlignTopOpt = 顶部
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -289,6 +289,14 @@ textVertAlignTopOpt = 顶部
 # ==> imageScaleStretchOpt = Stretch
 # ==> imageChooseDialogTitle = Select Image File
 # ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+# ==> imageSourceNone = (none)
+# ==> imageLicenseAttr = License
+# ==> imageLicenseUnspecifiedOpt = Unspecified
+# ==> imageLicenseOtherOpt = Other
+# ==> imageAttributionAttr = Source / Author
+# ==> imageCopyrightDialogTitle = Image Copyright Notice
+# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
+# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -299,6 +299,7 @@ textVertAlignTopOpt = 顶部
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
+# ==> imageDataSizeAttr = Data Size
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -269,6 +269,27 @@ textVertAlignBottomOpt = 底部
 textVertAlignCenterOpt = 居中
 textVertAlignTopOpt = 顶部
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = 找不到实体声明

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -299,9 +299,6 @@ textVertAlignTopOpt = 顶部
 # ==> imageLicenseUnspecifiedOpt = Unspecified
 # ==> imageLicenseOtherOpt = Other
 # ==> imageAttributionAttr = Source / Author
-# ==> imageCopyrightDialogTitle = Image Copyright Notice
-# ==> imageCopyrightDialogMessage = Please make sure you have the right to use inserted images.\n\nYou can document the author and license in the image attributes.
-# ==> imageCopyrightDontShowAgain = I understand, don't show this message again
 #
 # base/VhdlParser.java
 #

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -274,6 +274,27 @@ textVertAlignBottomOpt = 底部
 textVertAlignCenterOpt = 居中
 textVertAlignTopOpt = 顶部
 #
+# base/Image.java
+#
+# ==> imageComponent = Image
+# ==> imageSourceAttr = Image Source
+# ==> imageLocationXAttr = Location X
+# ==> imageLocationYAttr = Location Y
+# ==> imageWidthAttr = Width
+# ==> imageHeightAttr = Height
+# ==> imageScaleAttr = Scale Mode
+# ==> imageScaleCoverOpt = Crop / Fill
+# ==> imageResetSizeItem = Reset to Original Size
+# ==> imageOptimizeItem = Optimize Image Size
+# ==> imageOptimizeConfirmTitle = Optimize Image Size
+# ==> imageOptimizeConfirmMessage = The image resolution will be reduced from {0}x{1} to {2}x{3} pixels. This will significantly shrink the circuit file size and memory usage.\n\nDo you want to proceed?
+# ==> imageAlreadyOptimizedMessage = The image is already optimized for its current frame size ({0}x{1}).
+# ==> imageMakeWhiteTransparentItem = Make Outer Background Transparent
+# ==> imageScaleFitOpt = Fit (Aspect Ratio)
+# ==> imageScaleStretchOpt = Stretch
+# ==> imageChooseDialogTitle = Select Image File
+# ==> imageFileFilterDescription = Image Files (*.png, *.jpg, *.jpeg, *.gif)
+#
 # base/VhdlParser.java
 #
 CannotFindEntityException = 找不到实体声明

--- a/src/test/java/com/cburch/draw/shapes/ImageShapeTest.java
+++ b/src/test/java/com/cburch/draw/shapes/ImageShapeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.draw.shapes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ImageShapeTest {
+
+  @Test
+  void testImageShapeAttributesAndResizing() {
+    final var shape = new ImageShape(10, 20, 100, 50);
+
+    assertTrue(shape.getAttributes().contains(ImageShape.IMAGE_ATTR));
+    assertTrue(shape.getAttributes().contains(ImageShape.WIDTH_ATTR));
+    assertTrue(shape.getAttributes().contains(ImageShape.HEIGHT_ATTR));
+
+    assertEquals(10, shape.getX());
+    assertEquals(20, shape.getY());
+    assertEquals(100, shape.getWidth());
+    assertEquals(50, shape.getHeight());
+
+    assertEquals(100, shape.getValue(ImageShape.WIDTH_ATTR));
+    assertEquals(50, shape.getValue(ImageShape.HEIGHT_ATTR));
+
+    shape.setValue(ImageShape.WIDTH_ATTR, 200);
+    shape.setValue(ImageShape.HEIGHT_ATTR, 150);
+
+    assertEquals(10, shape.getX());
+    assertEquals(20, shape.getY());
+    assertEquals(200, shape.getWidth());
+    assertEquals(150, shape.getHeight());
+
+    assertEquals(200, shape.getValue(ImageShape.WIDTH_ATTR));
+    assertEquals(150, shape.getValue(ImageShape.HEIGHT_ATTR));
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/menu/PrintHandlerTest.java
+++ b/src/test/java/com/cburch/logisim/gui/menu/PrintHandlerTest.java
@@ -153,4 +153,42 @@ class PrintHandlerTest {
       }
     }
   }
+
+  @Test
+  void svgExportWithImageComponent() throws Exception {
+    final var handler = new ImagePrintHandler();
+    final var dest = tempDir.resolve("with-image.svg").toFile();
+    handler.exportImage(dest, ExportImage.FORMAT_SVG);
+    final var content = Files.readString(dest.toPath());
+    assertTrue(content.contains("<image"));
+    assertTrue(content.contains("href=\"data:image/png;base64,"));
+  }
+
+  @Test
+  void tikzExportWithImageComponent() throws Exception {
+    final var handler = new ImagePrintHandler();
+    final var dest = tempDir.resolve("with-image.tex").toFile();
+    handler.exportImage(dest, ExportImage.FORMAT_TIKZ);
+    final var content = Files.readString(dest.toPath());
+    assertTrue(content.contains("[Image: 30x30]"));
+    assertFalse(content.contains("data:image/png;base64,"));
+  }
+
+  static class ImagePrintHandler extends PrintHandler {
+    @Override
+    public int print(Graphics2D g, PageFormat pf, int pageNum, double w, double h) {
+      return 0;
+    }
+
+    @Override
+    public Dimension getExportImageSize() {
+      return new Dimension(100, 100);
+    }
+
+    @Override
+    public void paintExportImage(BufferedImage img, Graphics2D g) {
+      final var testImg = new BufferedImage(30, 30, BufferedImage.TYPE_INT_ARGB);
+      g.drawImage(testImg, 10, 10, 30, 30, null);
+    }
+  }
 }


### PR DESCRIPTION
### Summary
Adds support for embedding raster images (PNG, JPG, GIF) directly into the circuit canvas and subcircuit appearances. Images are stored as Base64 inside the `.circ` file, so projects stay fully self-contained.

### Motivation
This feature greatly enhances the visual and educational value of Logisim-evolution. Users can embed real-world chip pinouts, reference diagrams, or custom hardware logos directly on the canvas. It bridges the gap between abstract logic simulation and physical hardware, making it much easier to create visually intuitive projects, assignments, and custom IC appearances without relying on external documentation.

### Overview
Images can be placed both on the main canvas and inside the Appearance Editor (`<appear>`). All images are automatically converted to Base64 data URIs and saved inside the `.circ` file.

The changes are split into 3 commits for easier review:
- Core utilities (ImageUtil) — Base64 encoding, caching and flood-fill
- Image component + Appearance tool and related actions
- GUI integration — toolbar icon, clipboard paste handlers and UI polish

### Key User Features
- **Flexible insertion**:  
  – Select the `Image` tool from the Base library (or appearance toolbar) and load a file via the attribute table.  
  – Paste an image directly from clipboard (`Ctrl+V`).
- **Attributes**: width, height, coordinates, and scaling modes (`fit`, `stretch`, `original`).
- **Context menu**:
   - **Restore Original Size** — resets image to its original source dimensions.
   - **Make Outer Background Transparent** — removes solid white outer background while preserving internal white pixels.
   - **Optimize Image Size** — downscales and recompresses the embedded image data to the current component size (reduces `.circ` size). Fully undoable.

### Technical Implementation
- Main canvas: Base64 data URIs.
- Appearance editor: standard SVG `<image>` tags.
- Shared memory via global `WeakHashMap` cache (`ImageUtil`) — multiple instances of the same image share one `BufferedImage`.
- Background removal uses 4-connected BFS flood fill from the borders.
- Full undo/redo support through `ModelChangeAttributeAction` for all attribute changes and context-menu actions.
- i18n Support: Includes full translation strings for English and Russian, as well as fallback markers (`# ==>`) for all other supported languages.

### How to Test
A sample circuit (`tst_img_tool.circ.zip`) is attached. Please also verify the following:

1. Insert images on the main canvas both via `Image` tool and via clipboard paste.
2. Change size and scaling mode (`fit` / `stretch` / `original`) via Attribute Table and by dragging handles.
3. Right-click an image and try all three context-menu actions (including Undo after Optimize).
4. Open Subcircuit Appearance Editor, place an image, save and reopen — check that SVG serialization works.
5. Verify Undo/Redo after insertion, moves, attribute changes and context-menu actions.
6. Confirm that images survive project reload and opening the `.circ` on another machine.

<img width="1424" height="1110" alt="2026-08-05_14-18-20" src="https://github.com/user-attachments/assets/fc3624a2-74fa-4af8-9d4e-3064f17dfc7c" />

[tst_img_tool.circ.zip](https://github.com/user-attachments/files/30741888/tst_img_tool.circ.zip)
