### PR TITLE
gui: use literal arrows in floating converters

### DIFF
--- a/src/main/java/com/cburch/logisim/std/arith/floating/FpToFp.java
+++ b/src/main/java/com/cburch/logisim/std/arith/floating/FpToFp.java
@@ -64,7 +64,7 @@ public class FpToFp extends InstanceFactory {
         new Object[] {BitWidth.create(32), BitWidth.create(32)});
     setKeyConfigurator(new BitWidthConfigurator(FP_WIDTH_IN));
     setOffsetBounds(Bounds.create(-40, -20, 40, 40));
-    setIcon(new ArithmeticIcon("FP\u2192FP", 3));
+    setIcon(new ArithmeticIcon("FP→FP", 3));
   }
 
   @Override
@@ -100,7 +100,7 @@ public class FpToFp extends InstanceFactory {
     int y = loc.getY();
     GraphicsUtil.switchToWidth(g, 2);
     var font = g.getFont().deriveFont(20f);
-    GraphicsUtil.drawText(g, font, "\u2192", x - 20, y, GraphicsUtil.H_CENTER,
+    GraphicsUtil.drawText(g, font, "→", x - 20, y, GraphicsUtil.H_CENTER,
         GraphicsUtil.V_CENTER_OVERALL);
     GraphicsUtil.switchToWidth(g, 1);
 

--- a/src/main/java/com/cburch/logisim/std/arith/floating/FpToInt.java
+++ b/src/main/java/com/cburch/logisim/std/arith/floating/FpToInt.java
@@ -66,7 +66,7 @@ public class FpToInt extends InstanceFactory {
         new Object[] {BitWidth.create(8), BitWidth.create(32), ROUND_OPTION});
     setKeyConfigurator(new BitWidthConfigurator(StdAttr.FP_WIDTH));
     setOffsetBounds(Bounds.create(-40, -20, 40, 40));
-    setIcon(new ArithmeticIcon("FP\u2192I", 2));
+    setIcon(new ArithmeticIcon("FP→I", 2));
 
     final var ps = new Port[3];
     ps[IN] = new Port(-40, 0, Port.INPUT, StdAttr.FP_WIDTH);
@@ -84,7 +84,7 @@ public class FpToInt extends InstanceFactory {
     g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
     painter.drawBounds();
     painter.drawPort(IN);
-    painter.drawPort(OUT, "F\u2192I", Direction.WEST);
+    painter.drawPort(OUT, "F→I", Direction.WEST);
     painter.drawPort(ERR);
   }
 

--- a/src/main/java/com/cburch/logisim/std/arith/floating/IntToFp.java
+++ b/src/main/java/com/cburch/logisim/std/arith/floating/IntToFp.java
@@ -49,7 +49,7 @@ public class IntToFp extends InstanceFactory {
         new Object[] {BitWidth.create(8), BitWidth.create(32), Comparator.SIGNED_OPTION});
     setKeyConfigurator(new BitWidthConfigurator(StdAttr.FP_WIDTH));
     setOffsetBounds(Bounds.create(-40, -20, 40, 40));
-    setIcon(new ArithmeticIcon("I\u2192FP", 2));
+    setIcon(new ArithmeticIcon("I→FP", 2));
 
     final var ps = new Port[3];
     ps[IN] = new Port(-40, 0, Port.INPUT, StdAttr.WIDTH);
@@ -67,7 +67,7 @@ public class IntToFp extends InstanceFactory {
     g.setColor(new Color(AppPreferences.COMPONENT_COLOR.get()));
     painter.drawBounds();
     painter.drawPort(IN);
-    painter.drawPort(OUT, "I\u2192F", Direction.WEST);
+    painter.drawPort(OUT, "I→F", Direction.WEST);
     painter.drawPort(ERR);
   }
 


### PR DESCRIPTION
## Summary

- replace the six `\u2192` display escapes in the floating-point conversion components with literal `→` characters
- keep unrelated Unicode escapes unchanged
- rely on the existing explicit UTF-8 Java source encoding

## Validation

- `./gradlew compileJava checkstyleMain compileTestJava checkstyleTest`
- `./gradlew check --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew shadowJar`
- verified UTF-8 U+2192 bytes in the sources and compiled classes, with no U+FFFD replacement character
- verified all three toolbox icons and placed components on Windows/JDK 25
- `git diff --check`

Fixes #890