### PR TITLE
docs: add floating-point mathematical functions

### DIFF
--- a/src/main/resources/doc/en/contents.xml
+++ b/src/main/resources/doc/en/contents.xml
@@ -174,6 +174,10 @@
 			<tocitem target="fparith_multiplier" text="Floating Point Multiplier" image="icon_multiplier" />
 			<tocitem target="fparith_divider" text="Floating Point Divider" image="icon_divider" />
 			<tocitem target="fparith_negator" text="Floating Point Negator" image="icon_negator" />
+			<tocitem target="fparith_exponentiator" text="Floating Point Exponentiator" />
+			<tocitem target="fparith_logarithm" text="Floating Point Logarithm" />
+			<tocitem target="fparith_squareroot" text="Floating Point Square Root" />
+			<tocitem target="fparith_absolute" text="Floating Point Absolute" />
 		</tocitem>
 		<tocitem target="mem" text="Memory library">
 			<tocitem target="mem_flipflops" text="D/T/J-K/S-R Flip-Flop" image="icon_flipflops" />

--- a/src/main/resources/doc/en/html/libs/fparith/absolute.html
+++ b/src/main/resources/doc/en/html/libs/fparith/absolute.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Absolute</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>|x|</strong> <em>Floating Point Absolute</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component calculates the absolute value of the floating-point value on its west input
+        and places the result on the east output. Negative zero becomes positive zero; positive
+        values and positive infinity remain unchanged.
+      </p>
+      <p>
+        The <var>ERR</var> output is 1 when the result is NaN and 0 otherwise. An input containing
+        unknown or error bits is converted to NaN.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge (input, bit width matches Float size)</dt>
+        <dd>The floating-point value whose absolute value is calculated.</dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The absolute value of the input.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the result is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of the input and result: 8, 16, 32, or 64 bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/exponentiator.html
+++ b/src/main/resources/doc/en/html/libs/fparith/exponentiator.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Exponentiator</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>y<sup>x</sup></strong> <em>Floating Point Exponentiator</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component calculates one of three floating-point exponential functions, selected by
+        the <b class="propertie">Exponentiation Mode</b> attribute. The result is rounded to the
+        selected floating-point size.
+      </p>
+      <dl>
+        <dt><b class="propertie">Arbitrary base</b></dt>
+        <dd>
+          Calculates <var>y</var><sup><var>x</var></sup>, using the upper west input as the base
+          <var>y</var> and the lower west input as the exponent <var>x</var>.
+        </dd>
+        <dt><b class="propertie">Exponential</b></dt>
+        <dd>Calculates e<sup><var>x</var></sup> from the single west input.</dd>
+        <dt><b class="propertie">Exponential minus one</b></dt>
+        <dd>
+          Calculates e<sup><var>x</var></sup> &minus; 1 from the single west input. This mode
+          preserves better numerical accuracy than subtracting 1 from the exponential result when
+          <var>x</var> is close to zero.
+        </dd>
+      </dl>
+      <p>
+        The <var>ERR</var> output is 1 when the result is NaN and 0 otherwise. An input containing
+        unknown or error bits is converted to NaN. Other floating-point results, including
+        positive or negative infinity, do not set <var>ERR</var>.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge, north end (input, bit width matches Float size)</dt>
+        <dd>The base <var>y</var>. This pin is present only in <b class="propertie">Arbitrary base</b> mode.</dd>
+        <dt>West edge, south end (input, bit width matches Float size)</dt>
+        <dd>The exponent <var>x</var> in <b class="propertie">Arbitrary base</b> mode.</dd>
+        <dt>West edge, center (input, bit width matches Float size)</dt>
+        <dd>The exponent <var>x</var> in either single-input exponential mode.</dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The selected exponential result.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the result is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of all inputs and the result: 8, 16, 32, or 64 bits.</dd>
+          <dt><b class="propertie">Exponentiation Mode</b></dt>
+          <dd>Selects arbitrary-base exponentiation, the natural exponential, or the natural exponential minus one.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/index.html
+++ b/src/main/resources/doc/en/html/libs/fparith/index.html
@@ -17,9 +17,9 @@
         binary32, or binary64 representation.
       </p>
       <p>
-        The basic arithmetic components provide a one-bit <var>ERR</var> output. It is 1 when the
-        component's primary result is NaN and 0 otherwise. An input containing unknown or error
-        bits is converted to NaN.
+        The arithmetic and mathematical-function components documented here provide a one-bit
+        <var>ERR</var> output. It is 1 when the component's primary result is NaN and 0 otherwise.
+        An input containing unknown or error bits is converted to NaN.
       </p>
       <h2>Basic operations</h2>
       <table>
@@ -58,6 +58,31 @@
             </td>
             <td>&nbsp;</td>
             <td><a href="negator.html">Floating Point Negator</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Mathematical functions</h2>
+      <table>
+        <tbody>
+          <tr>
+            <td align="right"><a href="exponentiator.html"><strong>y<sup>x</sup></strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="exponentiator.html">Floating Point Exponentiator</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="logarithm.html"><strong>log</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="logarithm.html">Floating Point Logarithm</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="squareroot.html"><strong>&radic;</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="squareroot.html">Floating Point Square Root</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="absolute.html"><strong>|x|</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="absolute.html">Floating Point Absolute</a></td>
           </tr>
         </tbody>
       </table>

--- a/src/main/resources/doc/en/html/libs/fparith/logarithm.html
+++ b/src/main/resources/doc/en/html/libs/fparith/logarithm.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Logarithm</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>log</strong> <em>Floating Point Logarithm</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component calculates one of four floating-point logarithmic functions, selected by the
+        <b class="propertie">Logarithm Mode</b> attribute. The result is rounded to the selected
+        floating-point size.
+      </p>
+      <dl>
+        <dt><b class="propertie">Arbitrary base</b></dt>
+        <dd>
+          Calculates the logarithm of the upper west input <var>x</var> using the lower west input
+          <var>y</var> as its base. The implementation evaluates ln(<var>x</var>) / ln(<var>y</var>).
+        </dd>
+        <dt><b class="propertie">Natural logarithm</b></dt>
+        <dd>Calculates ln(<var>x</var>) from the single west input.</dd>
+        <dt><b class="propertie">Logarithm with base 10</b></dt>
+        <dd>Calculates log<sub>10</sub>(<var>x</var>) from the single west input.</dd>
+        <dt><b class="propertie">Natural logarithm of (input + 1)</b></dt>
+        <dd>
+          Calculates ln(1 + <var>x</var>) from the single west input. This mode preserves better
+          numerical accuracy than adding 1 before taking the logarithm when <var>x</var> is close
+          to zero.
+        </dd>
+      </dl>
+      <p>
+        The <var>ERR</var> output is 1 when the result is NaN and 0 otherwise. An input containing
+        unknown or error bits is converted to NaN. Other floating-point results, including
+        positive or negative infinity, do not set <var>ERR</var>.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge, north end (input, bit width matches Float size)</dt>
+        <dd>The value <var>x</var> in <b class="propertie">Arbitrary base</b> mode.</dd>
+        <dt>West edge, south end (input, bit width matches Float size)</dt>
+        <dd>The logarithm base <var>y</var>. This pin is present only in <b class="propertie">Arbitrary base</b> mode.</dd>
+        <dt>West edge, center (input, bit width matches Float size)</dt>
+        <dd>The value <var>x</var> in any single-input logarithm mode.</dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The selected logarithmic result.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the result is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of all inputs and the result: 8, 16, 32, or 64 bits.</dd>
+          <dt><b class="propertie">Logarithm Mode</b></dt>
+          <dd>Selects arbitrary-base, natural, base-10, or natural-logarithm-of-one-plus-input operation.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/squareroot.html
+++ b/src/main/resources/doc/en/html/libs/fparith/squareroot.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Square Root</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>&radic;</strong> <em>Floating Point Square Root</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component calculates the square root of the floating-point value on its west input
+        and places the result on the east output. The result is rounded to the selected
+        floating-point size.
+      </p>
+      <p>
+        The <var>ERR</var> output is 1 when the result is NaN and 0 otherwise. A negative finite
+        input produces NaN and sets <var>ERR</var> to 1. An input containing unknown or error bits
+        is also converted to NaN.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge (input, bit width matches Float size)</dt>
+        <dd>The floating-point value whose square root is calculated.</dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The floating-point square root.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the result is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of the input and result: 8, 16, 32, or 64 bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/index.html
+++ b/src/main/resources/doc/en/html/libs/index.html
@@ -516,6 +516,26 @@
           <td>&nbsp;</td>
           <td><a href="fparith/negator.html">Floating Point Negator</a></td>
         </tr>
+        <tr>
+          <td align="right"><a href="fparith/exponentiator.html"><strong>y<sup>x</sup></strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/exponentiator.html">Floating Point Exponentiator</a></td>
+        </tr>
+        <tr>
+          <td align="right"><a href="fparith/logarithm.html"><strong>log</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/logarithm.html">Floating Point Logarithm</a></td>
+        </tr>
+        <tr>
+          <td align="right"><a href="fparith/squareroot.html"><strong>&radic;</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/squareroot.html">Floating Point Square Root</a></td>
+        </tr>
+        <tr>
+          <td align="right"><a href="fparith/absolute.html"><strong>|x|</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/absolute.html">Floating Point Absolute</a></td>
+        </tr>
       </tbody>
     </table>
 	    <h2>

--- a/src/main/resources/doc/map_en.jhm
+++ b/src/main/resources/doc/map_en.jhm
@@ -158,6 +158,10 @@
 	<mapID target="fparith_multiplier"  url="en/html/libs/fparith/multiplier.html" />
 	<mapID target="fparith_divider"     url="en/html/libs/fparith/divider.html" />
 	<mapID target="fparith_negator"     url="en/html/libs/fparith/negator.html" />
+	<mapID target="fparith_exponentiator" url="en/html/libs/fparith/exponentiator.html" />
+	<mapID target="fparith_logarithm"     url="en/html/libs/fparith/logarithm.html" />
+	<mapID target="fparith_squareroot"    url="en/html/libs/fparith/squareroot.html" />
+	<mapID target="fparith_absolute"      url="en/html/libs/fparith/absolute.html" />
 	<mapID target="mem"                 url="en/html/libs/mem/index.html" />
 	<mapID target="mem_flipflops"       url="en/html/libs/mem/flipflops.html" />
 	<mapID target="mem_register"        url="en/html/libs/mem/register.html" />

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -157,6 +157,10 @@
 	<mapID target="fparith_multiplier"  url="en/html/libs/fparith/multiplier.html" />
 	<mapID target="fparith_divider"     url="en/html/libs/fparith/divider.html" />
 	<mapID target="fparith_negator"     url="en/html/libs/fparith/negator.html" />
+	<mapID target="fparith_exponentiator" url="en/html/libs/fparith/exponentiator.html" />
+	<mapID target="fparith_logarithm"     url="en/html/libs/fparith/logarithm.html" />
+	<mapID target="fparith_squareroot"    url="en/html/libs/fparith/squareroot.html" />
+	<mapID target="fparith_absolute"      url="en/html/libs/fparith/absolute.html" />
 	<mapID target="mem"                 url="pt/html/libs/mem/index.html" />
 	<mapID target="mem_flipflops"       url="pt/html/libs/mem/flipflops.html" />
 	<mapID target="mem_register"        url="pt/html/libs/mem/register.html" />


### PR DESCRIPTION
## Summary

- add English reference pages for Floating Point Exponentiator, Logarithm, Square Root, and Absolute
- connect the pages through the Floating Point Arithmetic indexes, English table of contents, and English/Portuguese help maps
- document the current component modes, pin behavior, floating-point widths, error semantics, and special values

This is the next focused documentation slice after #2809. The remaining analysis and conversion components stay in separate follow-up work.

## Validation

- `DocumentationStructureTest`
- exact-case relative-link and fragment validation for all four new pages
- `git diff --check`
- `.\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1`
- English and Portuguese JavaHelp smoke testing
