### PR TITLE
cli: return nonzero status for invalid option values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,7 @@
     * Added a VHDL standard preference for QuestaSim/ModelSim validation and simulation.
   * Improved command-line output and localization:
     * Command-line help now honors the selected locale.
+    * Invalid command-line option values now return a nonzero exit status.
     * TTY table output includes bit widths in headers.
     * Localized the Assembly Viewer.
   * Added and updated documentation for Telnet, FPGA Commander reports, the board editor, JAR

--- a/src/main/java/com/cburch/logisim/gui/start/Startup.java
+++ b/src/main/java/com/cburch/logisim/gui/start/Startup.java
@@ -99,6 +99,7 @@ public class Startup implements AWTEventListener {
   private String testVector = null;
   private String circuitToTest = null;
   private boolean exitAfterStartup = false;
+  private boolean quitAfterParsing = false;
   private boolean showSplash;
 
   /* File contains the data that should be loaded into a RAM/ROM with a label matching the String
@@ -298,16 +299,9 @@ public class Startup implements AWTEventListener {
     addOption(opts, stringBaseKey, shortKey, longKey, 0);
   }
 
-  /**
-   * Return code of last run argument handler.
-   */
-  private static RC lastHandlerRc;
-
-  /**
-   * Returns {@true} if last argument handler called requested app termination (w/o error).
-   */
+  /** Returns whether an argument requested successful application termination. */
   public boolean shallQuit() {
-    return lastHandlerRc == RC.QUIT;
+    return quitAfterParsing;
   }
 
   /**
@@ -411,9 +405,11 @@ public class Startup implements AWTEventListener {
         case ARG_MAIN_CIRCUIT -> handleArgMainCircuit(startup, opt);
         default -> RC.OK; // should not really happen IRL.
       };
-      lastHandlerRc = optHandlerRc;
       switch (optHandlerRc) {
+        case ERROR:
+          return null;
         case QUIT:
+          startup.quitAfterParsing = true;
           return startup;
         default:
           continue;
@@ -475,7 +471,11 @@ public class Startup implements AWTEventListener {
      */
     WARN,
     /**
-     * Unrecoverable error occurred while handling option. No fall back, must quit.
+     * Unrecoverable error occurred while handling an option. Parsing must fail.
+     */
+    ERROR,
+    /**
+     * Handler completed successfully and requested application termination.
      */
     QUIT
   }
@@ -502,14 +502,14 @@ public class Startup implements AWTEventListener {
 
         if (val == 0) {
           logger.error(S.get("ttyFormatError"));
-          return RC.QUIT;
+          return RC.ERROR;
         }
         startup.ttyFormat |= val;
       }
       return RC.OK;
     }
     logger.error(S.get("ttyFormatError"));
-    return RC.QUIT;
+    return RC.ERROR;
   }
 
   private static RC handleArgSubstitute(Startup startup, Option opt) {
@@ -522,7 +522,7 @@ public class Startup implements AWTEventListener {
 
     // FIXME: warning should be sufficient here maybe?
     logger.error(S.get("argDuplicateSubstitutionError"));
-    return RC.QUIT;
+    return RC.ERROR;
   }
 
   private static RC handleArgLoad(Startup startup, Option opt) {
@@ -530,19 +530,19 @@ public class Startup implements AWTEventListener {
 
     if (optArgs == null) {
       logger.error(S.get("argLoadInvalidArguments"));
-      return RC.QUIT;
+      return RC.ERROR;
     }
 
     final var argsCnt = optArgs.length;
     if (argsCnt < 1 || argsCnt > 2) {
       logger.error(S.get("argLoadInvalidArguments"));
-      return RC.QUIT;
+      return RC.ERROR;
     }
 
     final var label = argsCnt == 1 ? "" : optArgs[1];
     if (startup.memoryLoadFiles.containsKey(label)) {
       logger.error(S.get("argLoadDuplicateLabel", label));
-      return RC.QUIT;
+      return RC.ERROR;
     }
     startup.memoryLoadFiles.put(label, new File(optArgs[0]));
 
@@ -570,7 +570,7 @@ public class Startup implements AWTEventListener {
     }
 
     logger.error(S.get("argGatesOptionError"));
-    return RC.QUIT;
+    return RC.ERROR;
   }
 
   private static RC handleArgGeometry(Startup startup, Option opt) {
@@ -579,7 +579,7 @@ public class Startup implements AWTEventListener {
 
     if (wxh.length != 2 || wxh[0].length() < 1 || wxh[1].length() < 1) {
       logger.error(S.get("argGeometryError"));
-      return RC.QUIT;
+      return RC.ERROR;
     }
 
     final var p = wxh[1].indexOf('+', 1);
@@ -592,14 +592,14 @@ public class Startup implements AWTEventListener {
       final var xy = loc.split("\\+");
       if (xy.length != 2 || xy[0].length() < 1 || xy[1].length() < 1) {
         logger.error(S.get("argGeometryError"));
-        return RC.QUIT;
+        return RC.ERROR;
       }
       try {
         x = Integer.parseInt(xy[0]);
         y = Integer.parseInt(xy[1]);
       } catch (NumberFormatException e) {
         logger.error(S.get("argGeometryError"));
-        return RC.QUIT;
+        return RC.ERROR;
       }
     }
 
@@ -610,11 +610,11 @@ public class Startup implements AWTEventListener {
       h = Integer.parseInt(wxh[1]);
     } catch (NumberFormatException e) {
       logger.error(S.get("argGeometryError"));
-      return RC.QUIT;
+      return RC.ERROR;
     }
     if (w <= 0 || h <= 0) {
       logger.error(S.get("argGeometryError"));
-      return RC.QUIT;
+      return RC.ERROR;
     }
     AppPreferences.WINDOW_WIDTH.set(w);
     AppPreferences.WINDOW_HEIGHT.set(h);
@@ -632,7 +632,7 @@ public class Startup implements AWTEventListener {
   private static RC handleArgTemplate(Startup startup, Option opt) {
     if (startup.templFile != null || startup.templEmpty || startup.templPlain) {
       logger.error(S.get("argOneTemplateError"));
-      return RC.QUIT;
+      return RC.ERROR;
     }
     // first we get the option
     final var option = opt.getValue();
@@ -642,7 +642,7 @@ public class Startup implements AWTEventListener {
       startup.templFile = file;
       if (!startup.templFile.canRead()) {
         logger.error(S.get("templateCannotReadError", file));
-        return RC.QUIT;
+        return RC.ERROR;
       }
       return RC.OK;
     }
@@ -656,7 +656,7 @@ public class Startup implements AWTEventListener {
       return RC.OK;
     }
     logger.error(S.get("argOneTemplateError"));
-    return RC.QUIT;
+    return RC.ERROR;
   }
 
   private static RC handleArgNoSplash(Startup startup, Option opt) {
@@ -719,7 +719,7 @@ public class Startup implements AWTEventListener {
     }
 
     logger.error(S.get("argTestUnknownFlagOrValue", String.valueOf(argVal)));
-    return RC.QUIT;
+    return RC.ERROR;
   }
 
   // Indicates if handleArgTestFpgaParseArg() successfuly parsed and set tick freq.
@@ -730,13 +730,13 @@ public class Startup implements AWTEventListener {
 
     if (optArgs == null) {
       logger.error(S.get("argTestInvalidArguments"));
-      return RC.QUIT;
+      return RC.ERROR;
     }
 
     final var argsCnt = optArgs.length;
     if (argsCnt < 3 || argsCnt > 5) {
       logger.error(S.get("argTestInvalidArguments"));
-      return RC.QUIT;
+      return RC.ERROR;
     }
 
     // already handled above
@@ -747,11 +747,11 @@ public class Startup implements AWTEventListener {
     var handlerRc = RC.OK;
     if (argsCnt >= 4) {
       handlerRc = handleArgTestFpgaParseArg(startup, optArgs[3]);
-      if (handlerRc == RC.QUIT) return handlerRc;
+      if (handlerRc == RC.ERROR) return handlerRc;
     }
     if (argsCnt >= 5) {
       handlerRc = handleArgTestFpgaParseArg(startup, optArgs[4]);
-      if (handlerRc == RC.QUIT) return handlerRc;
+      if (handlerRc == RC.ERROR) return handlerRc;
     }
 
     startup.doFpgaDownload = true;

--- a/src/test/java/com/cburch/logisim/gui/start/StartupTest.java
+++ b/src/test/java/com/cburch/logisim/gui/start/StartupTest.java
@@ -10,6 +10,8 @@
 package com.cburch.logisim.gui.start;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cburch.logisim.Main;
@@ -17,15 +19,35 @@ import com.cburch.logisim.util.LocaleManager;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class StartupTest {
+  private boolean originalHeadless;
+  private Locale originalLocale;
+
+  @BeforeEach
+  void recordGlobalState() {
+    originalHeadless = Main.headless;
+    originalLocale = LocaleManager.getLocale();
+  }
+
+  @AfterEach
+  void restoreGlobalState() {
+    Main.headless = originalHeadless;
+    LocaleManager.setLocale(originalLocale);
+  }
 
   @Test
   void localeOptionAppliesToHelpText() {
     final var originalOut = System.out;
-    final var originalLocale = LocaleManager.getLocale();
-    final var originalHeadless = Main.headless;
     final var output = new ByteArrayOutputStream();
     try {
       System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
@@ -37,8 +59,74 @@ class StartupTest {
       assertFalse(helpText.contains("Displays this argument summary help page."));
     } finally {
       System.setOut(originalOut);
-      LocaleManager.setLocale(originalLocale);
-      Main.headless = originalHeadless;
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"--help", "--version"})
+  void informationalOptionsRequestSuccessfulTermination(String option) {
+    final var startup = parseWithoutOutput("--tty", "table", option);
+
+    assertNotNull(startup);
+    assertTrue(startup.shallQuit());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("invalidOptionArguments")
+  void invalidOptionValuesFailParsing(String description, String[] args) {
+    assertNull(Startup.parseArgs(args), description);
+  }
+
+  @Test
+  void parsingResultBelongsToItsStartupInstance() {
+    final var regularStartup = Startup.parseArgs(new String[] {"--tty", "table", "test.circ"});
+    final var helpStartup = parseWithoutOutput("--tty", "table", "--help");
+
+    assertNotNull(regularStartup);
+    assertFalse(regularStartup.shallQuit());
+    assertNotNull(helpStartup);
+    assertTrue(helpStartup.shallQuit());
+    assertFalse(regularStartup.shallQuit());
+  }
+
+  private static Stream<Arguments> invalidOptionArguments() {
+    return Stream.of(
+        Arguments.of("invalid TTY format", new String[] {"--tty", "invalid"}),
+        Arguments.of(
+            "duplicate substitution",
+            new String[] {
+              "--tty", "table", "--substitute", "old.circ", "new.circ", "--substitute",
+              "old.circ", "other.circ"
+            }),
+        Arguments.of(
+            "invalid load arity",
+            new String[] {"--tty", "table", "--load", "memory.hex", "label", "extra"}),
+        Arguments.of(
+            "duplicate load label",
+            new String[] {
+              "test.circ", "--tty", "table", "--load", "first.hex", "label", "--load",
+              "second.hex", "label"
+            }),
+        Arguments.of(
+            "invalid gate style", new String[] {"--tty", "table", "--gates", "invalid"}),
+        Arguments.of(
+            "invalid geometry", new String[] {"--tty", "table", "--geometry", "invalid"}),
+        Arguments.of(
+            "invalid template",
+            new String[] {"--tty", "table", "--user-template", "missing-template.circ"}),
+        Arguments.of(
+            "invalid FPGA flag",
+            new String[] {"--test-fpga", "test.circ", "main", "board", "invalid"}));
+  }
+
+  private static Startup parseWithoutOutput(String... args) {
+    final var originalOut = System.out;
+    try {
+      System.setOut(
+          new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8));
+      return Startup.parseArgs(args);
+    } finally {
+      System.setOut(originalOut);
     }
   }
 }


### PR DESCRIPTION
## Summary

- distinguish successful parser termination (`--help` and `--version`) from invalid option values
- route unrecoverable option-value errors through the existing `parseArgs() == null` contract, so `Main` returns its existing argument-error status 10
- keep the successful quit flag on each `Startup` instance instead of sharing static parser state
- add focused parser regressions and a `CHANGES.md` entry

## Motivation

Several invalid command-line values currently print an error but exit with status 0 because their handlers share `RC.QUIT` with the successful help and version paths. This makes failed command invocations appear successful to scripts and CI callers.

This is a focused first slice of #1546. It intentionally leaves option-combination policy, invalid-locale handling, runtime simulation/test statuses, GUI/TTY responsibility, and the wider `System.exit` cleanup unchanged.

## Validation

- `./gradlew test --tests com.cburch.logisim.gui.start.StartupTest compileJava checkstyleMain compileTestJava checkstyleTest --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew check --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew shadowJar --no-daemon --rerun-tasks --max-workers=1`
- real built-JAR matrix: help/version return 0; unknown options and all covered invalid-value families return 10; invalid locale retains its existing -1 status
- `git diff --check`
