### PR TITLE
feat: add floating point constant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
   * Added ability to load multiple RAM or ROM memories from the command line
   * Added an opt-in RAM data-bus mode where inactive output-enable drives separate outputs to high-impedance.
   * Added Real-Time Clock component.
+  * Added Floating Point Constant component.
   * Modified paste behavior to paste at current mouse location if it is on canvas.
   * Fixed a regression that caused TestVector to fail when the circuit had subcircuits.
   * Fixed TTL 7447 BI/RBO port to be an input/output port to allow cascading of blanking mode.

--- a/src/main/java/com/cburch/logisim/std/arith/floating/FPArithmeticLibrary.java
+++ b/src/main/java/com/cburch/logisim/std/arith/floating/FPArithmeticLibrary.java
@@ -26,6 +26,7 @@ public class FPArithmeticLibrary extends Library {
   public static final String _ID = "FPArithmetic";
 
   private static final FactoryDescription[] DESCRIPTIONS = {
+    new FactoryDescription(FpConstant.class, S.getter("fpConstantComponent"), "constant.gif"),
     new FactoryDescription(FpAdder.class, S.getter("fpAdderComponent"), "adder.gif"),
     new FactoryDescription(FpSubtractor.class, S.getter("fpSubtractorComponent"), "subtractor.gif"),
     new FactoryDescription(FpMultiplier.class, S.getter("fpMultiplierComponent"), "multiplier.gif"),

--- a/src/main/java/com/cburch/logisim/std/arith/floating/FpConstant.java
+++ b/src/main/java/com/cburch/logisim/std/arith/floating/FpConstant.java
@@ -1,0 +1,144 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.arith.floating;
+
+import static com.cburch.logisim.std.Strings.S;
+
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.data.Attributes;
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Bounds;
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.gui.icons.ArithmeticIcon;
+import com.cburch.logisim.instance.Instance;
+import com.cburch.logisim.instance.InstanceFactory;
+import com.cburch.logisim.instance.InstancePainter;
+import com.cburch.logisim.instance.InstanceState;
+import com.cburch.logisim.instance.Port;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.std.wiring.AbstractConstantHdlGeneratorFactory;
+import com.cburch.logisim.tools.key.BitWidthConfigurator;
+import com.cburch.logisim.util.GraphicsUtil;
+import java.awt.Color;
+import java.awt.Font;
+
+public class FpConstant extends InstanceFactory {
+  /**
+   * Unique identifier of the tool, used as reference in project files. Do NOT change as it will
+   * prevent project files from loading.
+   *
+   * <p>Identifier value must MUST be unique string among all tools.
+   */
+  public static final String _ID = "FPConstant";
+
+  public static final Attribute<Double> ATTR_VALUE =
+      Attributes.forDouble("value", S.getter("constantValueAttr"));
+
+  private static final int OUT = 0;
+  private static final int PER_DELAY = 1;
+  private static final Font DEFAULT_FONT = new Font("monospaced", Font.PLAIN, 12);
+
+  private static class FpConstantHdlGeneratorFactory
+      extends AbstractConstantHdlGeneratorFactory {
+    @Override
+    public long getConstant(AttributeSet attrs) {
+      return createValue(attrs.getValue(StdAttr.FP_WIDTH), attrs.getValue(ATTR_VALUE))
+          .toLongValue();
+    }
+  }
+
+  public FpConstant() {
+    super(_ID, S.getter("fpConstantComponent"), new FpConstantHdlGeneratorFactory());
+    setAttributes(
+        new Attribute[] {StdAttr.FP_WIDTH, ATTR_VALUE},
+        new Object[] {BitWidth.create(32), 0.0});
+    setKeyConfigurator(new BitWidthConfigurator(StdAttr.FP_WIDTH));
+    setIcon(new ArithmeticIcon("FP"));
+  }
+
+  static Value createValue(BitWidth width, double value) {
+    return Value.createKnown(width, value);
+  }
+
+  private static String getDisplayValue(AttributeSet attrs) {
+    return createValue(attrs.getValue(StdAttr.FP_WIDTH), attrs.getValue(ATTR_VALUE))
+        .toStringFromFloatValue();
+  }
+
+  @Override
+  protected void configureNewInstance(Instance instance) {
+    instance.addAttributeListener();
+    updatePorts(instance);
+  }
+
+  @Override
+  public Bounds getOffsetBounds(AttributeSet attrs) {
+    final var chars = getDisplayValue(attrs).length();
+    final var width = Math.max(30, 8 + 7 * chars);
+    return Bounds.create(-width, -10, width, 20);
+  }
+
+  @Override
+  protected void instanceAttributeChanged(Instance instance, Attribute<?> attr) {
+    if (attr == StdAttr.FP_WIDTH) {
+      instance.recomputeBounds();
+      updatePorts(instance);
+      instance.fireInvalidated();
+    } else if (attr == ATTR_VALUE) {
+      instance.recomputeBounds();
+      instance.fireInvalidated();
+    }
+  }
+
+  @Override
+  public void paintGhost(InstancePainter painter) {
+    final var bounds = getOffsetBounds(painter.getAttributeSet());
+    final var graphics = painter.getGraphics();
+    graphics.drawRect(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
+    graphics.setFont(DEFAULT_FONT);
+    GraphicsUtil.drawCenteredText(
+        graphics,
+        getDisplayValue(painter.getAttributeSet()),
+        bounds.getX() + bounds.getWidth() / 2,
+        bounds.getY() + bounds.getHeight() / 2 - 2);
+  }
+
+  @Override
+  public void paintInstance(InstancePainter painter) {
+    final var graphics = painter.getGraphics();
+    graphics.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
+    painter.drawBounds();
+
+    final var bounds = painter.getOffsetBounds();
+    final var location = painter.getLocation();
+    graphics.setFont(DEFAULT_FONT);
+    GraphicsUtil.drawCenteredText(
+        graphics,
+        getDisplayValue(painter.getAttributeSet()),
+        location.getX() + bounds.getX() + bounds.getWidth() / 2,
+        location.getY() + bounds.getY() + bounds.getHeight() / 2 - 2);
+    painter.drawPort(OUT);
+  }
+
+  @Override
+  public void propagate(InstanceState state) {
+    final var width = state.getAttributeValue(StdAttr.FP_WIDTH);
+    final var value = state.getAttributeValue(ATTR_VALUE);
+    state.setPort(OUT, createValue(width, value), PER_DELAY);
+  }
+
+  private void updatePorts(Instance instance) {
+    final var output = new Port(0, 0, Port.OUTPUT, StdAttr.FP_WIDTH);
+    output.setToolTip(S.getter("fpConstantOutputTip"));
+    instance.setPorts(new Port[] {output});
+  }
+}

--- a/src/main/resources/resources/logisim/strings/std/std.properties
+++ b/src/main/resources/resources/logisim/strings/std/std.properties
@@ -84,6 +84,11 @@ fpErrorTip = Error: 1 if input or output is NaN
 #
 fpArithmeticLibrary = Floating Point Arithmetic
 #
+# arith/floating/FpConstant.java
+#
+fpConstantComponent = Floating Point Constant
+fpConstantOutputTip = Output: the encoded floating point constant
+#
 # arith/floating/FPClassificator.java
 #
 fpClassificatorComponent: Floating Point Classificator

--- a/src/main/resources/resources/logisim/strings/std/std_de.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_de.properties
@@ -84,6 +84,11 @@ fpErrorTip = Error: 1 wenn ein Ein- oder Ausgang NaN ist
 #
 # ==> fpArithmeticLibrary =
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 # ==> fpClassificatorComponent:

--- a/src/main/resources/resources/logisim/strings/std/std_el.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_el.properties
@@ -84,6 +84,11 @@ dividerUpperInput = upper
 #
 # ==> fpArithmeticLibrary =
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 # ==> fpClassificatorComponent:

--- a/src/main/resources/resources/logisim/strings/std/std_es.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_es.properties
@@ -84,6 +84,11 @@ dividerUpperInput = upper
 #
 # ==> fpArithmeticLibrary =
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 # ==> fpClassificatorComponent:

--- a/src/main/resources/resources/logisim/strings/std/std_fr.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_fr.properties
@@ -84,6 +84,11 @@ fpErrorTip = Erreur : 1 si l’entrée ou la sortie est NaN
 #
 # ==> fpArithmeticLibrary =
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 # ==> fpClassificatorComponent:

--- a/src/main/resources/resources/logisim/strings/std/std_it.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_it.properties
@@ -84,6 +84,11 @@ dividerUpperInput = superiore
 #
 # ==> fpArithmeticLibrary =
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 # ==> fpClassificatorComponent:

--- a/src/main/resources/resources/logisim/strings/std/std_ja.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ja.properties
@@ -84,6 +84,11 @@ dividerUpperInput = upper
 #
 # ==> fpArithmeticLibrary =
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 # ==> fpClassificatorComponent:

--- a/src/main/resources/resources/logisim/strings/std/std_nl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_nl.properties
@@ -84,6 +84,11 @@ fpErrorTip = Fout: 1 als de ingang of uitgang geen getal is
 #
 # ==> fpArithmeticLibrary =
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 # ==> fpClassificatorComponent:

--- a/src/main/resources/resources/logisim/strings/std/std_pl.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pl.properties
@@ -84,6 +84,11 @@ fpErrorTip = Błąd: 1 jeśli wejście lub wyjście nie jest liczbą
 #
 # ==> fpArithmeticLibrary =
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 # ==> fpClassificatorComponent:

--- a/src/main/resources/resources/logisim/strings/std/std_pt.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_pt.properties
@@ -84,6 +84,11 @@ fpErrorTip = Erro: 1 se a entrada ou a saída não for um número (NaN)
 #
 fpArithmeticLibrary = Aritmética de Pontos Flutuantes
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 fpClassificatorComponent: Classificador de Pontos Flutuantes

--- a/src/main/resources/resources/logisim/strings/std/std_ru.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_ru.properties
@@ -84,6 +84,11 @@ fpErrorTip = Ошибка: 1, если на входе или выходе зн�
 #
 fpArithmeticLibrary = Арифметика с плавающей точкой
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 fpClassificatorComponent: Классификатор с плавающей точкой

--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -84,6 +84,11 @@ fpErrorTip = 输出：错误（如果输入或输出为 NaN，则输出 1）
 #
 # ==> fpArithmeticLibrary =
 #
+# arith/floating/FpConstant.java
+#
+# ==> fpConstantComponent =
+# ==> fpConstantOutputTip =
+#
 # arith/floating/FPClassificator.java
 #
 # ==> fpClassificatorComponent:

--- a/src/test/java/com/cburch/logisim/std/arith/floating/FpConstantTest.java
+++ b/src/test/java/com/cburch/logisim/std/arith/floating/FpConstantTest.java
@@ -1,0 +1,108 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.arith.floating;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.fpga.designrulecheck.netlistComponent;
+import com.cburch.logisim.fpga.hdlgenerator.Hdl;
+import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
+import com.cburch.logisim.instance.InstanceState;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.prefs.AppPreferences;
+import org.junit.jupiter.api.Test;
+
+class FpConstantTest {
+  @Test
+  void libraryContainsFloatingPointConstant() {
+    assertNotNull(new FPArithmeticLibrary().getTool(FpConstant._ID));
+  }
+
+  @Test
+  void encodesValueForEachSupportedFloatingPointWidth() {
+    assertEquals(0x3CL, FpConstant.createValue(BitWidth.create(8), 1.5).toLongValue());
+    assertEquals(0x3E00L, FpConstant.createValue(BitWidth.create(16), 1.5).toLongValue());
+    assertEquals(0x3FC00000L, FpConstant.createValue(BitWidth.create(32), 1.5).toLongValue());
+    assertEquals(
+        0x3FF8000000000000L,
+        FpConstant.createValue(BitWidth.create(64), 1.5).toLongValue());
+  }
+
+  @Test
+  void propagatesEncodedFloatingPointValue() {
+    final var width = BitWidth.create(16);
+    final var state = mock(InstanceState.class);
+    when(state.getAttributeValue(StdAttr.FP_WIDTH)).thenReturn(width);
+    when(state.getAttributeValue(FpConstant.ATTR_VALUE)).thenReturn(-2.25);
+
+    new FpConstant().propagate(state);
+
+    verify(state).setPort(0, Value.createKnown(width, -2.25), 1);
+  }
+
+  @Test
+  void componentUsesFloatingPointWidthForItsOutputAndHdlGenerator() {
+    final var constant = new FpConstant();
+    final var attrs = constant.createAttributeSet();
+    final var width = BitWidth.create(64);
+    attrs.setValue(StdAttr.FP_WIDTH, width);
+    attrs.setValue(FpConstant.ATTR_VALUE, -2.25);
+
+    final var component = constant.createComponent(Location.create(0, 0, false), attrs);
+
+    assertEquals(width, component.getEnd(0).getWidth());
+    assertNotNull(constant.getHDLGenerator(attrs));
+  }
+
+  @Test
+  void hdlGeneratorUsesEncodedFloatingPointBits() {
+    final var originalHdlType = AppPreferences.HdlType.get();
+    try {
+      AppPreferences.HdlType.set(HdlGeneratorFactory.VHDL);
+      final var constant = new FpConstant();
+      final var attrs = constant.createAttributeSet();
+      attrs.setValue(StdAttr.FP_WIDTH, BitWidth.create(16));
+      attrs.setValue(FpConstant.ATTR_VALUE, 1.5);
+      final var component = constant.createComponent(Location.create(0, 0, false), attrs);
+      final var componentInfo = mock(netlistComponent.class);
+      final var nets = mock(Netlist.class);
+      when(componentInfo.getComponent()).thenReturn(component);
+      when(componentInfo.isEndConnected(0)).thenReturn(true);
+      when(nets.isContinuesBus(componentInfo, 0)).thenReturn(true);
+
+      try (final var hdl = mockStatic(Hdl.class, CALLS_REAL_METHODS)) {
+        hdl.when(() -> Hdl.getBusNameContinues(componentInfo, 0, nets)).thenReturn("outputBus");
+
+        final var code =
+            String.join(
+                "\n",
+                constant
+                    .getHDLGenerator(attrs)
+                    .getInlinedCode(nets, 1L, componentInfo, "main")
+                    .get());
+
+        assertTrue(code.replaceAll("\\s+", "").contains("outputBus<=X\"3E00\";"), code);
+      }
+    } finally {
+      AppPreferences.HdlType.set(originalHdlType);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a dedicated Floating Point Constant to the Floating Point Arithmetic library
- reuse the existing 8/16/32/64-bit floating-point widths and `Value` encoders
- propagate the encoded bits to simulation and inline HDL output
- add focused discovery, encoding, propagation, port-width, and HDL regression coverage
- record the new component in `CHANGES.md`

## Rationale

Issue #793 notes that there is currently no way to set a floating-point constant. A dedicated component keeps the established Wiring Constant behavior and serialized attributes unchanged while presenting a decimal floating-point value in the library where it is used.

## Validation

- `./gradlew test --tests com.cburch.logisim.std.arith.floating.FpConstantTest compileJava checkstyleMain compileTestJava checkstyleTest`
- `./gradlew check --no-daemon --rerun-tasks`
- Windows GUI verification of library discovery, decimal editing, 8/16/32/64-bit encodings, connection stability, and save/reload persistence

Closes #793
