### PR TITLE
i18n: localize Square Root in Simplified Chinese

### DIFF
--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -239,11 +239,11 @@ shiftRollRight = 循环右移
 #
 # arith/SquareRoot.java
 #
-# ==> squareRootComponent =
-# ==> squareRootOutputTip =
-# ==> squareRootRadicandLowerTip =
-# ==> squareRootRadicandUpperTip =
-# ==> squareRootRemainderTip =
+squareRootComponent = 平方根
+squareRootOutputTip = 输出：平方根运算结果
+squareRootRadicandLowerTip = 输入：被开方数的低半部分
+squareRootRadicandUpperTip = 输入：被开方数的高半部分
+squareRootRemainderTip = 输出：余数（被开方数 - 平方根 × 平方根）
 #
 # arith/Subtractor.java
 #


### PR DESCRIPTION
## Summary

- localize the Square Root component in Simplified Chinese
- distinguish the lower and upper halves of the double-width radicand in the input tooltips
- describe both the square-root result and the remainder output
- keep the change limited to the five Square Root entries in `std_zh.properties`

This is a fifth focused follow-up to #2566, as invited in [the maintainer discussion](https://github.com/logisim-evolution/logisim-evolution/pull/2566#issuecomment-5357722957). It retains the useful terminology from that earlier effort while making the two radicand inputs explicit and describing the remainder as `被开方数 - 平方根 × 平方根`.

## Validation

- `.\gradlew.bat processResources checkstyleMain --no-daemon --max-workers=1`
- `.\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1`
- compared the Simplified Chinese translation-checker output with current `main`; all five Square Root fallback entries are resolved
- verified on Windows that `平方根` appears under the existing `运算器` library and that all four translated port tooltips render correctly; the compact in-symbol technical labels remain unchanged
- `git diff --check`
