### PR TITLE
feat: add Snapcraft build job to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,10 +94,13 @@ jobs:
 
   # ###############################################################################################
 
-  # Building for Linux.
-  build_linux:
-    name: 'Linux build'
-    runs-on: ubuntu-latest
+  snap:
+    name: "Snapcraft build"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04-arm]
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.os }}
     # Will run only if git_check determined it is needed.
     needs: git_check
     if: needs.git_check.outputs.run_build == 'true'
@@ -105,8 +108,6 @@ jobs:
       # https://github.com/z0al/dependent-issues
       - name: 'Checkout branch: ${{ env.GITHUB_REF }}'
         uses: actions/checkout@v7
-        with:
-          ref: 'main'
 
       - name: 'Build Snap package'
         # https://github.com/snapcore/action-build
@@ -125,7 +126,7 @@ jobs:
         if: success()
         with:
            path: ${{ steps.snapcraft.outputs.snap }}
-           name: ${{ needs.git_check.outputs.base_name }}_amd64.snap
+           name: ${{ needs.git_check.outputs.base_name }}_${{ matrix.arch }}.snap
 
       - name: 'Pushing *.snap to snapcraft.io'
         # https://github.com/snapcore/action-publish
@@ -140,7 +141,19 @@ jobs:
           snap: ${{ steps.snapcraft.outputs.snap }}
           release: edge
 
-      # ###########################################################################################
+  # Building for Linux.
+  build_linux:
+    name: 'Linux build'
+    runs-on: ubuntu-latest
+    # Will run only if git_check determined it is needed.
+    needs: git_check
+    if: needs.git_check.outputs.run_build == 'true'
+    steps:
+      # https://github.com/z0al/dependent-issues
+      - name: 'Checkout branch: ${{ env.GITHUB_REF }}'
+        uses: actions/checkout@v7
+        with:
+          ref: 'main'
 
       - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
         uses: actions/setup-java@v5
@@ -235,40 +248,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: 'main'
-
-      - name: 'Build Snap package'
-        # https://github.com/snapcore/action-build
-        uses: snapcore/action-build@v1
-        id: snapcraft
-
-      - name: Review the built snap
-        # https://github.com/snapcrafters/ci
-        uses: snapcrafters/ci/review-snap@main
-        if: success()
-        with:
-          snap: ${{ steps.snapcraft.outputs.snap }}
-
-      - name: 'Upload *.snap artifact.'
-        uses: actions/upload-artifact@v7
-        if: success()
-        with:
-           path: ${{ steps.snapcraft.outputs.snap }}
-           name: ${{ needs.git_check.outputs.base_name }}_arm64.snap
-
-      - name: 'Pushing *.snap to snapcraft.io'
-        # https://github.com/snapcore/action-publish
-        uses: snapcore/action-publish@v1
-        if: success()
-        env:
-          # Obtain Snapcraft.io store token:
-          # $ snapcraft export-login --snaps=logisim-evolution --acls package_access,package_push,package_update,package_release token.txt
-          # then open Github repository settings and add new secred named SNAPCRAFT_STORE_TOKEN with the value of token.txt
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
-        with:
-          snap: ${{ steps.snapcraft.outputs.snap }}
-          release: edge
-
-      # ###########################################################################################
 
       - name: Set up JDK ${{ env.JDK_VERSION }} ${{ env.JDK_DISTRO }}
         uses: actions/setup-java@v5


### PR DESCRIPTION
This pull request restructures the Linux build jobs in the `.github/workflows/nightly.yml` workflow to improve maintainability and enable building Snap packages for multiple architectures. The Snapcraft build logic is now handled in a dedicated `snap` job with a build matrix, and the previous duplicated Snap steps in the `build_linux` job have been removed. Artifact naming has also been updated to reflect the architecture.

**Snapcraft build improvements:**

* Introduced a new `snap` job that uses a build matrix to build Snap packages for both `amd64` and `arm64` architectures on `ubuntu-latest` and `ubuntu-22.04-arm` runners, streamlining multi-architecture support.
* Updated artifact upload step to dynamically name the Snap artifact according to the architecture (e.g., `*_amd64.snap`, `*_arm64.snap`).

**Workflow cleanup and refactoring:**

* Moved the Snapcraft build, review, upload, and publish steps out of the `build_linux` job into the new `snap` job, removing duplication and clarifying job responsibilities.
* Restored the `build_linux` job to focus solely on the standard Linux build, separate from Snap packaging.