### PR TITLE
i18n: localize Minimum and Maximum in Simplified Chinese

### DIFF
--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -219,10 +219,10 @@ negatorOutputTip = 输出：输入的相反数的补码
 #
 # arith/MinMax.java
 #
-# ==> minMaxComponent =
-# ==> minMaxInputTip =
-# ==> minMaxMaximumTip =
-# ==> minMaxMinimumTip =
+minMaxComponent = 最小值和最大值
+minMaxInputTip = 输入：待比较的一个数值
+minMaxMaximumTip = 输出：最大值（两个输入中的较大值）
+minMaxMinimumTip = 输出：最小值（两个输入中的较小值）
 #
 # arith/Shifter.java
 #


### PR DESCRIPTION
## Summary

- localize the Minimum and Maximum component in Simplified Chinese
- localize the shared input tooltip and the distinct minimum/maximum output tooltips
- use the concise input wording suggested during the review of #2566
- keep the change limited to the four MinMax entries in `std_zh.properties`

This is a fourth focused follow-up to #2566, as invited in [the maintainer discussion](https://github.com/logisim-evolution/logisim-evolution/pull/2566#issuecomment-5357722957). The input tooltip adopts @dangfan's review suggestion `输入：待比较的一个数值`, while the two output tooltips describe the smaller and larger of the component's two fixed inputs.

## Validation

- `.\gradlew.bat processResources checkstyleMain --no-daemon --max-workers=1`
- `.\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1`
- compared the Simplified Chinese translation-checker output with current `main`; all four MinMax fallback entries are resolved
- verified on Windows that the translated component name and all three distinct port tooltips render correctly; the in-symbol `Min`/`Max` labels remain unchanged
- `git diff --check`