### PR TITLE
fix: report NaN floating-point outputs

### DIFF
--- a/src/main/java/com/cburch/logisim/std/arith/floating/FpDivider.java
+++ b/src/main/java/com/cburch/logisim/std/arith/floating/FpDivider.java
@@ -106,14 +106,15 @@ public class FpDivider extends InstanceFactory {
     final var out_val = a_val / b_val;
     final var out = Value.createKnown(dataWidth, out_val);
 
-    final var rem_val =  Math.IEEEremainder(a_val, b_val);
+    final var rem_val = Math.IEEEremainder(a_val, b_val);
     final var rem = Value.createKnown(dataWidth, rem_val);
 
+    final var hasError = Double.isNaN(out_val) || Double.isNaN(rem_val);
 
     // propagate them
     final var delay = (dataWidth.getWidth() + 2) * PER_DELAY;
     state.setPort(OUT1, out, delay);
     state.setPort(OUT2, rem, delay);
-    state.setPort(ERR, Value.createKnown(BitWidth.create(1), Double.isNaN(out_val) ? 1 : 0), delay);
+    state.setPort(ERR, Value.createKnown(BitWidth.create(1), hasError ? 1 : 0), delay);
   }
 }

--- a/src/main/java/com/cburch/logisim/std/arith/floating/FpTrigonometry.java
+++ b/src/main/java/com/cburch/logisim/std/arith/floating/FpTrigonometry.java
@@ -152,12 +152,17 @@ public class FpTrigonometry extends InstanceFactory {
     final var sin = Value.createKnown(dataWidth, sin_val);
     final var tan = Value.createKnown(dataWidth, tan_val);
     final var cos = Value.createKnown(dataWidth, cos_val);
+    final var hasError =
+        Double.isNaN(a_val)
+            || Double.isNaN(sin_val)
+            || Double.isNaN(tan_val)
+            || Double.isNaN(cos_val);
 
     // propagate them
     final var delay = (dataWidth.getWidth() + 2) * PER_DELAY;
     state.setPort(SIN, sin, delay);
     state.setPort(TAN, tan, delay);
     state.setPort(COS, cos, delay);
-    state.setPort(ERR, Value.createKnown(BitWidth.create(1), Double.isNaN(a_val) ? 1 : 0), delay);
+    state.setPort(ERR, Value.createKnown(BitWidth.create(1), hasError ? 1 : 0), delay);
   }
 }

--- a/src/test/java/com/cburch/logisim/std/arith/floating/FpDividerTest.java
+++ b/src/test/java/com/cburch/logisim/std/arith/floating/FpDividerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.arith.floating;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.instance.InstanceState;
+import com.cburch.logisim.instance.StdAttr;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FpDividerTest {
+  @ParameterizedTest
+  @ValueSource(ints = {8, 16, 32, 64})
+  void leavesErrorClearWhenBothOutputsAreNumbers(int bitWidth) {
+    final var width = BitWidth.create(bitWidth);
+    final var state = mock(InstanceState.class);
+    when(state.getAttributeValue(StdAttr.FP_WIDTH)).thenReturn(width);
+    when(state.getPortValue(0)).thenReturn(Value.createKnown(width, 6.0));
+    when(state.getPortValue(1)).thenReturn(Value.createKnown(width, 4.0));
+
+    new FpDivider().propagate(state);
+
+    verify(state)
+        .setPort(4, Value.FALSE, (width.getWidth() + 2) * FpDivider.PER_DELAY);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {8, 16, 32, 64})
+  void reportsErrorWhenRemainderIsNaN(int bitWidth) {
+    final var width = BitWidth.create(bitWidth);
+    final var state = mock(InstanceState.class);
+    when(state.getAttributeValue(StdAttr.FP_WIDTH)).thenReturn(width);
+    when(state.getPortValue(0)).thenReturn(Value.createKnown(width, 1.0));
+    when(state.getPortValue(1)).thenReturn(Value.createKnown(width, 0.0));
+
+    new FpDivider().propagate(state);
+
+    verify(state)
+        .setPort(4, Value.TRUE, (width.getWidth() + 2) * FpDivider.PER_DELAY);
+  }
+}

--- a/src/test/java/com/cburch/logisim/std/arith/floating/FpTrigonometryTest.java
+++ b/src/test/java/com/cburch/logisim/std/arith/floating/FpTrigonometryTest.java
@@ -10,9 +10,18 @@
 package com.cburch.logisim.std.arith.floating;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.cburch.logisim.comp.EndData;
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Value;
+import com.cburch.logisim.instance.InstanceState;
+import com.cburch.logisim.instance.StdAttr;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class FpTrigonometryTest {
   @Test
@@ -24,5 +33,35 @@ class FpTrigonometryTest {
     assertEquals(EndData.OUTPUT_ONLY, ports.get(2).getType());
     assertEquals(EndData.OUTPUT_ONLY, ports.get(3).getType());
     assertEquals(EndData.OUTPUT_ONLY, ports.get(4).getType());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {8, 16, 32, 64})
+  void leavesErrorClearWhenInverseFunctionOutputsAreNumbers(int bitWidth) {
+    final var width = BitWidth.create(bitWidth);
+    final var state = mock(InstanceState.class);
+    when(state.getAttributeValue(StdAttr.FP_WIDTH)).thenReturn(width);
+    when(state.getAttributeValue(FpTrigonometry.TRIG_MODE)).thenReturn(FpTrigonometry.ARC);
+    when(state.getPortValue(0)).thenReturn(Value.createKnown(width, 0.5));
+
+    new FpTrigonometry().propagate(state);
+
+    verify(state)
+        .setPort(4, Value.FALSE, (width.getWidth() + 2) * FpTrigonometry.PER_DELAY);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {8, 16, 32, 64})
+  void reportsErrorWhenInverseFunctionOutputIsNaN(int bitWidth) {
+    final var width = BitWidth.create(bitWidth);
+    final var state = mock(InstanceState.class);
+    when(state.getAttributeValue(StdAttr.FP_WIDTH)).thenReturn(width);
+    when(state.getAttributeValue(FpTrigonometry.TRIG_MODE)).thenReturn(FpTrigonometry.ARC);
+    when(state.getPortValue(0)).thenReturn(Value.createKnown(width, 2.0));
+
+    new FpTrigonometry().propagate(state);
+
+    verify(state)
+        .setPort(4, Value.TRUE, (width.getWidth() + 2) * FpTrigonometry.PER_DELAY);
   }
 }


### PR DESCRIPTION
## Summary

- make Floating Point Divider assert `ERR` when either the quotient or remainder is NaN
- make Floating Point Trigonometry assert `ERR` when any generated output is NaN, including out-of-domain inverse sine and cosine results
- keep infinity distinct from NaN and preserve the existing output and delay behavior
- add propagation regressions for normal and error cases at 8-, 16-, 32-, and 64-bit floating-point widths

Closes #2820.

Maintainer agreement: https://github.com/logisim-evolution/logisim-evolution/issues/2820#issuecomment-5369533139

## Testing

- .\gradlew.bat test --tests "com.cburch.logisim.std.arith.floating.*" checkstyleMain checkstyleTest --no-daemon --rerun-tasks --max-workers=1
- .\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1
- git diff --check