### PR TITLE
fix: respect attribute choices in numeric shortcuts

### DIFF
--- a/src/main/java/com/cburch/logisim/tools/key/NumericConfigurator.java
+++ b/src/main/java/com/cburch/logisim/tools/key/NumericConfigurator.java
@@ -91,7 +91,15 @@ public abstract class NumericConfigurator<V> implements KeyConfigurator, Cloneab
         curValue = val;
 
         if (val >= min) {
-          final Object valObj = createValue(val);
+          final var valObj = createValue(val);
+          // The configurator's numeric bounds may be broader than the attribute's accepted values.
+          try {
+            if (!valObj.equals(attr.parse(attr.toStandardString(valObj)))) {
+              return null;
+            }
+          } catch (NumberFormatException ignored) {
+            return null;
+          }
           return new KeyConfigurationResult(event, attr, valObj);
         }
       }

--- a/src/test/java/com/cburch/logisim/tools/key/NumericConfiguratorTest.java
+++ b/src/test/java/com/cburch/logisim/tools/key/NumericConfiguratorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.tools.key;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.data.AttributeSets;
+import com.cburch.logisim.data.Attributes;
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.instance.StdAttr;
+import java.awt.Canvas;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import org.junit.jupiter.api.Test;
+
+class NumericConfiguratorTest {
+
+  @Test
+  void rejectsValuesOutsideOptionAttributeChoices() {
+    final var attributes = attributes(StdAttr.FP_WIDTH, 32);
+    final var configurator = new BitWidthConfigurator(StdAttr.FP_WIDTH);
+
+    assertNull(type(configurator, attributes, '5'));
+  }
+
+  @Test
+  void acceptsSingleAndMultiDigitOptionAttributeChoices() {
+    final var attributes = attributes(StdAttr.FP_WIDTH, 32);
+
+    assertEquals(
+        BitWidth.create(8),
+        configuredValue(StdAttr.FP_WIDTH, attributes, '8'));
+    assertEquals(BitWidth.create(16), configuredValue(StdAttr.FP_WIDTH, attributes, '1', '6'));
+    assertEquals(BitWidth.create(32), configuredValue(StdAttr.FP_WIDTH, attributes, '3', '2'));
+    assertEquals(BitWidth.create(64), configuredValue(StdAttr.FP_WIDTH, attributes, '6', '4'));
+  }
+
+  @Test
+  void continuesToAcceptValuesOfNonOptionAttributes() {
+    final Attribute<BitWidth> width = Attributes.forBitWidth("width");
+    final var attributes = attributes(width, 1);
+
+    assertEquals(BitWidth.create(5), configuredValue(width, attributes, '5'));
+  }
+
+  private static AttributeSet attributes(Attribute<BitWidth> attribute, int initialWidth) {
+    return AttributeSets.fixedSet(
+        new Attribute<?>[] {attribute}, new Object[] {BitWidth.create(initialWidth)});
+  }
+
+  private static BitWidth configuredValue(
+      Attribute<BitWidth> attribute, AttributeSet attributes, char... digits) {
+    final var configurator = new BitWidthConfigurator(attribute);
+    KeyConfigurationResult result = null;
+    for (final var digit : digits) {
+      result = type(configurator, attributes, digit);
+    }
+    assertNotNull(result);
+    return (BitWidth) result.getAttributeValues().get(attribute);
+  }
+
+  private static KeyConfigurationResult type(
+      BitWidthConfigurator configurator, AttributeSet attributes, char digit) {
+    final var keyEvent =
+        new KeyEvent(
+            new Canvas(),
+            KeyEvent.KEY_TYPED,
+            System.currentTimeMillis(),
+            InputEvent.ALT_DOWN_MASK,
+            KeyEvent.VK_UNDEFINED,
+            digit);
+    final var configurationEvent =
+        new KeyConfigurationEvent(
+            KeyConfigurationEvent.KEY_TYPED, attributes, keyEvent, null);
+    return configurator.keyEventReceived(configurationEvent);
+  }
+}


### PR DESCRIPTION
## Summary

- validate numeric shortcut candidates against the target attribute's accepted values
- prevent floating-point components from receiving unsupported widths such as 5 bits while preserving 8/16/32/64 multi-digit entry
- keep ordinary, non-option bit-width attributes accepting their existing valid range

## Testing

- `.\gradlew.bat test --tests com.cburch.logisim.tools.key.NumericConfiguratorTest compileJava checkstyleMain compileTestJava checkstyleTest --no-daemon --rerun-tasks`
- `$env:PATH = 'C:\Program Files\Git\usr\bin;' + $env:PATH; .\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1`
- `git diff --check`