### PR TITLE
feat: add the review and release of the Snap package to the nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -113,6 +113,13 @@ jobs:
         uses: snapcore/action-build@v1
         id: snapcraft
 
+      - name: Review the built snap
+        # https://github.com/snapcrafters/ci
+        uses: snapcrafters/ci/review-snap@main
+        if: success()
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+
       - name: 'Upload *.snap artifact.'
         uses: actions/upload-artifact@v7
         if: success()
@@ -120,20 +127,20 @@ jobs:
            path: ${{ steps.snapcraft.outputs.snap }}
            name: ${{ needs.git_check.outputs.base_name }}_amd64.snap
 
-#      - name: 'Pushing *.snap to snapcraft.io'
-#        # https://github.com/snapcore/action-publish
-#        uses: snapcore/action-publish@v1
-#        if: success()
-#        env:
-#          # Obtain Snapcraft.io store token:
-#          # $ snapcraft export-login --snaps=logisim-evolution --acls package_access,package_push,package_update,package_release token.txt
-#          # then open Github repository settings and add new secred named SNAPCRAFT_STORE_TOKEN with the value of token.txt
-#          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
-#        with:
-#          snap: ${{ steps.snapcraft.outputs.snap }}
-#          release: edge
+      - name: 'Pushing *.snap to snapcraft.io'
+        # https://github.com/snapcore/action-publish
+        uses: snapcore/action-publish@v1
+        if: success()
+        env:
+          # Obtain Snapcraft.io store token:
+          # $ snapcraft export-login --snaps=logisim-evolution --acls package_access,package_push,package_update,package_release token.txt
+          # then open Github repository settings and add new secred named SNAPCRAFT_STORE_TOKEN with the value of token.txt
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+          release: edge
 
-        # ###########################################################################################
+      # ###########################################################################################
 
       - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
         uses: actions/setup-java@v5
@@ -228,6 +235,40 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: 'main'
+
+      - name: 'Build Snap package'
+        # https://github.com/snapcore/action-build
+        uses: snapcore/action-build@v1
+        id: snapcraft
+
+      - name: Review the built snap
+        # https://github.com/snapcrafters/ci
+        uses: snapcrafters/ci/review-snap@main
+        if: success()
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+
+      - name: 'Upload *.snap artifact.'
+        uses: actions/upload-artifact@v7
+        if: success()
+        with:
+           path: ${{ steps.snapcraft.outputs.snap }}
+           name: ${{ needs.git_check.outputs.base_name }}_arm64.snap
+
+      - name: 'Pushing *.snap to snapcraft.io'
+        # https://github.com/snapcore/action-publish
+        uses: snapcore/action-publish@v1
+        if: success()
+        env:
+          # Obtain Snapcraft.io store token:
+          # $ snapcraft export-login --snaps=logisim-evolution --acls package_access,package_push,package_update,package_release token.txt
+          # then open Github repository settings and add new secred named SNAPCRAFT_STORE_TOKEN with the value of token.txt
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+          release: edge
+
+      # ###########################################################################################
 
       - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
         uses: actions/setup-java@v5


### PR DESCRIPTION
This PR improves the nightly Snap workflow by adding validation, artifact retention, and automated publishing in both Linux build jobs.

**What changed**

- Added a Snap review step after build using the Snapcrafters review action.
- Kept the generated Snap as a workflow artifact for inspection and troubleshooting.
- Re-enabled publishing to Snapcraft through the edge channel.
- Applied the same Snap flow consistently across the Linux and Linux ARM nightly jobs.

**Why**

- Catch packaging issues earlier before publication.
- Keep a downloadable Snap from CI for verification and manual checks.
- Restore fully automated nightly delivery to Snapcraft.

**Operational notes**

- Publishing requires the SNAPCRAFT_STORE_TOKEN secret to be configured.
- Existing JAR, DEB, and RPM build/release steps are unchanged.