### PR TITLE
feat: use Gradle plugin for Snap build

### DIFF
--- a/snap/local/usr/bin/logisim-evolution-wrapper
+++ b/snap/local/usr/bin/logisim-evolution-wrapper
@@ -10,4 +10,4 @@ opts=(
 )
 
 # Run logisim-evolution with the gathered arguments
-exec java "${opts[@]}" -jar "${SNAP}/logisim-evolution/logisim-evolution.jar" "$@"
+exec java "${opts[@]}" -jar "${SNAP}/jar/logisim-evolution.jar" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,27 +57,23 @@ apps:
 
 parts:
   logisim-evolution:
-    plugin: nil
-    build-attributes: [network]
+    plugin: gradle
     source: .
+    gradle-task: shadowJar
+    gradle-parameters:
+      - -x
+      - test
+      - --console=plain
     override-pull: |
-      # set version from git tag
       VERSION=$(git describe --tags --abbrev=0)
       craftctl set version="${VERSION}"
-    override-build: |
-      # Ensure that gradlew is executable
-      chmod +x gradlew
-      
-      # Build the application. Testing happened locally, so skip it here
-      ./gradlew shadowJar -x test --console=plain
-
-      mkdir -p $CRAFT_PART_INSTALL/logisim-evolution
-      cp build/libs/logisim-evolution-*-all.jar $CRAFT_PART_INSTALL/logisim-evolution/logisim-evolution.jar
     build-packages:
       - gradle
       - openjdk-21-jdk
     stage-packages:
       - openjdk-21-jre
+    organize:
+      jar/logisim-evolution-*-all.jar: jar/logisim-evolution.jar
 
   local-parts:
     plugin: dump


### PR DESCRIPTION
This pull request updates the Snapcraft build configuration for the `logisim-evolution` part to use the Gradle plugin and simplifies the build process. The most important changes are:

**Build system migration:**

* Switched the `logisim-evolution` part from using `plugin: nil` with manual build steps to `plugin: gradle`, leveraging Snapcraft's built-in Gradle support.
* Specified the `shadowJar` Gradle task and parameters to skip tests and provide cleaner console output during the build.

**Simplification and organization:**

* Removed custom `override-build` logic in favor of default Gradle plugin behavior, reducing manual steps.
* Added an `organize` step to consistently rename the built JAR file to `logisim-evolution.jar` in the snap package.