### PR TITLE
feat: upgrade snapcraft core and improve snap script

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# On Fedora $SNAP is under /var and there is some magic to map it to /snap.
+# We need to handle that case and reset $SNAP
+SNAP="${SNAP//\/var\/lib\/snapd/}"

--- a/snap/local/usr/bin/logisim-evolution-wrapper
+++ b/snap/local/usr/bin/logisim-evolution-wrapper
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the configure hook which sets defaults for any config options
+"${SNAP}/meta/hooks/configure"
+
+# Define an array of JVM options
+opts=(
+    "-Djava.util.prefs.userRoot=${SNAP_USER_DATA}"
+)
+
+# Run logisim-evolution with the gathered arguments
+exec java "${opts[@]}" -jar "${SNAP}/logisim-evolution/logisim-evolution.jar" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,10 +7,7 @@
 #
 
 name: logisim-evolution
-base: core22
-confinement: strict
-icon: support/jpackage/linux/logisim-icon-128.png
-license: GPL-3.0
+title: Logisim Evolution
 summary: Digital logic design tool and simulator
 description: |
  Logisim-evolution is educational software for designing and simulating digital logic circuits.
@@ -26,30 +23,27 @@ description: |
   * huge library of components (LEDs, TTLs, switches, SoCs),
   * supports multiple languages,
   * and more!
-grade: stable
-
+website: https://github.com/logisim-evolution/logisim-evolution
+contact: https://github.com/logisim-evolution/logisim-evolution/issues
+issues: https://github.com/logisim-evolution/logisim-evolution/issues
+source-code: https://github.com/logisim-evolution/logisim-evolution
+license: GPL-3.0
 adopt-info: logisim-evolution
+icon: snap/gui/logisim-icon-128.png
 
-architectures:
-  - build-on: amd64
+base: core24
+grade: stable
+confinement: strict
+compression: lzo
 
-layout:
-  /etc/fonts:
-    bind: $SNAP/etc/fonts
-  /usr/share/fonts:
-    bind: $SNAP/usr/share/fonts
-  /var/cache/fontconfig:
-    bind: $SNAP_DATA/var/cache/fontconfig
+platforms:
+  amd64:
+  arm64:
 
 apps:
   logisim-evolution:
     extensions: [gnome]
-    command: usr/lib/jvm/java-17-openjdk-$CRAFT_TARGET_ARCH/bin/java -jar $SNAP/logisim-evolution/logisim-evolution.jar
-    environment:
-      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
-      XDG_DATA_HOME: $SNAP/usr/share
-      FONTCONFIG_PATH: $SNAP/etc/fonts/conf.d
-      FONTCONFIG_FILE: $SNAP/etc/fonts/fonts.conf
+    command: usr/bin/logisim-evolution-wrapper
     plugs:
       - desktop
       - desktop-legacy
@@ -59,29 +53,33 @@ apps:
       - unity7
       - wayland
       - x11
+      - removable-media
 
 parts:
   logisim-evolution:
     plugin: nil
-    source: https://github.com/MarcinOrlowski/logisim-evolution.git
-    source-type: git
+    build-attributes: [network]
+    source: .
     override-pull: |
-      craftctl default
-      git checkout snap-packages-test-1
-      git status
-      LSE_VERSION="$(cat gradle.properties | grep '^version\s*=.*' | awk '{print $3}')"
-      craftctl set version="${LSE_VERSION}"
+      # set version from git tag
+      VERSION=$(git describe --tags --abbrev=0)
+      craftctl set version="${VERSION}"
     override-build: |
-      bash gradlew "$@" shadowJar && \
-      mkdir -p "$CRAFT_PART_INSTALL"/logisim-evolution && \
-        ls -ld build/libs/*
-        mv build/libs/logisim-evolution-*-all.jar "$CRAFT_PART_INSTALL"/logisim-evolution/logisim-evolution.jar
+      # Ensure that gradlew is executable
+      chmod +x gradlew
+      
+      # Build the application. Testing happened locally, so skip it here
+      ./gradlew shadowJar -x test --console=plain
+
+      mkdir -p $CRAFT_PART_INSTALL/logisim-evolution
+      cp build/libs/logisim-evolution-*-all.jar $CRAFT_PART_INSTALL/logisim-evolution/logisim-evolution.jar
     build-packages:
-      - git
-      - openjdk-17-jdk
-      - libfontconfig1-dev
+      - gradle
+      - openjdk-21-jdk
     stage-packages:
-      - openjdk-17-jre
-      - fonts-freefont-ttf
-      - fonts-arphic-uming
-      - fontconfig-config
+      - openjdk-21-jre
+
+  local-parts:
+    plugin: dump
+    source: ./snap/local
+    source-type: local


### PR DESCRIPTION
Closes https://github.com/logisim-evolution/logisim-evolution/issues/1647

This pull request updates the Snap packaging for Logisim Evolution to modernize its configuration, improve metadata, and streamline the build process. The main changes include upgrading the Snap base to `core24`, updating dependencies to use Java 21, improving metadata fields, and simplifying the build and launch process.

**Snap packaging modernization and metadata improvements:**
* Upgraded Snap base from `core22` to `core24`, updated the `icon` path, and added new metadata fields such as `website`, `contact`, `issues`, and `source-code` for better discoverability and compliance. Also changed the Snap `title` and reordered fields for clarity.
* Expanded supported architectures to include both `amd64` and `arm64` under `platforms`, replacing the previous `architectures` section.

**Build process and dependency updates:**
* Updated the Java version from 17 to 21 for both build and runtime (`openjdk-21-jdk` and `openjdk-21-jre`), and switched from using a remote git source to building from the local source directory. The build process now uses `gradlew` directly, skips tests during build, and sets the version from the latest git tag.
* Simplified the application launch by introducing a wrapper script (`usr/bin/logisim-evolution-wrapper`) instead of directly invoking the Java command, and removed custom environment variables.

**Other packaging improvements:**
* Added a new `local-parts` section to include additional files from `snap/local` using the `dump` plugin.
* Added the `removable-media` plug for broader file access.
* Added a new `configure` hook script to handle Fedora-specific Snap path issues by normalizing the `$SNAP` environment variable.