### PR TITLE
fix: mark trigonometry sine result as output

### DIFF
--- a/src/main/java/com/cburch/logisim/std/arith/floating/FpTrigonometry.java
+++ b/src/main/java/com/cburch/logisim/std/arith/floating/FpTrigonometry.java
@@ -73,7 +73,7 @@ public class FpTrigonometry extends InstanceFactory {
 
     final Port[] ps = new Port[5];
     ps[IN] = new Port(-40, 0, Port.INPUT, StdAttr.FP_WIDTH);
-    ps[SIN] = new Port(0, -10, Port.INPUT, StdAttr.FP_WIDTH);
+    ps[SIN] = new Port(0, -10, Port.OUTPUT, StdAttr.FP_WIDTH);
     ps[TAN] = new Port(0, 0, Port.OUTPUT, StdAttr.FP_WIDTH);
     ps[COS] = new Port(0, 10, Port.OUTPUT, StdAttr.FP_WIDTH);
     ps[ERR] = new Port(-20, 20, Port.OUTPUT, 1);

--- a/src/test/java/com/cburch/logisim/std/arith/floating/FpTrigonometryTest.java
+++ b/src/test/java/com/cburch/logisim/std/arith/floating/FpTrigonometryTest.java
@@ -1,0 +1,28 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.arith.floating;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cburch.logisim.comp.EndData;
+import org.junit.jupiter.api.Test;
+
+class FpTrigonometryTest {
+  @Test
+  void functionResultPortsAreOutputs() {
+    final var ports = new FpTrigonometry().getPorts();
+
+    assertEquals(EndData.INPUT_ONLY, ports.get(0).getType());
+    assertEquals(EndData.OUTPUT_ONLY, ports.get(1).getType());
+    assertEquals(EndData.OUTPUT_ONLY, ports.get(2).getType());
+    assertEquals(EndData.OUTPUT_ONLY, ports.get(3).getType());
+    assertEquals(EndData.OUTPUT_ONLY, ports.get(4).getType());
+  }
+}


### PR DESCRIPTION
## Summary

- mark the sine-family result port as an output
- add a regression test for all Floating Point Trigonometry port directions

## Problem

`FpTrigonometry` computes and drives `sin`, `asin`, or `sinh` on its first east-side port, but that port was declared as `Port.INPUT`. This gave it sink metadata unlike the neighboring tangent and cosine result ports.

## Validation

- `./gradlew test --tests com.cburch.logisim.std.arith.floating.FpTrigonometryTest`
- `./gradlew compileJava checkstyleMain compileTestJava checkstyleTest`
- `git diff --check`
