### PR TITLE
gui: avoid clipping current simulation names

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/main/SimulationTreeRenderer.java
+++ b/src/main/java/com/cburch/logisim/gui/main/SimulationTreeRenderer.java
@@ -15,6 +15,7 @@ import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.util.ColorUtil;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
 import javax.swing.Icon;
@@ -24,6 +25,8 @@ import javax.swing.tree.DefaultTreeCellRenderer;
 
 public class SimulationTreeRenderer extends DefaultTreeCellRenderer {
   private static final long serialVersionUID = 1L;
+  private static final String CURRENT_VIEW_SUFFIX = " ●";
+  private int preferredWidthAdjustment;
 
   @Override
   public Component getTreeCellRendererComponent(
@@ -34,6 +37,7 @@ public class SimulationTreeRenderer extends DefaultTreeCellRenderer {
       boolean leaf,
       int row,
       boolean hasFocus) {
+    preferredWidthAdjustment = 0;
     Component ret =
         super.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, hasFocus);
     final var model = (SimulationTreeModel) tree.getModel();
@@ -45,19 +49,35 @@ public class SimulationTreeRenderer extends DefaultTreeCellRenderer {
           label.setIcon(new RendererIcon(factory, viewed));
         }
 
-        final var plainFont = AppPreferences.getScaledFont(label.getFont());
+        final var baseFont = tree.getFont() != null ? tree.getFont() : label.getFont();
+        final var plainFont = AppPreferences.getScaledFont(baseFont);
         final var boldFont = plainFont.deriveFont(Font.BOLD);
 
         label.setFont(viewed ? boldFont : plainFont);
         if (viewed) {
-          label.setText(node.toString() + " ●");
+          label.setText(node.toString() + CURRENT_VIEW_SUFFIX);
           label.setForeground(ColorUtil.getThemeAccentColor());
         } else {
+          final var plainTextWidth = label.getFontMetrics(plainFont).stringWidth(label.getText());
+          final var currentViewTextWidth =
+              label
+                  .getFontMetrics(boldFont)
+                  .stringWidth(node.toString() + CURRENT_VIEW_SUFFIX);
+          preferredWidthAdjustment = Math.max(0, currentViewTextWidth - plainTextWidth);
           label.setForeground(selected ? getTextSelectionColor() : getTextNonSelectionColor());
         }
       }
     }
     return ret;
+  }
+
+  @Override
+  public Dimension getPreferredSize() {
+    final var size = super.getPreferredSize();
+    if (size == null || preferredWidthAdjustment == 0) {
+      return size;
+    }
+    return new Dimension(size.width + preferredWidthAdjustment, size.height);
   }
 
   private static class RendererIcon implements Icon {

--- a/src/test/java/com/cburch/logisim/gui/main/SimulationTreeRendererTest.java
+++ b/src/test/java/com/cburch/logisim/gui/main/SimulationTreeRendererTest.java
@@ -1,0 +1,98 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.main;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Font;
+import java.util.List;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.Test;
+
+class SimulationTreeRendererTest {
+
+  @Test
+  void inactiveNodeReservesWidthForCurrentViewDecoration() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          final var model = new SimulationTreeModel(List.of());
+          final var node = new TestNode(model, (SimulationTreeNode) model.getRoot(), "R00");
+          final var tree = new JTree(model);
+          tree.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+          final var renderer = new SimulationTreeRenderer();
+
+          node.currentView = false;
+          final var inactiveWidth = render(renderer, tree, node).getPreferredSize().width;
+
+          node.currentView = true;
+          final var currentViewWidth = render(renderer, tree, node).getPreferredSize().width;
+
+          assertTrue(
+              inactiveWidth >= currentViewWidth,
+              () ->
+                  "Inactive row width "
+                      + inactiveWidth
+                      + " does not reserve space for current-view width "
+                      + currentViewWidth);
+        });
+  }
+
+  @Test
+  void currentViewBoldFontDoesNotLeakIntoFollowingRows() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          final var model = new SimulationTreeModel(List.of());
+          final var root = (SimulationTreeNode) model.getRoot();
+          final var current = new TestNode(model, root, "current");
+          final var inactive = new TestNode(model, root, "inactive");
+          final var tree = new JTree(model);
+          tree.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+          final var renderer = new SimulationTreeRenderer();
+
+          current.currentView = true;
+          assertTrue(render(renderer, tree, current).getFont().isBold());
+
+          inactive.currentView = false;
+          assertFalse(render(renderer, tree, inactive).getFont().isBold());
+        });
+  }
+
+  private static java.awt.Component render(
+      SimulationTreeRenderer renderer, JTree tree, SimulationTreeNode node) {
+    return renderer.getTreeCellRendererComponent(tree, node, false, false, true, 0, false);
+  }
+
+  private static class TestNode extends SimulationTreeNode {
+    private boolean currentView;
+    private final String text;
+
+    TestNode(SimulationTreeModel model, SimulationTreeNode parent, String text) {
+      super(model, parent);
+      this.text = text;
+    }
+
+    @Override
+    public boolean isCurrentView(SimulationTreeModel model) {
+      return currentView;
+    }
+
+    @Override
+    public boolean isLeaf() {
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return text;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- reserve enough tree-row width for the bold current-view label and its red-dot suffix
- derive every rendered row from the tree's base font so renderer state does not leak between rows
- add focused regression coverage for both width reservation and font reset

## Validation

- `./gradlew test --tests com.cburch.logisim.gui.main.SimulationTreeRendererTest compileJava checkstyleMain compileTestJava checkstyleTest --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew check --no-daemon --rerun-tasks --max-workers=1`
- `./gradlew shadowJar --no-daemon --rerun-tasks --max-workers=1`
- verified on Windows with a nested `main → M → R00` hierarchy; the active `R00 ●` row remains fully visible
- `git diff --check`

Fixes #2853