### PR TITLE
fix: label floating-point logarithm mode correctly

### DIFF
--- a/src/main/java/com/cburch/logisim/std/arith/floating/FpLogarithm.java
+++ b/src/main/java/com/cburch/logisim/std/arith/floating/FpLogarithm.java
@@ -51,7 +51,7 @@ public class FpLogarithm extends InstanceFactory {
   static final Attribute<AttributeOption> LOG_MODE =
       Attributes.forOption(
           "mode",
-          S.getter("fpExponentMode"),
+          S.getter("fpLogarithmMode"),
           new AttributeOption[] {
             LOGXY,
             LOG,

--- a/src/test/java/com/cburch/logisim/std/arith/floating/FpLogarithmTest.java
+++ b/src/test/java/com/cburch/logisim/std/arith/floating/FpLogarithmTest.java
@@ -1,0 +1,24 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.arith.floating;
+
+import static com.cburch.logisim.std.Strings.S;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class FpLogarithmTest {
+  @Test
+  void modeAttributeUsesLogarithmLabel() {
+    final var displayName = FpLogarithm.LOG_MODE.getDisplayName();
+
+    assertEquals(S.get("fpLogarithmMode"), displayName);
+  }
+}


### PR DESCRIPTION
## Summary

- use the existing `fpLogarithmMode` resource for the Floating Point Logarithm mode attribute
- add a focused regression test for the localized attribute display name

## Root cause

`FpLogarithm.LOG_MODE` referenced `fpExponentMode`, so the component displayed an exponentiation label even though the dedicated localized logarithm-mode resource already existed.

## User impact

The attribute panel now identifies this setting as Logarithm Mode and follows the active locale. The serialized attribute name and component behavior are unchanged.

## Validation

- `./gradlew test --tests com.cburch.logisim.std.arith.floating.FpLogarithmTest compileJava checkstyleMain compileTestJava checkstyleTest`
- `./gradlew check`
- `git diff --check`
- Windows GUI verification in English and Portuguese