### PR TITLE
fix: revert version retrieval method in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,9 +61,9 @@ parts:
     build-attributes: [network]
     source: .
     override-pull: |
-      # set version from git tag
-      VERSION=$(git describe --tags --abbrev=0)
-      craftctl set version="${VERSION}"
+      craftctl default
+      LSE_VERSION="$(cat gradle.properties | grep '^version\s*=.*' | awk '{print $3}')"
+      craftctl set version="${LSE_VERSION}"
     override-build: |
       # Ensure that gradlew is executable
       chmod +x gradlew


### PR DESCRIPTION
This pull request updates the versioning logic in the `snapcraft.yaml` file to set the snap version from the `gradle.properties` file instead of using the latest Git tag. The change ensures the snap version aligns with the version specified in the build configuration.

Versioning update:

* Changed the `override-pull` step in `snap/snapcraft.yaml` to extract the version from the `version` property in `gradle.properties` instead of using `git describe`.