### PR TITLE
Add RAM and DualRAM component tests

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/DualRam.java
+++ b/src/main/java/com/cburch/logisim/std/memory/DualRam.java
@@ -190,7 +190,7 @@ public class DualRam extends Ram {
     final var attrs = state.getAttributeSet();
     final var myState = (RamState) getState(state);
     final var separate = isSeparate(attrs);
-    long oldMemValue = myState.getContents().get(myState.getCurrent());
+    long oldMemValue = myState.getContents().get(myState.getCurrent(portIndex));
     long newMemValue = oldMemValue;
     // perform writes
     Object trigger = state.getAttributeValue(StdAttr.TRIGGER);

--- a/src/test/java/com/cburch/logisim/std/memory/DualRamByteEnableTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/DualRamByteEnableTest.java
@@ -1,0 +1,180 @@
+package com.cburch.logisim.std.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.instance.StdAttr;
+import org.junit.jupiter.api.Test;
+
+class DualRamByteEnableTest {
+
+  @Test
+  void portAWritesSelectedBytes() {
+    assertWriteResult(0, 0b0101, 0xABCD1234, 0x12CD5634);
+  }
+
+  @Test
+  void portBWritesSelectedBytes() {
+    assertWriteResult(1, 0b1010, 0xABCD1234, 0xAB341278L);
+  }
+
+  @Test
+  void noBytesEnabledLeavesMemoryUnchanged() {
+    assertWriteResult(0, 0b0000, 0xABCD1234, 0x12345678);
+  }
+
+  @Test
+  void bothPortsCanUseDifferentByteEnables() {
+    final var ram = new DualRam();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(32));
+    attrs.setValue(
+        RamAttributes.ATTR_ByteEnables,
+        RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+
+    final var state = new RamLineEnableTest.TestInstanceState(ram, attrs);
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
+
+    contents.set(0, 0x12345678);
+    contents.set(1, 0x12345678);
+
+    state.setData(
+        new RamState(
+            state.getInstance(),
+            contents,
+            new Mem.MemListener(state.getInstance())));
+
+    for (int port = 0; port < 2; port++) {
+      state.setPortValue(
+          DualRamAppearance.getAddrIndex(port, attrs),
+          Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), port));
+      state.setPortValue(
+          DualRamAppearance.getWEIndex(port, attrs), Value.FALSE);
+      state.setPortValue(
+          DualRamAppearance.getClkIndex(port, attrs), Value.FALSE);
+      state.setPortValue(
+          DualRamAppearance.getOEIndex(port, attrs), Value.TRUE);
+    }
+
+    // Port A: write low byte.
+    state.setPortValue(
+        DualRamAppearance.getWEIndex(0, attrs), Value.TRUE);
+    state.setPortValue(
+        DualRamAppearance.getClkIndex(0, attrs), Value.TRUE);
+    state.setPortValue(
+        DualRamAppearance.getDataInIndex(0, attrs),
+        Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD1234));
+
+    // Port B: write the second byte.
+    state.setPortValue(
+        DualRamAppearance.getWEIndex(1, attrs), Value.TRUE);
+    state.setPortValue(
+        DualRamAppearance.getClkIndex(1, attrs), Value.TRUE);
+    state.setPortValue(
+        DualRamAppearance.getDataInIndex(1, attrs),
+        Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD1234));
+
+    final int bytesPerWord = DualRamAppearance.getNrBEPorts(attrs) / 2;
+
+    for (int i = 0; i < bytesPerWord; i++) {
+      state.setPortValue(
+          DualRamAppearance.getBEIndex(i, attrs),
+          i == 0 ? Value.TRUE : Value.FALSE);
+
+      state.setPortValue(
+          DualRamAppearance.getBEIndex(bytesPerWord + i, attrs),
+          i == 1 ? Value.TRUE : Value.FALSE);
+    }
+
+    ram.propagate(state);
+
+    assertEquals(0x12345634, contents.get(0));
+    assertEquals(0x12341278L, contents.get(1));
+  }
+
+  private static void assertWriteResult(
+      int port, int byteEnableMask, long data, long expected) {
+
+    final var ram = new DualRam();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(32));
+    attrs.setValue(
+        RamAttributes.ATTR_ByteEnables,
+        RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+
+    final var state =
+        new RamLineEnableTest.TestInstanceState(ram, attrs);
+
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
+
+    contents.set(0, 0x12345678);
+
+    state.setData(
+        new RamState(
+            state.getInstance(),
+            contents,
+            new Mem.MemListener(state.getInstance())));
+
+    state.setPortValue(
+        DualRamAppearance.getAddrIndex(port, attrs),
+        Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    state.setPortValue(
+        DualRamAppearance.getWEIndex(port, attrs), Value.TRUE);
+    state.setPortValue(
+        DualRamAppearance.getClkIndex(port, attrs), Value.TRUE);
+    state.setPortValue(
+        DualRamAppearance.getDataInIndex(port, attrs),
+        Value.createKnown(attrs.getValue(Mem.DATA_ATTR), data));
+    state.setPortValue(
+        DualRamAppearance.getOEIndex(port, attrs), Value.TRUE);
+
+    final int bytesPerWord = DualRamAppearance.getNrBEPorts(attrs) / 2;
+
+    for (int i = 0; i < bytesPerWord; i++) {
+      state.setPortValue(
+          DualRamAppearance.getBEIndex(port * bytesPerWord + i, attrs),
+          (byteEnableMask & (1 << i)) != 0
+              ? Value.TRUE
+              : Value.FALSE);
+    }
+
+    // Give the inactive port valid inputs so it doesn't accidentally
+    // interfere with the test.
+    final int otherPort = 1 - port;
+
+    state.setPortValue(
+        DualRamAppearance.getAddrIndex(otherPort, attrs),
+        Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    state.setPortValue(
+        DualRamAppearance.getWEIndex(otherPort, attrs), Value.FALSE);
+    state.setPortValue(
+        DualRamAppearance.getClkIndex(otherPort, attrs), Value.FALSE);
+    state.setPortValue(
+        DualRamAppearance.getOEIndex(otherPort, attrs), Value.FALSE);
+
+    ram.propagate(state);
+
+    assertEquals(
+        expected,
+        contents.get(0),
+        () ->
+            String.format(
+                "Port %d: expected 0x%08X but got 0x%08X",
+                port,
+                expected,
+                contents.get(0)));
+  }
+}

--- a/src/test/java/com/cburch/logisim/std/memory/RamByteEnableTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/RamByteEnableTest.java
@@ -18,10 +18,10 @@ import org.junit.jupiter.api.Test;
 
 class RamByteEnableTest {
 
-@Test
-void writesBothBytesWhenBothEnabled() {
+  @Test
+  void writesBothBytesWhenBothEnabled() {
     assertWriteResult(true, true, 0xABCD);
-    }
+  }
 
   @Test
   void writesLowByteOnly() {
@@ -38,178 +38,151 @@ void writesBothBytesWhenBothEnabled() {
     assertWriteResult(false, false, 0x1234);
   }
 
-@Test
+  @Test
   void writesOnFallingEdge() {
-  final var ram = new Ram();
-  final var attrs = (RamAttributes) ram.createAttributeSet();
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
 
-  attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-  attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_FALLING);
-  attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
-  attrs.setValue(Mem.LINE_ATTR, Mem.SINGLE);
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_FALLING);
+    attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
+    attrs.setValue(Mem.LINE_ATTR, Mem.SINGLE);
 
-  final var state = mock(InstanceState.class);
-  final var instance = mock(Instance.class);
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
 
-  final var contents =
-      MemContents.create(
-          attrs.getValue(Mem.ADDR_ATTR).getWidth(),
-          attrs.getValue(Mem.DATA_ATTR).getWidth(),
-          false);
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
 
-  final var ramState =
-      new RamState(null, contents, new Mem.MemListener(instance));
+    final var ramState = new RamState(null, contents, new Mem.MemListener(instance));
 
-  contents.set(0, 0x1234);
+    contents.set(0, 0x1234);
 
-  when(instance.getAttributeSet()).thenReturn(attrs);
-  when(state.getAttributeSet()).thenReturn(attrs);
-  when(state.getData()).thenReturn(ramState);
-  when(state.getInstance()).thenReturn(instance);
-  when(state.getAttributeValue(Mem.DATA_ATTR))
-      .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-  when(state.getAttributeValue(StdAttr.TRIGGER))
-      .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(ramState);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR)).thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER)).thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
-  when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
-      .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-  when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
-  when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
-      .thenReturn(
-          Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
-  when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs))).thenReturn(Value.TRUE);
 
-  // FALSE -> TRUE: not a falling edge.
-  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
-  ram.propagate(state);
+    // FALSE -> TRUE: not a falling edge.
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs))).thenReturn(Value.TRUE);
+    ram.propagate(state);
 
-  assertEquals(0x1234, contents.get(0));
+    assertEquals(0x1234, contents.get(0));
 
-  // TRUE -> FALSE: falling edge, so write occurs.
-  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-      .thenReturn(Value.FALSE);
-  ram.propagate(state);
+    // TRUE -> FALSE: falling edge, so write occurs.
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs))).thenReturn(Value.FALSE);
+    ram.propagate(state);
 
-  assertEquals(0xABCD, contents.get(0));
-}
+    assertEquals(0xABCD, contents.get(0));
+  }
 
-@Test
+  @Test
   void writesWhenClockIsLow() {
-  final var ram = new Ram();
-  final var attrs = (RamAttributes) ram.createAttributeSet();
-  attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-  attrs.setValue(
-      RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
-  attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_LOW);
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_LOW);
 
-  final var state = mock(InstanceState.class);
-  final var instance = mock(Instance.class);
-  final var contents =
-      MemContents.create(
-          attrs.getValue(Mem.ADDR_ATTR).getWidth(),
-          attrs.getValue(Mem.DATA_ATTR).getWidth(),
-          false);
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
 
-  final var data =
-      new RamState(null, contents, new Mem.MemListener(instance));
+    final var data = new RamState(null, contents, new Mem.MemListener(instance));
 
-  contents.set(0, 0x1234);
+    contents.set(0, 0x1234);
 
-  when(instance.getAttributeSet()).thenReturn(attrs);
-  when(state.getAttributeSet()).thenReturn(attrs);
-  when(state.getData()).thenReturn(data);
-  when(state.getInstance()).thenReturn(instance);
-  when(state.getAttributeValue(Mem.DATA_ATTR))
-      .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-  when(state.getAttributeValue(StdAttr.TRIGGER))
-      .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(data);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR)).thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER)).thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
-  when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
-      .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-  when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-      .thenReturn(Value.FALSE);
-  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-      .thenReturn(Value.FALSE);
-  when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
-      .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
-  when(state.getPortValue(RamAppearance.getBEIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
-  when(state.getPortValue(RamAppearance.getBEIndex(1, attrs)))
-      .thenReturn(Value.TRUE);
-  when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs))).thenReturn(Value.FALSE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs))).thenReturn(Value.FALSE);
+    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+    when(state.getPortValue(RamAppearance.getBEIndex(0, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getBEIndex(1, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs))).thenReturn(Value.TRUE);
 
-  ram.propagate(state);
+    ram.propagate(state);
 
-  assertEquals(0xABCD, contents.get(0));
-}
+    assertEquals(0xABCD, contents.get(0));
+  }
 
-@Test
+  @Test
   void writesWithHighLevelTrigger() {
-  final var ram = new Ram();
-  final var attrs = (RamAttributes) ram.createAttributeSet();
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
 
-  attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-  attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_HIGH);
-  attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
-  attrs.setValue(Mem.LINE_ATTR, Mem.SINGLE);
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_HIGH);
+    attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
+    attrs.setValue(Mem.LINE_ATTR, Mem.SINGLE);
 
-  final var state = mock(InstanceState.class);
-  final var instance = mock(Instance.class);
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
 
-  final var contents =
-      MemContents.create(
-          attrs.getValue(Mem.ADDR_ATTR).getWidth(),
-          attrs.getValue(Mem.DATA_ATTR).getWidth(),
-          false);
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
 
-  final var ramState =
-      new RamState(null, contents, new Mem.MemListener(instance));
+    final var ramState = new RamState(null, contents, new Mem.MemListener(instance));
 
-  contents.set(0, 0x1234);
+    contents.set(0, 0x1234);
 
-  when(instance.getAttributeSet()).thenReturn(attrs);
-  when(state.getAttributeSet()).thenReturn(attrs);
-  when(state.getData()).thenReturn(ramState);
-  when(state.getInstance()).thenReturn(instance);
-  when(state.getAttributeValue(Mem.DATA_ATTR))
-      .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-  when(state.getAttributeValue(StdAttr.TRIGGER))
-      .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(ramState);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR)).thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER)).thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
-  when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
-      .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-  when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
-  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
-  when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
-      .thenReturn(
-          Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
-  when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs))).thenReturn(Value.TRUE);
 
-  ram.propagate(state);
+    ram.propagate(state);
 
-  assertEquals(0xABCD, contents.get(0));
-}
+    assertEquals(0xABCD, contents.get(0));
+  }
 
   @Test
   void byteEnableWritesCoverAllBusStyles() {
     for (var busStyle :
         new AttributeOption[] {
-          RamAttributes.BUS_BIDIR,
-          RamAttributes.BUS_SEP,
-          RamAttributes.BUS_SEP_CONTROLLED
+          RamAttributes.BUS_BIDIR, RamAttributes.BUS_SEP, RamAttributes.BUS_SEP_CONTROLLED
         }) {
       for (var enableMask : new int[] {0b0000, 0b0001, 0b0101, 0b1111}) {
         final var expected = expected32BitValue(enableMask);
 
-        assertWriteResult32(
-            busStyle, enableMask, 0xABCD1234, expected);
+        assertWriteResult32(busStyle, enableMask, 0xABCD1234, expected);
       }
     }
   }
@@ -222,8 +195,7 @@ void writesBothBytesWhenBothEnabled() {
     attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
     attrs.setValue(RamAttributes.ATTR_DBUS, RamAttributes.BUS_BIDIR);
     attrs.setValue(Mem.ENABLES_ATTR, Mem.USEBYTEENABLES);
-    attrs.setValue(
-        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
     attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
 
     assertEquals(0, RamAppearance.getNrDataInPorts(attrs));
@@ -233,73 +205,66 @@ void writesBothBytesWhenBothEnabled() {
     assertEquals(2, RamAppearance.getNrBEPorts(attrs));
   }
 
-@Test
+  @Test
   void readAfterWriteReturnsNewValue() {
-  assertReadWriteBehavior(Mem.READAFTERWRITE, false, 0xABCD);
-}
+    assertReadWriteBehavior(Mem.READAFTERWRITE, false, 0xABCD);
+  }
 
-@Test
+  @Test
   void writeAfterReadReturnsOldValue() {
-  assertReadWriteBehavior(Mem.WRITEAFTERREAD, false, 0x1234);
-}
+    assertReadWriteBehavior(Mem.WRITEAFTERREAD, false, 0x1234);
+  }
 
-@Test
+  @Test
   void asyncReadReturnsCurrentValueWithoutClockEdge() {
-  final var ram = new Ram();
-  final var attrs = (RamAttributes) ram.createAttributeSet();
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
 
-  attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-  attrs.setValue(
-      RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
-  attrs.setValue(Mem.ASYNC_READ, true);
-  attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(Mem.ASYNC_READ, true);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
 
-  final var state = mock(InstanceState.class);
-  final var instance = mock(Instance.class);
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
 
-  final var contents =
-      MemContents.create(
-          attrs.getValue(Mem.ADDR_ATTR).getWidth(),
-          attrs.getValue(Mem.DATA_ATTR).getWidth(),
-          false);
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
 
-  final var ramState =
-      new RamState(null, contents, new Mem.MemListener(instance));
+    final var ramState = new RamState(null, contents, new Mem.MemListener(instance));
 
-  contents.set(0, 0x1234);
+    contents.set(0, 0x1234);
 
-  when(instance.getAttributeSet()).thenReturn(attrs);
-  when(state.getAttributeSet()).thenReturn(attrs);
-  when(state.getData()).thenReturn(ramState);
-  when(state.getInstance()).thenReturn(instance);
-  when(state.getAttributeValue(Mem.DATA_ATTR))
-      .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-  when(state.getAttributeValue(StdAttr.TRIGGER))
-      .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(ramState);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR)).thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER)).thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
-  when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
-      .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-  when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-      .thenReturn(Value.FALSE);
-  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-      .thenReturn(Value.FALSE);
-  when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs))).thenReturn(Value.FALSE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs))).thenReturn(Value.FALSE);
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs))).thenReturn(Value.TRUE);
 
-  final var output = new Value[1];
+    final var output = new Value[1];
 
-  doAnswer(
-      invocation -> {
-          output[0] = invocation.getArgument(1);
-          return null;
-      })
-      .when(state)
-      .setPort(anyInt(), any(Value.class), eq(Mem.DELAY));
+    doAnswer(
+            invocation -> {
+              output[0] = invocation.getArgument(1);
+              return null;
+            })
+        .when(state)
+        .setPort(anyInt(), any(Value.class), eq(Mem.DELAY));
 
-  ram.propagate(state);
+    ram.propagate(state);
 
-  assertEquals(0x1234, output[0].toLongValue());
-}
+    assertEquals(0x1234, output[0].toLongValue());
+  }
 
   private static void assertWriteResult(
       boolean lowByteEnabled, boolean highByteEnabled, int expected) {
@@ -307,8 +272,7 @@ void writesBothBytesWhenBothEnabled() {
     final var ram = new Ram();
     final var attrs = (RamAttributes) ram.createAttributeSet();
     attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-    attrs.setValue(
-        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
     attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
 
     final var state = mock(InstanceState.class);
@@ -328,17 +292,13 @@ void writesBothBytesWhenBothEnabled() {
     when(state.getAttributeSet()).thenReturn(attrs);
     when(state.getData()).thenReturn(data);
     when(state.getInstance()).thenReturn(instance);
-    when(state.getAttributeValue(Mem.DATA_ATTR))
-        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-    when(state.getAttributeValue(StdAttr.TRIGGER))
-        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+    when(state.getAttributeValue(Mem.DATA_ATTR)).thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER)).thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
     when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
         .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs))).thenReturn(Value.TRUE);
     when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
         .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
 
@@ -346,8 +306,7 @@ void writesBothBytesWhenBothEnabled() {
         .thenReturn(lowByteEnabled ? Value.TRUE : Value.FALSE);
     when(state.getPortValue(RamAppearance.getBEIndex(1, attrs)))
         .thenReturn(highByteEnabled ? Value.TRUE : Value.FALSE);
-    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs))).thenReturn(Value.TRUE);
 
     ram.propagate(state);
 
@@ -360,8 +319,7 @@ void writesBothBytesWhenBothEnabled() {
     final var ram = new Ram();
     final var attrs = (RamAttributes) ram.createAttributeSet();
     attrs.setValue(Mem.DATA_ATTR, BitWidth.create(32));
-    attrs.setValue(
-        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
     attrs.setValue(RamAttributes.ATTR_DBUS, busStyle);
     attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
 
@@ -374,8 +332,7 @@ void writesBothBytesWhenBothEnabled() {
             attrs.getValue(Mem.DATA_ATTR).getWidth(),
             false);
 
-    final var ramState =
-        new RamState(null, contents, new Mem.MemListener(instance));
+    final var ramState = new RamState(null, contents, new Mem.MemListener(instance));
 
     contents.set(0, 0x12345678);
 
@@ -383,26 +340,20 @@ void writesBothBytesWhenBothEnabled() {
     when(state.getAttributeSet()).thenReturn(attrs);
     when(state.getData()).thenReturn(ramState);
     when(state.getInstance()).thenReturn(instance);
-    when(state.getAttributeValue(Mem.DATA_ATTR))
-        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-    when(state.getAttributeValue(StdAttr.TRIGGER))
-        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+    when(state.getAttributeValue(Mem.DATA_ATTR)).thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER)).thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
     when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
         .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs))).thenReturn(Value.TRUE);
     when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
         .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), data));
-    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs))).thenReturn(Value.TRUE);
 
     for (int i = 0; i < 4; i++) {
       when(state.getPortValue(RamAppearance.getBEIndex(i, attrs)))
-          .thenReturn(
-              (byteEnableMask & (1 << i)) != 0 ? Value.TRUE : Value.FALSE);
+          .thenReturn((byteEnableMask & (1 << i)) != 0 ? Value.TRUE : Value.FALSE);
     }
 
     ram.propagate(state);
@@ -410,11 +361,7 @@ void writesBothBytesWhenBothEnabled() {
     assertEquals(
         expected & 0xFFFFFFFFL,
         contents.get(0) & 0xFFFFFFFFL,
-        () ->
-            String.format(
-                "Expected 0x%08X but got 0x%08X",
-                expected,
-                contents.get(0)));
+        () -> String.format("Expected 0x%08X but got 0x%08X", expected, contents.get(0)));
   }
 
   private static int expected32BitValue(int enableMask) {
@@ -431,72 +378,62 @@ void writesBothBytesWhenBothEnabled() {
     return expected;
   }
 
-private static void assertReadWriteBehavior(
+  private static void assertReadWriteBehavior(
       AttributeOption readBehavior, boolean asyncRead, int expectedOutput) {
 
-  final var ram = new Ram();
-  final var attrs = (RamAttributes) ram.createAttributeSet();
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
 
-  attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-  attrs.setValue(
-      RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
-  attrs.setValue(Mem.READ_ATTR, readBehavior);
-  attrs.setValue(Mem.ASYNC_READ, asyncRead);
-  attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(Mem.READ_ATTR, readBehavior);
+    attrs.setValue(Mem.ASYNC_READ, asyncRead);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
 
-  final var state = mock(InstanceState.class);
-  final var instance = mock(Instance.class);
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
 
-  final var contents =
-      MemContents.create(
-          attrs.getValue(Mem.ADDR_ATTR).getWidth(),
-          attrs.getValue(Mem.DATA_ATTR).getWidth(),
-          false);
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
 
-  final var ramState =
-      new RamState(null, contents, new Mem.MemListener(instance));
+    final var ramState = new RamState(null, contents, new Mem.MemListener(instance));
 
-  contents.set(0, 0x1234);
+    contents.set(0, 0x1234);
 
-  when(instance.getAttributeSet()).thenReturn(attrs);
-  when(state.getAttributeSet()).thenReturn(attrs);
-  when(state.getData()).thenReturn(ramState);
-  when(state.getInstance()).thenReturn(instance);
-  when(state.getAttributeValue(Mem.DATA_ATTR))
-      .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-  when(state.getAttributeValue(StdAttr.TRIGGER))
-      .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(ramState);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR)).thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER)).thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
-  when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
-      .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-  when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
-  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
-  when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
-      .thenReturn(
-          Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
 
-  when(state.getPortValue(RamAppearance.getBEIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
-  when(state.getPortValue(RamAppearance.getBEIndex(1, attrs)))
-      .thenReturn(Value.TRUE);
-  when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-      .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getBEIndex(0, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getBEIndex(1, attrs))).thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs))).thenReturn(Value.TRUE);
 
-  final var output = new Value[1];
+    final var output = new Value[1];
 
-  doAnswer(
-      invocation -> {
-          output[0] = invocation.getArgument(1);
-          return null;
-      })
-      .when(state)
-      .setPort(anyInt(), any(Value.class), eq(Mem.DELAY));
+    doAnswer(
+            invocation -> {
+              output[0] = invocation.getArgument(1);
+              return null;
+            })
+        .when(state)
+        .setPort(anyInt(), any(Value.class), eq(Mem.DELAY));
 
-  ram.propagate(state);
+    ram.propagate(state);
 
-  assertEquals(0xABCD, contents.get(0));
-  assertEquals(expectedOutput, output[0].toLongValue());
-}
+    assertEquals(0xABCD, contents.get(0));
+    assertEquals(expectedOutput, output[0].toLongValue());
+  }
 }

--- a/src/test/java/com/cburch/logisim/std/memory/RamByteEnableTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/RamByteEnableTest.java
@@ -1,0 +1,502 @@
+package com.cburch.logisim.std.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.data.AttributeOption;
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.instance.Instance;
+import com.cburch.logisim.instance.InstanceState;
+import com.cburch.logisim.instance.StdAttr;
+import org.junit.jupiter.api.Test;
+
+class RamByteEnableTest {
+
+  @Test
+  void writesBothBytesWhenBothEnabled() {
+    assertWriteResult(true, true, 0xABCD);
+  }
+
+  @Test
+  void writesLowByteOnly() {
+    assertWriteResult(true, false, 0x12CD);
+  }
+
+  @Test
+  void writesHighByteOnly() {
+    assertWriteResult(false, true, 0xAB34);
+  }
+
+  @Test
+  void writesNeitherByteWhenBothDisabled() {
+    assertWriteResult(false, false, 0x1234);
+  }
+
+    @Test
+    void writesOnFallingEdge() {
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_FALLING);
+    attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
+    attrs.setValue(Mem.LINE_ATTR, Mem.SINGLE);
+
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
+
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
+
+    final var ramState =
+        new RamState(null, contents, new Mem.MemListener(instance));
+
+    contents.set(0, 0x1234);
+
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(ramState);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR))
+        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER))
+        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+        .thenReturn(
+            Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    // FALSE -> TRUE: not a falling edge.
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    ram.propagate(state);
+
+    assertEquals(0x1234, contents.get(0));
+
+    // TRUE -> FALSE: falling edge, so write occurs.
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+        .thenReturn(Value.FALSE);
+    ram.propagate(state);
+
+    assertEquals(0xABCD, contents.get(0));
+    }
+
+    @Test
+    void writesWhenClockIsLow() {
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(
+        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_LOW);
+
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
+
+    final var data =
+        new RamState(null, contents, new Mem.MemListener(instance));
+
+    contents.set(0, 0x1234);
+
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(data);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR))
+        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER))
+        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+        .thenReturn(Value.FALSE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+        .thenReturn(Value.FALSE);
+    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+    when(state.getPortValue(RamAppearance.getBEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getBEIndex(1, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    ram.propagate(state);
+
+    assertEquals(0xABCD, contents.get(0));
+    }
+
+    @Test
+    void writesWithHighLevelTrigger() {
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_HIGH);
+    attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
+    attrs.setValue(Mem.LINE_ATTR, Mem.SINGLE);
+
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
+
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
+
+    final var ramState =
+        new RamState(null, contents, new Mem.MemListener(instance));
+
+    contents.set(0, 0x1234);
+
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(ramState);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR))
+        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER))
+        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+        .thenReturn(
+            Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    ram.propagate(state);
+
+    assertEquals(0xABCD, contents.get(0));
+    }
+
+  @Test
+  void byteEnableWritesCoverAllBusStyles() {
+    for (var busStyle :
+        new AttributeOption[] {
+          RamAttributes.BUS_BIDIR,
+          RamAttributes.BUS_SEP,
+          RamAttributes.BUS_SEP_CONTROLLED
+        }) {
+      for (var enableMask : new int[] {0b0000, 0b0001, 0b0101, 0b1111}) {
+        final var expected = expected32BitValue(enableMask);
+
+        assertWriteResult32(
+            busStyle, enableMask, 0xABCD1234, expected);
+      }
+    }
+  }
+
+  @Test
+  void configuresBidirectionalDataBus() {
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(RamAttributes.ATTR_DBUS, RamAttributes.BUS_BIDIR);
+    attrs.setValue(Mem.ENABLES_ATTR, Mem.USEBYTEENABLES);
+    attrs.setValue(
+        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+
+    assertEquals(0, RamAppearance.getNrDataInPorts(attrs));
+    assertEquals(1, RamAppearance.getNrDataOutPorts(attrs));
+    assertEquals(1, RamAppearance.getNrOEPorts(attrs));
+    assertEquals(1, RamAppearance.getNrWEPorts(attrs));
+    assertEquals(2, RamAppearance.getNrBEPorts(attrs));
+  }
+
+    @Test
+    void readAfterWriteReturnsNewValue() {
+    assertReadWriteBehavior(Mem.READAFTERWRITE, false, 0xABCD);
+    }
+
+    @Test
+    void writeAfterReadReturnsOldValue() {
+    assertReadWriteBehavior(Mem.WRITEAFTERREAD, false, 0x1234);
+    }
+
+    @Test
+    void asyncReadReturnsCurrentValueWithoutClockEdge() {
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(
+        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(Mem.ASYNC_READ, true);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
+
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
+
+    final var ramState =
+        new RamState(null, contents, new Mem.MemListener(instance));
+
+    contents.set(0, 0x1234);
+
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(ramState);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR))
+        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER))
+        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+        .thenReturn(Value.FALSE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+        .thenReturn(Value.FALSE);
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    final var output = new Value[1];
+
+    doAnswer(
+        invocation -> {
+            output[0] = invocation.getArgument(1);
+            return null;
+        })
+        .when(state)
+        .setPort(anyInt(), any(Value.class), eq(Mem.DELAY));
+
+    ram.propagate(state);
+
+    assertEquals(0x1234, output[0].toLongValue());
+    }
+
+  private static void assertWriteResult(
+      boolean lowByteEnabled, boolean highByteEnabled, int expected) {
+
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(
+        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
+
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
+
+    final var data = new RamState(null, contents, new Mem.MemListener(instance));
+
+    contents.set(0, 0x1234);
+
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(data);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR))
+        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER))
+        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+
+    when(state.getPortValue(RamAppearance.getBEIndex(0, attrs)))
+        .thenReturn(lowByteEnabled ? Value.TRUE : Value.FALSE);
+    when(state.getPortValue(RamAppearance.getBEIndex(1, attrs)))
+        .thenReturn(highByteEnabled ? Value.TRUE : Value.FALSE);
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    ram.propagate(state);
+
+    assertEquals(expected, contents.get(0));
+  }
+
+  private static void assertWriteResult32(
+      AttributeOption busStyle, int byteEnableMask, int data, int expected) {
+
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(32));
+    attrs.setValue(
+        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(RamAttributes.ATTR_DBUS, busStyle);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
+
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
+
+    final var ramState =
+        new RamState(null, contents, new Mem.MemListener(instance));
+
+    contents.set(0, 0x12345678);
+
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(ramState);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR))
+        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER))
+        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), data));
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    for (int i = 0; i < 4; i++) {
+      when(state.getPortValue(RamAppearance.getBEIndex(i, attrs)))
+          .thenReturn(
+              (byteEnableMask & (1 << i)) != 0 ? Value.TRUE : Value.FALSE);
+    }
+
+    ram.propagate(state);
+
+    assertEquals(
+        expected & 0xFFFFFFFFL,
+        contents.get(0) & 0xFFFFFFFFL,
+        () ->
+            String.format(
+                "Expected 0x%08X but got 0x%08X",
+                expected,
+                contents.get(0)));
+  }
+
+  private static int expected32BitValue(int enableMask) {
+    int expected = 0x12345678;
+    final int data = 0xABCD1234;
+
+    for (var i = 0; i < 4; i++) {
+      if ((enableMask & (1 << i)) != 0) {
+        final int mask = 0xFF << (i * 8);
+        expected = (expected & ~mask) | (data & mask);
+      }
+    }
+
+    return expected;
+  }
+
+    private static void assertReadWriteBehavior(
+        AttributeOption readBehavior, boolean asyncRead, int expectedOutput) {
+
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+
+    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+    attrs.setValue(
+        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+    attrs.setValue(Mem.READ_ATTR, readBehavior);
+    attrs.setValue(Mem.ASYNC_READ, asyncRead);
+    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+
+    final var state = mock(InstanceState.class);
+    final var instance = mock(Instance.class);
+
+    final var contents =
+        MemContents.create(
+            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+            attrs.getValue(Mem.DATA_ATTR).getWidth(),
+            false);
+
+    final var ramState =
+        new RamState(null, contents, new Mem.MemListener(instance));
+
+    contents.set(0, 0x1234);
+
+    when(instance.getAttributeSet()).thenReturn(attrs);
+    when(state.getAttributeSet()).thenReturn(attrs);
+    when(state.getData()).thenReturn(ramState);
+    when(state.getInstance()).thenReturn(instance);
+    when(state.getAttributeValue(Mem.DATA_ATTR))
+        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+    when(state.getAttributeValue(StdAttr.TRIGGER))
+        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+
+    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+        .thenReturn(
+            Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+
+    when(state.getPortValue(RamAppearance.getBEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getBEIndex(1, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    final var output = new Value[1];
+
+    doAnswer(
+        invocation -> {
+            output[0] = invocation.getArgument(1);
+            return null;
+        })
+        .when(state)
+        .setPort(anyInt(), any(Value.class), eq(Mem.DELAY));
+
+    ram.propagate(state);
+
+    assertEquals(0xABCD, contents.get(0));
+    assertEquals(expectedOutput, output[0].toLongValue());
+    }
+}

--- a/src/test/java/com/cburch/logisim/std/memory/RamByteEnableTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/RamByteEnableTest.java
@@ -18,10 +18,10 @@ import org.junit.jupiter.api.Test;
 
 class RamByteEnableTest {
 
-  @Test
-  void writesBothBytesWhenBothEnabled() {
+@Test
+void writesBothBytesWhenBothEnabled() {
     assertWriteResult(true, true, 0xABCD);
-  }
+    }
 
   @Test
   void writesLowByteOnly() {
@@ -38,164 +38,164 @@ class RamByteEnableTest {
     assertWriteResult(false, false, 0x1234);
   }
 
-    @Test
-    void writesOnFallingEdge() {
-    final var ram = new Ram();
-    final var attrs = (RamAttributes) ram.createAttributeSet();
+@Test
+  void writesOnFallingEdge() {
+  final var ram = new Ram();
+  final var attrs = (RamAttributes) ram.createAttributeSet();
 
-    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_FALLING);
-    attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
-    attrs.setValue(Mem.LINE_ATTR, Mem.SINGLE);
+  attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+  attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_FALLING);
+  attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
+  attrs.setValue(Mem.LINE_ATTR, Mem.SINGLE);
 
-    final var state = mock(InstanceState.class);
-    final var instance = mock(Instance.class);
+  final var state = mock(InstanceState.class);
+  final var instance = mock(Instance.class);
 
-    final var contents =
-        MemContents.create(
-            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
-            attrs.getValue(Mem.DATA_ATTR).getWidth(),
-            false);
+  final var contents =
+      MemContents.create(
+          attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+          attrs.getValue(Mem.DATA_ATTR).getWidth(),
+          false);
 
-    final var ramState =
-        new RamState(null, contents, new Mem.MemListener(instance));
+  final var ramState =
+      new RamState(null, contents, new Mem.MemListener(instance));
 
-    contents.set(0, 0x1234);
+  contents.set(0, 0x1234);
 
-    when(instance.getAttributeSet()).thenReturn(attrs);
-    when(state.getAttributeSet()).thenReturn(attrs);
-    when(state.getData()).thenReturn(ramState);
-    when(state.getInstance()).thenReturn(instance);
-    when(state.getAttributeValue(Mem.DATA_ATTR))
-        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-    when(state.getAttributeValue(StdAttr.TRIGGER))
-        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+  when(instance.getAttributeSet()).thenReturn(attrs);
+  when(state.getAttributeSet()).thenReturn(attrs);
+  when(state.getData()).thenReturn(ramState);
+  when(state.getInstance()).thenReturn(instance);
+  when(state.getAttributeValue(Mem.DATA_ATTR))
+      .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+  when(state.getAttributeValue(StdAttr.TRIGGER))
+      .thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
-    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
-        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
-        .thenReturn(
-            Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
-    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+      .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+  when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+      .thenReturn(
+          Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+  when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
 
-    // FALSE -> TRUE: not a falling edge.
-    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
-    ram.propagate(state);
+  // FALSE -> TRUE: not a falling edge.
+  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
+  ram.propagate(state);
 
-    assertEquals(0x1234, contents.get(0));
+  assertEquals(0x1234, contents.get(0));
 
-    // TRUE -> FALSE: falling edge, so write occurs.
-    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-        .thenReturn(Value.FALSE);
-    ram.propagate(state);
+  // TRUE -> FALSE: falling edge, so write occurs.
+  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+      .thenReturn(Value.FALSE);
+  ram.propagate(state);
 
-    assertEquals(0xABCD, contents.get(0));
-    }
+  assertEquals(0xABCD, contents.get(0));
+}
 
-    @Test
-    void writesWhenClockIsLow() {
-    final var ram = new Ram();
-    final var attrs = (RamAttributes) ram.createAttributeSet();
-    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-    attrs.setValue(
-        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
-    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_LOW);
+@Test
+  void writesWhenClockIsLow() {
+  final var ram = new Ram();
+  final var attrs = (RamAttributes) ram.createAttributeSet();
+  attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+  attrs.setValue(
+      RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+  attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_LOW);
 
-    final var state = mock(InstanceState.class);
-    final var instance = mock(Instance.class);
-    final var contents =
-        MemContents.create(
-            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
-            attrs.getValue(Mem.DATA_ATTR).getWidth(),
-            false);
+  final var state = mock(InstanceState.class);
+  final var instance = mock(Instance.class);
+  final var contents =
+      MemContents.create(
+          attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+          attrs.getValue(Mem.DATA_ATTR).getWidth(),
+          false);
 
-    final var data =
-        new RamState(null, contents, new Mem.MemListener(instance));
+  final var data =
+      new RamState(null, contents, new Mem.MemListener(instance));
 
-    contents.set(0, 0x1234);
+  contents.set(0, 0x1234);
 
-    when(instance.getAttributeSet()).thenReturn(attrs);
-    when(state.getAttributeSet()).thenReturn(attrs);
-    when(state.getData()).thenReturn(data);
-    when(state.getInstance()).thenReturn(instance);
-    when(state.getAttributeValue(Mem.DATA_ATTR))
-        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-    when(state.getAttributeValue(StdAttr.TRIGGER))
-        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+  when(instance.getAttributeSet()).thenReturn(attrs);
+  when(state.getAttributeSet()).thenReturn(attrs);
+  when(state.getData()).thenReturn(data);
+  when(state.getInstance()).thenReturn(instance);
+  when(state.getAttributeValue(Mem.DATA_ATTR))
+      .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+  when(state.getAttributeValue(StdAttr.TRIGGER))
+      .thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
-    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
-        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-        .thenReturn(Value.FALSE);
-    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-        .thenReturn(Value.FALSE);
-    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
-        .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
-    when(state.getPortValue(RamAppearance.getBEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getBEIndex(1, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+      .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+  when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+      .thenReturn(Value.FALSE);
+  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+      .thenReturn(Value.FALSE);
+  when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+      .thenReturn(Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+  when(state.getPortValue(RamAppearance.getBEIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getBEIndex(1, attrs)))
+      .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
 
-    ram.propagate(state);
+  ram.propagate(state);
 
-    assertEquals(0xABCD, contents.get(0));
-    }
+  assertEquals(0xABCD, contents.get(0));
+}
 
-    @Test
-    void writesWithHighLevelTrigger() {
-    final var ram = new Ram();
-    final var attrs = (RamAttributes) ram.createAttributeSet();
+@Test
+  void writesWithHighLevelTrigger() {
+  final var ram = new Ram();
+  final var attrs = (RamAttributes) ram.createAttributeSet();
 
-    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_HIGH);
-    attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
-    attrs.setValue(Mem.LINE_ATTR, Mem.SINGLE);
+  attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+  attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_HIGH);
+  attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
+  attrs.setValue(Mem.LINE_ATTR, Mem.SINGLE);
 
-    final var state = mock(InstanceState.class);
-    final var instance = mock(Instance.class);
+  final var state = mock(InstanceState.class);
+  final var instance = mock(Instance.class);
 
-    final var contents =
-        MemContents.create(
-            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
-            attrs.getValue(Mem.DATA_ATTR).getWidth(),
-            false);
+  final var contents =
+      MemContents.create(
+          attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+          attrs.getValue(Mem.DATA_ATTR).getWidth(),
+          false);
 
-    final var ramState =
-        new RamState(null, contents, new Mem.MemListener(instance));
+  final var ramState =
+      new RamState(null, contents, new Mem.MemListener(instance));
 
-    contents.set(0, 0x1234);
+  contents.set(0, 0x1234);
 
-    when(instance.getAttributeSet()).thenReturn(attrs);
-    when(state.getAttributeSet()).thenReturn(attrs);
-    when(state.getData()).thenReturn(ramState);
-    when(state.getInstance()).thenReturn(instance);
-    when(state.getAttributeValue(Mem.DATA_ATTR))
-        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-    when(state.getAttributeValue(StdAttr.TRIGGER))
-        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+  when(instance.getAttributeSet()).thenReturn(attrs);
+  when(state.getAttributeSet()).thenReturn(attrs);
+  when(state.getData()).thenReturn(ramState);
+  when(state.getInstance()).thenReturn(instance);
+  when(state.getAttributeValue(Mem.DATA_ATTR))
+      .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+  when(state.getAttributeValue(StdAttr.TRIGGER))
+      .thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
-    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
-        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
-        .thenReturn(
-            Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
-    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+      .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+  when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+      .thenReturn(
+          Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+  when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
 
-    ram.propagate(state);
+  ram.propagate(state);
 
-    assertEquals(0xABCD, contents.get(0));
-    }
+  assertEquals(0xABCD, contents.get(0));
+}
 
   @Test
   void byteEnableWritesCoverAllBusStyles() {
@@ -233,73 +233,73 @@ class RamByteEnableTest {
     assertEquals(2, RamAppearance.getNrBEPorts(attrs));
   }
 
-    @Test
-    void readAfterWriteReturnsNewValue() {
-    assertReadWriteBehavior(Mem.READAFTERWRITE, false, 0xABCD);
-    }
+@Test
+  void readAfterWriteReturnsNewValue() {
+  assertReadWriteBehavior(Mem.READAFTERWRITE, false, 0xABCD);
+}
 
-    @Test
-    void writeAfterReadReturnsOldValue() {
-    assertReadWriteBehavior(Mem.WRITEAFTERREAD, false, 0x1234);
-    }
+@Test
+  void writeAfterReadReturnsOldValue() {
+  assertReadWriteBehavior(Mem.WRITEAFTERREAD, false, 0x1234);
+}
 
-    @Test
-    void asyncReadReturnsCurrentValueWithoutClockEdge() {
-    final var ram = new Ram();
-    final var attrs = (RamAttributes) ram.createAttributeSet();
+@Test
+  void asyncReadReturnsCurrentValueWithoutClockEdge() {
+  final var ram = new Ram();
+  final var attrs = (RamAttributes) ram.createAttributeSet();
 
-    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-    attrs.setValue(
-        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
-    attrs.setValue(Mem.ASYNC_READ, true);
-    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+  attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+  attrs.setValue(
+      RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+  attrs.setValue(Mem.ASYNC_READ, true);
+  attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
 
-    final var state = mock(InstanceState.class);
-    final var instance = mock(Instance.class);
+  final var state = mock(InstanceState.class);
+  final var instance = mock(Instance.class);
 
-    final var contents =
-        MemContents.create(
-            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
-            attrs.getValue(Mem.DATA_ATTR).getWidth(),
-            false);
+  final var contents =
+      MemContents.create(
+          attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+          attrs.getValue(Mem.DATA_ATTR).getWidth(),
+          false);
 
-    final var ramState =
-        new RamState(null, contents, new Mem.MemListener(instance));
+  final var ramState =
+      new RamState(null, contents, new Mem.MemListener(instance));
 
-    contents.set(0, 0x1234);
+  contents.set(0, 0x1234);
 
-    when(instance.getAttributeSet()).thenReturn(attrs);
-    when(state.getAttributeSet()).thenReturn(attrs);
-    when(state.getData()).thenReturn(ramState);
-    when(state.getInstance()).thenReturn(instance);
-    when(state.getAttributeValue(Mem.DATA_ATTR))
-        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-    when(state.getAttributeValue(StdAttr.TRIGGER))
-        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+  when(instance.getAttributeSet()).thenReturn(attrs);
+  when(state.getAttributeSet()).thenReturn(attrs);
+  when(state.getData()).thenReturn(ramState);
+  when(state.getInstance()).thenReturn(instance);
+  when(state.getAttributeValue(Mem.DATA_ATTR))
+      .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+  when(state.getAttributeValue(StdAttr.TRIGGER))
+      .thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
-    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
-        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-        .thenReturn(Value.FALSE);
-    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-        .thenReturn(Value.FALSE);
-    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+      .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+  when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+      .thenReturn(Value.FALSE);
+  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+      .thenReturn(Value.FALSE);
+  when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
 
-    final var output = new Value[1];
+  final var output = new Value[1];
 
-    doAnswer(
-        invocation -> {
-            output[0] = invocation.getArgument(1);
-            return null;
-        })
-        .when(state)
-        .setPort(anyInt(), any(Value.class), eq(Mem.DELAY));
+  doAnswer(
+      invocation -> {
+          output[0] = invocation.getArgument(1);
+          return null;
+      })
+      .when(state)
+      .setPort(anyInt(), any(Value.class), eq(Mem.DELAY));
 
-    ram.propagate(state);
+  ram.propagate(state);
 
-    assertEquals(0x1234, output[0].toLongValue());
-    }
+  assertEquals(0x1234, output[0].toLongValue());
+}
 
   private static void assertWriteResult(
       boolean lowByteEnabled, boolean highByteEnabled, int expected) {
@@ -431,72 +431,72 @@ class RamByteEnableTest {
     return expected;
   }
 
-    private static void assertReadWriteBehavior(
-        AttributeOption readBehavior, boolean asyncRead, int expectedOutput) {
+private static void assertReadWriteBehavior(
+      AttributeOption readBehavior, boolean asyncRead, int expectedOutput) {
 
-    final var ram = new Ram();
-    final var attrs = (RamAttributes) ram.createAttributeSet();
+  final var ram = new Ram();
+  final var attrs = (RamAttributes) ram.createAttributeSet();
 
-    attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
-    attrs.setValue(
-        RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
-    attrs.setValue(Mem.READ_ATTR, readBehavior);
-    attrs.setValue(Mem.ASYNC_READ, asyncRead);
-    attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
+  attrs.setValue(Mem.DATA_ATTR, BitWidth.create(16));
+  attrs.setValue(
+      RamAttributes.ATTR_ByteEnables, RamAttributes.BUS_WITH_BYTEENABLES);
+  attrs.setValue(Mem.READ_ATTR, readBehavior);
+  attrs.setValue(Mem.ASYNC_READ, asyncRead);
+  attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
 
-    final var state = mock(InstanceState.class);
-    final var instance = mock(Instance.class);
+  final var state = mock(InstanceState.class);
+  final var instance = mock(Instance.class);
 
-    final var contents =
-        MemContents.create(
-            attrs.getValue(Mem.ADDR_ATTR).getWidth(),
-            attrs.getValue(Mem.DATA_ATTR).getWidth(),
-            false);
+  final var contents =
+      MemContents.create(
+          attrs.getValue(Mem.ADDR_ATTR).getWidth(),
+          attrs.getValue(Mem.DATA_ATTR).getWidth(),
+          false);
 
-    final var ramState =
-        new RamState(null, contents, new Mem.MemListener(instance));
+  final var ramState =
+      new RamState(null, contents, new Mem.MemListener(instance));
 
-    contents.set(0, 0x1234);
+  contents.set(0, 0x1234);
 
-    when(instance.getAttributeSet()).thenReturn(attrs);
-    when(state.getAttributeSet()).thenReturn(attrs);
-    when(state.getData()).thenReturn(ramState);
-    when(state.getInstance()).thenReturn(instance);
-    when(state.getAttributeValue(Mem.DATA_ATTR))
-        .thenReturn(attrs.getValue(Mem.DATA_ATTR));
-    when(state.getAttributeValue(StdAttr.TRIGGER))
-        .thenReturn(attrs.getValue(StdAttr.TRIGGER));
+  when(instance.getAttributeSet()).thenReturn(attrs);
+  when(state.getAttributeSet()).thenReturn(attrs);
+  when(state.getData()).thenReturn(ramState);
+  when(state.getInstance()).thenReturn(instance);
+  when(state.getAttributeValue(Mem.DATA_ATTR))
+      .thenReturn(attrs.getValue(Mem.DATA_ATTR));
+  when(state.getAttributeValue(StdAttr.TRIGGER))
+      .thenReturn(attrs.getValue(StdAttr.TRIGGER));
 
-    when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
-        .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
-    when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
-        .thenReturn(
-            Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
+  when(state.getPortValue(RamAppearance.getAddrIndex(0, attrs)))
+      .thenReturn(Value.createKnown(attrs.getValue(Mem.ADDR_ATTR), 0));
+  when(state.getPortValue(RamAppearance.getWEIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getDataInIndex(0, attrs)))
+      .thenReturn(
+          Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0xABCD));
 
-    when(state.getPortValue(RamAppearance.getBEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getBEIndex(1, attrs)))
-        .thenReturn(Value.TRUE);
-    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
-        .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getBEIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getBEIndex(1, attrs)))
+      .thenReturn(Value.TRUE);
+  when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+      .thenReturn(Value.TRUE);
 
-    final var output = new Value[1];
+  final var output = new Value[1];
 
-    doAnswer(
-        invocation -> {
-            output[0] = invocation.getArgument(1);
-            return null;
-        })
-        .when(state)
-        .setPort(anyInt(), any(Value.class), eq(Mem.DELAY));
+  doAnswer(
+      invocation -> {
+          output[0] = invocation.getArgument(1);
+          return null;
+      })
+      .when(state)
+      .setPort(anyInt(), any(Value.class), eq(Mem.DELAY));
 
-    ram.propagate(state);
+  ram.propagate(state);
 
-    assertEquals(0xABCD, contents.get(0));
-    assertEquals(expectedOutput, output[0].toLongValue());
-    }
+  assertEquals(0xABCD, contents.get(0));
+  assertEquals(expectedOutput, output[0].toLongValue());
+}
 }

--- a/src/test/java/com/cburch/logisim/std/memory/RamLineEnableTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/RamLineEnableTest.java
@@ -79,6 +79,152 @@ class RamLineEnableTest {
   }
 
   @Test
+  void ramErrorAddressDrivesErrorOutput() {
+    final var ram = new Ram();
+    final var attrs = ramAttrs(Mem.SINGLE);
+    final var state = new TestInstanceState(ram, attrs);
+    final var contents =
+        MemContents.create(ADDR_WIDTH.getWidth(), DATA_WIDTH.getWidth(), false);
+
+    state.setData(
+        new RamState(
+            state.getInstance(),
+            contents,
+            new Mem.MemListener(state.getInstance())));
+
+    state.setPortValue(
+        RamAppearance.getAddrIndex(0, attrs),
+        Value.createError(ADDR_WIDTH));
+    state.setPortValue(
+        RamAppearance.getOEIndex(0, attrs),
+        Value.TRUE);
+
+    ram.propagate(state);
+
+    assertEquals(
+        Value.createError(DATA_WIDTH),
+        state.getPortValue(RamAppearance.getDataOutIndex(0, attrs)));
+  }
+
+  @Test
+  void ramUnknownAddressDrivesUnknownOutput() {
+    final var ram = new Ram();
+    final var attrs = ramAttrs(Mem.SINGLE);
+    final var state = new TestInstanceState(ram, attrs);
+    final var contents =
+        MemContents.create(ADDR_WIDTH.getWidth(), DATA_WIDTH.getWidth(), false);
+
+    state.setData(
+        new RamState(
+            state.getInstance(),
+            contents,
+            new Mem.MemListener(state.getInstance())));
+
+    state.setPortValue(
+        RamAppearance.getAddrIndex(0, attrs),
+        Value.createUnknown(ADDR_WIDTH));
+    state.setPortValue(
+        RamAppearance.getOEIndex(0, attrs),
+        Value.TRUE);
+
+    ram.propagate(state);
+
+    assertEquals(
+        Value.createUnknown(DATA_WIDTH),
+        state.getPortValue(RamAppearance.getDataOutIndex(0, attrs)));
+  }
+
+  private static void verifyLineEnableConfiguration(
+      AttributeOption busStyle, AttributeOption lineSize, int enableMask) {
+
+    final var ram = new Ram();
+    final var attrs = ramAttrs(lineSize, busStyle);
+    final var state = new TestInstanceState(ram, attrs);
+    final var contents =
+        MemContents.create(ADDR_WIDTH.getWidth(), DATA_WIDTH.getWidth(), false);
+
+    state.setData(
+        new RamState(
+            state.getInstance(), contents, new Mem.MemListener(state.getInstance())));
+
+    final int dataLines =
+        lineSize.equals(Mem.SINGLE)
+            ? 1
+            : lineSize.equals(Mem.DUAL)
+                ? 2
+                : lineSize.equals(Mem.QUAD) ? 4 : 8;
+
+    state.setPortValue(
+        RamAppearance.getAddrIndex(0, attrs), known(ADDR_WIDTH, 0));
+    state.setPortValue(RamAppearance.getWEIndex(0, attrs), Value.TRUE);
+    state.setPortValue(RamAppearance.getClkIndex(0, attrs), Value.TRUE);
+
+    for (var i = 0; i < dataLines; i++) {
+      state.setPortValue(
+          RamAppearance.getDataInIndex(i, attrs), known(DATA_WIDTH, 0x40 + i));
+
+      if (dataLines > 1) {
+        state.setPortValue(
+          RamAppearance.getLEIndex(i, attrs),
+          (enableMask & (1 << i)) != 0 ? Value.TRUE : Value.FALSE);
+      }
+    }
+
+    ram.propagate(state);
+
+    for (var i = 0; i < dataLines; i++) {
+      final var expected =
+          dataLines == 1
+              ? 0x40
+              : (enableMask & (1 << i)) != 0 ? 0x40 + i : 0;
+
+      assertEquals(
+          expected,
+          contents.get(i),
+          "unexpected value at line " + i
+              + " for bus=" + busStyle
+              + ", lineSize=" + lineSize
+              + ", enableMask=" + Integer.toBinaryString(enableMask));
+    }
+  }
+
+  @Test
+  void ramDualLineWritesOnlyEnabledLines() {
+    verifyRamLineWritesOnlyEnabledLines(Mem.DUAL, 2);
+  }
+
+  @Test
+  void ramQuadLineWritesOnlyEnabledLines() {
+    verifyRamLineWritesOnlyEnabledLines(Mem.QUAD, 4);
+  }
+
+  @Test
+  void lineEnableWritesCoverAllBusStylesAndLineSizes() {
+    final var busStyles =
+        new AttributeOption[] {
+          RamAttributes.BUS_BIDIR,
+          RamAttributes.BUS_SEP,
+          RamAttributes.BUS_SEP_CONTROLLED
+        };
+
+    final var lineSizes =
+        new AttributeOption[] {
+          Mem.SINGLE,
+          Mem.DUAL,
+          Mem.QUAD,
+          Mem.OCTO
+        };
+
+    for (var bus : busStyles) {
+      for (var lineSize : lineSizes) {
+        for (var enableMask : new int[] {0b0000, 0b0001, 0b0101, 0b1111}) {
+          verifyLineEnableConfiguration(bus, lineSize, enableMask);
+        }
+      }
+    }
+  }
+
+  @Test
   void ramOctoLineAllowMisalignedWritesOnlyTrueLineAtArbitraryAddress() {
     final var ram = new Ram();
     final var attrs = ramAttrs(Mem.OCTO);
@@ -151,6 +297,28 @@ class RamLineEnableTest {
   }
 
   @Test
+  void dualRamLineEnableWritesCoverDualQuadOcto() {
+    for (var lineSize :
+        new AttributeOption[] {
+          Mem.DUAL,
+          Mem.QUAD,
+          Mem.OCTO
+        }) {
+      for (var port = 0; port < 2; port++) {
+        final var dataLines =
+            lineSize.equals(Mem.DUAL) ? 2
+                : lineSize.equals(Mem.QUAD) ? 4
+                : 8;
+
+        for (var enableMask : new int[] {0, 1, (1 << (dataLines - 1)), (1 << dataLines) - 1}) {
+          verifyDualRamLineEnableConfiguration(
+              lineSize, port, enableMask, dataLines);
+        }
+      }
+    }
+  }
+
+  @Test
   void dualRamOctoLineDisallowedMisalignmentKeepsFixedLineAlignment() {
     final var ram = new DualRam();
     final var attrs = dualRamAttrs(Mem.OCTO);
@@ -169,6 +337,37 @@ class RamLineEnableTest {
 
     assertEquals(0, contents.get(3));
     assertEquals(Value.createError(DATA_WIDTH), state.getPortValue(DualRamAppearance.getDataOutIndex(0, attrs)));
+  }
+
+  private static void verifyRamLineWritesOnlyEnabledLines(
+      AttributeOption lineSize, int dataLines) {
+
+    final var ram = new Ram();
+    final var attrs = ramAttrs(lineSize);
+    final var state = new TestInstanceState(ram, attrs);
+    final var contents =
+        MemContents.create(ADDR_WIDTH.getWidth(), DATA_WIDTH.getWidth(), false);
+
+    state.setData(
+        new RamState(state.getInstance(), contents, new Mem.MemListener(state.getInstance())));
+
+    state.setPortValue(RamAppearance.getAddrIndex(0, attrs), known(ADDR_WIDTH, 0));
+    state.setPortValue(RamAppearance.getWEIndex(0, attrs), Value.TRUE);
+    state.setPortValue(RamAppearance.getClkIndex(0, attrs), Value.TRUE);
+
+    for (var i = 0; i < dataLines; i++) {
+      state.setPortValue(
+          RamAppearance.getDataInIndex(i, attrs), known(DATA_WIDTH, 0x30 + i));
+      state.setPortValue(
+          RamAppearance.getLEIndex(i, attrs), i == 0 ? Value.TRUE : Value.FALSE);
+    }
+
+    ram.propagate(state);
+
+    assertEquals(0x30, contents.get(0));
+    for (var i = 1; i < dataLines; i++) {
+      assertEquals(0, contents.get(i), "disabled line " + i + " must not be written");
+    }
   }
 
   private static void verifyDualRamOctoLineWritesOnlyEnabledLine(int port, int baseAddress, int dataBase) {
@@ -197,6 +396,60 @@ class RamLineEnableTest {
           0,
           contents.get(baseAddress + i),
           "port " + port + " line " + i + " must not be written by unknown LE");
+    }
+  }
+
+  private static void verifyDualRamLineEnableConfiguration(
+      AttributeOption lineSize, int port, int enableMask, int dataLines) {
+
+    final var ram = new DualRam();
+    final var attrs = dualRamAttrs(lineSize);
+    final var state = new TestInstanceState(ram, attrs);
+    final var contents =
+        MemContents.create(ADDR_WIDTH.getWidth(), DATA_WIDTH.getWidth(), false);
+
+    state.setData(
+        new RamState(
+            state.getInstance(),
+            contents,
+            new Mem.MemListener(state.getInstance())));
+
+    final var baseLine = port * dataLines;
+    final var baseAddress = port == 0 ? 0 : 8;
+
+    state.setPortValue(
+        DualRamAppearance.getAddrIndex(port, attrs),
+        known(ADDR_WIDTH, baseAddress));
+    state.setPortValue(
+        DualRamAppearance.getWEIndex(port, attrs),
+        Value.TRUE);
+    state.setPortValue(
+        DualRamAppearance.getClkIndex(port, attrs),
+        Value.TRUE);
+
+    for (var i = 0; i < dataLines; i++) {
+      state.setPortValue(
+          DualRamAppearance.getDataInIndex(baseLine + i, attrs),
+          known(DATA_WIDTH, 0x40 + i));
+
+      state.setPortValue(
+          DualRamAppearance.getLEIndex(baseLine + i, attrs),
+          (enableMask & (1 << i)) != 0 ? Value.TRUE : Value.FALSE);
+    }
+
+    ram.propagate(state);
+
+    for (var i = 0; i < dataLines; i++) {
+      final var expected =
+          (enableMask & (1 << i)) != 0 ? 0x40 + i : 0;
+
+      assertEquals(
+          expected,
+          contents.get(baseAddress + i),
+          "unexpected value at line " + i
+              + " for port=" + port
+              + ", lineSize=" + lineSize
+              + ", enableMask=" + Integer.toBinaryString(enableMask));
     }
   }
 
@@ -234,15 +487,19 @@ class RamLineEnableTest {
     }
   }
 
-  private static AttributeSet ramAttrs(AttributeOption lineSize) {
+  private static AttributeSet ramAttrs(AttributeOption lineSize, AttributeOption busStyle) {
     final var attrs = new Ram().createAttributeSet();
     attrs.setValue(Mem.ADDR_ATTR, ADDR_WIDTH);
     attrs.setValue(Mem.DATA_ATTR, DATA_WIDTH);
     attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
     attrs.setValue(Mem.LINE_ATTR, lineSize);
-    attrs.setValue(RamAttributes.ATTR_DBUS, RamAttributes.BUS_SEP);
+    attrs.setValue(RamAttributes.ATTR_DBUS, busStyle);
     attrs.setValue(StdAttr.TRIGGER, StdAttr.TRIG_RISING);
     return attrs;
+  }
+
+  private static AttributeSet ramAttrs(AttributeOption lineSize) {
+    return ramAttrs(lineSize, RamAttributes.BUS_SEP);
   }
 
   private static AttributeSet dualRamAttrs(AttributeOption lineSize) {
@@ -260,14 +517,14 @@ class RamLineEnableTest {
     return Value.createKnown(width, value);
   }
 
-  private static final class TestInstanceState implements com.cburch.logisim.instance.InstanceState {
+  static final class TestInstanceState implements com.cburch.logisim.instance.InstanceState {
     private final AttributeSet attrs;
     private final Instance instance;
     private final Map<Integer, Value> portValues = new HashMap<>();
     private final Set<Integer> connectedPorts = new HashSet<>();
     private InstanceData data;
 
-    private TestInstanceState(InstanceFactory factory, AttributeSet attrs) {
+    TestInstanceState(InstanceFactory factory, AttributeSet attrs) {
       this.attrs = attrs;
       final var component = factory.createComponent(Location.create(0, 0, false), attrs);
       this.instance = Instance.getInstanceFor(component);
@@ -346,7 +603,7 @@ class RamLineEnableTest {
       portValues.put(portIndex, value);
     }
 
-    private void setPortValue(int portIndex, Value value) {
+    void setPortValue(int portIndex, Value value) {
       portValues.put(portIndex, value);
       connectPort(portIndex);
     }

--- a/src/test/java/com/cburch/logisim/std/memory/RamLineEnableTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/RamLineEnableTest.java
@@ -165,8 +165,8 @@ class RamLineEnableTest {
 
       if (dataLines > 1) {
         state.setPortValue(
-          RamAppearance.getLEIndex(i, attrs),
-          (enableMask & (1 << i)) != 0 ? Value.TRUE : Value.FALSE);
+            RamAppearance.getLEIndex(i, attrs),
+            (enableMask & (1 << i)) != 0 ? Value.TRUE : Value.FALSE);
       }
     }
 

--- a/src/test/java/com/cburch/logisim/std/memory/RamOutputEnableTest.java
+++ b/src/test/java/com/cburch/logisim/std/memory/RamOutputEnableTest.java
@@ -9,6 +9,7 @@
 
 package com.cburch.logisim.std.memory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -102,6 +103,84 @@ class RamOutputEnableTest {
 
     attrs.setValue(Mem.ENABLES_ATTR, Mem.USELINEENABLES);
     assertFalse(hdl.isHdlSupportedTarget(attrs));
+  }
+
+  @Test
+  void outputEnableDrivesStoredValueOnSeparateBus() {
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+    attrs.setValue(RamAttributes.ATTR_DBUS, RamAttributes.BUS_SEP);
+
+    final var state = ramState(attrs);
+    when(state.getPortValue(RamAppearance.getOEIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+    when(state.getPortValue(RamAppearance.getClkIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    ram.propagate(state);
+
+    verify(state)
+        .setPort(
+            RamAppearance.getDataOutIndex(0, attrs),
+            Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0x5A),
+            Mem.DELAY);
+  }
+
+  @Test
+  void clearPinClearsMemoryAndDrivesZeroOnSeparateBus() {
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+    attrs.setValue(RamAttributes.CLEAR_PIN, true);
+    attrs.setValue(RamAttributes.ATTR_DBUS, RamAttributes.BUS_SEP);
+
+    final var state = ramState(attrs);
+    when(state.getPortValue(RamAppearance.getClrIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    ram.propagate(state);
+
+    verify(state)
+        .setPort(
+            RamAppearance.getDataOutIndex(0, attrs),
+            Value.createKnown(attrs.getValue(Mem.DATA_ATTR), 0),
+            Mem.DELAY);
+  }
+
+  @Test
+  void clearPinDrivesUnknownOnBidirectionalBus() {
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+    attrs.setValue(RamAttributes.CLEAR_PIN, true);
+    attrs.setValue(RamAttributes.ATTR_DBUS, RamAttributes.BUS_BIDIR);
+
+    final var state = ramState(attrs);
+    when(state.getPortValue(RamAppearance.getClrIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    ram.propagate(state);
+
+    verify(state)
+        .setPort(
+            RamAppearance.getDataOutIndex(0, attrs),
+            Value.createUnknown(attrs.getValue(Mem.DATA_ATTR)),
+            Mem.DELAY);
+  }
+
+  @Test
+  void clearPinActuallyErasesMemory() {
+    final var ram = new Ram();
+    final var attrs = (RamAttributes) ram.createAttributeSet();
+    attrs.setValue(RamAttributes.CLEAR_PIN, true);
+    attrs.setValue(RamAttributes.ATTR_DBUS, RamAttributes.BUS_SEP);
+
+    final var state = ramState(attrs);
+    when(state.getPortValue(RamAppearance.getClrIndex(0, attrs)))
+        .thenReturn(Value.TRUE);
+
+    ram.propagate(state);
+
+    final var data = (RamState) state.getData();
+    assertEquals(0, data.getContents().get(0));
   }
 
   private static InstanceState ramState(RamAttributes attrs) {


### PR DESCRIPTION
## Description

Adds comprehensive regression coverage for the RAM and DualRAM components,
including byte enables, line enables, output enables, clear behavior,
address edge cases, misaligned accesses, and dual-port behavior.

Also fixes a DualRAM byte-enable write issue where the previous memory value
was read using the shared/current address instead of the address associated
with the active port.

## Changes

### RAM
- Add byte-enable write/read regression tests
- Expand line-enable coverage for single, dual, quad, and octo configurations
- Verify that only enabled lines are written
- Add misaligned-access coverage with `ALLOW_MISALIGNED` enabled and disabled
- Add unknown, error, and invalid-address output behavior tests
- Add output-enable behavior tests for the supported bus configurations
- Add clear-pin behavior tests, including verification that memory is actually cleared

### DualRAM
- Add byte-enable coverage for both Port A and Port B
- Verify different byte-enable selections on the two ports
- Add line-enable coverage for both ports across dual, quad, and octo configurations
- Add misaligned-access regression coverage
- Verify that disabled lines/bytes do not modify memory
- Fix byte-enable writes to use the correct per-port current address

## Testing

- `./gradlew test --tests 'com.cburch.logisim.std.memory.*Test'`
- `git diff --check`

All tests pass.

## Related issue

Related to [#2728](https://github.com/logisim-evolution/logisim-evolution/issues/2728)