### PR TITLE
fix: reuse shared Logisim library imports

### DIFF
--- a/src/main/java/com/cburch/logisim/file/LibraryManager.java
+++ b/src/main/java/com/cburch/logisim/file/LibraryManager.java
@@ -330,7 +330,8 @@ public final class LibraryManager {
   }
 
   public LoadedLibrary loadLogisimLibrary(Loader loader, File toRead) {
-    var ret = findKnown(toRead);
+    final var descriptor = new LogisimProjectDescriptor(toRead);
+    var ret = findKnown(descriptor);
     if (ret != null) return ret;
 
     try {
@@ -340,9 +341,8 @@ public final class LibraryManager {
       return null;
     }
 
-    final var desc = new LogisimProjectDescriptor(toRead);
-    fileMap.put(desc, new WeakReference<>(ret));
-    invMap.put(ret, desc);
+    fileMap.put(descriptor, new WeakReference<>(ret));
+    invMap.put(ret, descriptor);
     return ret;
   }
 

--- a/src/test/java/com/cburch/logisim/file/NestedLibraryResolutionTest.java
+++ b/src/test/java/com/cburch/logisim/file/NestedLibraryResolutionTest.java
@@ -11,6 +11,7 @@ package com.cburch.logisim.file;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -64,6 +65,46 @@ class NestedLibraryResolutionTest {
         reloaded.getMainCircuit().getNonWires().stream()
             .anyMatch(component -> component.getFactory().getName().equals("Leaf")));
     assertFalse(reloadLoader.hasErrors(), reloadLoader.errors());
+  }
+
+  @Test
+  void reusesSharedNestedLogisimLibraryAcrossParentLibraries() throws Exception {
+    final var sharedPath = tempDir.resolve("Shared.circ").toFile();
+    final var aPath = tempDir.resolve("A.circ").toFile();
+    final var bPath = tempDir.resolve("B.circ").toFile();
+
+    final var sharedLoader = new RecordingLoader();
+    save(sharedLoader, newProject(sharedLoader, "Common"), sharedPath);
+
+    final var aLoader = new RecordingLoader();
+    final var aFile = newProject(aLoader, "ParentA");
+    final var sharedFromA = aLoader.loadLogisimLibrary(sharedPath);
+    assertNotNull(sharedFromA, aLoader.errors());
+    aFile.addLibrary(sharedFromA);
+    addComponent(aFile.getMainCircuit(), tool(sharedFromA, "Common"));
+    save(aLoader, aFile, aPath);
+
+    final var bLoader = new RecordingLoader();
+    final var bFile = newProject(bLoader, "ParentB");
+    final var sharedFromB = bLoader.loadLogisimLibrary(sharedPath);
+    assertNotNull(sharedFromB, bLoader.errors());
+    bFile.addLibrary(sharedFromB);
+    addComponent(bFile.getMainCircuit(), tool(sharedFromB, "Common"));
+    save(bLoader, bFile, bPath);
+
+    final var rootLoader = new RecordingLoader();
+    final var aLibrary = rootLoader.loadLogisimLibrary(aPath);
+    final var bLibrary = rootLoader.loadLogisimLibrary(bPath);
+    assertNotNull(aLibrary, rootLoader.errors());
+    assertNotNull(bLibrary, rootLoader.errors());
+
+    final var nestedSharedFromA = findLibrary(aLibrary, "Shared");
+    final var nestedSharedFromB = findLibrary(bLibrary, "Shared");
+    assertSame(nestedSharedFromA, nestedSharedFromB);
+    assertSame(
+        tool(nestedSharedFromA, "Common").getFactory(),
+        tool(nestedSharedFromB, "Common").getFactory());
+    assertFalse(rootLoader.hasErrors(), rootLoader.errors());
   }
 
   private static void addComponent(Circuit circuit, AddTool tool) {


### PR DESCRIPTION
## Summary

- query the Logisim library cache with the same descriptor type used as its key
- reuse one loaded circuit library when two parent libraries import the same file
- cover the shared nested-library scenario with a real three-library regression

## Root cause

`fileMap` stores Logisim libraries under `LogisimProjectDescriptor`, but `loadLogisimLibrary` queried it with a raw `File`. The lookup therefore always missed, so a common imported `.circ` file was parsed into separate circuit objects and FPGA DRC could report their shared sheet names as duplicates.

## Testing

- `./gradlew test --tests com.cburch.logisim.file.NestedLibraryResolutionTest --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew compileJava checkstyleMain compileTestJava checkstyleTest test --tests com.cburch.logisim.file.NestedLibraryResolutionTest --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew check --no-daemon --rerun-tasks --max-workers=1`
- `git diff --check`
- confirmed the new regression fails at the shared-library identity assertion with the old lookup and passes with the fix

Fixes #1663