### PR TITLE
Move the circuit listener from TestThread to Model

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/test/Model.java
+++ b/src/main/java/com/cburch/logisim/gui/test/Model.java
@@ -10,6 +10,8 @@
 package com.cburch.logisim.gui.test;
 
 import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.CircuitEvent;
+import com.cburch.logisim.circuit.CircuitListener;
 import com.cburch.logisim.circuit.TestVectorEvaluator;
 import com.cburch.logisim.data.TestException;
 import com.cburch.logisim.data.TestVector;
@@ -19,7 +21,7 @@ import com.cburch.logisim.util.EventSourceWeakSupport;
 import java.util.ArrayList;
 import javax.swing.SwingUtilities;
 
-class Model {
+class Model implements CircuitListener {
 
   private final EventSourceWeakSupport<ModelListener> listeners;
   private final Project project;
@@ -42,6 +44,17 @@ class Model {
     listeners = new EventSourceWeakSupport<>();
     this.circuit = circuit;
     this.project = proj;
+    // Listen for the lifetime of the model rather than the lifetime of a test
+    // run: TestThread comes and goes, and circuit listeners are held weakly, so
+    // a thread-owned registration is dropped or duplicated unpredictably.
+    circuit.addCircuitListener(this);
+  }
+
+  @Override
+  public void circuitChanged(CircuitEvent event) {
+    // A rename doesn't invalidate results.
+    if (event.getAction() == CircuitEvent.ACTION_SET_NAME) return;
+    clearResults();
   }
 
   public void addModelListener(ModelListener l) {

--- a/src/main/java/com/cburch/logisim/gui/test/TestThread.java
+++ b/src/main/java/com/cburch/logisim/gui/test/TestThread.java
@@ -12,8 +12,6 @@ package com.cburch.logisim.gui.test;
 import static com.cburch.logisim.gui.Strings.S;
 
 import com.cburch.logisim.circuit.Circuit;
-import com.cburch.logisim.circuit.CircuitEvent;
-import com.cburch.logisim.circuit.CircuitListener;
 import com.cburch.logisim.circuit.CircuitState;
 import com.cburch.logisim.circuit.TestVectorEvaluator;
 import com.cburch.logisim.data.TestException;
@@ -21,7 +19,7 @@ import com.cburch.logisim.data.TestVector;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.util.UniquelyNamedThread;
 
-public class TestThread extends UniquelyNamedThread implements CircuitListener {
+public class TestThread extends UniquelyNamedThread {
 
   private final Project project;
   private final Circuit circuit;
@@ -41,7 +39,6 @@ public class TestThread extends UniquelyNamedThread implements CircuitListener {
     this.circuitState = this.project.getCircuitState().cloneAsNewRootState(this);
     this.vector = model.getVector();
     this.evaluator = new TestVectorEvaluator(circuitState, vector);
-    model.getCircuit().addCircuitListener(this);
   }
 
   // used only for automated testing via command line arguments
@@ -92,13 +89,6 @@ public class TestThread extends UniquelyNamedThread implements CircuitListener {
 
   public void cancel() {
     canceled = true;
-  }
-
-  @Override
-  public void circuitChanged(CircuitEvent event) {
-    int action = event.getAction();
-    if (action == CircuitEvent.ACTION_SET_NAME) return;
-    else model.clearResults();
   }
 
   @Override


### PR DESCRIPTION
Resolves #2874

## What

`TestThread` implemented `CircuitListener` and forwarded every non-rename change to `model.clearResults()`. The listener now lives on `Model`, and `TestThread` is out of that path entirely.

## Why

`Circuit` stores its listeners in an `EventSourceWeakSupport<CircuitListener>` (`Circuit.java:284`), so registrations are weak. A `TestThread` exists for one run; the `Model` it belongs to is cached in `TestFrame`'s `Map<Circuit, Model>` and lives as long as the frame. Registering the short-lived object against a weak collection gave the two failure modes described in the issue:

- released `TestThread`s keep relaying `clearResults` until the collector gets to them, so one change can clear results several times;
- if collection happens promptly, the link is gone and a change is missed.

`Model` already owns `clearResults()` and has the lifetime that matches the results being guarded, so it is the natural listener.

## The change

`Model` implements `CircuitListener`, registers in its constructor, and keeps the original rename guard:

```java
@Override
public void circuitChanged(CircuitEvent event) {
  // A rename doesn't invalidate results.
  if (event.getAction() == CircuitEvent.ACTION_SET_NAME) return;
  clearResults();
}
```

`TestThread` drops `implements CircuitListener`, its `addCircuitListener` call, its `circuitChanged` override, and two imports that are now unused. Behaviour on a change is unchanged — `clearResults()` still calls `stop()`, which cancels and releases the running tester.

## Verification

- `./gradlew compileJava` — passes
- `./gradlew test` — **512 tests across 100 suites, 0 failures, 0 errors, 0 skipped** (counted from `build/test-results/test/*.xml`, not just the build status)

Built on JDK 21 to match `sourceCompatibility`.

**What I have not done:** exercised the test panel in the running GUI. The existing suite doesn't cover this path, and the symptom is a timing-and-GC interaction that a unit test would struggle to pin down honestly. A maintainer opening a circuit's test panel, running a vector, then editing the circuit would confirm results still clear exactly once — that check is worth having before merge.

Two related points, deliberately left out of this change:

- #2873 concerns the circuit no longer being listened to after a component drag. If that turns out to share this root cause, this may reduce it, but I have not verified any link and did not want to claim one.
- `Model` never removes its listener. Given the weak collection and `TestFrame`'s cache that appears intentional rather than a leak, but say the word if you would rather it deregistered explicitly.

> [!NOTE]
> AI model used — `claude-opus-5`, reasoning effort `high`. I read and verified every line before submitting.