### PR TITLE
Follow up to #2839, fix the ram with line-enables for the single-bus case

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/DualRam.java
+++ b/src/main/java/com/cburch/logisim/std/memory/DualRam.java
@@ -161,9 +161,8 @@ public class DualRam extends Ram {
     }
 
     final var width = state.getAttributeValue(DATA_ATTR);
-    final var outputEnabled = (separate) ? true :
-        !(state.getPortValue(DualRamAppearance.getOEIndex(portIndex, attrs)).equals(Value.FALSE)
-        && RamAttributes.hasControlledOutput(attrs));
+    final var outputEnabled = separate
+        || !state.getPortValue(DualRamAppearance.getOEIndex(portIndex, attrs)).equals(Value.FALSE);
 
     if (outputEnabled && goodAddr && !misalignError) {
       for (var i = 0; i < dataLines; i++) {

--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -301,7 +301,7 @@ public class Ram extends Mem {
     // perform reads
     final var width = state.getAttributeValue(DATA_ATTR);
     final var outputEnabled = separate  
-        || !state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(Value.TRUE);
+        || !state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(Value.FALSE);
     if (outputEnabled && goodAddr && !misalignError) {
       for (var i = 0; i < dataLines; i++) {
         long val = myState.getContents().get(addr + i);

--- a/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -300,9 +300,8 @@ public class Ram extends Mem {
 
     // perform reads
     final var width = state.getAttributeValue(DATA_ATTR);
-    final var outputEnabled = (separate) ? true : 
-        !(state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(Value.FALSE)
-            && RamAttributes.hasControlledOutput(attrs));
+    final var outputEnabled = separate  
+        || !state.getPortValue(RamAppearance.getOEIndex(0, attrs)).equals(Value.TRUE);
     if (outputEnabled && goodAddr && !misalignError) {
       for (var i = 0; i < dataLines; i++) {
         long val = myState.getContents().get(addr + i);


### PR DESCRIPTION
My previous PR still had a bug for the RAMs with line-enables in case there was a single bus. This PR fixes this.
