### PR TITLE
cli: normalize invalid locale exit status

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/start/Startup.java
+++ b/src/main/java/com/cburch/logisim/gui/start/Startup.java
@@ -625,8 +625,16 @@ public class Startup implements AWTEventListener {
   }
 
   private static RC handleArgLocale(Startup startup, Option opt) {
-    setLocale(opt.getValue());
-    return RC.OK;
+    if (trySetLocale(opt.getValue())) return RC.OK;
+
+    final var opts = S.getLocaleOptions();
+    logger.warn(S.get("invalidLocaleError"));
+    logger.warn(S.get("invalidLocaleOptionsHeader"));
+
+    for (final var locale : opts) {
+      logger.warn("   {}", locale.toString());
+    }
+    return RC.ERROR;
   }
 
   private static RC handleArgTemplate(Startup startup, Option opt) {
@@ -793,19 +801,6 @@ public class Startup implements AWTEventListener {
       }
     }
     return false;
-  }
-
-  private static void setLocale(String lang) {
-    if (trySetLocale(lang)) return;
-
-    final var opts = S.getLocaleOptions();
-    logger.warn(S.get("invalidLocaleError"));
-    logger.warn(S.get("invalidLocaleOptionsHeader"));
-
-    for (final var opt : opts) {
-      logger.warn("   {}", opt.toString());
-    }
-    System.exit(-1);
   }
 
   private static String getProgramDirectory() {

--- a/src/test/java/com/cburch/logisim/gui/start/StartupTest.java
+++ b/src/test/java/com/cburch/logisim/gui/start/StartupTest.java
@@ -91,6 +91,8 @@ class StartupTest {
 
   private static Stream<Arguments> invalidOptionArguments() {
     return Stream.of(
+        Arguments.of(
+            "invalid locale", new String[] {"--tty", "table", "--locale", "not-a-locale"}),
         Arguments.of("invalid TTY format", new String[] {"--tty", "invalid"}),
         Arguments.of(
             "duplicate substitution",


### PR DESCRIPTION
## Summary

- route invalid `--locale` values through the existing parser error path instead of calling `System.exit(-1)` directly
- preserve the localized error, supported-locale list, valid-locale preloading, and localized help behavior
- add a focused parser regression for an invalid locale

## Motivation

Merged PR #2836 normalized the exit status for the other parse-time option validation failures, but deliberately left locale handling unchanged. An invalid locale therefore still returns the platform representation of `-1`, while other argument errors return status 10 from `Main`.

This is a narrow follow-up for #1546. It does not change runtime TTY/simulation statuses, option-combination behavior, or any other `System.exit` path.

## Validation

- `./gradlew test --tests com.cburch.logisim.gui.start.StartupTest --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew compileJava checkstyleMain compileTestJava checkstyleTest --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew check --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew shadowJar --no-daemon --rerun-tasks --max-workers=1`
- real built-JAR matrix: help 0; unknown option 10; invalid locale 10; valid Chinese locale help 0
- `git diff --check`