### PR TITLE
Fix clock frequency to stick with root circuit of simulation tree.

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/Simulator.java
+++ b/src/main/java/com/cburch/logisim/circuit/Simulator.java
@@ -230,11 +230,13 @@ public class Simulator {
       var smoothFactor = 1;
       if (prop != null) {
         final var opts = prop.getRootState().getProject().getOptions();
-        //smoothFactor = opts.getAttributeSet().getValue(Options.ATTR_SIM_SMOOTH); #TODO: implement smooth factor
+        // smoothFactor = opts.getAttributeSet().getValue(Options.ATTR_SIM_SMOOTH); #TODO: implement smooth factor
         if (smoothFactor < 1) {
           smoothFactor = 1;
         }
       }
+      final var newRootCircuit = prop == null ? null : prop.getRootState().getCircuit();
+      final var newFrequency = newRootCircuit == null ? -1 : newRootCircuit.getTickFrequency();
       simStateLock.lock();
       try {
         if (propagator == prop) {
@@ -245,6 +247,7 @@ public class Simulator {
         smoothingFactor = smoothFactor;
         manualTicksRequested = 0;
         manualStepsRequested = 0;
+        if (newFrequency > 0) setTickFrequency(newFrequency); // simStateLock is reentrant so this works here.
         if (Thread.currentThread() != this) {
           simStateUpdated.signalAll();
         }

--- a/src/main/java/com/cburch/logisim/proj/Project.java
+++ b/src/main/java/com/cburch/logisim/proj/Project.java
@@ -529,12 +529,8 @@ public class Project {
         for (final var l : circuitListeners) {
           newCircuit.addCircuitListener(l);
         }
-        final var circTickFrequency = newCircuit.getTickFrequency();
-        final var simTickFrequency = simulator.getTickFrequency();
-        if (circTickFrequency < 0) {
-          newCircuit.setTickFrequency(simTickFrequency);
-        } else if (circTickFrequency != simTickFrequency) {
-          simulator.setTickFrequency(circTickFrequency);
+        if (circuitState.getParentState() == null && newCircuit.getTickFrequency() < 0) {
+          newCircuit.setTickFrequency(simulator.getTickFrequency());
         }
       }
       if (oldCircuit != null) oldCircuit.displayChanged();


### PR DESCRIPTION
This PR fixes the problem reported in issue #2827.

It has the simulator change the frequency to the simulation tree root state frequency when the propagator is changed. There is one propagator per simulation tree.

The frequency action in Project.setCircuitState is limited to setting the circuit's frequency to the simulator frequency after the simulator has set the propagator and only when the circuitState is the root of the simulation tree and the circuit's frequency has not yet been set. In that case the propagator will have kept its old frequency which is now applied to this circuit.