### PR TITLE
docs: add floating-point arithmetic basics

### DIFF
--- a/src/main/resources/doc/en/contents.xml
+++ b/src/main/resources/doc/en/contents.xml
@@ -168,6 +168,13 @@
 			<tocitem target="arith_bitadder" text="Bit Adder" image="icon_bitadder" />
 			<tocitem target="arith_bitfinder" text="Bit Finder" image="icon_bitfinder" />
 		</tocitem>
+		<tocitem target="fparith" text="Floating Point Arithmetic library">
+			<tocitem target="fparith_adder" text="Floating Point Adder" image="icon_adder" />
+			<tocitem target="fparith_subtractor" text="Floating Point Subtractor" image="icon_subtractor" />
+			<tocitem target="fparith_multiplier" text="Floating Point Multiplier" image="icon_multiplier" />
+			<tocitem target="fparith_divider" text="Floating Point Divider" image="icon_divider" />
+			<tocitem target="fparith_negator" text="Floating Point Negator" image="icon_negator" />
+		</tocitem>
 		<tocitem target="mem" text="Memory library">
 			<tocitem target="mem_flipflops" text="D/T/J-K/S-R Flip-Flop" image="icon_flipflops" />
 			<tocitem target="mem_register" text="Register" image="icon_register" />

--- a/src/main/resources/doc/en/html/libs/arith/index.html
+++ b/src/main/resources/doc/en/html/libs/arith/index.html
@@ -17,7 +17,7 @@
       Arithmetic library
     </h1>
     <p>
-      The Arithmetic Library includes combinatorial components that perform arithmetic operations on unsigned, two's complement and floating point values.
+      The Arithmetic Library includes combinatorial components that perform arithmetic operations on unsigned and two's complement values. Floating-point components are documented separately in the <a href="../fparith/index.html">Floating Point Arithmetic library</a>.
     </p>
     <table>
       <tbody>
@@ -101,70 +101,6 @@
           </td><td>
             <a href="bitfinder.html">Bit Finder</a>
           </td>
-        </tr>
-		 <tr>
-          <td align="right">
-            <a href="adder.html"><img  class="iconlibs" src="../../../../icons/6464/adder.png" alt="#########" width="32" height="32" border="0" ></a>
-          <td>
-            &nbsp;
-          </td><td>
-            <a href="fpadder.html">Floating Point Adder</a>
-          </td>
-        </tr>
-        <tr>
-          <td align="right">
-            <a href="fpsubtractor.html"><img  class="iconlibs" src="../../../../icons/6464/subtractor.png"alt="#########"  width="32" height="32" border="0" ></a>
-          </td><td>
-            &nbsp;
-          </td> <td>
-            <a href="subtractor.html">Floating Point Subtractor</a>
-          </td>
-        </tr>
-        <tr>
-          <td align="right">
-            <a href="fpmultiplier.html"><img  class="iconlibs" src="../../../../icons/6464/multiplier.png" alt="#########" width="32" height="32" border="0"></a>
-          </td><td>
-            &nbsp;
-          </td><td>
-            <a href="fpmultiplier.html">Floating Point Multiplier</a>
-          </td>
-        </tr>
-        <tr>
-          <td align="right">
-            <a href="divider.html"><img  class="iconlibs" src="../../../../icons/6464/divider.png" alt="#########" width="32" height="32" border="0"></a>
-          </td><td>
-            &nbsp;
-          </td><td>
-            <a href="fpdivider.html">Floating Point Divider</a>
-          </td>
-        </tr>
-        <tr>
-          <td align="right">
-            <a href="negator.html"><img  class="iconlibs" src="../../../../icons/6464/negator.png" alt="#########" width="32" height="32" border="0"></a>
-          </td><td>
-            &nbsp;
-          </td><td>
-            <a href="fpnegator.html">Floating Point Negator</a>
-          </td>
-        </tr>
-        <tr>
-          <td align="right">
-            <a href="comparator.html"><img  class="iconlibs" src="../../../../icons/6464/comparator.png" alt="#########" width="32" height="32" border="0" ></a>
-          </td><td>
-            &nbsp;
-          </td><td>
-            <a href="fptoint.html">Floating Point to Integer</a>
-          </td>
-        </tr>
-		<tr>
-          <td align="right">
-            <a href="comparator.html"><img  class="iconlibs" src="../../../../icons/6464/comparator.png" alt="#########" width="32" height="32" border="0" ></a>
-          </td><td>
-            &nbsp;
-          </td><td>
-            <a href="inttofp.html">Integer to Floating Point</a>
-          </td>
-        </tr>
         </tr>
       </tbody>
     </table>

--- a/src/main/resources/doc/en/html/libs/fparith/adder.html
+++ b/src/main/resources/doc/en/html/libs/fparith/adder.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Adder</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/adder.png" alt="Adder icon" width="32" height="32" align="middle">
+        <em>Floating Point Adder</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component adds the two floating-point values on its west inputs and places their sum
+        on the east output. The result is rounded to the selected floating-point size. The
+        <var>ERR</var> output is 1 when the sum is NaN and 0 otherwise.
+      </p>
+      <p>
+        An input containing unknown or error bits is converted to NaN, so it produces a NaN result
+        and sets <var>ERR</var> to 1.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge, north end (input, bit width matches Float size)</dt>
+        <dd>The first addend.</dd>
+        <dt>West edge, south end (input, bit width matches Float size)</dt>
+        <dd>The second addend.</dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The floating-point sum of the two inputs.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the sum is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of both inputs and the result: 8, 16, 32, or 64 bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/divider.html
+++ b/src/main/resources/doc/en/html/libs/fparith/divider.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Divider</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/divider.png" alt="Divider icon" width="32" height="32" align="middle">
+        <em>Floating Point Divider</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component divides the floating-point dividend on the upper west input by the divisor
+        on the lower west input. It places the quotient on the east output and the IEEE remainder
+        on the south output. Both results are rounded to the selected floating-point size.
+      </p>
+      <p>
+        The IEEE remainder is <var>dividend</var> &minus; <var>divisor</var> &times; <var>n</var>,
+        where <var>n</var> is the integer nearest to the exact quotient; if two integers are equally
+        near, the even integer is used. This differs from the remainder produced by truncating the
+        quotient toward zero.
+      </p>
+      <p>
+        The <var>ERR</var> output reports the quotient: it is 1 when the quotient is NaN and 0
+        otherwise. For example, a nonzero finite value divided by zero produces an infinite
+        quotient and a NaN remainder, while <var>ERR</var> remains 0. An input containing unknown
+        or error bits is converted to NaN.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge, north end (input, bit width matches Float size)</dt>
+        <dd>The dividend.</dd>
+        <dt>West edge, south end (input, bit width matches Float size)</dt>
+        <dd>The divisor.</dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The floating-point quotient.</dd>
+        <dt>South edge, east end (output, bit width matches Float size)</dt>
+        <dd>The IEEE remainder.</dd>
+        <dt>South edge, west end (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the quotient is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of both inputs and both arithmetic outputs: 8, 16, 32, or 64 bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/index.html
+++ b/src/main/resources/doc/en/html/libs/fparith/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Arithmetic Library</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>Floating Point Arithmetic library</h1>
+      <p>
+        The Floating Point Arithmetic library contains components that operate on floating-point
+        values. The <b class="propertie">Float size</b> attribute selects an 8-bit minifloat
+        (one sign bit, four exponent bits, and three fraction bits), or an IEEE 754 binary16,
+        binary32, or binary64 representation.
+      </p>
+      <p>
+        The basic arithmetic components provide a one-bit <var>ERR</var> output. It is 1 when the
+        component's primary result is NaN and 0 otherwise. An input containing unknown or error
+        bits is converted to NaN.
+      </p>
+      <h2>Basic operations</h2>
+      <table>
+        <tbody>
+          <tr>
+            <td align="right">
+              <a href="adder.html"><img class="iconlibs" src="../../../../icons/6464/adder.png" alt="Adder icon" width="32" height="32" border="0"></a>
+            </td>
+            <td>&nbsp;</td>
+            <td><a href="adder.html">Floating Point Adder</a></td>
+          </tr>
+          <tr>
+            <td align="right">
+              <a href="subtractor.html"><img class="iconlibs" src="../../../../icons/6464/subtractor.png" alt="Subtractor icon" width="32" height="32" border="0"></a>
+            </td>
+            <td>&nbsp;</td>
+            <td><a href="subtractor.html">Floating Point Subtractor</a></td>
+          </tr>
+          <tr>
+            <td align="right">
+              <a href="multiplier.html"><img class="iconlibs" src="../../../../icons/6464/multiplier.png" alt="Multiplier icon" width="32" height="32" border="0"></a>
+            </td>
+            <td>&nbsp;</td>
+            <td><a href="multiplier.html">Floating Point Multiplier</a></td>
+          </tr>
+          <tr>
+            <td align="right">
+              <a href="divider.html"><img class="iconlibs" src="../../../../icons/6464/divider.png" alt="Divider icon" width="32" height="32" border="0"></a>
+            </td>
+            <td>&nbsp;</td>
+            <td><a href="divider.html">Floating Point Divider</a></td>
+          </tr>
+          <tr>
+            <td align="right">
+              <a href="negator.html"><img class="iconlibs" src="../../../../icons/6464/negator.png" alt="Negator icon" width="32" height="32" border="0"></a>
+            </td>
+            <td>&nbsp;</td>
+            <td><a href="negator.html">Floating Point Negator</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <p><b>Back to</b> <a href="../index.html">Library Reference</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/multiplier.html
+++ b/src/main/resources/doc/en/html/libs/fparith/multiplier.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Multiplier</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/multiplier.png" alt="Multiplier icon" width="32" height="32" align="middle">
+        <em>Floating Point Multiplier</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        In <b class="propertie">Multiply</b> mode, this component multiplies the two
+        floating-point values on its west inputs and places the product on the east output.
+      </p>
+      <p>
+        In <b class="propertie">Fused Multiply and Add</b> mode, a third input appears on the north
+        edge. The component computes <var>a</var> &times; <var>b</var> + <var>c</var> as a fused
+        operation, with one final rounding to the selected floating-point size instead of rounding
+        the multiplication separately.
+      </p>
+      <p>
+        The <var>ERR</var> output is 1 when the product or fused result is NaN and 0 otherwise. An
+        input containing unknown or error bits is converted to NaN.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge, north end (input, bit width matches Float size)</dt>
+        <dd>The first factor, <var>a</var>.</dd>
+        <dt>West edge, south end (input, bit width matches Float size)</dt>
+        <dd>The second factor, <var>b</var>.</dd>
+        <dt>North edge (input, bit width matches Float size)</dt>
+        <dd>
+          The addend, <var>c</var>. This pin is present only when <b class="propertie">Multiplier
+          Mode</b> is <b class="propertie">Fused Multiply and Add</b>.
+        </dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The product <var>a</var> &times; <var>b</var>, or the fused result <var>a</var> &times; <var>b</var> + <var>c</var>.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the result is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of all inputs and the result: 8, 16, 32, or 64 bits.</dd>
+          <dt><b class="propertie">Multiplier Mode</b></dt>
+          <dd>
+            <b class="propertie">Multiply</b> selects two-input multiplication.
+            <b class="propertie">Fused Multiply and Add</b> adds the north input and performs only
+            one final rounding.
+          </dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/negator.html
+++ b/src/main/resources/doc/en/html/libs/fparith/negator.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Negator</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/negator.png" alt="Negator icon" width="32" height="32" align="middle">
+        <em>Floating Point Negator</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component changes the sign of the floating-point value on its west input and places
+        the negated value on the east output. The <var>ERR</var> output is 1 when the result is NaN
+        and 0 otherwise.
+      </p>
+      <p>
+        An input containing unknown or error bits is converted to NaN, so it produces a NaN result
+        and sets <var>ERR</var> to 1.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge (input, bit width matches Float size)</dt>
+        <dd>The floating-point value to negate.</dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The negated floating-point value.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the result is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of the input and result: 8, 16, 32, or 64 bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/subtractor.html
+++ b/src/main/resources/doc/en/html/libs/fparith/subtractor.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Subtractor</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/subtractor.png" alt="Subtractor icon" width="32" height="32" align="middle">
+        <em>Floating Point Subtractor</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component subtracts the floating-point value on the lower west input from the value
+        on the upper west input and places the difference on the east output. The result is rounded
+        to the selected floating-point size. The <var>ERR</var> output is 1 when the difference is
+        NaN and 0 otherwise.
+      </p>
+      <p>
+        An input containing unknown or error bits is converted to NaN, so it produces a NaN result
+        and sets <var>ERR</var> to 1.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge, north end (input, bit width matches Float size)</dt>
+        <dd>The minuend, from which the other input is subtracted.</dd>
+        <dt>West edge, south end (input, bit width matches Float size)</dt>
+        <dd>The subtrahend.</dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The floating-point difference: upper input minus lower input.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the difference is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of both inputs and the result: 8, 16, 32, or 64 bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/index.html
+++ b/src/main/resources/doc/en/html/libs/index.html
@@ -476,6 +476,48 @@
         </tr>
       </tbody>
     </table>
+	<h2>
+      <b><a href="fparith/index.html">Floating Point Arithmetic library</a></b>
+    </h2>
+    <table>
+      <tbody>
+        <tr>
+          <td align="right">
+            <a href="fparith/adder.html"><img class="iconlibs" src="../../../icons/6464/adder.png" alt="Adder icon" border="0" height="32" width="32"></a>
+          </td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/adder.html">Floating Point Adder</a></td>
+        </tr>
+        <tr>
+          <td align="right">
+            <a href="fparith/subtractor.html"><img class="iconlibs" src="../../../icons/6464/subtractor.png" alt="Subtractor icon" border="0" height="32" width="32"></a>
+          </td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/subtractor.html">Floating Point Subtractor</a></td>
+        </tr>
+        <tr>
+          <td align="right">
+            <a href="fparith/multiplier.html"><img class="iconlibs" src="../../../icons/6464/multiplier.png" alt="Multiplier icon" border="0" height="32" width="32"></a>
+          </td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/multiplier.html">Floating Point Multiplier</a></td>
+        </tr>
+        <tr>
+          <td align="right">
+            <a href="fparith/divider.html"><img class="iconlibs" src="../../../icons/6464/divider.png" alt="Divider icon" border="0" height="32" width="32"></a>
+          </td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/divider.html">Floating Point Divider</a></td>
+        </tr>
+        <tr>
+          <td align="right">
+            <a href="fparith/negator.html"><img class="iconlibs" src="../../../icons/6464/negator.png" alt="Negator icon" border="0" height="32" width="32"></a>
+          </td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/negator.html">Floating Point Negator</a></td>
+        </tr>
+      </tbody>
+    </table>
 	    <h2>
       <b><a href="mem/index.html">Memory library</a></b>
     </h2>

--- a/src/main/resources/doc/map_en.jhm
+++ b/src/main/resources/doc/map_en.jhm
@@ -152,6 +152,12 @@
 	<mapID target="arith_shifter"       url="en/html/libs/arith/shifter.html" />
 	<mapID target="arith_bitadder"      url="en/html/libs/arith/bitadder.html" />
 	<mapID target="arith_bitfinder"     url="en/html/libs/arith/bitfinder.html" />
+	<mapID target="fparith"             url="en/html/libs/fparith/index.html" />
+	<mapID target="fparith_adder"       url="en/html/libs/fparith/adder.html" />
+	<mapID target="fparith_subtractor"  url="en/html/libs/fparith/subtractor.html" />
+	<mapID target="fparith_multiplier"  url="en/html/libs/fparith/multiplier.html" />
+	<mapID target="fparith_divider"     url="en/html/libs/fparith/divider.html" />
+	<mapID target="fparith_negator"     url="en/html/libs/fparith/negator.html" />
 	<mapID target="mem"                 url="en/html/libs/mem/index.html" />
 	<mapID target="mem_flipflops"       url="en/html/libs/mem/flipflops.html" />
 	<mapID target="mem_register"        url="en/html/libs/mem/register.html" />

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -151,6 +151,12 @@
 	<mapID target="arith_shifter"       url="pt/html/libs/arith/shifter.html" />
 	<mapID target="arith_bitadder"      url="pt/html/libs/arith/bitadder.html" />
 	<mapID target="arith_bitfinder"     url="pt/html/libs/arith/bitfinder.html" />
+	<mapID target="fparith"             url="en/html/libs/fparith/index.html" />
+	<mapID target="fparith_adder"       url="en/html/libs/fparith/adder.html" />
+	<mapID target="fparith_subtractor"  url="en/html/libs/fparith/subtractor.html" />
+	<mapID target="fparith_multiplier"  url="en/html/libs/fparith/multiplier.html" />
+	<mapID target="fparith_divider"     url="en/html/libs/fparith/divider.html" />
+	<mapID target="fparith_negator"     url="en/html/libs/fparith/negator.html" />
 	<mapID target="mem"                 url="pt/html/libs/mem/index.html" />
 	<mapID target="mem_flipflops"       url="pt/html/libs/mem/flipflops.html" />
 	<mapID target="mem_register"        url="pt/html/libs/mem/register.html" />


### PR DESCRIPTION
## Summary

- add a separate English Floating Point Arithmetic library index and JavaHelp TOC/map entries
- document the floating-point add, subtract, multiply/FMA, divide/remainder, and negate components
- remove stale floating-point entries from the integer Arithmetic index and link to the new library
- map the Portuguese HelpSet's reused English TOC targets to the new English pages

## Rationale

The current Floating Point Arithmetic library is separate from the integer Arithmetic library, but the English help still lists broken floating-point links under Arithmetic and has no library section in the JavaHelp navigation. This is the review-sized first slice proposed in #303; the remaining advanced functions and conversions stay out of scope for follow-up documentation work.

## Validation

- `./gradlew test --tests com.cburch.logisim.docs.DocumentationStructureTest`
- `./gradlew check` (with Git for Windows' bundled `xxd` added to the command-local `PATH`)
- `git diff --check`
- Windows JavaHelp smoke test: the new section and five pages open normally; the Portuguese HelpSet's English-TOC fallback also resolves the new pages

Part of #303.
