### PR TITLE
docs: clarify development vs installed paths in library import docs (#2368)

### DIFF
--- a/docs/automatic_library_import.md
+++ b/docs/automatic_library_import.md
@@ -8,12 +8,10 @@ To do this, create a directory named `logisim-defaults` in the program directory
   `C:\Program Files\logisim-evolution\app\logisim-defaults`.
 - For a standalone `.jar`, place `logisim-defaults` in the same directory as the `.jar` file that starts Logisim Evolution.
   ![Where the logisim-defaults folder goes, if executing from a JAR file.](img/logisim-defaults-jar.png)
-- For a Gradle run, place `logisim-defaults` inside `/build/classes/java/`.
-  ![Where the logisim-defaults folder goes, if running from Gradle.](img/logisim-defaults-build.png)
+- For a Gradle run (development environment), place `logisim-defaults` inside `/build/classes/java/`.
+  ![Where the logisim-defaults folder goes, if running from Gradle (development environment).](img/logisim-defaults-build.png)
 
-Inside the `logisim-defaults` folder should be any `.circ` files which you would like to load automatically at startup.
-**Every circuit must have a unique name, and must not be called
-"main"**. This is to avoid conflicts caused by loading libraries with the same name.
+> **Note:** The screenshots above show the development environment paths. For end users who have installed Logisim Evolution using the installer, use the `app` directory as described in the first option.
 
 ![An example of a CIRC file in the logisim-defaults folder](img/logisim-defaults-folder.png)
 

--- a/docs/automatic_library_import.md
+++ b/docs/automatic_library_import.md
@@ -1,17 +1,21 @@
 # Automatically Importing Logisim Libraries
 
-Logisim Evolution supports loading custom libraries at startup, contained in Logisim `.circ` files.
+Logisim-evolution supports loading custom libraries at startup, contained in Logisim `.circ` files.
 
-To do this, create a directory named `logisim-defaults` in the program directory used to start Logisim Evolution:
+To do this, create a directory named `logisim-defaults` in the program directory used to start Logisim-evolution:
 
 - For an installed application, this is the application directory. On a default Windows install, that may be
   `C:\Program Files\logisim-evolution\app\logisim-defaults`.
-- For a standalone `.jar`, place `logisim-defaults` in the same directory as the `.jar` file that starts Logisim Evolution.
+- For a standalone `.jar`, place `logisim-defaults` in the same directory as the `.jar` file that starts Logisim-evolution.
   ![Where the logisim-defaults folder goes, if executing from a JAR file.](img/logisim-defaults-jar.png)
-- For a Gradle run (development environment), place `logisim-defaults` inside `/build/classes/java/`.
+- For a Gradle run (development environment), place `logisim-defaults` inside `build/classes/java/`.
   ![Where the logisim-defaults folder goes, if running from Gradle (development environment).](img/logisim-defaults-build.png)
 
-> **Note:** The screenshots above show the development environment paths. For end users who have installed Logisim Evolution using the installer, use the `app` directory as described in the first option.
+**Note:** The screenshots above show the development environment paths. For end users, who have installed Logisim-evolution using the installer, use the `app` directory as described in the first option.
+
+Inside the `logisim-defaults` folder should be any `.circ` files which you would like to load automatically at startup.
+**Every circuit must have a unique name, and must not be called
+"main"**. This is to avoid conflicts caused by loading libraries with the same name.
 
 ![An example of a CIRC file in the logisim-defaults folder](img/logisim-defaults-folder.png)
 


### PR DESCRIPTION
## Description

This PR clarifies the difference between development environment paths and installed application paths in the automatic library import documentation.

## Changes

- Added a note explaining that the screenshots show development environment paths
- Clarified that end users who installed Logisim Evolution should use the `app` directory path
- Improved documentation to prevent user confusion

## Problem

The existing documentation and screenshots showed paths like `build/classes/java/` which are only applicable for Gradle development runs. Users who installed the application via the installer were confused about the correct path.

## Solution

Added a clear note distinguishing between:
- Development environment (Gradle): `/build/classes/java/`
- Installed application: `C:\Program Files\logisim-evolution\app\logisim-defaults`

## Fixes
Closes #2368