### PR TITLE
gui: initialize unseen circuit views

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,7 @@
     ranges, scanning I/O constraints, and Xilinx download placeholder handling.
   * Improved project editing stability:
     * Layout zoom and scroll position are remembered separately for each circuit during a session.
+    * Circuits without a remembered view initially fit the window at up to 100% zoom and are centered.
     * Moving components preserves component state.
     * Floating subcircuit inputs now propagate floating values.
     * Nested library tools resolve correctly.

--- a/src/main/java/com/cburch/logisim/gui/generic/ZoomControl.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ZoomControl.java
@@ -12,6 +12,7 @@ package com.cburch.logisim.gui.generic;
 import static com.cburch.logisim.gui.Strings.S;
 
 import com.cburch.contracts.BaseMouseListenerContract;
+import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.gui.icons.ZoomIcon;
 import com.cburch.logisim.gui.main.Canvas;
 import com.cburch.logisim.prefs.AppPreferences;
@@ -30,6 +31,7 @@ import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.text.DecimalFormat;
+import java.util.List;
 import javax.swing.DefaultBoundedRangeModel;
 import javax.swing.Icon;
 import javax.swing.JButton;
@@ -41,6 +43,7 @@ import javax.swing.SwingConstants;
 
 public class ZoomControl extends JPanel {
   private static final long serialVersionUID = 1L;
+  private static final int AUTO_ZOOM_PADDING = 50;
   private final ZoomLabel label;
   private final JSlider slider;
   private final GridIcon grid;
@@ -147,6 +150,34 @@ public class ZoomControl extends JPanel {
     final var choices = model.getZoomOptions();
     i = Math.max(Math.min(i, choices.size() - 1), 0);
     model.setZoomFactor(choices.get(i) / 100.0);
+  }
+
+  public static double computeFitZoomFactor(
+      Bounds bounds, Dimension viewportSize, List<Double> zoomOptions) {
+    if (bounds == null
+        || bounds.getWidth() <= 0
+        || bounds.getHeight() <= 0
+        || viewportSize == null
+        || viewportSize.width <= 0
+        || viewportSize.height <= 0
+        || zoomOptions == null
+        || zoomOptions.isEmpty()) {
+      return Double.NaN;
+    }
+
+    final var paddedWidth = bounds.getWidth() + 2.0 * AUTO_ZOOM_PADDING;
+    final var paddedHeight = bounds.getHeight() + 2.0 * AUTO_ZOOM_PADDING;
+    final var fitZoom =
+        Math.min(viewportSize.getWidth() / paddedWidth, viewportSize.getHeight() / paddedHeight);
+    final var minZoom = zoomOptions.get(0) / 100.0;
+    final var maxZoom = zoomOptions.get(zoomOptions.size() - 1) / 100.0;
+    return Math.max(minZoom, Math.min(fitZoom, maxZoom));
+  }
+
+  public static double computeInitialZoomFactor(
+      Bounds bounds, Dimension viewportSize, List<Double> zoomOptions) {
+    final var fitZoom = computeFitZoomFactor(bounds, viewportSize, zoomOptions);
+    return Double.isNaN(fitZoom) ? 1.0 : Math.min(1.0, fitZoom);
   }
 
   public void setAutoZoomButtonEnabled(boolean val) {
@@ -384,22 +415,10 @@ public class ZoomControl extends JPanel {
 
         final var canvasPane = canvas.getCanvasPane();
         if (canvasPane == null) return;
-        // the white space around
-        final var padding = 50;
-        // set autozoom
         final var zoomFactor = zoomModel.getZoomFactor();
-        final var height = (bounds.getHeight() + 2 * padding) * zoomFactor;
-        final var width = (bounds.getWidth() + 2 * padding) * zoomFactor;
-        var autozoom = zoomFactor;
-        autozoom *=
-            Math.min(
-                canvasPane.getViewport().getSize().getWidth() / width,
-                canvasPane.getViewport().getSize().getHeight() / height);
-        final var max =
-            zoomModel.getZoomOptions().get(zoomModel.getZoomOptions().size() - 1) / 100.0;
-        final var min = zoomModel.getZoomOptions().get(0) / 100.0;
-        if (autozoom > max) autozoom = max;
-        if (autozoom < min) autozoom = min;
+        final var autozoom =
+            computeFitZoomFactor(
+                bounds, canvasPane.getViewport().getSize(), zoomModel.getZoomOptions());
         if (Math.abs(autozoom - zoomFactor) >= 0.01) {
           zoomModel.setZoomFactorCenter(autozoom);
         }

--- a/src/main/java/com/cburch/logisim/gui/main/Frame.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Frame.java
@@ -86,6 +86,8 @@ import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
+import javax.swing.JViewport;
+import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -263,6 +265,8 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
 
     LocaleManager.addLocaleListener(this);
     toolbox.updateStructure();
+
+    restoreLayoutView(project.getCurrentCircuit());
   }
 
   private final class FileDropTargetListener extends DropTargetAdapter {
@@ -707,10 +711,43 @@ public class Frame extends LFrame.MainWindow implements LocaleListener {
 
   private void restoreLayoutView(Circuit circuit) {
     layoutCanvas.computeSize(true);
-    layoutViewMemory.restore(
+    if (layoutViewMemory.restore(
         circuit,
         layoutZoomModel,
-        position -> layoutCanvasPane.getViewport().setViewPosition(position));
+        position ->
+            restoreViewPosition(
+                layoutCanvasPane.getViewport(), layoutCanvas.getPreferredSize(), position))) {
+      return;
+    }
+
+    SwingUtilities.invokeLater(() -> initializeLayoutView(circuit));
+  }
+
+  private void initializeLayoutView(Circuit circuit) {
+    if (circuit == null || project.getCurrentCircuit() != circuit) return;
+
+    final var graphics = layoutCanvas.getGraphics();
+    final var bounds = graphics == null ? circuit.getBounds() : circuit.getBounds(graphics);
+    final var initialZoom =
+        ZoomControl.computeInitialZoomFactor(
+            bounds,
+            layoutCanvasPane.getViewport().getSize(),
+            layoutZoomModel.getZoomOptions());
+    layoutZoomModel.setZoomFactor(initialZoom);
+    SwingUtilities.invokeLater(
+        () -> {
+          if (project.getCurrentCircuit() == circuit) {
+            layoutCanvas.computeSize(true);
+            layoutCanvasPane.getViewport().setViewSize(layoutCanvas.getPreferredSize());
+            layoutCanvas.center();
+          }
+        });
+  }
+
+  static void restoreViewPosition(JViewport viewport, java.awt.Dimension viewSize, Point position) {
+    if (viewport == null || viewSize == null || position == null) return;
+    viewport.setViewSize(viewSize);
+    viewport.setViewPosition(position);
   }
 
   @Override

--- a/src/test/java/com/cburch/logisim/gui/generic/ZoomControlTest.java
+++ b/src/test/java/com/cburch/logisim/gui/generic/ZoomControlTest.java
@@ -1,0 +1,103 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.data.Bounds;
+import java.awt.Dimension;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ZoomControlTest {
+  private static final double ZOOM_DELTA = 1.0e-6;
+  private static final List<Double> ZOOM_OPTIONS = List.of(5.0, 100.0, 1000.0);
+
+  @Test
+  void computesFitZoomFromPaddedCircuitBounds() {
+    assertEquals(
+        0.5,
+        ZoomControl.computeFitZoomFactor(
+            Bounds.create(40, 30, 1900, 900), new Dimension(1000, 500), ZOOM_OPTIONS),
+        ZOOM_DELTA);
+  }
+
+  @Test
+  void usesMostRestrictiveViewportDimension() {
+    assertEquals(
+        0.75,
+        ZoomControl.computeFitZoomFactor(
+            Bounds.create(0, 0, 300, 700), new Dimension(1000, 600), ZOOM_OPTIONS),
+        ZOOM_DELTA);
+  }
+
+  @Test
+  void allowsAutoZoomButtonToEnlargeSmallCircuits() {
+    assertEquals(
+        2.5,
+        ZoomControl.computeFitZoomFactor(
+            Bounds.create(0, 0, 300, 200), new Dimension(1000, 800), ZOOM_OPTIONS),
+        ZOOM_DELTA);
+  }
+
+  @Test
+  void initialViewUsesOneHundredPercentInsteadOfEnlargingSmallCircuits() {
+    assertEquals(
+        1.0,
+        ZoomControl.computeInitialZoomFactor(
+            Bounds.create(0, 0, 300, 200), new Dimension(1000, 800), ZOOM_OPTIONS),
+        ZOOM_DELTA);
+  }
+
+  @Test
+  void initialViewShrinksLargeCircuitsToFit() {
+    assertEquals(
+        0.5,
+        ZoomControl.computeInitialZoomFactor(
+            Bounds.create(40, 30, 1900, 900), new Dimension(1000, 500), ZOOM_OPTIONS),
+        ZOOM_DELTA);
+  }
+
+  @Test
+  void initialViewUsesOneHundredPercentForEmptyCircuits() {
+    assertEquals(
+        1.0,
+        ZoomControl.computeInitialZoomFactor(
+            Bounds.EMPTY_BOUNDS, new Dimension(1000, 800), ZOOM_OPTIONS),
+        ZOOM_DELTA);
+  }
+
+  @Test
+  void clampsFitZoomToConfiguredRange() {
+    assertEquals(
+        0.05,
+        ZoomControl.computeFitZoomFactor(
+            Bounds.create(0, 0, 50000, 50000), new Dimension(100, 100), ZOOM_OPTIONS),
+        ZOOM_DELTA);
+    assertEquals(
+        10.0,
+        ZoomControl.computeFitZoomFactor(
+            Bounds.create(0, 0, 1, 1), new Dimension(5000, 5000), ZOOM_OPTIONS),
+        ZOOM_DELTA);
+  }
+
+  @Test
+  void rejectsEmptyContentOrUnavailableViewport() {
+    assertTrue(
+        Double.isNaN(
+            ZoomControl.computeFitZoomFactor(
+                Bounds.EMPTY_BOUNDS, new Dimension(1000, 800), ZOOM_OPTIONS)));
+    assertTrue(
+        Double.isNaN(
+            ZoomControl.computeFitZoomFactor(
+                Bounds.create(0, 0, 300, 200), new Dimension(), ZOOM_OPTIONS)));
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/main/FrameTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/FrameTest.java
@@ -13,6 +13,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.awt.Dimension;
+import java.awt.Point;
+import javax.swing.JPanel;
+import javax.swing.JViewport;
+import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
 
 class FrameTest {
@@ -106,6 +111,23 @@ class FrameTest {
     assertFalse(Frame.isUsableExplorerSplitFraction(0.99));
     assertFalse(Frame.isUsableExplorerSplitFraction(1.0));
     assertFalse(Frame.isUsableExplorerSplitFraction(Double.POSITIVE_INFINITY));
+  }
+
+  @Test
+  void growsCircuitViewBeforeRestoringItsScrollPosition() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          final var viewport = new JViewport();
+          viewport.setView(new JPanel());
+          viewport.setExtentSize(new Dimension(400, 300));
+          viewport.setViewSize(new Dimension(400, 300));
+
+          Frame.restoreViewPosition(
+              viewport, new Dimension(1000, 800), new Point(325, 175));
+
+          assertEquals(new Dimension(1000, 800), viewport.getViewSize());
+          assertEquals(new Point(325, 175), viewport.getViewPosition());
+        });
   }
 
   private static Object allocateWithoutConstructor(Class<?> type) throws Exception {


### PR DESCRIPTION
## Summary

- initialize circuits without a remembered session view at 100% zoom, or shrink them to fit when necessary
- center newly initialized circuit views while preserving the existing per-circuit zoom and scroll memory
- reuse the Auto zoom calculation and expand the Swing viewport before restoring saved scroll positions
- keep view state session-local; no `.circ` format or persistence changes

## Testing

- `./gradlew.bat test --tests com.cburch.logisim.gui.main.FrameTest --tests com.cburch.logisim.gui.main.CircuitViewMemoryTest --tests com.cburch.logisim.gui.generic.ZoomControlTest compileJava checkstyleMain compileTestJava checkstyleTest --no-daemon --console=plain`
- `./gradlew.bat check --no-daemon --rerun-tasks --max-workers=1 --console=plain`
- `./gradlew.bat shadowJar --no-daemon --rerun-tasks --console=plain`
- Windows GUI: small, oversized, and empty circuits; switching away and back after changing zoom/scroll; close and reopen to confirm session-only behavior

Closes #2012
