### PR TITLE
fpga: localize HDL clock warnings

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactory.java
@@ -9,6 +9,8 @@
 
 package com.cburch.logisim.fpga.hdlgenerator;
 
+import static com.cburch.logisim.fpga.Strings.S;
+
 import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.fpga.designrulecheck.CorrectLabel;
 import com.cburch.logisim.fpga.designrulecheck.Netlist;
@@ -383,16 +385,16 @@ public class AbstractHdlGeneratorFactory implements HdlGeneratorFactory {
           final var activeLow = StdAttr.TRIG_LOW.equals(clockAttr) || StdAttr.TRIG_FALLING.equals(clockAttr);
           final var compPinId = myPorts.getComponentPortId(port);
           if (!componentInfo.isEndConnected(compPinId)) {
-            // FIXME hard coded string
             Reporter.report.addSevereWarning(
-                String.format("Component \"%s\" in circuit \"%s\" has no clock connection!", compName, nets.getCircuitName()));
+                getClockWarning(
+                    "HDLGenerator_NoClockConnection", compName, nets.getCircuitName()));
             hasClock = false;
           }
           final var clockNetName = Hdl.getClockNetName(componentInfo, compPinId, nets);
           if (StringUtil.isNullOrEmpty(clockNetName)) {
-            // FIXME hard coded string
             Reporter.report.addSevereWarning(
-                String.format("Component \"%s\" in circuit \"%s\" has a gated clock connection!", compName, nets.getCircuitName()));
+                getClockWarning(
+                    "HDLGenerator_GatedClockConnection", compName, nets.getCircuitName()));
             gatedClock = true;
           }
           if (hasClock && !gatedClock && Netlist.isFlipFlop(attrs)) {
@@ -431,6 +433,10 @@ public class AbstractHdlGeneratorFactory implements HdlGeneratorFactory {
       }
     }
     return result;
+  }
+
+  static String getClockWarning(String messageKey, String componentName, String circuitName) {
+    return S.get(messageKey, componentName, circuitName);
   }
 
   @Override

--- a/src/main/resources/resources/logisim/strings/fpga/fpga.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga.properties
@@ -115,6 +115,11 @@ TopLevelNoIO = Top level “%s” has no input(s) and/or no output(s)!
 WorkDirIllegalChars = Your workspace contains a directory with an illegal name “%s”. Please change to a workspace directory that only contains a-f, A-F, 0-9, and/or underscores.
 WorkDirWithSpaces = Your workspace directory contains spaces. Please change to a workspace directory without spaces.
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+HDLGenerator_GatedClockConnection = Component "%s" in circuit "%s" has a gated clock connection!
+HDLGenerator_NoClockConnection = Component "%s" in circuit "%s" has no clock connection!
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generating COF file for flashing

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
@@ -118,6 +118,11 @@ TopLevelNoIO = Der Toplevel „%s“ hat keine(n) Eingäng(e) und/oder keine Aus
 #==> WorkDirIllegalChars =
 #==> WorkDirWithSpaces =
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+# ==> HDLGenerator_GatedClockConnection =
+# ==> HDLGenerator_NoClockConnection =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Erzeugen einer COF-Datei für das Flashen

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
@@ -115,6 +115,11 @@
 # ==> WorkDirIllegalChars =
 # ==> WorkDirWithSpaces =
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+# ==> HDLGenerator_GatedClockConnection =
+# ==> HDLGenerator_NoClockConnection =
+#
 # download/AlteraDownload.java
 #
 # ==> AlteraCofFile =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
@@ -115,6 +115,11 @@ TopLevelNoIO = El nivel superior «%s» no tiene ninguna entrada(s) y/o ninguna 
 # ==> WorkDirIllegalChars =
 # ==> WorkDirWithSpaces =
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+# ==> HDLGenerator_GatedClockConnection =
+# ==> HDLGenerator_NoClockConnection =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generación de archivos cof para flasheo

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
@@ -115,6 +115,11 @@ NetMerge_BitWidthError = Tentative de fusion des réseaux de tailles différente
 # ==> WorkDirWithSpaces =
 TopLevelNoIO = Le niveau supérieur « %s » n’a pas d’entrée(s) et/ou pas de sortie(s) !
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+# ==> HDLGenerator_GatedClockConnection =
+# ==> HDLGenerator_NoClockConnection =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Génération d’un fichier COF pour le flashage

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
@@ -115,6 +115,11 @@ TopLevelNoIO = Il livello superiore «%s» non ha ingressi e/o uscite!
 # ==> WorkDirIllegalChars =
 # ==> WorkDirWithSpaces =
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+# ==> HDLGenerator_GatedClockConnection =
+# ==> HDLGenerator_NoClockConnection =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generazione di file co-file per lampeggiante

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
@@ -115,6 +115,11 @@ TopLevelNoIO = トップ・レベル “%s” は入力および/または出力
 # ==> WorkDirIllegalChars =
 # ==> WorkDirWithSpaces =
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+# ==> HDLGenerator_GatedClockConnection =
+# ==> HDLGenerator_NoClockConnection =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = フラッシング用の cof ファイルの生成

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
@@ -115,6 +115,11 @@ TopLevelNoIO = Top level „%s” heeft geen ingang(en) en/of geen uitgang(en)!
 # ==> WorkDirIllegalChars =
 # ==> WorkDirWithSpaces =
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+# ==> HDLGenerator_GatedClockConnection =
+# ==> HDLGenerator_NoClockConnection =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Cof-bestand voor het flashen wordt gegenereerd.

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
@@ -115,6 +115,11 @@ TopLevelNoIO = Górny poziom „%s” nie ma wejścia(ów) i/lub wyjścia(ów)!
 # ==> WorkDirIllegalChars =
 # ==> WorkDirWithSpaces =
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+# ==> HDLGenerator_GatedClockConnection =
+# ==> HDLGenerator_NoClockConnection =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generowanie pliku współrzędnych dla flashingu

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
@@ -115,6 +115,11 @@ TopLevelNoIO = O nível superior «%s» não tem entrada(s) e/ou saída(s)!
 # ==> WorkDirIllegalChars =
 # ==> WorkDirWithSpaces =
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+# ==> HDLGenerator_GatedClockConnection =
+# ==> HDLGenerator_NoClockConnection =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Gerando arquivo cof para piscar

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
@@ -115,6 +115,11 @@ TopLevelNoIO = Схема верхнего уровня «%s» не имеет �
 # ==> WorkDirIllegalChars =
 # ==> WorkDirWithSpaces =
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+# ==> HDLGenerator_GatedClockConnection =
+# ==> HDLGenerator_NoClockConnection =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Создание файла COF для прошивки

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
@@ -115,6 +115,11 @@ TopLevelNoIO = 顶层电路“%s”缺少输入和/或输出
 # ==> WorkDirIllegalChars =
 # ==> WorkDirWithSpaces =
 #
+# hdlgenerator/AbstractHdlGeneratorFactory.java
+#
+HDLGenerator_GatedClockConnection = 元件 "%s" 在电路 "%s" 中有门控时钟连接!
+HDLGenerator_NoClockConnection = 元件 "%s" 在电路 "%s" 中没有时钟连接!
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = 正在生成用于烧录的 COF 文件

--- a/src/test/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.fpga.hdlgenerator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cburch.logisim.util.LocaleManager;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+class AbstractHdlGeneratorFactoryTest {
+
+  @Test
+  void clockWarningsUseCurrentLocaleAndKeepContext() {
+    final var originalLocale = LocaleManager.getLocale();
+    try {
+      LocaleManager.setLocale(Locale.ENGLISH);
+      assertEquals(
+          "Component \"Clock\" in circuit \"main\" has no clock connection!",
+          AbstractHdlGeneratorFactory.getClockWarning(
+              "HDLGenerator_NoClockConnection", "Clock", "main"));
+      assertEquals(
+          "Component \"Clock\" in circuit \"main\" has a gated clock connection!",
+          AbstractHdlGeneratorFactory.getClockWarning(
+              "HDLGenerator_GatedClockConnection", "Clock", "main"));
+
+      LocaleManager.setLocale(Locale.SIMPLIFIED_CHINESE);
+      assertEquals(
+          "元件 \"Clock\" 在电路 \"main\" 中没有时钟连接!",
+          AbstractHdlGeneratorFactory.getClockWarning(
+              "HDLGenerator_NoClockConnection", "Clock", "main"));
+      assertEquals(
+          "元件 \"Clock\" 在电路 \"main\" 中有门控时钟连接!",
+          AbstractHdlGeneratorFactory.getClockWarning(
+              "HDLGenerator_GatedClockConnection", "Clock", "main"));
+    } finally {
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- move the component-specific missing-clock and gated-clock HDL warnings into the FPGA localization resources
- preserve the component and circuit names in both messages
- provide complete English and Simplified Chinese strings, with the standard missing-translation markers for the remaining locales
- add regression coverage for English/Chinese locale switching and context substitution

This is a focused first slice of #1144 and does not close the broader localization issue.

## Validation

- `.\gradlew.bat test --tests com.cburch.logisim.fpga.hdlgenerator.AbstractHdlGeneratorFactoryTest compileJava checkstyleMain compileTestJava checkstyleTest --no-daemon`
- `.\gradlew.bat check --no-daemon`
- `git diff --check`
- `trans-tool` 2.5.2 against `fpga.properties` (the workflow still reports the repository's pre-existing baseline diagnostics and the expected missing-translation warnings, which are represented by the standard fallback markers)
