### PR TITLE
feat: support multiline text labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
   * Added Real-Time Clock component.
   * Added Floating Point Constant component.
   * Modified paste behavior to paste at current mouse location if it is on canvas.
+  * Added multiline Text Tool labels using Shift+Enter or multiline clipboard text.
   * Fixed a regression that caused TestVector to fail when the circuit had subcircuits.
   * Fixed TTL 7447 BI/RBO port to be an input/output port to allow cascading of blanking mode.
   * Added TTL 7476: dual J-K Flip-flop with preset and clear.

--- a/src/main/java/com/cburch/logisim/comp/TextField.java
+++ b/src/main/java/com/cburch/logisim/comp/TextField.java
@@ -32,18 +32,24 @@ public class TextField {
   private int valign;
   private Font font;
   private String text = "";
+  private final boolean multiline;
   private final LinkedList<TextFieldListener> listeners = new LinkedList<>();
 
   public TextField(int x, int y, int halign, int valign) {
-    this(x, y, halign, valign, null);
+    this(x, y, halign, valign, null, false);
   }
 
   public TextField(int x, int y, int halign, int valign, Font font) {
+    this(x, y, halign, valign, font, false);
+  }
+
+  public TextField(int x, int y, int halign, int valign, Font font, boolean multiline) {
     this.x = x;
     this.y = y;
     this.halign = halign;
     this.valign = valign;
     this.font = font;
+    this.multiline = multiline;
   }
 
   //
@@ -56,28 +62,31 @@ public class TextField {
   public void draw(Graphics g) {
     final var old = g.getFont();
     if (font != null) g.setFont(font);
-
-    var x = this.x;
-    var y = this.y;
-    final var fm = g.getFontMetrics();
-    final var width = fm.stringWidth(text);
-    final var ascent = fm.getAscent();
-    final var descent = fm.getDescent();
-    switch (halign) {
-      case TextField.H_CENTER -> x -= width / 2;
-      case TextField.H_RIGHT -> x -= width;
-      default -> {
+    if (multiline) {
+      GraphicsUtil.drawText(g, text, x, y, halign, valign);
+    } else {
+      var drawX = x;
+      var drawY = y;
+      final var fm = g.getFontMetrics();
+      final var width = fm.stringWidth(text);
+      final var ascent = fm.getAscent();
+      final var descent = fm.getDescent();
+      switch (halign) {
+        case TextField.H_CENTER -> drawX -= width / 2;
+        case TextField.H_RIGHT -> drawX -= width;
+        default -> {
+        }
       }
-    }
-    switch (valign) {
-      case TextField.V_TOP -> y += ascent;
-      case TextField.V_CENTER -> y += ascent / 2;
-      case TextField.V_CENTER_OVERALL -> y += (ascent - descent) / 2;
-      case TextField.V_BOTTOM -> y -= descent;
-      default -> {
+      switch (valign) {
+        case TextField.V_TOP -> drawY += ascent;
+        case TextField.V_CENTER -> drawY += ascent / 2;
+        case TextField.V_CENTER_OVERALL -> drawY += (ascent - descent) / 2;
+        case TextField.V_BOTTOM -> drawY -= descent;
+        default -> {
+        }
       }
+      g.drawString(text, drawX, drawY);
     }
-    g.drawString(text, x, y);
     g.setFont(old);
   }
 
@@ -88,29 +97,30 @@ public class TextField {
   }
 
   public Bounds getBounds(Graphics g) {
-    var x = this.x;
-    var y = this.y;
+    if (multiline) {
+      return Bounds.create(GraphicsUtil.getTextBounds(g, font, text, x, y, halign, valign));
+    }
+    var boundsX = x;
+    var boundsY = y;
     final var fm = (font == null) ? g.getFontMetrics() : g.getFontMetrics(font);
     final var width = fm.stringWidth(text);
     final var ascent = fm.getAscent();
     final var descent = fm.getDescent();
-
     switch (halign) {
-      case TextField.H_CENTER -> x -= width / 2;
-      case TextField.H_RIGHT -> x -= width;
+      case TextField.H_CENTER -> boundsX -= width / 2;
+      case TextField.H_RIGHT -> boundsX -= width;
       default -> {
       }
     }
-
     switch (valign) {
-      case TextField.V_TOP -> y += ascent;
-      case TextField.V_CENTER -> y += ascent / 2;
-      case TextField.V_CENTER_OVERALL -> y += (ascent - descent) / 2;
-      case TextField.V_BOTTOM -> y -= descent;
+      case TextField.V_TOP -> boundsY += ascent;
+      case TextField.V_CENTER -> boundsY += ascent / 2;
+      case TextField.V_CENTER_OVERALL -> boundsY += (ascent - descent) / 2;
+      case TextField.V_BOTTOM -> boundsY -= descent;
       default -> {
       }
     }
-    return Bounds.create(x, y - ascent, width, ascent + descent);
+    return Bounds.create(boundsX, boundsY - ascent, width, ascent + descent);
   }
 
   public TextFieldCaret getCaret(Graphics g, int pos) {
@@ -138,6 +148,10 @@ public class TextField {
 
   public int getVAlign() {
     return valign;
+  }
+
+  public boolean isMultiline() {
+    return multiline;
   }
 
   //

--- a/src/main/java/com/cburch/logisim/comp/TextFieldCaret.java
+++ b/src/main/java/com/cburch/logisim/comp/TextFieldCaret.java
@@ -113,9 +113,11 @@ class TextFieldCaret implements Caret, TextFieldListener, TextEditActions {
     // draw selection
     if (pos != end) {
       g.setColor(SELECTION_BACKGROUND);
-      final var p = GraphicsUtil.getTextCursor(g, curText, x, y, Math.min(pos, end), halign, valign);
-      final var e = GraphicsUtil.getTextCursor(g, curText, x, y, Math.max(pos, end), halign, valign);
-      g.fillRect(p.x, p.y - 1, e.x - p.x + 1, e.height + 2);
+      for (final var selection :
+          GraphicsUtil.getTextSelectionBounds(g, curText, x, y, pos, end, halign, valign)) {
+        g.fillRect(
+            selection.x, selection.y - 1, selection.width + 1, selection.height + 2);
+      }
     }
 
     // draw text
@@ -177,9 +179,9 @@ class TextFieldCaret implements Caret, TextFieldListener, TextEditActions {
     if (!shift) normalizeSelection();
 
     if (dy < 0) {
-      pos = 0;
+      pos = field.isMultiline() ? adjacentLinePosition(pos, -1) : 0;
     } else if (dy > 0) {
-      pos = curText.length();
+      pos = field.isMultiline() ? adjacentLinePosition(pos, 1) : curText.length();
     } else if (pos + dx >= 0 && pos + dx <= curText.length()) {
       if (!shift && pos != end) {
         if (dx < 0) end = pos;
@@ -251,14 +253,14 @@ class TextFieldCaret implements Caret, TextFieldListener, TextEditActions {
         e.consume();
       }
       case KeyEvent.VK_HOME -> {
-        pos = 0;
+        pos = field.isMultiline() && !ctrl ? lineStart(pos) : 0;
         if (!shift) {
           end = pos;
         }
         e.consume();
       }
       case KeyEvent.VK_END -> {
-        pos = curText.length();
+        pos = field.isMultiline() && !ctrl ? lineEnd(pos) : curText.length();
         if (!shift) {
           end = pos;
         }
@@ -277,7 +279,15 @@ class TextFieldCaret implements Caret, TextFieldListener, TextEditActions {
           end = pos = 0;
         }
       }
-      case KeyEvent.VK_ENTER -> stopEditing();
+      case KeyEvent.VK_ENTER -> {
+        if (field.isMultiline() && shift) {
+          rememberEdit();
+          replaceSelection("\n");
+        } else {
+          stopEditing();
+        }
+        e.consume();
+      }
       case KeyEvent.VK_BACK_SPACE -> {
         if (pos != end) {
           rememberEdit();
@@ -313,7 +323,7 @@ class TextFieldCaret implements Caret, TextFieldListener, TextEditActions {
     if (allowedCharacter(c)) {
       rememberEdit();
       replaceSelection(String.valueOf(c));
-    } else if (c == '\n') {
+    } else if (c == '\n' && !(field.isMultiline() && e.isShiftDown())) {
       stopEditing();
     }
   }
@@ -392,11 +402,17 @@ class TextFieldCaret implements Caret, TextFieldListener, TextEditActions {
     return curText.substring(pp, ee);
   }
 
-  private String normalizePastedText(String s) {
+  String normalizePastedText(String s) {
     final var result = new StringBuilder();
     var lastWasSpace = false;
     for (var i = 0; i < s.length(); i++) {
       var c = s.charAt(i);
+      if (field.isMultiline() && (c == '\r' || c == '\n')) {
+        if (c == '\r' && i + 1 < s.length() && s.charAt(i + 1) == '\n') i++;
+        result.append('\n');
+        lastWasSpace = false;
+        continue;
+      }
       if (!allowedCharacter(c)) {
         if (lastWasSpace) continue;
         c = ' ';
@@ -478,6 +494,30 @@ class TextFieldCaret implements Caret, TextFieldListener, TextEditActions {
       end = pos;
       pos = t;
     }
+  }
+
+  private int adjacentLinePosition(int offset, int direction) {
+    final var start = lineStart(offset);
+    final var column = offset - start;
+    if (direction < 0) {
+      if (start == 0) return offset;
+      final var previousEnd = start - 1;
+      final var previousStart = lineStart(previousEnd);
+      return previousStart + Math.min(column, previousEnd - previousStart);
+    }
+    final var endOfLine = lineEnd(offset);
+    if (endOfLine == curText.length()) return offset;
+    final var nextStart = endOfLine + 1;
+    return nextStart + Math.min(column, lineEnd(nextStart) - nextStart);
+  }
+
+  private int lineEnd(int offset) {
+    final var newline = curText.indexOf('\n', offset);
+    return newline < 0 ? curText.length() : newline;
+  }
+
+  private int lineStart(int offset) {
+    return offset <= 0 ? 0 : curText.lastIndexOf('\n', offset - 1) + 1;
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/data/Attributes.java
+++ b/src/main/java/com/cburch/logisim/data/Attributes.java
@@ -424,6 +424,23 @@ public class Attributes {
     }
   }
 
+  private static class MultilineStringAttribute extends StringAttribute {
+    private MultilineStringAttribute(String name, StringGetter disp) {
+      super(name, disp);
+    }
+
+    @Override
+    public String toStandardString(String value) {
+      final var normalized = value.replace("\r\n", "\n").replace('\r', '\n');
+      final var result = new StringBuilder(normalized.length());
+      for (var i = 0; i < normalized.length(); i++) {
+        final var character = normalized.charAt(i);
+        if (character == '\n' || character >= ' ') result.append(character);
+      }
+      return result.toString().replaceAll("&#.*?;", "");
+    }
+  }
+
   private static class HiddenAttribute extends Attribute<String> {
     private HiddenAttribute() {
       super();
@@ -577,6 +594,10 @@ public class Attributes {
   //
   public static Attribute<String> forString(String name, StringGetter disp) {
     return new StringAttribute(name, disp);
+  }
+
+  public static Attribute<String> forMultilineString(String name, StringGetter disp) {
+    return new MultilineStringAttribute(name, disp);
   }
 
   private static StringGetter getter(String s) {

--- a/src/main/java/com/cburch/logisim/instance/Instance.java
+++ b/src/main/java/com/cburch/logisim/instance/Instance.java
@@ -104,7 +104,18 @@ public final class Instance implements Location.At {
   }
 
   public void setTextField(Attribute<String> labelAttr, Attribute<Font> fontAttr, int x, int y, int hAlign, int vAlign) {
-    comp.setTextField(labelAttr, fontAttr, x, y, hAlign, vAlign);
+    setTextField(labelAttr, fontAttr, x, y, hAlign, vAlign, false);
+  }
+
+  public void setTextField(
+      Attribute<String> labelAttr,
+      Attribute<Font> fontAttr,
+      int x,
+      int y,
+      int hAlign,
+      int vAlign,
+      boolean multiline) {
+    comp.setTextField(labelAttr, fontAttr, x, y, hAlign, vAlign, multiline);
   }
 
   public static final int AVOID_TOP = 1;

--- a/src/main/java/com/cburch/logisim/instance/InstanceComponent.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceComponent.java
@@ -463,13 +463,24 @@ public final class InstanceComponent implements Component, AttributeListener, To
 
   void setTextField(
       Attribute<String> labelAttr, Attribute<Font> fontAttr, int x, int y, int halign, int valign) {
+    setTextField(labelAttr, fontAttr, x, y, halign, valign, false);
+  }
+
+  void setTextField(
+      Attribute<String> labelAttr,
+      Attribute<Font> fontAttr,
+      int x,
+      int y,
+      int halign,
+      int valign,
+      boolean multiline) {
     var field = textField;
     if (field == null) {
       field = new InstanceTextField(this);
-      field.update(labelAttr, fontAttr, x, y, halign, valign);
+      field.update(labelAttr, fontAttr, x, y, halign, valign, multiline);
       textField = field;
     } else {
-      field.update(labelAttr, fontAttr, x, y, halign, valign);
+      field.update(labelAttr, fontAttr, x, y, halign, valign, multiline);
     }
   }
 

--- a/src/main/java/com/cburch/logisim/instance/InstanceTextField.java
+++ b/src/main/java/com/cburch/logisim/instance/InstanceTextField.java
@@ -45,6 +45,7 @@ public class InstanceTextField implements AttributeListener, TextFieldListener, 
   private int fieldY;
   private int halign;
   private int valign;
+  private boolean multiline;
 
   InstanceTextField(InstanceComponent comp) {
     this.comp = comp;
@@ -70,7 +71,7 @@ public class InstanceTextField implements AttributeListener, TextFieldListener, 
 
   private void createField(AttributeSet attrs, String text) {
     final var font = attrs.getValue(fontAttr);
-    field = new TextField(fieldX, fieldY, halign, valign, font);
+    field = new TextField(fieldX, fieldY, halign, valign, font, multiline);
     field.setText(text);
     field.addTextFieldListener(this);
   }
@@ -137,6 +138,17 @@ public class InstanceTextField implements AttributeListener, TextFieldListener, 
 
   void update(
       Attribute<String> labelAttr, Attribute<Font> fontAttr, int x, int y, int halign, int valign) {
+    update(labelAttr, fontAttr, x, y, halign, valign, false);
+  }
+
+  void update(
+      Attribute<String> labelAttr,
+      Attribute<Font> fontAttr,
+      int x,
+      int y,
+      int halign,
+      int valign,
+      boolean multiline) {
     final var wasReg = shouldRegister();
     this.labelAttr = labelAttr;
     this.fontAttr = fontAttr;
@@ -144,6 +156,11 @@ public class InstanceTextField implements AttributeListener, TextFieldListener, 
     this.fieldY = y;
     this.halign = halign;
     this.valign = valign;
+    if (field != null && this.multiline != multiline) {
+      field.removeTextFieldListener(this);
+      field = null;
+    }
+    this.multiline = multiline;
     final var shouldReg = shouldRegister();
     var attrs = comp.getAttributeSet();
     fontColor =
@@ -156,6 +173,10 @@ public class InstanceTextField implements AttributeListener, TextFieldListener, 
     if (wasReg && !shouldReg) attrs.removeAttributeListener(this);
 
     updateField(attrs);
+  }
+
+  boolean isMultiline() {
+    return multiline;
   }
 
   private void updateField(AttributeSet attrs) {

--- a/src/main/java/com/cburch/logisim/std/base/Text.java
+++ b/src/main/java/com/cburch/logisim/std/base/Text.java
@@ -41,7 +41,7 @@ public class Text extends InstanceFactory {
   public static final String _ID = "Text";
 
   public static final Attribute<String> ATTR_TEXT =
-      Attributes.forString("text", S.getter("textTextAttr"));
+      Attributes.forMultilineString("text", S.getter("textTextAttr"));
   public static final Attribute<Font> ATTR_FONT =
       Attributes.forFont("font", S.getter("textFontAttr"));
   public static final Attribute<Color> ATTR_COLOR =
@@ -82,7 +82,8 @@ public class Text extends InstanceFactory {
         loc.getX(),
         loc.getY(),
         attrs.getHorizontalAlign(),
-        attrs.getVerticalAlign());
+        attrs.getVerticalAlign(),
+        true);
   }
 
   //

--- a/src/main/java/com/cburch/logisim/util/GraphicsUtil.java
+++ b/src/main/java/com/cburch/logisim/util/GraphicsUtil.java
@@ -19,6 +19,8 @@ import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class GraphicsUtil {
 
@@ -108,26 +110,60 @@ public final class GraphicsUtil {
   }
 
   public static Rectangle getTextCursor(Graphics g, String text, int x, int y, int pos, int halign, int valign) {
-    final var r = getTextBounds(g, text, x, y, halign, valign);
-    if (pos > 0) r.x += new TextMetrics(g, text.substring(0, pos)).width;
-    r.width = 1;
-    return r;
+    final var layout = textLayout(g, text);
+    final var offset = Math.max(0, Math.min(pos, text.length()));
+    final var line = lineAtOffset(text, offset);
+    final var top = textTop(y, layout.ascent(), layout.height(), layout.lines().length, valign);
+    final var left = textLeft(x, layout.widths()[line.index()], halign);
+    final var prefix = text.substring(line.start(), offset);
+    return new Rectangle(
+        left + new TextMetrics(g, prefix).width,
+        top + line.index() * layout.lineHeight(),
+        1,
+        layout.lineHeight());
   }
 
   public static int getTextPosition(Graphics g, String text, int x, int y, int halign, int valign) {
-    final var r = getTextBounds(g, text, 0, 0, halign, valign);
-    x -= r.x;
+    final var layout = textLayout(g, text);
+    final var top = textTop(0, layout.ascent(), layout.height(), layout.lines().length, valign);
+    final var lineIndex =
+        Math.max(0, Math.min((y - top) / layout.lineHeight(), layout.lines().length - 1));
+    final var line = layout.lines()[lineIndex];
+    x -= textLeft(0, layout.widths()[lineIndex], halign);
     var last = 0;
     final var font = g.getFont();
     final var fr = ((Graphics2D) g).getFontRenderContext();
-    for (var i = 0; i < text.length(); i++) {
-      final var cur = (int) font.getStringBounds(text.substring(0, i + 1), fr).getWidth();
+    for (var i = 0; i < line.length(); i++) {
+      final var cur = (int) font.getStringBounds(line.substring(0, i + 1), fr).getWidth();
       if (x <= (last + cur) / 2) {
-        return i;
+        return lineStart(text, lineIndex) + i;
       }
       last = cur;
     }
-    return text.length();
+    return lineStart(text, lineIndex) + line.length();
+  }
+
+  public static List<Rectangle> getTextSelectionBounds(
+      Graphics g, String text, int x, int y, int start, int end, int halign, int valign) {
+    final var result = new ArrayList<Rectangle>();
+    final var first = Math.max(0, Math.min(Math.min(start, end), text.length()));
+    final var last = Math.max(0, Math.min(Math.max(start, end), text.length()));
+    if (first == last) return result;
+
+    final var layout = textLayout(g, text);
+    var lineStart = 0;
+    for (var i = 0; i < layout.lines().length; i++) {
+      final var lineEnd = lineStart + layout.lines()[i].length();
+      final var selectionStart = Math.max(first, lineStart);
+      final var selectionEnd = Math.min(last, lineEnd);
+      if (selectionStart < selectionEnd) {
+        final var from = getTextCursor(g, text, x, y, selectionStart, halign, valign);
+        final var to = getTextCursor(g, text, x, y, selectionEnd, halign, valign);
+        result.add(new Rectangle(from.x, from.y, Math.max(1, to.x - from.x), from.height));
+      }
+      lineStart = lineEnd + 1;
+    }
+    return result;
   }
 
   public static void drawText(
@@ -156,21 +192,25 @@ public final class GraphicsUtil {
 
   public static void drawText(Graphics g, String text, int x, int y, int halign, int valign) {
     if (text.length() == 0) return;
-    final var bd = getTextBounds(g, text, x, y, halign, valign);
-    final var tm = new TextMetrics(g, text);
-    g.drawString(text, bd.x, bd.y + tm.ascent);
+    final var layout = textLayout(g, text);
+    final var top = textTop(y, layout.ascent(), layout.height(), layout.lines().length, valign);
+    for (var i = 0; i < layout.lines().length; i++) {
+      g.drawString(
+          layout.lines()[i],
+          textLeft(x, layout.widths()[i], halign),
+          top + layout.ascent() + i * layout.lineHeight());
+    }
   }
 
   public static void drawText(Graphics g, String text, int x, int y, int halign, int valign, Color fg, Color bg) {
     if (text.length() == 0) return;
     final var bd = getTextBounds(g, text, x, y, halign, valign);
-    final var tm = new TextMetrics(g, text);
     if (g instanceof Graphics2D g2d) {
       g2d.setPaint(bg);
       g.fillRect(bd.x, bd.y, bd.width, bd.height);
       g2d.setPaint(fg);
     }
-    g.drawString(text, bd.x, bd.y + tm.ascent);
+    drawText(g, text, x, y, halign, valign);
   }
 
   public static void outlineText(Graphics g, String text, int x, int y, Color fg, Color bg) {
@@ -198,36 +238,68 @@ public final class GraphicsUtil {
   public static Rectangle getTextBounds(Graphics g, String text, int x, int y, int halign, int valign) {
     if (g == null) return new Rectangle(x, y, 0, 0);
 
-    final var tm = new TextMetrics(g, text);
-    final var width = tm.width;
-    final var ascent = tm.ascent;
-    final var height = tm.height;
+    final var layout = textLayout(g, text);
+    final var width = layout.width();
+    final var height = layout.height();
 
-    final var ret = new Rectangle(x, y, width, height);
-    switch (halign) {
-      case H_CENTER -> ret.translate(-(width / 2), 0);
-      case H_RIGHT -> ret.translate(-width, 0);
-      default -> {
-      }
+    return new Rectangle(
+        textLeft(x, width, halign),
+        textTop(y, layout.ascent(), height, layout.lines().length, valign),
+        width,
+        height);
+  }
+
+  private record LineOffset(int index, int start) {}
+
+  private record TextLayout(
+      String[] lines, int[] widths, int width, int ascent, int lineHeight, int height) {}
+
+  private static LineOffset lineAtOffset(String text, int offset) {
+    var start = 0;
+    var index = 0;
+    while (true) {
+      final var newline = text.indexOf('\n', start);
+      if (newline < 0 || offset <= newline) return new LineOffset(index, start);
+      start = newline + 1;
+      index++;
     }
-    switch (valign) {
-      case V_TOP:
-        break;
-      case V_CENTER:
-        ret.translate(0, -(ascent / 2));
-        break;
-      case V_CENTER_OVERALL:
-        ret.translate(0, -(height / 2));
-        break;
-      case V_BASELINE:
-        ret.translate(0, -ascent);
-        break;
-      case V_BOTTOM:
-        ret.translate(0, -height);
-        break;
-      default:
+  }
+
+  private static int lineStart(String text, int lineIndex) {
+    var start = 0;
+    for (var i = 0; i < lineIndex; i++) start = text.indexOf('\n', start) + 1;
+    return start;
+  }
+
+  private static int textLeft(int x, int width, int halign) {
+    return switch (halign) {
+      case H_CENTER -> x - width / 2;
+      case H_RIGHT -> x - width;
+      default -> x;
+    };
+  }
+
+  private static TextLayout textLayout(Graphics g, String text) {
+    final var lines = text.split("\\n", -1);
+    final var widths = new int[lines.length];
+    var width = 0;
+    for (var i = 0; i < lines.length; i++) {
+      widths[i] = new TextMetrics(g, lines[i]).width;
+      width = Math.max(width, widths[i]);
     }
-    return ret;
+    final var metrics = new TextMetrics(g, lines[0]);
+    return new TextLayout(
+        lines, widths, width, metrics.ascent, metrics.height, metrics.height * lines.length);
+  }
+
+  private static int textTop(int y, int ascent, int height, int lineCount, int valign) {
+    return switch (valign) {
+      case V_CENTER -> y - (lineCount == 1 ? ascent / 2 : height / 2);
+      case V_CENTER_OVERALL -> y - height / 2;
+      case V_BASELINE -> y - ascent;
+      case V_BOTTOM -> y - height;
+      default -> y;
+    };
   }
 
   public static void switchToWidth(Graphics gfx, int width) {

--- a/src/main/resources/doc/en/html/libs/base/text.html
+++ b/src/main/resources/doc/en/html/libs/base/text.html
@@ -46,10 +46,10 @@ a label, you need to click within the label. If you click at a point where there
 is not currently a label to be edited, Logisim will initiate the addition of a
 new Label component.</p>
 
-<p>In the current version of Logisim, text editing features are
-still fairly primitive.
-Selections of a region of text within a label is impossible.
-There is no way to insert a line break into a label.</p>
+<p>Labels created on the canvas can contain multiple lines. Press
+<strong>Shift+Enter</strong> to insert a line break, or paste multiline
+clipboard text. Press <strong>Enter</strong> to finish editing. Labels attached
+to components remain single-line.</p>
 
 <h2>Attributes</h2>
 

--- a/src/test/java/com/cburch/logisim/comp/TextFieldCaretTest.java
+++ b/src/test/java/com/cburch/logisim/comp/TextFieldCaretTest.java
@@ -127,6 +127,52 @@ class TextFieldCaretTest {
     assertEquals("abc", mirroredTextWhenCommitted.get());
   }
 
+  @Test
+  void shiftEnterAddsNewlineOnlyToMultilineField() {
+    final var caret = multilineCaret("ab", 1);
+
+    caret.keyPressed(keyPressed(KeyEvent.VK_ENTER, InputEvent.SHIFT_DOWN_MASK));
+    caret.keyTyped(keyTyped('\n', InputEvent.SHIFT_DOWN_MASK));
+
+    assertEquals("a\nb", caret.getText());
+  }
+
+  @Test
+  void shiftEnterDoesNotAddNewlineToSingleLineField() {
+    final var caret = caret("ab", 1);
+
+    caret.keyPressed(keyPressed(KeyEvent.VK_ENTER, InputEvent.SHIFT_DOWN_MASK));
+
+    assertEquals("ab", caret.getText());
+  }
+
+  @Test
+  void verticalArrowsKeepColumnWithinMultilineText() {
+    final var caret = multilineCaret("ab\ncde", 1);
+
+    caret.keyPressed(keyPressed(KeyEvent.VK_DOWN, 0));
+    caret.keyTyped(keyTyped('X'));
+
+    assertEquals("ab\ncXde", caret.getText());
+  }
+
+  @Test
+  void homeMovesToStartOfCurrentLine() {
+    final var caret = multilineCaret("ab\ncde", 5);
+
+    caret.keyPressed(keyPressed(KeyEvent.VK_HOME, 0));
+    caret.keyTyped(keyTyped('X'));
+
+    assertEquals("ab\nXcde", caret.getText());
+  }
+
+  @Test
+  void multilinePastePreservesLineBreaksAndNormalizesWindowsEndings() {
+    final var caret = multilineCaret("", 0);
+
+    assertEquals("a\nb\nc d", caret.normalizePastedText("a\r\nb\rc\td"));
+  }
+
   private static TextFieldCaret caret(String text, int pos) {
     return caret(text, pos, false);
   }
@@ -137,13 +183,24 @@ class TextFieldCaretTest {
     return new TextFieldCaret(field, null, pos, metaMenuShortcutEnabled);
   }
 
+  private static TextFieldCaret multilineCaret(String text, int pos) {
+    final var field =
+        new TextField(0, 0, TextField.H_LEFT, TextField.V_BASELINE, null, true);
+    field.setText(text);
+    return new TextFieldCaret(field, null, pos, false);
+  }
+
   private static KeyEvent keyPressed(int keyCode, int modifiers) {
     return new KeyEvent(
         EVENT_SOURCE, KeyEvent.KEY_PRESSED, 0, modifiers, keyCode, KeyEvent.CHAR_UNDEFINED);
   }
 
   private static KeyEvent keyTyped(char keyChar) {
+    return keyTyped(keyChar, 0);
+  }
+
+  private static KeyEvent keyTyped(char keyChar, int modifiers) {
     return new KeyEvent(
-        EVENT_SOURCE, KeyEvent.KEY_TYPED, 0, 0, KeyEvent.VK_UNDEFINED, keyChar);
+        EVENT_SOURCE, KeyEvent.KEY_TYPED, 0, modifiers, KeyEvent.VK_UNDEFINED, keyChar);
   }
 }

--- a/src/test/java/com/cburch/logisim/file/TextPersistenceTest.java
+++ b/src/test/java/com/cburch/logisim/file/TextPersistenceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.std.base.BaseLibrary;
+import com.cburch.logisim.std.base.Text;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TextPersistenceTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void multilineTextSurvivesSaveAndReload() throws Exception {
+    final var text = "first line\nsecond line";
+    final var loader = new Loader(null);
+    final var file = LogisimFile.createNew(loader, null);
+    file.addLibrary(loader.getBuiltin().getLibrary(BaseLibrary._ID));
+    final var attrs = Text.FACTORY.createAttributeSet();
+    attrs.setValue(Text.ATTR_TEXT, text);
+    final var component =
+        Text.FACTORY.createComponent(Location.create(100, 100, false), attrs);
+    final var mutation = new CircuitMutation(file.getMainCircuit());
+    mutation.add(component);
+    mutation.execute();
+    final var path = tempDir.resolve("multiline-text.circ").toFile();
+
+    assertTrue(loader.save(file, path));
+    final var reloaded = new Loader(null).openLogisimFile(path);
+    final var reloadedComponent = reloaded.getMainCircuit().getNonWires().iterator().next();
+
+    assertEquals(
+        text,
+        reloadedComponent.getAttributeSet().getValue(Text.ATTR_TEXT),
+        Files.readString(path.toPath()));
+  }
+}

--- a/src/test/java/com/cburch/logisim/instance/InstanceTextFieldTest.java
+++ b/src/test/java/com/cburch/logisim/instance/InstanceTextFieldTest.java
@@ -10,8 +10,10 @@
 package com.cburch.logisim.instance;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,6 +67,29 @@ public class InstanceTextFieldTest {
     assertEquals("new", comp.getAttributeSet().getValue(Text.ATTR_TEXT));
     project.undoAction();
     assertEquals("old", comp.getAttributeSet().getValue(Text.ATTR_TEXT));
+  }
+
+  @Test
+  public void standaloneTextEnablesMultilineEditing() {
+    final var attrs = Text.FACTORY.createAttributeSet();
+    final var comp = Text.FACTORY.createComponent(Location.create(0, 0, false), attrs);
+
+    final var textField = (InstanceTextField) comp.getFeature(TextEditable.class);
+
+    assertNotNull(textField);
+    assertTrue(textField.isMultiline());
+  }
+
+  @Test
+  public void componentLabelKeepsSingleLineEditing() {
+    final var led = new Led();
+    final var comp =
+        led.createComponent(Location.create(100, 100, false), led.createAttributeSet());
+
+    final var textField = (InstanceTextField) comp.getFeature(TextEditable.class);
+
+    assertNotNull(textField);
+    assertFalse(textField.isMultiline());
   }
 
   @Test

--- a/src/test/java/com/cburch/logisim/util/GraphicsUtilTest.java
+++ b/src/test/java/com/cburch/logisim/util/GraphicsUtilTest.java
@@ -1,0 +1,89 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Font;
+import java.awt.image.BufferedImage;
+import org.junit.jupiter.api.Test;
+
+class GraphicsUtilTest {
+
+  @Test
+  void multilineBoundsUseLongestLineAndAllLineHeights() {
+    final var graphics =
+        new BufferedImage(200, 200, BufferedImage.TYPE_INT_ARGB).createGraphics();
+    graphics.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+
+    final var first =
+        GraphicsUtil.getTextBounds(
+            graphics, "long", 0, 0, GraphicsUtil.H_LEFT, GraphicsUtil.V_TOP);
+    final var second =
+        GraphicsUtil.getTextBounds(
+            graphics, "x", 0, 0, GraphicsUtil.H_LEFT, GraphicsUtil.V_TOP);
+    final var multiline =
+        GraphicsUtil.getTextBounds(
+            graphics, "long\nx", 0, 0, GraphicsUtil.H_LEFT, GraphicsUtil.V_TOP);
+
+    assertEquals(Math.max(first.width, second.width), multiline.width);
+    assertEquals(first.height * 2, multiline.height);
+    graphics.dispose();
+  }
+
+  @Test
+  void multilineCursorAndHitTestingUseClickedLine() {
+    final var graphics =
+        new BufferedImage(200, 200, BufferedImage.TYPE_INT_ARGB).createGraphics();
+    graphics.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+    final var text = "ab\ncde";
+    final var bounds =
+        GraphicsUtil.getTextBounds(
+            graphics, text, 0, 0, GraphicsUtil.H_LEFT, GraphicsUtil.V_TOP);
+    final var secondLineStart =
+        GraphicsUtil.getTextCursor(
+            graphics, text, 0, 0, 3, GraphicsUtil.H_LEFT, GraphicsUtil.V_TOP);
+
+    assertTrue(secondLineStart.y > bounds.y);
+    assertEquals(
+        3,
+        GraphicsUtil.getTextPosition(
+            graphics,
+            text,
+            secondLineStart.x,
+            secondLineStart.y + secondLineStart.height / 2,
+            GraphicsUtil.H_LEFT,
+            GraphicsUtil.V_TOP));
+    graphics.dispose();
+  }
+
+  @Test
+  void selectionAcrossLinesProducesOneRectanglePerLine() {
+    final var graphics =
+        new BufferedImage(200, 200, BufferedImage.TYPE_INT_ARGB).createGraphics();
+    graphics.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+
+    final var selection =
+        GraphicsUtil.getTextSelectionBounds(
+            graphics,
+            "ab\ncde",
+            0,
+            0,
+            1,
+            5,
+            GraphicsUtil.H_LEFT,
+            GraphicsUtil.V_TOP);
+
+    assertEquals(2, selection.size());
+    assertTrue(selection.get(1).y > selection.get(0).y);
+    graphics.dispose();
+  }
+}


### PR DESCRIPTION
Fixes #1422

## Summary

- support multiple lines in standalone Text Tool labels while keeping ordinary component labels single-line
- use Shift+Enter to insert a line break, with line-aware keyboard navigation, mouse positioning, selection, rendering, and bounds
- preserve real newline characters through `.circ` save and reload using a dedicated multiline string attribute
- document the interaction in `CHANGES.md` and the English Text Tool help

## Testing

- 24 focused unit and regression tests covering editing, navigation, selection, bounds, component-label isolation, and `.circ` persistence
- `./gradlew.bat check --no-daemon --rerun-tasks`
- `git diff --check`
- Windows GUI: create and edit two-line text, verify ordinary component labels remain single-line, then save, close, and reopen the circuit