### PR TITLE
fpga: localize empty HDL description errors

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/Hdl.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/Hdl.java
@@ -9,6 +9,8 @@
 
 package com.cburch.logisim.fpga.hdlgenerator;
 
+import static com.cburch.logisim.fpga.Strings.S;
+
 import com.cburch.logisim.fpga.designrulecheck.Netlist;
 import com.cburch.logisim.fpga.designrulecheck.netlistComponent;
 import com.cburch.logisim.fpga.file.FileWriter;
@@ -419,8 +421,7 @@ public class Hdl {
   public static boolean writeEntity(String targetDirectory, List<String> contents, String componentName) {
     if (!Hdl.isVhdl()) return true;
     if (contents.isEmpty()) {
-      // FIXME: hardcoded string
-      Reporter.report.addFatalError("INTERNAL ERROR: Empty entity description received!");
+      Reporter.report.addFatalError(S.get("HdlEmptyEntityError"));
       return false;
     }
     final var outFile = FileWriter.getFilePointer(targetDirectory, componentName, true);
@@ -430,8 +431,7 @@ public class Hdl {
 
   public static boolean writeArchitecture(String targetDirectory, List<String> contents, String componentName) {
     if (CollectionUtil.isNullOrEmpty(contents)) {
-      // FIXME: hardcoded string
-      Reporter.report.addFatalErrorFmt("INTERNAL ERROR: Empty behavior description for Component '%s' received!", componentName);
+      Reporter.report.addFatalError(S.get("HdlEmptyBehaviorError", componentName));
       return false;
     }
     final var outFile = FileWriter.getFilePointer(targetDirectory, componentName, false);

--- a/src/main/resources/resources/logisim/strings/fpga/fpga.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga.properties
@@ -120,6 +120,11 @@ WorkDirWithSpaces = Your workspace directory contains spaces. Please change to a
 HDLGenerator_GatedClockConnection = Component "%s" in circuit "%s" has a gated clock connection!
 HDLGenerator_NoClockConnection = Component "%s" in circuit "%s" has no clock connection!
 #
+# hdlgenerator/Hdl.java
+#
+HdlEmptyEntityError = INTERNAL ERROR: Empty entity description received!
+HdlEmptyBehaviorError = INTERNAL ERROR: Empty behavior description for Component '%s' received!
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generating COF file for flashing

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
@@ -123,6 +123,11 @@ TopLevelNoIO = Der Toplevel „%s“ hat keine(n) Eingäng(e) und/oder keine Aus
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
 #
+# hdlgenerator/Hdl.java
+#
+# ==> HdlEmptyEntityError =
+# ==> HdlEmptyBehaviorError =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Erzeugen einer COF-Datei für das Flashen

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
@@ -120,6 +120,11 @@
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
 #
+# hdlgenerator/Hdl.java
+#
+# ==> HdlEmptyEntityError =
+# ==> HdlEmptyBehaviorError =
+#
 # download/AlteraDownload.java
 #
 # ==> AlteraCofFile =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
@@ -120,6 +120,11 @@ TopLevelNoIO = El nivel superior «%s» no tiene ninguna entrada(s) y/o ninguna 
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
 #
+# hdlgenerator/Hdl.java
+#
+# ==> HdlEmptyEntityError =
+# ==> HdlEmptyBehaviorError =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generación de archivos cof para flasheo

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
@@ -120,6 +120,11 @@ TopLevelNoIO = Le niveau supérieur « %s » n’a pas d’entrée(s) et/ou pa
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
 #
+# hdlgenerator/Hdl.java
+#
+# ==> HdlEmptyEntityError =
+# ==> HdlEmptyBehaviorError =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Génération d’un fichier COF pour le flashage

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
@@ -120,6 +120,11 @@ TopLevelNoIO = Il livello superiore «%s» non ha ingressi e/o uscite!
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
 #
+# hdlgenerator/Hdl.java
+#
+# ==> HdlEmptyEntityError =
+# ==> HdlEmptyBehaviorError =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generazione di file co-file per lampeggiante

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
@@ -120,6 +120,11 @@ TopLevelNoIO = トップ・レベル “%s” は入力および/または出力
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
 #
+# hdlgenerator/Hdl.java
+#
+# ==> HdlEmptyEntityError =
+# ==> HdlEmptyBehaviorError =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = フラッシング用の cof ファイルの生成

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
@@ -120,6 +120,11 @@ TopLevelNoIO = Top level „%s” heeft geen ingang(en) en/of geen uitgang(en)!
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
 #
+# hdlgenerator/Hdl.java
+#
+# ==> HdlEmptyEntityError =
+# ==> HdlEmptyBehaviorError =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Cof-bestand voor het flashen wordt gegenereerd.

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
@@ -120,6 +120,11 @@ TopLevelNoIO = Górny poziom „%s” nie ma wejścia(ów) i/lub wyjścia(ów)!
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
 #
+# hdlgenerator/Hdl.java
+#
+# ==> HdlEmptyEntityError =
+# ==> HdlEmptyBehaviorError =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generowanie pliku współrzędnych dla flashingu

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
@@ -120,6 +120,11 @@ TopLevelNoIO = O nível superior «%s» não tem entrada(s) e/ou saída(s)!
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
 #
+# hdlgenerator/Hdl.java
+#
+# ==> HdlEmptyEntityError =
+# ==> HdlEmptyBehaviorError =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Gerando arquivo cof para piscar

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
@@ -120,6 +120,11 @@ TopLevelNoIO = Схема верхнего уровня «%s» не имеет �
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
 #
+# hdlgenerator/Hdl.java
+#
+# ==> HdlEmptyEntityError =
+# ==> HdlEmptyBehaviorError =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Создание файла COF для прошивки

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
@@ -120,6 +120,11 @@ TopLevelNoIO = 顶层电路“%s”缺少输入和/或输出
 HDLGenerator_GatedClockConnection = 元件 "%s" 在电路 "%s" 中有门控时钟连接!
 HDLGenerator_NoClockConnection = 元件 "%s" 在电路 "%s" 中没有时钟连接!
 #
+# hdlgenerator/Hdl.java
+#
+HdlEmptyEntityError = 内部错误：收到的实体描述为空！
+HdlEmptyBehaviorError = 内部错误：收到的元件“%s”行为描述为空！
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = 正在生成用于烧录的 COF 文件

--- a/src/test/java/com/cburch/logisim/fpga/hdlgenerator/HdlTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/hdlgenerator/HdlTest.java
@@ -10,14 +10,25 @@
 package com.cburch.logisim.fpga.hdlgenerator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 
 import com.cburch.logisim.TestBase;
+import com.cburch.logisim.fpga.designrulecheck.SimpleDrcContainer;
+import com.cburch.logisim.fpga.gui.FpgaReportTabbedPane;
+import com.cburch.logisim.fpga.gui.Reporter;
+import com.cburch.logisim.util.LocaleManager;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -25,6 +36,28 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class HdlTest extends TestBase {
 
   private record Item(String methodName, String vhdl, String verilog) {}
+
+  @AfterEach
+  void detachReporterGui() {
+    Reporter.report.setGuiLogger(null);
+  }
+
+  @Test
+  void emptyHdlDescriptionErrorsUseCurrentLocaleAndKeepComponentName() {
+    final var originalLocale = LocaleManager.getLocale();
+    try {
+      assertEmptyDescriptionErrors(
+          Locale.ENGLISH,
+          "INTERNAL ERROR: Empty entity description received!",
+          "INTERNAL ERROR: Empty behavior description for Component 'TestComponent' received!");
+      assertEmptyDescriptionErrors(
+          Locale.SIMPLIFIED_CHINESE,
+          "内部错误：收到的实体描述为空！",
+          "内部错误：收到的元件“TestComponent”行为描述为空！");
+    } finally {
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
 
   /** Ensures HDL markers are as we expect them. */
   @Test
@@ -80,5 +113,29 @@ public class HdlTest extends TestBase {
       fail();
     }
     return result;
+  }
+
+  private void assertEmptyDescriptionErrors(
+      Locale locale, String expectedEntityError, String expectedBehaviorError) {
+    LocaleManager.setLocale(locale);
+    final var reporterGui = mock(FpgaReportTabbedPane.class);
+    Reporter.report.setGuiLogger(reporterGui);
+    final var error = ArgumentCaptor.forClass(Object.class);
+
+    try (final var mockedHdl = mockStatic(Hdl.class, Mockito.CALLS_REAL_METHODS)) {
+      mockedHdl.when(Hdl::isVhdl).thenReturn(true);
+      assertFalse(Hdl.writeEntity("unused", List.of(), "TestComponent"));
+    }
+    verify(reporterGui).addErrors(error.capture());
+    assertEquals(expectedEntityError, error.getValue().toString());
+    assertEquals(
+        SimpleDrcContainer.LEVEL_FATAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
+
+    clearInvocations(reporterGui);
+    assertFalse(Hdl.writeArchitecture("unused", List.of(), "TestComponent"));
+    verify(reporterGui).addErrors(error.capture());
+    assertEquals(expectedBehaviorError, error.getValue().toString());
+    assertEquals(
+        SimpleDrcContainer.LEVEL_FATAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
   }
 } // end of Test class


### PR DESCRIPTION
## Summary

- localize the fatal errors reported for empty HDL entity and behavior descriptions
- preserve the existing English wording and component-name substitution
- add Simplified Chinese translations and standard fallback markers for the other locales
- add a reporter-path regression covering locale selection, fatal severity, return values, and substitution

## Scope

This is a focused follow-up to #1144. Other hard-coded diagnostics and HDL generation behavior remain unchanged and outside this pull request.

## Testing

- `./gradlew test --tests com.cburch.logisim.fpga.hdlgenerator.HdlTest --no-daemon --rerun-tasks`
- `./gradlew compileJava checkstyleMain compileTestJava checkstyleTest --no-daemon --rerun-tasks`
- `git diff --check`
- `./gradlew check --no-daemon --rerun-tasks --max-workers=1`
