### PR TITLE
docs: add floating-point analysis functions

### DIFF
--- a/src/main/resources/doc/en/contents.xml
+++ b/src/main/resources/doc/en/contents.xml
@@ -178,6 +178,11 @@
 			<tocitem target="fparith_logarithm" text="Floating Point Logarithm" />
 			<tocitem target="fparith_squareroot" text="Floating Point Square Root" />
 			<tocitem target="fparith_absolute" text="Floating Point Absolute" />
+			<tocitem target="fparith_comparator" text="Floating Point Comparator" />
+			<tocitem target="fparith_minmax" text="Floating Point Minimum and Maximum" />
+			<tocitem target="fparith_round" text="Floating Point Round" />
+			<tocitem target="fparith_trigonometry" text="Floating Point Trigonometry" />
+			<tocitem target="fparith_classificator" text="Floating Point Classificator" />
 		</tocitem>
 		<tocitem target="mem" text="Memory library">
 			<tocitem target="mem_flipflops" text="D/T/J-K/S-R Flip-Flop" image="icon_flipflops" />

--- a/src/main/resources/doc/en/html/libs/fparith/classificator.html
+++ b/src/main/resources/doc/en/html/libs/fparith/classificator.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Classificator</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>class</strong> <em>Floating Point Classificator</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component classifies the floating-point value on its west input. For a fully defined
+        input, exactly one of the Zero, Subnormal, Normal, Infinite, and NaN outputs is 1. The
+        Negative output reports the encoded sign bit independently, so it can be 1 at the same
+        time as any class output, including for negative zero or a NaN with its sign bit set.
+      </p>
+      <p>
+        Zero recognizes both positive and negative zero. Subnormal recognizes an exponent of zero
+        with a nonzero fraction. Normal recognizes a nonzero, nonmaximum exponent. The NaN output
+        covers all NaN encodings; the component does not distinguish quiet from signaling NaNs.
+        An input containing unknown or error bits is treated as NaN by the current value conversion.
+      </p>
+      <p>This component has no <var>ERR</var> output.</p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge (input, bit width matches Float size)</dt>
+        <dd>The floating-point value to classify.</dd>
+        <dt>East edge, top to bottom (six outputs, bit width 1 each)</dt>
+        <dd>
+          <b>Negative</b>, <b>Zero</b>, <b>Subnormal</b>, <b>Normal</b>, <b>Infinite</b>, and
+          <b>NaN</b>, in that order.
+        </dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of the input: 8, 16, 32, or 64 bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/comparator.html
+++ b/src/main/resources/doc/en/html/libs/fparith/comparator.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Comparator</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>&#8822;</strong> <em>Floating Point Comparator</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component compares the floating-point value <var>A</var> on its upper west input with
+        <var>B</var> on its lower west input. The three east outputs indicate whether
+        <var>A</var> is greater than, equal to, or less than <var>B</var>.
+      </p>
+      <p>
+        For ordinary numbers and infinities, exactly one comparison output is 1. Positive and
+        negative zero compare as equal. If either input is NaN, all three comparison outputs are 0
+        and <var>ERR</var> is 1. An input containing unknown or error bits is converted to NaN.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge, north end (input, bit width matches Float size)</dt>
+        <dd>The first operand, <var>A</var>.</dd>
+        <dt>West edge, south end (input, bit width matches Float size)</dt>
+        <dd>The second operand, <var>B</var>.</dd>
+        <dt>East edge, north end (output, bit width 1)</dt>
+        <dd>1 when <var>A</var> is greater than <var>B</var>; otherwise 0.</dd>
+        <dt>East edge, center (output, bit width 1)</dt>
+        <dd>1 when <var>A</var> is equal to <var>B</var>; otherwise 0.</dd>
+        <dt>East edge, south end (output, bit width 1)</dt>
+        <dd>1 when <var>A</var> is less than <var>B</var>; otherwise 0.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if either input is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of both inputs: 8, 16, 32, or 64 bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/index.html
+++ b/src/main/resources/doc/en/html/libs/fparith/index.html
@@ -17,9 +17,9 @@
         binary32, or binary64 representation.
       </p>
       <p>
-        The arithmetic and mathematical-function components documented here provide a one-bit
-        <var>ERR</var> output. It is 1 when the component's primary result is NaN and 0 otherwise.
-        An input containing unknown or error bits is converted to NaN.
+        Most arithmetic and mathematical-function components provide a one-bit <var>ERR</var>
+        output. Its exact condition is described on each component page. An input containing
+        unknown or error bits is converted to NaN.
       </p>
       <h2>Basic operations</h2>
       <table>
@@ -83,6 +83,36 @@
             <td align="right"><a href="absolute.html"><strong>|x|</strong></a></td>
             <td>&nbsp;</td>
             <td><a href="absolute.html">Floating Point Absolute</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Comparison, rounding, and classification</h2>
+      <table>
+        <tbody>
+          <tr>
+            <td align="right"><a href="comparator.html"><strong>&#8822;</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="comparator.html">Floating Point Comparator</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="minmax.html"><strong>min/max</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="minmax.html">Floating Point Minimum and Maximum</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="round.html"><strong>round</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="round.html">Floating Point Round</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="trigonometry.html"><strong>sin/cos</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="trigonometry.html">Floating Point Trigonometry</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="classificator.html"><strong>class</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="classificator.html">Floating Point Classificator</a></td>
           </tr>
         </tbody>
       </table>

--- a/src/main/resources/doc/en/html/libs/fparith/minmax.html
+++ b/src/main/resources/doc/en/html/libs/fparith/minmax.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Minimum and Maximum</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>min/max</strong> <em>Floating Point Minimum and Maximum</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component compares its two west inputs. The upper east output contains their minimum
+        and the lower east output contains their maximum. For positive and negative zero, the
+        minimum is negative zero and the maximum is positive zero.
+      </p>
+      <p>
+        If either input is NaN, both results are NaN and <var>ERR</var> is 1. An input containing
+        unknown or error bits is converted to NaN. Infinities otherwise participate in the
+        comparison normally.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge, north end (input, bit width matches Float size)</dt>
+        <dd>The first value to compare.</dd>
+        <dt>West edge, south end (input, bit width matches Float size)</dt>
+        <dd>The second value to compare.</dd>
+        <dt>East edge, north end (output, bit width matches Float size)</dt>
+        <dd>The minimum of the two inputs.</dd>
+        <dt>East edge, south end (output, bit width matches Float size)</dt>
+        <dd>The maximum of the two inputs.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if either input is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of both inputs and both results: 8, 16, 32, or 64 bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/round.html
+++ b/src/main/resources/doc/en/html/libs/fparith/round.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Round</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>round</strong> <em>Floating Point Round</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component rounds the floating-point value on its west input to an integral value and
+        returns that value in the selected floating-point format. The
+        <b class="propertie">Rounding mode</b> attribute selects the operation.
+      </p>
+      <dl>
+        <dt><b class="propertie">Round up</b></dt>
+        <dd>Returns the smallest integral value greater than or equal to the input.</dd>
+        <dt><b class="propertie">Round down</b></dt>
+        <dd>Returns the greatest integral value less than or equal to the input.</dd>
+        <dt><b class="propertie">Round to nearest</b></dt>
+        <dd>Returns the nearest integral value; a halfway case is rounded toward positive infinity.</dd>
+        <dt><b class="propertie">Round to nearest, ties to even</b></dt>
+        <dd>Returns the nearest integral value; a halfway case is rounded to the even integer.</dd>
+        <dt><b class="propertie">Truncate</b></dt>
+        <dd>Discards the fractional part, rounding toward zero.</dd>
+      </dl>
+      <p>
+        <b class="propertie">Round to nearest</b> and <b class="propertie">Truncate</b> use a
+        signed 64-bit integer intermediate. Values outside that range, including infinities, are
+        limited to the nearest signed 64-bit endpoint before being encoded in the selected
+        floating-point format. The other three modes preserve infinities.
+      </p>
+      <p>
+        The <var>ERR</var> output is 1 when the input is NaN and 0 otherwise. An input containing
+        unknown or error bits is converted to NaN. With a NaN input, <b class="propertie">Round to
+        nearest</b> and <b class="propertie">Truncate</b> produce zero, while the other modes
+        produce NaN; the result should not be used while <var>ERR</var> is 1.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge (input, bit width matches Float size)</dt>
+        <dd>The floating-point value to round.</dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The integral-valued floating-point result.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the input is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of the input and result: 8, 16, 32, or 64 bits.</dd>
+          <dt><b class="propertie">Rounding mode</b></dt>
+          <dd>Selects round up, round down, nearest, nearest with ties to even, or truncate.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/trigonometry.html
+++ b/src/main/resources/doc/en/html/libs/fparith/trigonometry.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Trigonometry</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>sin/cos</strong> <em>Floating Point Trigonometry</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component applies three related functions to the floating-point value on its west
+        input. Standard trigonometric inputs and inverse-trigonometric results use radians. The
+        three results are rounded to the selected floating-point size.
+      </p>
+      <dl>
+        <dt><b class="propertie">Standard trigonometry</b></dt>
+        <dd>The north, center, and south outputs are sin(<var>x</var>), tan(<var>x</var>), and cos(<var>x</var>).</dd>
+        <dt><b class="propertie">Inverse trigonometry</b></dt>
+        <dd>The north, center, and south outputs are asin(<var>x</var>), atan(<var>x</var>), and acos(<var>x</var>).</dd>
+        <dt><b class="propertie">Hyperbolic trigonometry</b></dt>
+        <dd>The north, center, and south outputs are sinh(<var>x</var>), tanh(<var>x</var>), and cosh(<var>x</var>).</dd>
+      </dl>
+      <p>
+        The <var>ERR</var> output is 1 when the input is NaN and 0 otherwise. It does not indicate
+        NaN results produced from a finite or infinite input; for example, asin(2) and acos(2) are
+        NaN while <var>ERR</var> remains 0. An input containing unknown or error bits is converted
+        to NaN.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge (input, bit width matches Float size)</dt>
+        <dd>The value <var>x</var> supplied to all three selected functions.</dd>
+        <dt>East edge, north end (output, bit width matches Float size)</dt>
+        <dd>The sine, inverse-sine, or hyperbolic-sine result.</dd>
+        <dt>East edge, center (output, bit width matches Float size)</dt>
+        <dd>The tangent, inverse-tangent, or hyperbolic-tangent result.</dd>
+        <dt>East edge, south end (output, bit width matches Float size)</dt>
+        <dd>The cosine, inverse-cosine, or hyperbolic-cosine result.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the input is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point width of the input and all results: 8, 16, 32, or 64 bits.</dd>
+          <dt><b class="propertie">Function Type</b></dt>
+          <dd>Selects standard, inverse, or hyperbolic trigonometry.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/index.html
+++ b/src/main/resources/doc/en/html/libs/index.html
@@ -536,6 +536,31 @@
           <td>&nbsp;</td>
           <td><a href="fparith/absolute.html">Floating Point Absolute</a></td>
         </tr>
+        <tr>
+          <td align="right"><a href="fparith/comparator.html"><strong>&#8822;</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/comparator.html">Floating Point Comparator</a></td>
+        </tr>
+        <tr>
+          <td align="right"><a href="fparith/minmax.html"><strong>min/max</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/minmax.html">Floating Point Minimum and Maximum</a></td>
+        </tr>
+        <tr>
+          <td align="right"><a href="fparith/round.html"><strong>round</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/round.html">Floating Point Round</a></td>
+        </tr>
+        <tr>
+          <td align="right"><a href="fparith/trigonometry.html"><strong>sin/cos</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/trigonometry.html">Floating Point Trigonometry</a></td>
+        </tr>
+        <tr>
+          <td align="right"><a href="fparith/classificator.html"><strong>class</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/classificator.html">Floating Point Classificator</a></td>
+        </tr>
       </tbody>
     </table>
 	    <h2>

--- a/src/main/resources/doc/map_en.jhm
+++ b/src/main/resources/doc/map_en.jhm
@@ -162,6 +162,11 @@
 	<mapID target="fparith_logarithm"     url="en/html/libs/fparith/logarithm.html" />
 	<mapID target="fparith_squareroot"    url="en/html/libs/fparith/squareroot.html" />
 	<mapID target="fparith_absolute"      url="en/html/libs/fparith/absolute.html" />
+	<mapID target="fparith_comparator"    url="en/html/libs/fparith/comparator.html" />
+	<mapID target="fparith_minmax"        url="en/html/libs/fparith/minmax.html" />
+	<mapID target="fparith_round"         url="en/html/libs/fparith/round.html" />
+	<mapID target="fparith_trigonometry"  url="en/html/libs/fparith/trigonometry.html" />
+	<mapID target="fparith_classificator" url="en/html/libs/fparith/classificator.html" />
 	<mapID target="mem"                 url="en/html/libs/mem/index.html" />
 	<mapID target="mem_flipflops"       url="en/html/libs/mem/flipflops.html" />
 	<mapID target="mem_register"        url="en/html/libs/mem/register.html" />

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -161,6 +161,11 @@
 	<mapID target="fparith_logarithm"     url="en/html/libs/fparith/logarithm.html" />
 	<mapID target="fparith_squareroot"    url="en/html/libs/fparith/squareroot.html" />
 	<mapID target="fparith_absolute"      url="en/html/libs/fparith/absolute.html" />
+	<mapID target="fparith_comparator"    url="en/html/libs/fparith/comparator.html" />
+	<mapID target="fparith_minmax"        url="en/html/libs/fparith/minmax.html" />
+	<mapID target="fparith_round"         url="en/html/libs/fparith/round.html" />
+	<mapID target="fparith_trigonometry"  url="en/html/libs/fparith/trigonometry.html" />
+	<mapID target="fparith_classificator" url="en/html/libs/fparith/classificator.html" />
 	<mapID target="mem"                 url="pt/html/libs/mem/index.html" />
 	<mapID target="mem_flipflops"       url="pt/html/libs/mem/flipflops.html" />
 	<mapID target="mem_register"        url="pt/html/libs/mem/register.html" />


### PR DESCRIPTION
## Summary

- add English reference pages for the floating-point Comparator, Min/Max, Round, Classificator, and Trigonometry components
- wire those pages into the Floating Point Arithmetic index, library overview, HelpSet maps, and table of contents
- retain the English-page fallback used by the Portuguese HelpSet

This is the next review-sized documentation slice after #2809 and #2834. Floating-point conversion pages are intentionally left for a later dependent PR.

Part of #303.

## Validation

- `DocumentationStructureTest`
- `checkstyleDocgen`, `checkstyleMain`, and `checkstyleTest`
- complete serial `check --no-daemon --rerun-tasks --max-workers=1`
- `git diff --check`
