### PR TITLE
fpga: localize board file errors

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/file/BoardReaderClass.java
+++ b/src/main/java/com/cburch/logisim/fpga/file/BoardReaderClass.java
@@ -9,6 +9,8 @@
 
 package com.cburch.logisim.fpga.file;
 
+import static com.cburch.logisim.fpga.Strings.S;
+
 import com.cburch.logisim.fpga.data.BoardInformation;
 import com.cburch.logisim.fpga.data.FpgaClass;
 import com.cburch.logisim.fpga.data.FpgaIoInformationContainer;
@@ -101,21 +103,15 @@ public class BoardReaderClass {
         }
       }
       if (CodeTable == null) {
-        DialogNotification.showDialogNotification(
-            // FIXME: hardcoded string
-            null, "Error", "The selected XML file does not contain a compression code table");
+        showBoardFileError("BoardReaderMissingCodeTable");
         return null;
       }
       if ((PictureWidth == 0) || (PictureHeight == 0)) {
-        DialogNotification.showDialogNotification(
-            // FIXME: hardcoded string
-            null, "Error", "The selected XML file does not contain the picture dimensions");
+        showBoardFileError("BoardReaderMissingPictureDimensions");
         return null;
       }
       if (PixelData == null) {
-        DialogNotification.showDialogNotification(
-            // FIXME: hardcoded string
-            null, "Error", "The selected XML file does not contain the picture data");
+        showBoardFileError("BoardReaderMissingPictureData");
         return null;
       }
 
@@ -230,9 +226,7 @@ public class BoardReaderClass {
         || (family == null)
         || (Package == null)
         || (speed == null)) {
-      // FIXME: hardcoded string
-      DialogNotification.showDialogNotification(
-          null, "Error", "The selected xml file does not contain the required FPGA parameters");
+      showBoardFileError("BoardReaderMissingFpgaParameters");
       return null;
     }
     if (usbTmc == null) usbTmc = Boolean.toString(false);
@@ -255,6 +249,11 @@ public class BoardReaderClass {
         flashName,
         flashPos);
     return result;
+  }
+
+  private static void showBoardFileError(String messageKey) {
+    DialogNotification.showDialogNotification(
+        null, S.get("BoardReaderErrorTitle"), S.get(messageKey));
   }
 
   private void processComponentList(NodeList compList, BoardInformation board) {

--- a/src/main/resources/resources/logisim/strings/fpga/fpga.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga.properties
@@ -212,6 +212,14 @@ FpgaBoardSaveInvalidName = The board name you have chosen is invalid.\nBoard nam
 FpgaBoardSaveInvalidNameTitle = Invalid Board Name
 FpgaBoardSelect = Select build-in board to load:
 #
+# file/BoardReaderClass.java
+#
+BoardReaderErrorTitle = Error
+BoardReaderMissingCodeTable = The selected XML file does not contain a compression code table
+BoardReaderMissingPictureDimensions = The selected XML file does not contain the picture dimensions
+BoardReaderMissingPictureData = The selected XML file does not contain the picture data
+BoardReaderMissingFpgaParameters = The selected XML file does not contain the required FPGA parameters
+#
 # gui/BoardManipulator.java
 #
 BoardManipLoad = Load board picture

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
@@ -215,6 +215,14 @@ FpgaBoardSaveInvalidName = Der gewählte Board-Name ist ungültig.\nBoard-Namen 
 FpgaBoardSaveInvalidNameTitle = Ungültiger Board-Name
 FpgaBoardSelect = Wähle zu ladendes Built-in Board:
 #
+# file/BoardReaderClass.java
+#
+# ==> BoardReaderErrorTitle =
+# ==> BoardReaderMissingCodeTable =
+# ==> BoardReaderMissingPictureDimensions =
+# ==> BoardReaderMissingPictureData =
+# ==> BoardReaderMissingFpgaParameters =
+#
 # gui/BoardManipulator.java
 #
 BoardManipLoad = Bild vom Board laden

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
@@ -212,6 +212,14 @@
 # ==> FpgaBoardSaveInvalidNameTitle =
 # ==> FpgaBoardSelect =
 #
+# file/BoardReaderClass.java
+#
+# ==> BoardReaderErrorTitle =
+# ==> BoardReaderMissingCodeTable =
+# ==> BoardReaderMissingPictureDimensions =
+# ==> BoardReaderMissingPictureData =
+# ==> BoardReaderMissingFpgaParameters =
+#
 # gui/BoardManipulator.java
 #
 # ==> BoardManipLoad =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
@@ -212,6 +212,14 @@ FPGABoardEditor = Editor de la tarjeta FPGA
 # ==> FpgaBoardSaveInvalidNameTitle =
 # ==> FpgaBoardSelect =
 #
+# file/BoardReaderClass.java
+#
+# ==> BoardReaderErrorTitle =
+# ==> BoardReaderMissingCodeTable =
+# ==> BoardReaderMissingPictureDimensions =
+# ==> BoardReaderMissingPictureData =
+# ==> BoardReaderMissingFpgaParameters =
+#
 # gui/BoardManipulator.java
 #
 # ==> BoardManipLoad =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
@@ -212,6 +212,14 @@ FpgaBoardSaveInvalidName = Le nom du circuit choisi est invalide.\nUn nom de cir
 FpgaBoardSaveInvalidNameTitle = Nom de circuit invalide
 FpgaBoardSelect = Sélectionner le circuit intégré à charger :
 #
+# file/BoardReaderClass.java
+#
+# ==> BoardReaderErrorTitle =
+# ==> BoardReaderMissingCodeTable =
+# ==> BoardReaderMissingPictureDimensions =
+# ==> BoardReaderMissingPictureData =
+# ==> BoardReaderMissingFpgaParameters =
+#
 # gui/BoardManipulator.java
 #
 BoardManipLoad = Charger l’image du circuit

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
@@ -212,6 +212,14 @@ FPGABoardEditor = Editore della scheda FPGA
 # ==> FpgaBoardSaveInvalidNameTitle =
 # ==> FpgaBoardSelect =
 #
+# file/BoardReaderClass.java
+#
+# ==> BoardReaderErrorTitle =
+# ==> BoardReaderMissingCodeTable =
+# ==> BoardReaderMissingPictureDimensions =
+# ==> BoardReaderMissingPictureData =
+# ==> BoardReaderMissingFpgaParameters =
+#
 # gui/BoardManipulator.java
 #
 # ==> BoardManipLoad =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
@@ -212,6 +212,14 @@ FpgaBoardSaveDir = ボードファイルを保存するディレクトリを選�
 # ==> FpgaBoardSaveInvalidNameTitle =
 FpgaBoardSelect = ロードするビルドインボードを選択します:
 #
+# file/BoardReaderClass.java
+#
+# ==> BoardReaderErrorTitle =
+# ==> BoardReaderMissingCodeTable =
+# ==> BoardReaderMissingPictureDimensions =
+# ==> BoardReaderMissingPictureData =
+# ==> BoardReaderMissingFpgaParameters =
+#
 # gui/BoardManipulator.java
 #
 BoardManipLoad = ボードピクチャの読み込み

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
@@ -212,6 +212,14 @@ FpgaBoardSaveDir = Kies map om het bord bestand in op te slaan:
 # ==> FpgaBoardSaveInvalidNameTitle =
 FpgaBoardSelect = Kies ingebouwd bord om te laden:
 #
+# file/BoardReaderClass.java
+#
+# ==> BoardReaderErrorTitle =
+# ==> BoardReaderMissingCodeTable =
+# ==> BoardReaderMissingPictureDimensions =
+# ==> BoardReaderMissingPictureData =
+# ==> BoardReaderMissingFpgaParameters =
+#
 # gui/BoardManipulator.java
 #
 BoardManipLoad = Laad bord afbeelding

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
@@ -212,6 +212,14 @@ FpgaBoardSaveDir = Wybierz katalog do zapisania pliku płytki:
 # ==> FpgaBoardSaveInvalidNameTitle =
 FpgaBoardSelect = Wybierz wbudowaną płytkę do wczytania:
 #
+# file/BoardReaderClass.java
+#
+# ==> BoardReaderErrorTitle =
+# ==> BoardReaderMissingCodeTable =
+# ==> BoardReaderMissingPictureDimensions =
+# ==> BoardReaderMissingPictureData =
+# ==> BoardReaderMissingFpgaParameters =
+#
 # gui/BoardManipulator.java
 #
 BoardManipLoad = Wczytaj zdjęcie płytki

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
@@ -212,6 +212,14 @@ FPGABoardEditor = Editor de FPGA
 # ==> FpgaBoardSaveInvalidNameTitle =
 # ==> FpgaBoardSelect =
 #
+# file/BoardReaderClass.java
+#
+# ==> BoardReaderErrorTitle =
+# ==> BoardReaderMissingCodeTable =
+# ==> BoardReaderMissingPictureDimensions =
+# ==> BoardReaderMissingPictureData =
+# ==> BoardReaderMissingFpgaParameters =
+#
 # gui/BoardManipulator.java
 #
 # ==> BoardManipLoad =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
@@ -212,6 +212,14 @@ FpgaBoardSaveInvalidName = Выбранное имя платы недопуст
 FpgaBoardSaveInvalidNameTitle = Недопустимое имя платы
 FpgaBoardSelect = Выберите встроенную плату для загрузки:
 #
+# file/BoardReaderClass.java
+#
+# ==> BoardReaderErrorTitle =
+# ==> BoardReaderMissingCodeTable =
+# ==> BoardReaderMissingPictureDimensions =
+# ==> BoardReaderMissingPictureData =
+# ==> BoardReaderMissingFpgaParameters =
+#
 # gui/BoardManipulator.java
 #
 BoardManipLoad = Загрузить изображение платы

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
@@ -212,6 +212,14 @@ FpgaBoardSaveDir = 选择保存板卡文件的目录：
 # ==> FpgaBoardSaveInvalidNameTitle =
 FpgaBoardSelect = 选择要加载的内置板卡：
 #
+# file/BoardReaderClass.java
+#
+BoardReaderErrorTitle = 错误
+BoardReaderMissingCodeTable = 所选 XML 文件不包含压缩编码表
+BoardReaderMissingPictureDimensions = 所选 XML 文件不包含图片尺寸
+BoardReaderMissingPictureData = 所选 XML 文件不包含图片数据
+BoardReaderMissingFpgaParameters = 所选 XML 文件不包含必需的 FPGA 参数
+#
 # gui/BoardManipulator.java
 #
 BoardManipLoad = 加载板卡图片

--- a/src/test/java/com/cburch/logisim/fpga/file/BoardReaderClassTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/file/BoardReaderClassTest.java
@@ -1,0 +1,51 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.fpga.file;
+
+import static com.cburch.logisim.fpga.Strings.S;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cburch.logisim.util.LocaleManager;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+class BoardReaderClassTest {
+
+  @Test
+  void boardFileErrorsUseCurrentLocale() {
+    final var originalLocale = LocaleManager.getLocale();
+    try {
+      LocaleManager.setLocale(Locale.ENGLISH);
+      assertEquals("Error", S.get("BoardReaderErrorTitle"));
+      assertEquals(
+          "The selected XML file does not contain a compression code table",
+          S.get("BoardReaderMissingCodeTable"));
+      assertEquals(
+          "The selected XML file does not contain the picture dimensions",
+          S.get("BoardReaderMissingPictureDimensions"));
+      assertEquals(
+          "The selected XML file does not contain the picture data",
+          S.get("BoardReaderMissingPictureData"));
+      assertEquals(
+          "The selected XML file does not contain the required FPGA parameters",
+          S.get("BoardReaderMissingFpgaParameters"));
+
+      LocaleManager.setLocale(Locale.SIMPLIFIED_CHINESE);
+      assertEquals("错误", S.get("BoardReaderErrorTitle"));
+      assertEquals("所选 XML 文件不包含压缩编码表", S.get("BoardReaderMissingCodeTable"));
+      assertEquals("所选 XML 文件不包含图片尺寸", S.get("BoardReaderMissingPictureDimensions"));
+      assertEquals("所选 XML 文件不包含图片数据", S.get("BoardReaderMissingPictureData"));
+      assertEquals(
+          "所选 XML 文件不包含必需的 FPGA 参数", S.get("BoardReaderMissingFpgaParameters"));
+    } finally {
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- localize the four malformed board-file dialogs in `BoardReaderClass`, including their error title
- add complete English and Simplified Chinese strings while using the repository-standard fallback markers for the other locales
- add focused locale regression coverage for every message

This only changes user-visible text. Board XML parsing, validation conditions, and failure behavior remain unchanged.

Relates to #1144.

## Validation

- `./gradlew test --tests com.cburch.logisim.fpga.file.BoardReaderClassTest compileJava checkstyleMain compileTestJava checkstyleTest --no-daemon`
- `./gradlew check --no-daemon --rerun-tasks --max-workers=1`
- `git diff --check`
