### PR TITLE
i18n: localize Real-Time Clock in Simplified Chinese

### DIFF
--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -643,12 +643,12 @@ rgbVideoY = Y 坐标
 #
 # io/RealTimeClock.java
 #
-# ==> realTimeClockComponent =
-# ==> realTimeClockSeconds =
-# ==> realTimeClockMilliseconds =
-# ==> realTimeClockTimeType = Tipo de tempo
-# ==> realTimeClockEpochMilliseconds =
-# ==> realTimeClockEpochSeconds =
+realTimeClockComponent = 实时时钟
+realTimeClockSeconds = 秒
+realTimeClockMilliseconds = 毫秒
+realTimeClockTimeType = 时间类型
+realTimeClockEpochMilliseconds = UNIX 时间戳（毫秒）
+realTimeClockEpochSeconds = UNIX 时间戳（秒）
 #
 # bfh/bcd2sevenseg.java
 #


### PR DESCRIPTION
## Summary

- localize the Real-Time Clock component and its time-type attribute in Simplified Chinese
- localize both UNIX timestamp choices and the matching seconds/milliseconds output tooltips
- keep the change limited to the six Real-Time Clock strings in `std_zh.properties`

This is a focused follow-up to #2566, as invited in [the maintainer discussion](https://github.com/logisim-evolution/logisim-evolution/pull/2566#issuecomment-5357722957). It uses the `UNIX 时间戳（毫秒/秒）` wording suggested by @dangfan during that PR's review and does not include its unrelated `CircuitAttributes` change.

## Validation

- `.\gradlew.bat processResources checkstyleMain --no-daemon --max-workers=1`
- `.\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1`
- compared the Simplified Chinese translation-checker output with current `main`; all six Real-Time Clock fallback entries are resolved
- verified on Windows that the component name, time-type attribute, both UNIX timestamp choices, and the matching `秒`/`毫秒` output-port tooltips render correctly
- `git diff --check`