### PR TITLE
fpga: localize invalid connection point errors

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactory.java
@@ -9,6 +9,8 @@
 
 package com.cburch.logisim.circuit;
 
+import static com.cburch.logisim.fpga.Strings.S;
+
 import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.fpga.data.MapComponent;
 import com.cburch.logisim.fpga.data.MappableResourcesContainer;
@@ -550,13 +552,14 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     return portMap;
   }
 
-  private static Map<String, String> getSignalMap(String portName, netlistComponent comp, int endIndex, Netlist theNets) {
+  static Map<String, String> getSignalMap(
+      String portName, netlistComponent comp, int endIndex, Netlist theNets) {
     final var signal = new HashMap<String, String>();
     if ((endIndex < 0) || (endIndex >= comp.nrOfEnds())) {
-      // FIXME: hardcoded string
-      Reporter.report.addFatalErrorFmt(
-              "INTERNAL ERROR: Component tried to index non-existing SolderPoint: '%s'",
-              comp.getComponent().getAttributeSet().getValue(StdAttr.LABEL));
+      Reporter.report.addFatalError(
+          S.get(
+              "HdlInvalidSolderPointComponentError",
+              comp.getComponent().getAttributeSet().getValue(StdAttr.LABEL)));
       return signal;
     }
     final var connectionInformation = comp.getEnd(endIndex);

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/Hdl.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/Hdl.java
@@ -443,7 +443,7 @@ public class Hdl {
       netlistComponent comp, int endIndex, Netlist theNets) {
     final var netMap = new HashMap<String, String>();
     if ((endIndex < 0) || (endIndex >= comp.nrOfEnds())) {
-      Reporter.report.addFatalError("INTERNAL ERROR: Component tried to index non-existing SolderPoint");
+      Reporter.report.addFatalError(S.get("HdlInvalidSolderPointError"));
       return netMap;
     }
     final var connectionInformation = comp.getEnd(endIndex);

--- a/src/main/resources/resources/logisim/strings/fpga/fpga.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga.properties
@@ -124,6 +124,8 @@ HDLGenerator_NoClockConnection = Component "%s" in circuit "%s" has no clock con
 #
 HdlEmptyEntityError = INTERNAL ERROR: Empty entity description received!
 HdlEmptyBehaviorError = INTERNAL ERROR: Empty behavior description for Component '%s' received!
+HdlInvalidSolderPointError = INTERNAL ERROR: Component tried to index non-existing SolderPoint
+HdlInvalidSolderPointComponentError = INTERNAL ERROR: Component tried to index non-existing SolderPoint: '%s'
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
@@ -127,6 +127,8 @@ TopLevelNoIO = Der Toplevel „%s“ hat keine(n) Eingäng(e) und/oder keine Aus
 #
 # ==> HdlEmptyEntityError =
 # ==> HdlEmptyBehaviorError =
+# ==> HdlInvalidSolderPointError =
+# ==> HdlInvalidSolderPointComponentError =
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
@@ -124,6 +124,8 @@
 #
 # ==> HdlEmptyEntityError =
 # ==> HdlEmptyBehaviorError =
+# ==> HdlInvalidSolderPointError =
+# ==> HdlInvalidSolderPointComponentError =
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
@@ -124,6 +124,8 @@ TopLevelNoIO = El nivel superior «%s» no tiene ninguna entrada(s) y/o ninguna 
 #
 # ==> HdlEmptyEntityError =
 # ==> HdlEmptyBehaviorError =
+# ==> HdlInvalidSolderPointError =
+# ==> HdlInvalidSolderPointComponentError =
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
@@ -124,6 +124,8 @@ TopLevelNoIO = Le niveau supérieur « %s » n’a pas d’entrée(s) et/ou pa
 #
 # ==> HdlEmptyEntityError =
 # ==> HdlEmptyBehaviorError =
+# ==> HdlInvalidSolderPointError =
+# ==> HdlInvalidSolderPointComponentError =
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
@@ -124,6 +124,8 @@ TopLevelNoIO = Il livello superiore «%s» non ha ingressi e/o uscite!
 #
 # ==> HdlEmptyEntityError =
 # ==> HdlEmptyBehaviorError =
+# ==> HdlInvalidSolderPointError =
+# ==> HdlInvalidSolderPointComponentError =
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
@@ -124,6 +124,8 @@ TopLevelNoIO = トップ・レベル “%s” は入力および/または出力
 #
 # ==> HdlEmptyEntityError =
 # ==> HdlEmptyBehaviorError =
+# ==> HdlInvalidSolderPointError =
+# ==> HdlInvalidSolderPointComponentError =
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
@@ -124,6 +124,8 @@ TopLevelNoIO = Top level „%s” heeft geen ingang(en) en/of geen uitgang(en)!
 #
 # ==> HdlEmptyEntityError =
 # ==> HdlEmptyBehaviorError =
+# ==> HdlInvalidSolderPointError =
+# ==> HdlInvalidSolderPointComponentError =
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
@@ -124,6 +124,8 @@ TopLevelNoIO = Górny poziom „%s” nie ma wejścia(ów) i/lub wyjścia(ów)!
 #
 # ==> HdlEmptyEntityError =
 # ==> HdlEmptyBehaviorError =
+# ==> HdlInvalidSolderPointError =
+# ==> HdlInvalidSolderPointComponentError =
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
@@ -124,6 +124,8 @@ TopLevelNoIO = O nível superior «%s» não tem entrada(s) e/ou saída(s)!
 #
 # ==> HdlEmptyEntityError =
 # ==> HdlEmptyBehaviorError =
+# ==> HdlInvalidSolderPointError =
+# ==> HdlInvalidSolderPointComponentError =
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
@@ -124,6 +124,8 @@ TopLevelNoIO = Схема верхнего уровня «%s» не имеет �
 #
 # ==> HdlEmptyEntityError =
 # ==> HdlEmptyBehaviorError =
+# ==> HdlInvalidSolderPointError =
+# ==> HdlInvalidSolderPointComponentError =
 #
 # download/AlteraDownload.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
@@ -124,6 +124,8 @@ HDLGenerator_NoClockConnection = 元件 "%s" 在电路 "%s" 中没有时钟连�
 #
 HdlEmptyEntityError = 内部错误：收到的实体描述为空！
 HdlEmptyBehaviorError = 内部错误：收到的元件“%s”行为描述为空！
+HdlInvalidSolderPointError = 内部错误：元件尝试索引不存在的连接点！
+HdlInvalidSolderPointComponentError = 内部错误：元件尝试索引不存在的连接点："%s"
 #
 # download/AlteraDownload.java
 #

--- a/src/test/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.circuit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.TestBase;
+import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.designrulecheck.SimpleDrcContainer;
+import com.cburch.logisim.fpga.designrulecheck.netlistComponent;
+import com.cburch.logisim.fpga.gui.FpgaReportTabbedPane;
+import com.cburch.logisim.fpga.gui.Reporter;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.util.LocaleManager;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class CircuitHdlGeneratorFactoryTest extends TestBase {
+
+  @AfterEach
+  void detachReporterGui() {
+    Reporter.report.setGuiLogger(null);
+  }
+
+  @Test
+  void invalidSolderPointErrorUsesCurrentLocaleAndKeepsComponentName() {
+    final var originalLocale = LocaleManager.getLocale();
+    try {
+      assertInvalidSolderPointError(
+          Locale.ENGLISH,
+          "INTERNAL ERROR: Component tried to index non-existing SolderPoint: 'TestComponent'");
+      assertInvalidSolderPointError(
+          Locale.SIMPLIFIED_CHINESE,
+          "内部错误：元件尝试索引不存在的连接点：\"TestComponent\"");
+    } finally {
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
+
+  private void assertInvalidSolderPointError(Locale locale, String expectedError) {
+    LocaleManager.setLocale(locale);
+    final var reporterGui = mock(FpgaReportTabbedPane.class);
+    Reporter.report.setGuiLogger(reporterGui);
+    final var component = mock(netlistComponent.class);
+    final var circuitComponent = mock(Component.class);
+    final var attributes = mock(AttributeSet.class);
+    when(component.nrOfEnds()).thenReturn(0);
+    when(component.getComponent()).thenReturn(circuitComponent);
+    when(circuitComponent.getAttributeSet()).thenReturn(attributes);
+    when(attributes.getValue(StdAttr.LABEL)).thenReturn("TestComponent");
+
+    assertEquals(
+        Map.of(), CircuitHdlGeneratorFactory.getSignalMap("unused", component, 0, null));
+
+    final var error = ArgumentCaptor.forClass(Object.class);
+    verify(reporterGui).addErrors(error.capture());
+    assertEquals(expectedError, error.getValue().toString());
+    assertEquals(
+        SimpleDrcContainer.LEVEL_FATAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
+  }
+}

--- a/src/test/java/com/cburch/logisim/fpga/hdlgenerator/HdlTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/hdlgenerator/HdlTest.java
@@ -19,12 +19,14 @@ import static org.mockito.Mockito.verify;
 
 import com.cburch.logisim.TestBase;
 import com.cburch.logisim.fpga.designrulecheck.SimpleDrcContainer;
+import com.cburch.logisim.fpga.designrulecheck.netlistComponent;
 import com.cburch.logisim.fpga.gui.FpgaReportTabbedPane;
 import com.cburch.logisim.fpga.gui.Reporter;
 import com.cburch.logisim.util.LocaleManager;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,6 +56,21 @@ public class HdlTest extends TestBase {
           Locale.SIMPLIFIED_CHINESE,
           "内部错误：收到的实体描述为空！",
           "内部错误：收到的元件“TestComponent”行为描述为空！");
+    } finally {
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
+
+  @Test
+  void invalidSolderPointErrorUsesCurrentLocale() {
+    final var originalLocale = LocaleManager.getLocale();
+    try {
+      assertInvalidSolderPointError(
+          Locale.ENGLISH,
+          "INTERNAL ERROR: Component tried to index non-existing SolderPoint");
+      assertInvalidSolderPointError(
+          Locale.SIMPLIFIED_CHINESE,
+          "内部错误：元件尝试索引不存在的连接点！");
     } finally {
       LocaleManager.setLocale(originalLocale);
     }
@@ -135,6 +152,21 @@ public class HdlTest extends TestBase {
     assertFalse(Hdl.writeArchitecture("unused", List.of(), "TestComponent"));
     verify(reporterGui).addErrors(error.capture());
     assertEquals(expectedBehaviorError, error.getValue().toString());
+    assertEquals(
+        SimpleDrcContainer.LEVEL_FATAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
+  }
+
+  private void assertInvalidSolderPointError(Locale locale, String expectedError) {
+    LocaleManager.setLocale(locale);
+    final var reporterGui = mock(FpgaReportTabbedPane.class);
+    Reporter.report.setGuiLogger(reporterGui);
+    final var component = mock(netlistComponent.class);
+
+    assertEquals(Map.of(), Hdl.getNetMap("unused", false, component, -1, null));
+
+    final var error = ArgumentCaptor.forClass(Object.class);
+    verify(reporterGui).addErrors(error.capture());
+    assertEquals(expectedError, error.getValue().toString());
     assertEquals(
         SimpleDrcContainer.LEVEL_FATAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
   }


### PR DESCRIPTION
## Summary

- localize the fatal errors reported when HDL mapping indexes a non-existing connection point
- preserve the existing English wording, component-label substitution, fatal severity, and empty-map behavior
- add Simplified Chinese translations and standard fallback markers for the other locales
- add focused English/Chinese reporter-path regressions for both affected methods

## Scope

This is a focused fourth follow-up to #1144. Other hard-coded diagnostics and HDL generation behavior remain unchanged and outside this pull request.

## Testing

- `./gradlew test --tests com.cburch.logisim.fpga.hdlgenerator.HdlTest --tests com.cburch.logisim.circuit.CircuitHdlGeneratorFactoryTest --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew compileJava checkstyleMain compileTestJava checkstyleTest --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew check --no-daemon --rerun-tasks --max-workers=1`
- `git diff --check`
- `trans-tool` 2.5.2 differential audit against `main` for FPGA resources