### PR TITLE
docs: add floating-point conversions

### DIFF
--- a/src/main/resources/doc/en/contents.xml
+++ b/src/main/resources/doc/en/contents.xml
@@ -183,6 +183,9 @@
 			<tocitem target="fparith_round" text="Floating Point Round" />
 			<tocitem target="fparith_trigonometry" text="Floating Point Trigonometry" />
 			<tocitem target="fparith_classificator" text="Floating Point Classificator" />
+			<tocitem target="fparith_fpconverter" text="Floating Point Converter" />
+			<tocitem target="fparith_fptoint" text="Floating Point to Integer" />
+			<tocitem target="fparith_inttofp" text="Integer to Floating Point" />
 		</tocitem>
 		<tocitem target="mem" text="Memory library">
 			<tocitem target="mem_flipflops" text="D/T/J-K/S-R Flip-Flop" image="icon_flipflops" />

--- a/src/main/resources/doc/en/html/libs/fparith/fpconverter.html
+++ b/src/main/resources/doc/en/html/libs/fparith/fpconverter.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point Converter</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>FP&rarr;FP</strong> <em>Floating Point Converter</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component converts a floating-point value between independently selected input and
+        output formats. The letters drawn beside the ports identify the format: <b>M</b> for 8-bit
+        minifloat, <b>H</b> for binary16, <b>F</b> for binary32, and <b>D</b> for binary64.
+      </p>
+      <p>
+        Narrowing conversion rounds to the output precision. A finite value may overflow to
+        infinity or underflow to a subnormal value or zero. The conversion is numeric rather than
+        bit-preserving, so a NaN payload may be normalized even when both sizes are the same.
+      </p>
+      <p>
+        The <var>ERR</var> output is 1 when the input is NaN and 0 otherwise. An input containing
+        unknown or error bits is converted to NaN. Overflow to infinity does not set
+        <var>ERR</var>.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge (input, bit width matches Input float size)</dt>
+        <dd>The floating-point value to convert.</dd>
+        <dt>East edge (output, bit width matches Output float size)</dt>
+        <dd>The value represented in the selected output format.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the input is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Input float size</b></dt>
+          <dd>The input format: 8, 16, 32, or 64 bits.</dd>
+          <dt><b class="propertie">Output float size</b></dt>
+          <dd>The output format: 8, 16, 32, or 64 bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/fptoint.html
+++ b/src/main/resources/doc/en/html/libs/fparith/fptoint.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Floating Point to Integer</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>FP&rarr;I</strong> <em>Floating Point to Integer</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component rounds the floating-point input to a signed 64-bit integer intermediate,
+        then places the low <b class="propertie">Data Bits</b> bits on the east output. The output
+        is a signed two's-complement value.
+      </p>
+      <dl>
+        <dt><b class="propertie">Round up</b></dt>
+        <dd>Rounds toward positive infinity.</dd>
+        <dt><b class="propertie">Round down</b></dt>
+        <dd>Rounds toward negative infinity.</dd>
+        <dt><b class="propertie">Round to nearest</b></dt>
+        <dd>Rounds to the nearest integer; a halfway case is rounded toward positive infinity.</dd>
+        <dt><b class="propertie">Round to nearest, ties to even</b></dt>
+        <dd>Rounds to the nearest integer; a halfway case is rounded to the even integer.</dd>
+        <dt><b class="propertie">Truncate</b></dt>
+        <dd>Discards the fractional part, rounding toward zero.</dd>
+      </dl>
+      <p>
+        NaN converts to zero and sets <var>ERR</var> to 1. Values above or below the signed 64-bit
+        range, including positive and negative infinity, are limited to the corresponding 64-bit
+        endpoint. If the selected output width is smaller than 64 bits, higher bits are discarded;
+        neither saturation nor discarded bits set <var>ERR</var>.
+      </p>
+      <p>An input containing unknown or error bits is converted to NaN.</p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge (input, bit width matches Float size)</dt>
+        <dd>The floating-point value to convert.</dd>
+        <dt>East edge (output, bit width matches Data Bits)</dt>
+        <dd>The low bits of the rounded signed integer result.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the input is NaN; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Data Bits</b></dt>
+          <dd>The integer output width, from 1 to 64 bits.</dd>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point input width: 8, 16, 32, or 64 bits.</dd>
+          <dt><b class="propertie">Rounding mode</b></dt>
+          <dd>Selects the rounding operation used before the result is reduced to the output width.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/fparith/index.html
+++ b/src/main/resources/doc/en/html/libs/fparith/index.html
@@ -116,6 +116,26 @@
           </tr>
         </tbody>
       </table>
+      <h2>Conversions</h2>
+      <table>
+        <tbody>
+          <tr>
+            <td align="right"><a href="fpconverter.html"><strong>FP&rarr;FP</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="fpconverter.html">Floating Point Converter</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="fptoint.html"><strong>FP&rarr;I</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="fptoint.html">Floating Point to Integer</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="inttofp.html"><strong>I&rarr;FP</strong></a></td>
+            <td>&nbsp;</td>
+            <td><a href="inttofp.html">Integer to Floating Point</a></td>
+          </tr>
+        </tbody>
+      </table>
       <p><b>Back to</b> <a href="../index.html">Library Reference</a></p>
     </div>
   </body>

--- a/src/main/resources/doc/en/html/libs/fparith/inttofp.html
+++ b/src/main/resources/doc/en/html/libs/fparith/inttofp.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Integer to Floating Point</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1><strong>I&rarr;FP</strong> <em>Integer to Floating Point</em></h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Floating Point Arithmetic</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Behavior</h2>
+      <p>
+        This component interprets the integer on its west input according to
+        <b class="propertie">Numeric Type</b>, then converts that numeric value to the selected
+        floating-point format.
+      </p>
+      <p>
+        <b class="propertie">2’s Complement</b> treats the most significant input bit as a sign
+        bit. <b class="propertie">Unsigned</b> treats every input bit as part of a nonnegative
+        magnitude, including for a 64-bit input.
+      </p>
+      <p>
+        An integer that cannot be represented exactly is rounded to the output precision. A large
+        magnitude may overflow to infinity. Neither rounding nor overflow sets <var>ERR</var>.
+        If the input contains unknown or error bits, the result is NaN and <var>ERR</var> is 1.
+      </p>
+      <h2>Pins</h2>
+      <dl>
+        <dt>West edge (input, bit width matches Data Bits)</dt>
+        <dd>The signed or unsigned integer value to convert.</dd>
+        <dt>East edge (output, bit width matches Float size)</dt>
+        <dd>The floating-point representation of the input value.</dd>
+        <dt>South edge (output, bit width 1)</dt>
+        <dd><var>ERR</var>: 1 if the integer input is not fully defined; otherwise 0.</dd>
+      </dl>
+      <h2>Attributes</h2>
+      <div class="attliste">
+        <dl>
+          <dt><b class="propertie">Data Bits</b></dt>
+          <dd>The integer input width, from 1 to 64 bits.</dd>
+          <dt><b class="propertie">Float size</b></dt>
+          <dd>The floating-point output width: 8, 16, 32, or 64 bits.</dd>
+          <dt><b class="propertie">Numeric Type</b></dt>
+          <dd>Selects signed two's-complement or unsigned interpretation of the input bits.</dd>
+        </dl>
+      </div>
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+      <p><b>Back to</b> <a href="index.html">Floating Point Arithmetic library</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/index.html
+++ b/src/main/resources/doc/en/html/libs/index.html
@@ -561,6 +561,21 @@
           <td>&nbsp;</td>
           <td><a href="fparith/classificator.html">Floating Point Classificator</a></td>
         </tr>
+        <tr>
+          <td align="right"><a href="fparith/fpconverter.html"><strong>FP&rarr;FP</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/fpconverter.html">Floating Point Converter</a></td>
+        </tr>
+        <tr>
+          <td align="right"><a href="fparith/fptoint.html"><strong>FP&rarr;I</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/fptoint.html">Floating Point to Integer</a></td>
+        </tr>
+        <tr>
+          <td align="right"><a href="fparith/inttofp.html"><strong>I&rarr;FP</strong></a></td>
+          <td>&nbsp;</td>
+          <td><a href="fparith/inttofp.html">Integer to Floating Point</a></td>
+        </tr>
       </tbody>
     </table>
 	    <h2>

--- a/src/main/resources/doc/map_en.jhm
+++ b/src/main/resources/doc/map_en.jhm
@@ -167,6 +167,9 @@
 	<mapID target="fparith_round"         url="en/html/libs/fparith/round.html" />
 	<mapID target="fparith_trigonometry"  url="en/html/libs/fparith/trigonometry.html" />
 	<mapID target="fparith_classificator" url="en/html/libs/fparith/classificator.html" />
+	<mapID target="fparith_fpconverter"   url="en/html/libs/fparith/fpconverter.html" />
+	<mapID target="fparith_fptoint"       url="en/html/libs/fparith/fptoint.html" />
+	<mapID target="fparith_inttofp"       url="en/html/libs/fparith/inttofp.html" />
 	<mapID target="mem"                 url="en/html/libs/mem/index.html" />
 	<mapID target="mem_flipflops"       url="en/html/libs/mem/flipflops.html" />
 	<mapID target="mem_register"        url="en/html/libs/mem/register.html" />

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -166,6 +166,9 @@
 	<mapID target="fparith_round"         url="en/html/libs/fparith/round.html" />
 	<mapID target="fparith_trigonometry"  url="en/html/libs/fparith/trigonometry.html" />
 	<mapID target="fparith_classificator" url="en/html/libs/fparith/classificator.html" />
+	<mapID target="fparith_fpconverter"   url="en/html/libs/fparith/fpconverter.html" />
+	<mapID target="fparith_fptoint"       url="en/html/libs/fparith/fptoint.html" />
+	<mapID target="fparith_inttofp"       url="en/html/libs/fparith/inttofp.html" />
 	<mapID target="mem"                 url="pt/html/libs/mem/index.html" />
 	<mapID target="mem_flipflops"       url="pt/html/libs/mem/flipflops.html" />
 	<mapID target="mem_register"        url="pt/html/libs/mem/register.html" />


### PR DESCRIPTION
## Summary

- add English reference pages for the Floating Point Converter, Floating Point to Integer, and Integer to Floating Point components
- wire those pages into the Floating Point Arithmetic index, library overview, HelpSet maps, and table of contents
- retain the English-page fallback used by the Portuguese HelpSet

This is the final Floating Point Arithmetic documentation slice after #2809, #2834, and #2842, completing reference coverage for all 17 components in that library.

Part of #303.

## Validation

- `DocumentationStructureTest`
- `checkstyleDocgen`, `checkstyleMain`, and `checkstyleTest`
- `git diff --check`