### PR TITLE
export: embed raster images in SVG

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/TikZInfo.java
@@ -24,13 +24,18 @@ import java.awt.font.TextAttribute;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.text.AttributedCharacterIterator;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.HexFormat;
+import javax.imageio.ImageIO;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerException;
@@ -43,6 +48,8 @@ import org.w3c.dom.Element;
 public class TikZInfo implements Cloneable {
 
   private static final double BASIC_STROKE_WIDTH = 1;
+  private static final String PNG_DATA_URI_PREFIX = "data:image/png;base64,";
+  private static final String XLINK_NAMESPACE = "http://www.w3.org/1999/xlink";
 
   private AffineTransform myTransformer = new AffineTransform();
   private Color drawColor;
@@ -233,6 +240,10 @@ public class TikZInfo implements Cloneable {
     contents.add(new TikZString(str, x, y));
   }
 
+  public void addImage(BufferedImage image, AffineTransform transform) {
+    contents.add(new TikZImage(image, transform));
+  }
+
   public void rotate(double theta) {
     getAffineTransform().rotate(theta);
     myRotation += theta;
@@ -419,6 +430,7 @@ public class TikZInfo implements Cloneable {
     final var svgInfo = parser.newDocument();
     final var svg = svgInfo.createElement("svg");
     svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    svg.setAttribute("xmlns:xlink", XLINK_NAMESPACE);
     svg.setAttribute("version", "1.1");
     svg.setAttribute("viewBox", "0 0 " + width + " " + height);
     // Specifying only a viewBox is not sufficient.
@@ -1222,6 +1234,99 @@ public class TikZInfo implements Cloneable {
       content.append(" ").append(rounded(startAngle)).append(info);
       content.append(getBarePoint(stopPos));
       ne.setAttribute("d", content.toString());
+    }
+  }
+
+  private class TikZImage implements DrawObject {
+    private final String dataUri;
+    private final int width;
+    private final int height;
+    private AffineTransform transform;
+
+    public TikZImage(BufferedImage image, AffineTransform transform) {
+      dataUri = encodePng(image);
+      width = image.getWidth();
+      height = image.getHeight();
+      this.transform = new AffineTransform(transform);
+    }
+
+    private TikZImage(String dataUri, int width, int height, AffineTransform transform) {
+      this.dataUri = dataUri;
+      this.width = width;
+      this.height = height;
+      this.transform = transform;
+    }
+
+    private String encodePng(BufferedImage image) {
+      try {
+        final var output = new ByteArrayOutputStream();
+        if (!ImageIO.write(image, "png", output)) {
+          throw new IllegalStateException("No PNG image writer is available");
+        }
+        return PNG_DATA_URI_PREFIX + Base64.getEncoder().encodeToString(output.toByteArray());
+      } catch (IOException exception) {
+        throw new IllegalStateException("Unable to encode an image for SVG export", exception);
+      }
+    }
+
+    @Override
+    public String getTikZCommand() {
+      return "% Raster image omitted: TikZ image export is not supported.";
+    }
+
+    @Override
+    public void getSvgCommand(Document root, Element e) {
+      final var image = root.createElement("image");
+      image.setAttribute("x", "0");
+      image.setAttribute("y", "0");
+      image.setAttribute("width", Integer.toString(width));
+      image.setAttribute("height", Integer.toString(height));
+      image.setAttribute("preserveAspectRatio", "none");
+      final var matrix = new double[6];
+      transform.getMatrix(matrix);
+      image.setAttribute(
+          "transform",
+          "matrix("
+              + rounded(matrix[0])
+              + " "
+              + rounded(matrix[1])
+              + " "
+              + rounded(matrix[2])
+              + " "
+              + rounded(matrix[3])
+              + " "
+              + rounded(matrix[4])
+              + " "
+              + rounded(matrix[5])
+              + ")");
+      image.setAttributeNS(XLINK_NAMESPACE, "xlink:href", dataUri);
+      e.appendChild(image);
+    }
+
+    @Override
+    public boolean insideArea(int x, int y, int areaWidth, int areaHeight) {
+      final var imageBounds =
+          transform
+              .createTransformedShape(new Rectangle2D.Double(0, 0, width, height))
+              .getBounds2D();
+      final var areaBounds =
+          getAffineTransform()
+              .createTransformedShape(new Rectangle2D.Double(x, y, areaWidth, areaHeight))
+              .getBounds2D();
+      return areaBounds.contains(imageBounds);
+    }
+
+    @Override
+    public DrawObject clone() {
+      return new TikZImage(dataUri, width, height, new AffineTransform(transform));
+    }
+
+    @Override
+    public void move(int dx, int dy) {
+      final var delta = new Point2D.Double();
+      getAffineTransform().deltaTransform(new Point2D.Double(dx, dy), delta);
+      transform.preConcatenate(
+          AffineTransform.getTranslateInstance(delta.getX(), delta.getY()));
     }
   }
 

--- a/src/main/java/com/cburch/logisim/gui/generic/TikZWriter.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/TikZWriter.java
@@ -60,15 +60,17 @@ public class TikZWriter extends Graphics2D {
 
   @Override
   public boolean drawImage(Image img, AffineTransform xform, ImageObserver obs) {
-    System.out.println(
-        "TikZ not yet supported : drawImage(Image img, AffineTransform xform, ImageObserver obs)");
-    return false;
+    final var buffered = toBufferedImage(img, obs);
+    if (buffered == null) return false;
+    final var transform = new AffineTransform(MyInfo.getAffineTransform());
+    transform.concatenate(xform);
+    MyInfo.addImage(buffered, transform);
+    return true;
   }
 
   @Override
   public void drawImage(BufferedImage img, BufferedImageOp op, int x, int y) {
-    System.out.println(
-        "TikZ not yet supported : drawImage(BufferedImage img, BufferedImageOp op, int x, int y)");
+    drawImage(op == null ? img : op.filter(img, null), x, y, null);
   }
 
   @Override
@@ -397,31 +399,52 @@ public class TikZWriter extends Graphics2D {
 
   @Override
   public boolean drawImage(Image img, int x, int y, ImageObserver observer) {
-    System.out.println(
-        "TikZ not yet supported : drawImage(Image img, int x, int y, ImageObserver observer)");
-    return false;
+    if (img == null) return false;
+    final var width = img.getWidth(observer);
+    final var height = img.getHeight(observer);
+    if (width < 0 || height < 0) return false;
+    return drawImage(img, x, y, x + width, y + height, 0, 0, width, height, observer);
   }
 
   @Override
   public boolean drawImage(Image img, int x, int y, int width, int height, ImageObserver observer) {
-    System.out.println(
-        "TikZ not yet supported : drawImage(Image img, int x, int y, int width, int height, ImageObserver observer)");
-    return false;
+    if (img == null) return false;
+    final var imageWidth = img.getWidth(observer);
+    final var imageHeight = img.getHeight(observer);
+    if (imageWidth < 0 || imageHeight < 0) return false;
+    return drawImage(
+        img, x, y, x + width, y + height, 0, 0, imageWidth, imageHeight, observer);
   }
 
   @Override
   public boolean drawImage(Image img, int x, int y, Color bgcolor, ImageObserver observer) {
-    System.out.println(
-        "TikZ not yet supported : drawImage(Image img, int x, int y, Color bgcolor, ImageObserver observer)");
-    return false;
+    if (img == null) return false;
+    final var width = img.getWidth(observer);
+    final var height = img.getHeight(observer);
+    if (width < 0 || height < 0) return false;
+    return drawImage(
+        img, x, y, x + width, y + height, 0, 0, width, height, bgcolor, observer);
   }
 
   @Override
   public boolean drawImage(
       Image img, int x, int y, int width, int height, Color bgcolor, ImageObserver observer) {
-    System.out.println(
-        "TikZ not yet supported : drawImage(Image img, int x, int y, int width, int height, Color bgcolor, ImageObserver observer)");
-    return false;
+    if (img == null) return false;
+    final var imageWidth = img.getWidth(observer);
+    final var imageHeight = img.getHeight(observer);
+    if (imageWidth < 0 || imageHeight < 0) return false;
+    return drawImage(
+        img,
+        x,
+        y,
+        x + width,
+        y + height,
+        0,
+        0,
+        imageWidth,
+        imageHeight,
+        bgcolor,
+        observer);
   }
 
   @Override
@@ -436,10 +459,8 @@ public class TikZWriter extends Graphics2D {
       int sx2,
       int sy2,
       ImageObserver observer) {
-    System.out.println(
-        "TikZ not yet supported : drawImage(Image img, int dx1, int dy1, int dx2, int dy2, int sx1, int sy1, int sx2, int sy2,\n"
-            + "      ImageObserver observer)");
-    return false;
+    return drawImageRegion(
+        img, dx1, dy1, dx2, dy2, sx1, sy1, sx2, sy2, null, observer);
   }
 
   @Override
@@ -455,10 +476,73 @@ public class TikZWriter extends Graphics2D {
       int sy2,
       Color bgcolor,
       ImageObserver observer) {
-    System.out.println(
-        "TikZ not yet supported : drawImage(Image img, int dx1, int dy1, int dx2, int dy2, int sx1, int sy1, int sx2, int sy2,\n"
-            + "      Color bgcolor, ImageObserver observer)");
-    return false;
+    return drawImageRegion(
+        img, dx1, dy1, dx2, dy2, sx1, sy1, sx2, sy2, bgcolor, observer);
+  }
+
+  private boolean drawImageRegion(
+      Image img,
+      int dx1,
+      int dy1,
+      int dx2,
+      int dy2,
+      int sx1,
+      int sy1,
+      int sx2,
+      int sy2,
+      Color background,
+      ImageObserver observer) {
+    if (img == null) return false;
+    if (img.getWidth(observer) < 0 || img.getHeight(observer) < 0) return false;
+
+    final var sourceWidth = Math.abs(sx2 - sx1);
+    final var sourceHeight = Math.abs(sy2 - sy1);
+    if (sourceWidth == 0 || sourceHeight == 0 || dx1 == dx2 || dy1 == dy2) return true;
+
+    final var selected = new BufferedImage(sourceWidth, sourceHeight, BufferedImage.TYPE_INT_ARGB);
+    final var graphics = selected.createGraphics();
+    final boolean complete;
+    if (background == null) {
+      complete =
+          graphics.drawImage(
+              img, 0, 0, sourceWidth, sourceHeight, sx1, sy1, sx2, sy2, observer);
+    } else {
+      complete =
+          graphics.drawImage(
+              img,
+              0,
+              0,
+              sourceWidth,
+              sourceHeight,
+              sx1,
+              sy1,
+              sx2,
+              sy2,
+              background,
+              observer);
+    }
+    graphics.dispose();
+    if (!complete) return false;
+
+    final var transform = new AffineTransform(MyInfo.getAffineTransform());
+    transform.translate(dx1, dy1);
+    transform.scale(
+        (double) (dx2 - dx1) / sourceWidth, (double) (dy2 - dy1) / sourceHeight);
+    MyInfo.addImage(selected, transform);
+    return true;
+  }
+
+  private static BufferedImage toBufferedImage(Image image, ImageObserver observer) {
+    if (image == null) return null;
+    if (image instanceof BufferedImage buffered) return buffered;
+    final var width = image.getWidth(observer);
+    final var height = image.getHeight(observer);
+    if (width < 0 || height < 0) return null;
+    final var buffered = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+    final var graphics = buffered.createGraphics();
+    final var complete = graphics.drawImage(image, 0, 0, observer);
+    graphics.dispose();
+    return complete ? buffered : null;
   }
 
   @Override

--- a/src/test/java/com/cburch/logisim/gui/generic/TikZWriterTest.java
+++ b/src/test/java/com/cburch/logisim/gui/generic/TikZWriterTest.java
@@ -1,0 +1,140 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.util.XmlUtil;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+class TikZWriterTest {
+
+  private static final String PNG_DATA_URI_PREFIX = "data:image/png;base64,";
+  private static final String XLINK_NAMESPACE = "http://www.w3.org/1999/xlink";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void svgEmbedsImagesWithTheCurrentTransformAndDrawingOrder() throws Exception {
+    final var source = new BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB);
+    source.setRGB(0, 0, new Color(255, 0, 0, 128).getRGB());
+    source.setRGB(1, 0, Color.GREEN.getRGB());
+    source.setRGB(0, 1, Color.BLUE.getRGB());
+    source.setRGB(1, 1, Color.WHITE.getRGB());
+
+    final var writer = new TikZWriter();
+    writer.fillRect(0, 0, 1, 1);
+    writer.translate(10, 20);
+    writer.scale(2, 3);
+    assertTrue(writer.drawImage(source, 1, 2, null));
+    writer.fillRect(3, 4, 1, 1);
+
+    final var output = tempDir.resolve("embedded-image.svg");
+    writer.writeSvg(40, 50, output.toFile());
+
+    final var document = parseSvg(output);
+    final var children = document.getDocumentElement().getChildNodes();
+    final var elementNames = new ArrayList<String>();
+    for (var index = 0; index < children.getLength(); index++) {
+      final var child = children.item(index);
+      if (child.getNodeType() == Node.ELEMENT_NODE) elementNames.add(child.getNodeName());
+    }
+    assertEquals(java.util.List.of("rect", "image", "rect"), elementNames);
+
+    final var image = (Element) document.getElementsByTagName("image").item(0);
+    assertEquals("0", image.getAttribute("x"));
+    assertEquals("0", image.getAttribute("y"));
+    assertEquals("2", image.getAttribute("width"));
+    assertEquals("2", image.getAttribute("height"));
+    assertEquals("matrix(2 0 0 3 12 26)", image.getAttribute("transform"));
+
+    final var decoded = decodeEmbeddedPng(image);
+    assertEquals(2, decoded.getWidth());
+    assertEquals(2, decoded.getHeight());
+    assertEquals(source.getRGB(0, 0), decoded.getRGB(0, 0));
+    assertEquals(source.getRGB(1, 0), decoded.getRGB(1, 0));
+    assertEquals(source.getRGB(0, 1), decoded.getRGB(0, 1));
+    assertEquals(source.getRGB(1, 1), decoded.getRGB(1, 1));
+  }
+
+  @Test
+  void svgCropsAndScalesTheSourceRectangle() throws Exception {
+    final var source = new BufferedImage(3, 2, BufferedImage.TYPE_INT_ARGB);
+    source.setRGB(0, 0, Color.RED.getRGB());
+    source.setRGB(1, 0, Color.GREEN.getRGB());
+    source.setRGB(2, 0, Color.BLUE.getRGB());
+    source.setRGB(0, 1, Color.CYAN.getRGB());
+    source.setRGB(1, 1, Color.MAGENTA.getRGB());
+    source.setRGB(2, 1, Color.YELLOW.getRGB());
+
+    final var writer = new TikZWriter();
+    assertTrue(writer.drawImage(source, 10, 20, 14, 22, 1, 0, 3, 2, null));
+
+    final var output = tempDir.resolve("cropped-image.svg");
+    writer.writeSvg(30, 40, output.toFile());
+
+    final var document = parseSvg(output);
+    final var image = (Element) document.getElementsByTagName("image").item(0);
+    assertEquals("2", image.getAttribute("width"));
+    assertEquals("2", image.getAttribute("height"));
+    assertEquals("matrix(2 0 0 1 10 20)", image.getAttribute("transform"));
+
+    final var decoded = decodeEmbeddedPng(image);
+    assertEquals(source.getRGB(1, 0), decoded.getRGB(0, 0));
+    assertEquals(source.getRGB(2, 0), decoded.getRGB(1, 0));
+    assertEquals(source.getRGB(1, 1), decoded.getRGB(0, 1));
+    assertEquals(source.getRGB(2, 1), decoded.getRGB(1, 1));
+  }
+
+  @Test
+  void tikzOutputMarksRasterImagesAsUnsupported() throws Exception {
+    final var source = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+    source.setRGB(0, 0, Color.RED.getRGB());
+
+    final var writer = new TikZWriter();
+    assertTrue(writer.drawImage(source, 0, 0, null));
+
+    final var output = tempDir.resolve("image.tex");
+    writer.writeFile(output.toFile());
+
+    final var content = Files.readString(output);
+    assertTrue(content.contains("% Raster image omitted: TikZ image export is not supported."));
+    assertFalse(content.contains(PNG_DATA_URI_PREFIX));
+  }
+
+  private static org.w3c.dom.Document parseSvg(Path path) throws Exception {
+    final var factory = XmlUtil.getHardenedBuilderFactory();
+    factory.setNamespaceAware(true);
+    return factory.newDocumentBuilder().parse(path.toFile());
+  }
+
+  private static BufferedImage decodeEmbeddedPng(Element image) throws Exception {
+    final var dataUri = image.getAttributeNS(XLINK_NAMESPACE, "href");
+    assertTrue(dataUri.startsWith(PNG_DATA_URI_PREFIX));
+    final var png = Base64.getDecoder().decode(dataUri.substring(PNG_DATA_URI_PREFIX.length()));
+    final var decoded = ImageIO.read(new ByteArrayInputStream(png));
+    assertNotNull(decoded);
+    return decoded;
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/main/ExportImageTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/ExportImageTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.circuit.CircuitState;
 import com.cburch.logisim.comp.ComponentDrawContext;
 import com.cburch.logisim.data.Location;
 import com.cburch.logisim.file.Loader;
@@ -22,7 +23,9 @@ import com.cburch.logisim.gui.generic.TikZWriter;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.prefs.PrefMonitor;
+import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.gates.GatesLibrary;
+import com.cburch.logisim.std.io.IoLibrary;
 import com.cburch.logisim.tools.AddTool;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -139,6 +142,36 @@ class ExportImageTest {
     } finally {
       setPreference(AppPreferences.COMPONENT_COLOR, originalComponentColor);
     }
+  }
+
+  @Test
+  void rgbVideoCircuitEmbedsItsDisplayInSvg() throws Exception {
+    final var file = LogisimFile.createNew(new Loader(null), null);
+    final var project = new Project(file);
+    final var circuit = file.getMainCircuit();
+    circuit.setProject(project);
+    final var circuitState = CircuitState.createRootState(project, circuit);
+    final var videoFactory = ((AddTool) new IoLibrary().getTool("RGB Video")).getFactory();
+    final var video =
+        videoFactory.createComponent(
+            Location.create(100, 300, false), videoFactory.createAttributeSet());
+    final var mutation = new CircuitMutation(circuit);
+    mutation.add(video);
+    mutation.execute();
+
+    final var graphics = new TikZWriter();
+    final var context =
+        new ComponentDrawContext(null, circuit, circuitState, graphics, graphics, false);
+    circuit.draw(context, null);
+    final var svg = tempDir.resolve("rgb-video.svg").toFile();
+    graphics.writeSvg(350, 350, svg);
+
+    final var content = Files.readString(svg.toPath());
+    assertTrue(content.contains("<image"));
+    assertTrue(content.contains("width=\"128\""));
+    assertTrue(content.contains("height=\"128\""));
+    assertTrue(content.contains("transform=\"matrix(2 0 0 2 77 37)\""));
+    assertTrue(content.contains("data:image/png;base64,"));
   }
 
   private static boolean hasNonWhitePixel(BufferedImage image) {


### PR DESCRIPTION
## Summary

- record Java2D raster-image drawing operations for export
- embed raster snapshots as PNG data URIs in SVG while preserving alpha, drawing order, and affine transforms
- support source cropping and destination scaling used by RGB Video
- emit an explicit omission comment for TikZ instead of claiming unsupported raster-image output

## Motivation

The SVG exporter previously omitted `BufferedImage`-backed component content, including the display image drawn by RGB Video and the simple image placement used by SoC VGA. This adds the missing SVG serialization without introducing a TikZ sidecar/resource policy.

This is the bounded SVG portion of #787; TikZ raster-image packaging remains outside this PR.

## Validation

- focused `TikZWriterTest` and `ExportImageTest` regressions
- real RGB Video circuit/state/drawing integration regression
- `compileJava checkstyleMain compileTestJava checkstyleTest`
- `git diff --check`
- complete `gradlew check`
- Windows GUI smoke test: exported a default RGB Video to SVG and verified the embedded screen, frame, pins, geometry, and drawing order; the SVG contained one embedded PNG data URI and no external image URL
