### PR TITLE
fpga: localize unconnected output warnings

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactory.java
@@ -573,8 +573,7 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
         if (comp.isEndConnected(endIndex)) {
           signal.put(portName, Hdl.getNetName(comp, endIndex, true, theNets));
         } else {
-          // FIXME: hardcoded string
-          Reporter.report.addSevereWarning("Found an unconnected output pin, tied the pin to ground!");
+          Reporter.report.addSevereWarning(S.get("HdlUnconnectedOutputPinWarning"));
           signal.put(portName, Hdl.zeroBit());
         }
       }
@@ -591,8 +590,7 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
       if (!connected) {
         /* Here is the easy case, the bus is unconnected */
         if (!isInputConnection) {
-          // FIXME: hardcoded string
-          Reporter.report.addSevereWarning("Found an unconnected output bus pin, tied all the pin bits to ground!");
+          Reporter.report.addSevereWarning(S.get("HdlUnconnectedOutputBusWarning"));
           signal.put(portName, Hdl.getZeroVector(nrOfBits, true));
         }
       } else {
@@ -615,8 +613,8 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
             if (solderPoint.getParentNet() == null) {
               /* The net is not connected */
               if (isInputConnection) continue;
-              // FIXME: hardcoded string
-              Reporter.report.addSevereWarning(String.format("Found an unconnected output bus pin, tied bit %d to ground!", bit));
+              Reporter.report.addSevereWarning(
+                  S.get("HdlUnconnectedOutputBusBitWarning", bit));
               signal.put(bitConnection, Hdl.zeroBit());
             } else {
               /*

--- a/src/main/resources/resources/logisim/strings/fpga/fpga.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga.properties
@@ -127,6 +127,12 @@ HdlEmptyBehaviorError = INTERNAL ERROR: Empty behavior description for Component
 HdlInvalidSolderPointError = INTERNAL ERROR: Component tried to index non-existing SolderPoint
 HdlInvalidSolderPointComponentError = INTERNAL ERROR: Component tried to index non-existing SolderPoint: '%s'
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+HdlUnconnectedOutputPinWarning = Found an unconnected output pin, tied the pin to ground!
+HdlUnconnectedOutputBusWarning = Found an unconnected output bus pin, tied all the pin bits to ground!
+HdlUnconnectedOutputBusBitWarning = Found an unconnected output bus pin, tied bit %d to ground!
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generating COF file for flashing

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
@@ -130,6 +130,12 @@ TopLevelNoIO = Der Toplevel „%s“ hat keine(n) Eingäng(e) und/oder keine Aus
 # ==> HdlInvalidSolderPointError =
 # ==> HdlInvalidSolderPointComponentError =
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+# ==> HdlUnconnectedOutputPinWarning =
+# ==> HdlUnconnectedOutputBusWarning =
+# ==> HdlUnconnectedOutputBusBitWarning =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Erzeugen einer COF-Datei für das Flashen

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
@@ -127,6 +127,12 @@
 # ==> HdlInvalidSolderPointError =
 # ==> HdlInvalidSolderPointComponentError =
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+# ==> HdlUnconnectedOutputPinWarning =
+# ==> HdlUnconnectedOutputBusWarning =
+# ==> HdlUnconnectedOutputBusBitWarning =
+#
 # download/AlteraDownload.java
 #
 # ==> AlteraCofFile =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
@@ -127,6 +127,12 @@ TopLevelNoIO = El nivel superior «%s» no tiene ninguna entrada(s) y/o ninguna 
 # ==> HdlInvalidSolderPointError =
 # ==> HdlInvalidSolderPointComponentError =
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+# ==> HdlUnconnectedOutputPinWarning =
+# ==> HdlUnconnectedOutputBusWarning =
+# ==> HdlUnconnectedOutputBusBitWarning =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generación de archivos cof para flasheo

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
@@ -127,6 +127,12 @@ TopLevelNoIO = Le niveau supérieur « %s » n’a pas d’entrée(s) et/ou pa
 # ==> HdlInvalidSolderPointError =
 # ==> HdlInvalidSolderPointComponentError =
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+# ==> HdlUnconnectedOutputPinWarning =
+# ==> HdlUnconnectedOutputBusWarning =
+# ==> HdlUnconnectedOutputBusBitWarning =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Génération d’un fichier COF pour le flashage

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
@@ -127,6 +127,12 @@ TopLevelNoIO = Il livello superiore «%s» non ha ingressi e/o uscite!
 # ==> HdlInvalidSolderPointError =
 # ==> HdlInvalidSolderPointComponentError =
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+# ==> HdlUnconnectedOutputPinWarning =
+# ==> HdlUnconnectedOutputBusWarning =
+# ==> HdlUnconnectedOutputBusBitWarning =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generazione di file co-file per lampeggiante

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
@@ -127,6 +127,12 @@ TopLevelNoIO = トップ・レベル “%s” は入力および/または出力
 # ==> HdlInvalidSolderPointError =
 # ==> HdlInvalidSolderPointComponentError =
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+# ==> HdlUnconnectedOutputPinWarning =
+# ==> HdlUnconnectedOutputBusWarning =
+# ==> HdlUnconnectedOutputBusBitWarning =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = フラッシング用の cof ファイルの生成

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
@@ -127,6 +127,12 @@ TopLevelNoIO = Top level „%s” heeft geen ingang(en) en/of geen uitgang(en)!
 # ==> HdlInvalidSolderPointError =
 # ==> HdlInvalidSolderPointComponentError =
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+# ==> HdlUnconnectedOutputPinWarning =
+# ==> HdlUnconnectedOutputBusWarning =
+# ==> HdlUnconnectedOutputBusBitWarning =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Cof-bestand voor het flashen wordt gegenereerd.

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
@@ -127,6 +127,12 @@ TopLevelNoIO = Górny poziom „%s” nie ma wejścia(ów) i/lub wyjścia(ów)!
 # ==> HdlInvalidSolderPointError =
 # ==> HdlInvalidSolderPointComponentError =
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+# ==> HdlUnconnectedOutputPinWarning =
+# ==> HdlUnconnectedOutputBusWarning =
+# ==> HdlUnconnectedOutputBusBitWarning =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Generowanie pliku współrzędnych dla flashingu

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
@@ -127,6 +127,12 @@ TopLevelNoIO = O nível superior «%s» não tem entrada(s) e/ou saída(s)!
 # ==> HdlInvalidSolderPointError =
 # ==> HdlInvalidSolderPointComponentError =
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+# ==> HdlUnconnectedOutputPinWarning =
+# ==> HdlUnconnectedOutputBusWarning =
+# ==> HdlUnconnectedOutputBusBitWarning =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Gerando arquivo cof para piscar

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
@@ -127,6 +127,12 @@ TopLevelNoIO = Схема верхнего уровня «%s» не имеет �
 # ==> HdlInvalidSolderPointError =
 # ==> HdlInvalidSolderPointComponentError =
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+# ==> HdlUnconnectedOutputPinWarning =
+# ==> HdlUnconnectedOutputBusWarning =
+# ==> HdlUnconnectedOutputBusBitWarning =
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = Создание файла COF для прошивки

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
@@ -127,6 +127,12 @@ HdlEmptyBehaviorError = 内部错误：收到的元件“%s”行为描述为空
 HdlInvalidSolderPointError = 内部错误：元件尝试索引不存在的连接点！
 HdlInvalidSolderPointComponentError = 内部错误：元件尝试索引不存在的连接点："%s"
 #
+# circuit/CircuitHdlGeneratorFactory.java
+#
+HdlUnconnectedOutputPinWarning = 发现未连接的输出引脚；已将该引脚接地！
+HdlUnconnectedOutputBusWarning = 发现未连接的输出总线引脚；已将该总线引脚的所有位接地！
+HdlUnconnectedOutputBusBitWarning = 发现未连接的输出总线引脚；已将第 %d 位接地！
+#
 # download/AlteraDownload.java
 #
 AlteraCofFile = 正在生成用于烧录的 COF 文件

--- a/src/test/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactoryTest.java
@@ -17,11 +17,17 @@ import static org.mockito.Mockito.when;
 import com.cburch.logisim.TestBase;
 import com.cburch.logisim.comp.Component;
 import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.designrulecheck.ConnectionEnd;
+import com.cburch.logisim.fpga.designrulecheck.ConnectionPoint;
+import com.cburch.logisim.fpga.designrulecheck.Net;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
 import com.cburch.logisim.fpga.designrulecheck.SimpleDrcContainer;
 import com.cburch.logisim.fpga.designrulecheck.netlistComponent;
 import com.cburch.logisim.fpga.gui.FpgaReportTabbedPane;
 import com.cburch.logisim.fpga.gui.Reporter;
+import com.cburch.logisim.fpga.hdlgenerator.Hdl;
 import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.util.LineBuffer;
 import com.cburch.logisim.util.LocaleManager;
 import java.util.Locale;
 import java.util.Map;
@@ -51,8 +57,112 @@ class CircuitHdlGeneratorFactoryTest extends TestBase {
     }
   }
 
+  @Test
+  void unconnectedOutputWarningsUseCurrentLocaleAndKeepGroundingBehavior() {
+    final var originalLocale = LocaleManager.getLocale();
+    try {
+      assertUnconnectedOutputWarnings(
+          Locale.ENGLISH,
+          "Found an unconnected output pin, tied the pin to ground!",
+          "Found an unconnected output bus pin, tied all the pin bits to ground!",
+          "Found an unconnected output bus pin, tied bit 0 to ground!");
+      assertUnconnectedOutputWarnings(
+          Locale.SIMPLIFIED_CHINESE,
+          "发现未连接的输出引脚；已将该引脚接地！",
+          "发现未连接的输出总线引脚；已将该总线引脚的所有位接地！",
+          "发现未连接的输出总线引脚；已将第 0 位接地！");
+    } finally {
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
+
+  private void assertUnconnectedOutputWarnings(
+      Locale locale, String pinWarning, String busWarning, String busBitWarning) {
+    setLocaleAndReloadBundles(locale);
+    assertUnconnectedOutputPinWarning(pinWarning);
+    assertUnconnectedOutputBusWarning(busWarning);
+    assertPartiallyConnectedOutputBusWarning(busBitWarning);
+  }
+
+  private void assertUnconnectedOutputPinWarning(String expectedWarning) {
+    final var reporterGui = attachReporterGui();
+    final var component = mock(netlistComponent.class);
+    final var connection = mock(ConnectionEnd.class);
+    when(component.nrOfEnds()).thenReturn(1);
+    when(component.getEnd(0)).thenReturn(connection);
+    when(connection.getNrOfBits()).thenReturn(1);
+    when(connection.isOutputEnd()).thenReturn(false);
+    when(component.isEndConnected(0)).thenReturn(false);
+
+    assertEquals(
+        Map.of("output", Hdl.zeroBit()),
+        CircuitHdlGeneratorFactory.getSignalMap("output", component, 0, null));
+    assertSingleSevereWarning(reporterGui, expectedWarning);
+  }
+
+  private void assertUnconnectedOutputBusWarning(String expectedWarning) {
+    final var reporterGui = attachReporterGui();
+    final var component = mock(netlistComponent.class);
+    final var connection = mock(ConnectionEnd.class);
+    when(component.nrOfEnds()).thenReturn(1);
+    when(component.getEnd(0)).thenReturn(connection);
+    when(connection.getNrOfBits()).thenReturn(2);
+    when(connection.isOutputEnd()).thenReturn(false);
+    when(connection.get((byte) 0)).thenReturn(mock(ConnectionPoint.class));
+    when(connection.get((byte) 1)).thenReturn(mock(ConnectionPoint.class));
+
+    assertEquals(
+        Map.of("output", Hdl.getZeroVector(2, true)),
+        CircuitHdlGeneratorFactory.getSignalMap("output", component, 0, null));
+    assertSingleSevereWarning(reporterGui, expectedWarning);
+  }
+
+  private void assertPartiallyConnectedOutputBusWarning(String expectedWarning) {
+    final var reporterGui = attachReporterGui();
+    final var component = mock(netlistComponent.class);
+    final var connection = mock(ConnectionEnd.class);
+    final var disconnectedPoint = mock(ConnectionPoint.class);
+    final var connectedPoint = mock(ConnectionPoint.class);
+    final var connectedNet = mock(Net.class);
+    final var netlist = mock(Netlist.class);
+    when(component.nrOfEnds()).thenReturn(1);
+    when(component.getEnd(0)).thenReturn(connection);
+    when(connection.getNrOfBits()).thenReturn(2);
+    when(connection.isOutputEnd()).thenReturn(false);
+    when(connection.get((byte) 0)).thenReturn(disconnectedPoint);
+    when(connection.get((byte) 1)).thenReturn(connectedPoint);
+    when(connectedPoint.getParentNet()).thenReturn(connectedNet);
+    when(connectedNet.getBitWidth()).thenReturn(1);
+    when(netlist.isContinuesBus(component, 0)).thenReturn(false);
+    when(netlist.getNetId(connectedNet)).thenReturn(7);
+
+    final var signal =
+        CircuitHdlGeneratorFactory.getSignalMap("output", component, 0, netlist);
+
+    assertEquals(2, signal.size());
+    assertEquals(
+        Hdl.zeroBit(), signal.get(LineBuffer.formatHdl("{{1}}{{<}}{{2}}{{>}}", "output", 0)));
+    assertSingleSevereWarning(reporterGui, expectedWarning);
+  }
+
+  private FpgaReportTabbedPane attachReporterGui() {
+    final var reporterGui = mock(FpgaReportTabbedPane.class);
+    Reporter.report.setGuiLogger(reporterGui);
+    return reporterGui;
+  }
+
+  private void assertSingleSevereWarning(
+      FpgaReportTabbedPane reporterGui, String expectedWarning) {
+    final var warning = ArgumentCaptor.forClass(Object.class);
+    verify(reporterGui).addWarning(warning.capture());
+    assertEquals(expectedWarning, warning.getValue().toString());
+    assertEquals(
+        SimpleDrcContainer.LEVEL_SEVERE,
+        ((SimpleDrcContainer) warning.getValue()).getSeverity());
+  }
+
   private void assertInvalidSolderPointError(Locale locale, String expectedError) {
-    LocaleManager.setLocale(locale);
+    setLocaleAndReloadBundles(locale);
     final var reporterGui = mock(FpgaReportTabbedPane.class);
     Reporter.report.setGuiLogger(reporterGui);
     final var component = mock(netlistComponent.class);
@@ -71,5 +181,13 @@ class CircuitHdlGeneratorFactoryTest extends TestBase {
     assertEquals(expectedError, error.getValue().toString());
     assertEquals(
         SimpleDrcContainer.LEVEL_FATAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
+  }
+
+  private void setLocaleAndReloadBundles(Locale locale) {
+    Hdl.zeroBit();
+    com.cburch.logisim.fpga.Strings.S.get("HdlUnconnectedOutputPinWarning");
+    LocaleManager.setLocale(
+        Locale.ENGLISH.equals(locale) ? Locale.SIMPLIFIED_CHINESE : Locale.ENGLISH);
+    LocaleManager.setLocale(locale);
   }
 }


### PR DESCRIPTION
## Summary

- localize the three severe warnings for unconnected one-bit outputs, wholly unconnected output buses, and individual unconnected output-bus bits
- preserve the existing English wording, severe-warning level, bit-index substitution, generated signal maps, and zero/zero-vector grounding behavior
- add Simplified Chinese translations and standard fallback markers for the other locales
- add focused English/Chinese regression coverage for all three paths

## Scope

This implements the proposed fifth slice from the tracking inventory in #1144 and does not close the broader localization issue. Other hard-coded HDL-generation and FPGA-download diagnostics remain outside this pull request.

Tracking inventory: https://github.com/logisim-evolution/logisim-evolution/issues/1144#issuecomment-5369245087
Maintainer approval: https://github.com/logisim-evolution/logisim-evolution/issues/1144#issuecomment-5369405036

## Testing

- .\gradlew.bat test --tests com.cburch.logisim.circuit.CircuitHdlGeneratorFactoryTest --no-daemon --rerun-tasks --max-workers=1
- .\gradlew.bat processResources checkstyleMain checkstyleTest --no-daemon --rerun-tasks --max-workers=1
- .\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1
- git diff --check
- verified that all three keys are present in all 12 FPGA locale files