### PR TITLE
gui: smoothly pan while placing components

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/main/Canvas.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Canvas.java
@@ -76,6 +76,7 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollBar;
 import javax.swing.JViewport;
+import javax.swing.Timer;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 
@@ -91,6 +92,10 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
   private static final int THRESH_SIZE_UPDATE = 10;
   private static final int BUTTONS_MASK =
       InputEvent.BUTTON1_DOWN_MASK | InputEvent.BUTTON2_DOWN_MASK | InputEvent.BUTTON3_DOWN_MASK;
+  private static final int AUTO_PAN_MARGIN = 32;
+  private static final int AUTO_PAN_MIN_STEP = 4;
+  private static final int AUTO_PAN_MAX_STEP = 16;
+  private static final int AUTO_PAN_DELAY = 40;
   private static final Color DEFAULT_ERROR_COLOR = new Color(192, 0, 0);
   private static final Color OSC_ERR_COLOR = DEFAULT_ERROR_COLOR;
   private static final Color SIM_EXCEPTION_COLOR = DEFAULT_ERROR_COLOR;
@@ -109,7 +114,10 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
   private final TickCounter tickCounter;
   private final CanvasPaintCoordinator paintCoordinator;
   private final CanvasPainter painter;
+  private final Timer autoPanTimer;
   private final Object repaintLock = new Object(); // for waitForRepaintDone
+  private int autoPanDeltaX;
+  private int autoPanDeltaY;
   private Tool dragTool;
   private Tool tempTool;
   private MouseMappings mappings;
@@ -126,6 +134,8 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
     this.mappings = proj.getOptions().getMouseMappings();
     this.canvasPane = null;
     this.tickCounter = new TickCounter();
+    this.autoPanTimer = new Timer(AUTO_PAN_DELAY, event -> autoPanPreview());
+    this.autoPanTimer.setCoalesce(true);
 
     setBackground(new Color(AppPreferences.CANVAS_BG_COLOR.get()));
     addMouseListener(myListener);
@@ -265,6 +275,7 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
   }
 
   public void closeCanvas() {
+    stopAutoPan();
     // paintCoordinator.requestStop();
   }
 
@@ -369,6 +380,88 @@ public class Canvas extends JPanel implements LocaleListener, CanvasPaneContents
 
   public StringGetter getErrorMessage() {
     return viewport.errorMessage;
+  }
+
+  public void updatePreviewAutoPan(int x, int y) {
+    if (canvasPane == null) {
+      return;
+    }
+
+    final var zoom = getZoomFactor();
+    final var view = canvasPane.getViewport().getViewRect();
+    final var deltaX = autoPanDelta((int) Math.round(x * zoom), view.x, view.width);
+    final var deltaY = autoPanDelta((int) Math.round(y * zoom), view.y, view.height);
+    autoPanDeltaX = deltaX;
+    autoPanDeltaY = deltaY;
+
+    if (deltaX == 0 && deltaY == 0) {
+      stopAutoPan();
+    } else if (!autoPanTimer.isRunning()) {
+      autoPanTimer.start();
+    }
+  }
+
+  public void stopAutoPan() {
+    autoPanTimer.stop();
+    autoPanDeltaX = 0;
+    autoPanDeltaY = 0;
+  }
+
+  static int autoPanDelta(int pointer, int viewStart, int viewExtent) {
+    final var offset = pointer - viewStart;
+    if (offset < AUTO_PAN_MARGIN) {
+      return -autoPanStep(AUTO_PAN_MARGIN - offset);
+    }
+
+    final var trailingEdge = viewExtent - AUTO_PAN_MARGIN;
+    if (offset >= trailingEdge) {
+      return autoPanStep(offset - trailingEdge + 1);
+    }
+    return 0;
+  }
+
+  private static int autoPanStep(int depth) {
+    final var boundedDepth = Math.min(AUTO_PAN_MARGIN, Math.max(1, depth));
+    return AUTO_PAN_MIN_STEP
+        + (AUTO_PAN_MAX_STEP - AUTO_PAN_MIN_STEP) * boundedDepth / AUTO_PAN_MARGIN;
+  }
+
+  private void autoPanPreview() {
+    if (canvasPane == null || !(proj.getTool() instanceof AddTool tool)) {
+      stopAutoPan();
+      return;
+    }
+
+    final var horizontal = canvasPane.getHorizontalScrollBar();
+    final var vertical = canvasPane.getVerticalScrollBar();
+    final var oldX = horizontal.getValue();
+    final var oldY = vertical.getValue();
+    horizontal.setValue(oldX + autoPanDeltaX);
+    vertical.setValue(oldY + autoPanDeltaY);
+    if (horizontal.getValue() == oldX && vertical.getValue() == oldY) {
+      stopAutoPan();
+      return;
+    }
+
+    final var pointer = getMousePosition();
+    if (pointer == null) {
+      stopAutoPan();
+      return;
+    }
+
+    final var event =
+        new MouseEvent(
+            this,
+            MouseEvent.MOUSE_MOVED,
+            System.currentTimeMillis(),
+            0,
+            pointer.x,
+            pointer.y,
+            0,
+            false,
+            MouseEvent.NOBUTTON);
+    repairMouseEvent(event);
+    tool.mouseMoved(this, getGraphics(), event);
   }
 
   public void setErrorMessage(final StringGetter message) {

--- a/src/main/java/com/cburch/logisim/tools/AddTool.java
+++ b/src/main/java/com/cburch/logisim/tools/AddTool.java
@@ -160,6 +160,7 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
 
   @Override
   public void deselect(Canvas canvas) {
+    canvas.stopAutoPan();
     setState(canvas, SHOW_GHOST);
     moveTo(canvas, canvas.getGraphics(), INVALID_COORD, INVALID_COORD);
     bounds = null;
@@ -454,6 +455,7 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
 
   @Override
   public void mouseExited(Canvas canvas, Graphics gfx, MouseEvent event) {
+    canvas.stopAutoPan();
     if (state == SHOW_GHOST) {
       moveTo(canvas, canvas.getGraphics(), INVALID_COORD, INVALID_COORD);
       setState(canvas, SHOW_NONE);
@@ -466,15 +468,19 @@ public class AddTool extends Tool implements Transferable, PropertyChangeListene
   @Override
   public void mouseMoved(Canvas canvas, Graphics gfx, MouseEvent event) {
     if (state != SHOW_NONE) {
+      canvas.updatePreviewAutoPan(event.getX(), event.getY());
       if (shouldSnap) {
         Canvas.snapToGrid(event);
       }
       moveTo(canvas, gfx, event.getX(), event.getY());
+    } else {
+      canvas.stopAutoPan();
     }
   }
 
   @Override
   public void mousePressed(Canvas canvas, Graphics g, MouseEvent e) {
+    canvas.stopAutoPan();
     // verify the addition would be valid
     final var circ = canvas.getCircuit();
     if (!canvas.getProject().getLogisimFile().contains(circ)) {

--- a/src/test/java/com/cburch/logisim/gui/main/CanvasAutoPanTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/CanvasAutoPanTest.java
@@ -1,0 +1,56 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CanvasAutoPanTest {
+  @Test
+  void pointerInCenterDoesNotPan() {
+    assertEquals(0, Canvas.autoPanDelta(150, 100, 200));
+  }
+
+  @Test
+  void pointerNearEdgesPansOutward() {
+    assertTrue(Canvas.autoPanDelta(105, 100, 200) < 0);
+    assertTrue(Canvas.autoPanDelta(295, 100, 200) > 0);
+  }
+
+  @Test
+  void pointerOutsideHotZonesDoesNotPan() {
+    assertEquals(0, Canvas.autoPanDelta(132, 100, 200));
+    assertEquals(0, Canvas.autoPanDelta(267, 100, 200));
+  }
+
+  @Test
+  void pointerAtHotZoneBoundariesPansOutward() {
+    assertTrue(Canvas.autoPanDelta(131, 100, 200) < 0);
+    assertTrue(Canvas.autoPanDelta(268, 100, 200) > 0);
+  }
+
+  @Test
+  void panningAcceleratesTowardEdge() {
+    final var nearHotZoneStart = Canvas.autoPanDelta(270, 100, 200);
+    final var atEdge = Canvas.autoPanDelta(299, 100, 200);
+
+    assertTrue(atEdge > nearHotZoneStart);
+  }
+
+  @Test
+  void panningSpeedIsCappedOutsideView() {
+    assertEquals(
+        Canvas.autoPanDelta(100, 100, 200), Canvas.autoPanDelta(50, 100, 200));
+    assertEquals(
+        Canvas.autoPanDelta(299, 100, 200), Canvas.autoPanDelta(350, 100, 200));
+  }
+}

--- a/src/test/java/com/cburch/logisim/tools/AddToolTest.java
+++ b/src/test/java/com/cburch/logisim/tools/AddToolTest.java
@@ -10,11 +10,18 @@
 package com.cburch.logisim.tools;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import com.cburch.logisim.gui.main.Canvas;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.std.base.Text;
 import java.awt.Color;
+import java.awt.event.MouseEvent;
 import java.util.Objects;
+import javax.swing.JPanel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -50,6 +57,35 @@ class AddToolTest {
     setTextToolPreference(Color.RED);
 
     assertEquals(Color.BLACK, Text.FACTORY.createAttributeSet().getValue(Text.ATTR_COLOR));
+  }
+
+  @Test
+  void movingComponentPreviewRequestsAutoPan() {
+    final var tool = new AddTool(Text.FACTORY);
+    final var canvas = mock(Canvas.class);
+    final var event =
+        new MouseEvent(
+            new JPanel(), MouseEvent.MOUSE_MOVED, 0, 0, 123, 87, 0, false, MouseEvent.NOBUTTON);
+
+    tool.mouseMoved(canvas, null, event);
+
+    verify(canvas).updatePreviewAutoPan(123, 87);
+  }
+
+  @Test
+  void movingOutsideCanvasDoesNotRequestAutoPan() {
+    final var tool = new AddTool(Text.FACTORY);
+    final var canvas = mock(Canvas.class);
+    final var event =
+        new MouseEvent(
+            new JPanel(), MouseEvent.MOUSE_MOVED, 0, 0, 123, 87, 0, false, MouseEvent.NOBUTTON);
+
+    tool.mouseExited(canvas, null, event);
+    clearInvocations(canvas);
+    tool.mouseMoved(canvas, null, event);
+
+    verify(canvas, never()).updatePreviewAutoPan(123, 87);
+    verify(canvas).stopAutoPan();
   }
 
   private static void setTextToolPreference(Color color) throws InterruptedException {


### PR DESCRIPTION
Closes #255.

## What changed

- add edge-triggered auto-pan while previewing a new component with `AddTool`
- keep scrolling while the pointer remains still in a 32 px edge zone
- accelerate smoothly toward the edge with a bounded step size
- stop when the pointer returns to the center, leaves the canvas, a component is placed, the tool is cancelled or changed, or no further scrolling is possible
- leave the existing drag and wire auto-scroll paths unchanged

## Why

Existing components and new wires already auto-pan, but a component that has not yet been placed stops at the canvas edge. A single scroll request from `mouseMoved` is insufficient because no further mouse events arrive once the pointer is held still. A coalescing Swing timer keeps the preview and viewport moving together on the EDT until the edge condition ends.

## Validation

- `./gradlew.bat test --tests com.cburch.logisim.tools.AddToolTest --tests com.cburch.logisim.gui.main.CanvasAutoPanTest compileJava checkstyleMain compileTestJava checkstyleTest --no-daemon --console=plain`
- `./gradlew.bat check --no-daemon --rerun-tasks --max-workers=1 --console=plain`
- `./gradlew.bat shadowJar --no-daemon --console=plain`
- `git diff --check`
- Windows GUI testing: continuous new-component preview panning with the pointer held still at the edge; immediate stop after returning to the center or pressing Escape; existing-component dragging and wire drawing still auto-pan normally
