### PR TITLE
i18n: localize Absolute in Simplified Chinese

### DIFF
--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -1,10 +1,10 @@
 #
 # arith/Absolute.java
 #
-# ==> absoluteComponent =
-# ==> absoluteInputTip =
-# ==> absoluteOutputTip =
-# ==> absoluteOverflowTip =
+absoluteComponent = 绝对值
+absoluteInputTip = 输入：待取绝对值的数
+absoluteOutputTip = 输出：输入的绝对值
+absoluteOverflowTip = 溢出：输入为当前位宽可表示的最小值时为 1
 #
 # arith/Adder.java
 #


### PR DESCRIPTION
## Summary

- localize the Absolute component and its three port tooltips in Simplified Chinese
- describe the overflow output using the exact minimum-value condition for the selected bit width
- avoid calling every result positive, because the minimum signed input has no representable positive magnitude
- keep the change limited to the four Absolute entries in `std_zh.properties`

This is a third focused follow-up to #2566, as invited in [the maintainer discussion](https://github.com/logisim-evolution/logisim-evolution/pull/2566#issuecomment-5357722957). It retains the useful wording from that earlier effort while making the output and overflow descriptions accurate for the minimum signed value handled by the current implementation.

## Validation

- `.\gradlew.bat processResources checkstyleMain --no-daemon --max-workers=1`
- `.\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1`
- compared the Simplified Chinese translation-checker output with current `main`; all four Absolute fallback entries are resolved
- verified on Windows that `绝对值` appears under the existing `运算器` library and that all three translated port tooltips render correctly
- `git diff --check`