### PR TITLE
i18n: localize Telnet in Simplified Chinese

### DIFF
--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -601,15 +601,15 @@ SevenSegDP = 有小数点
 #
 # io/Telnet.java
 #
-# ==> telnetComponent =
-# ==> telnetModeAttr =
-# ==> telnetPortAttr =
-# ==> telnetInTip =
-# ==> telnetOutTip =
-# ==> telnetClkTip =
-# ==> telnetWriteTip =
-# ==> telnetReadTip =
-# ==> telnetAvailableTip =
+telnetComponent = Telnet
+telnetModeAttr = 使用 Telnet 协议
+telnetPortAttr = 端口
+telnetInTip = 输入：待发送的数据
+telnetOutTip = 输出：接收到的数据
+telnetClkTip = 输入：时钟（在时钟沿执行已启用的读写操作）
+telnetWriteTip = 输入：写使能（在时钟沿发送输入数据）
+telnetReadTip = 输入：读使能（输出接收到的数据，并在时钟沿将其移除）
+telnetAvailableTip = 输出：可用（有数据可读取时为 1）
 #
 # io/Tty.java
 #


### PR DESCRIPTION
## Summary

- localize the nine Telnet component strings in Simplified Chinese
- preserve the `Telnet` protocol name while translating its boolean protocol option and TCP port attribute
- describe all six ports using the component's current byte-buffer and clock-edge behavior
- keep the change limited to the Telnet entries in `std_zh.properties`

This is a second focused follow-up to #2566, as invited in [the maintainer discussion](https://github.com/logisim-evolution/logisim-evolution/pull/2566#issuecomment-5357722957). It keeps the useful translations from that earlier effort while clarifying the protocol-mode attribute and the read-enable behavior against the current implementation and reference page.

## Validation

- `.\gradlew.bat processResources checkstyleMain --no-daemon --max-workers=1`
- `.\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1`
- compared the Simplified Chinese translation-checker output with current `main`; all nine Telnet fallback entries are resolved
- verified on Windows that the component name, both Telnet-specific attributes, and all six translated port tooltips render correctly
- `git diff --check`