### PR TITLE
gui: add components to Find Action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@
     name, with fuzzy and acronym matching (e.g. "expim" or "ei" find "Export Image"). It opens from
     the Help menu, from Ctrl+Shift+A (configurable under Preferences > Hotkey settings), or by
     tapping Shift twice (switchable under Preferences > Window). It is built as a hub over pluggable
-    search providers, so further sources of results can be added without changing the dialog.
+    search providers, so further sources of results can be added without changing the dialog. Its
+    Add provider can select components for placement from the project's open libraries.
   * Fixed FlatLaf "restricted native access" warning on newer Java versions.
   * Improved file merging and export capabilities:
     * Added ability to selectively merge individual circuits and subcircuit dependencies from a Logisim file.

--- a/src/main/java/com/cburch/logisim/gui/search/OmniSearchDialog.java
+++ b/src/main/java/com/cburch/logisim/gui/search/OmniSearchDialog.java
@@ -348,10 +348,7 @@ public class OmniSearchDialog extends JDialog {
             .reversed());
 
     final var previous = resultList.getSelectedValue();
-    resultModel.clear();
-    for (final var result : merged) {
-      resultModel.addElement(result);
-    }
+    replaceResults(resultModel, merged);
 
     var selection = previous == null ? -1 : resultModel.indexOf(previous);
     if (selection < 0 && !resultModel.isEmpty()) selection = 0;
@@ -368,6 +365,13 @@ public class OmniSearchDialog extends JDialog {
                 "searchResultCount",
                 String.valueOf(resultModel.size()),
                 providerCount));
+  }
+
+  /** Replaces the visible results using one removal and one addition event. */
+  static void replaceResults(
+      DefaultListModel<SearchResult> model, List<SearchResult> results) {
+    model.clear();
+    model.addAll(results);
   }
 
   /**

--- a/src/main/java/com/cburch/logisim/gui/search/SearchProviders.java
+++ b/src/main/java/com/cburch/logisim/gui/search/SearchProviders.java
@@ -9,6 +9,7 @@
 
 package com.cburch.logisim.gui.search;
 
+import com.cburch.logisim.gui.search.providers.AddToolSearchProvider;
 import com.cburch.logisim.gui.search.providers.MenuSearchProvider;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -27,6 +28,7 @@ public final class SearchProviders {
 
   static {
     register(new MenuSearchProvider());
+    register(new AddToolSearchProvider());
   }
 
   private SearchProviders() {

--- a/src/main/java/com/cburch/logisim/gui/search/providers/AddToolSearchProvider.java
+++ b/src/main/java/com/cburch/logisim/gui/search/providers/AddToolSearchProvider.java
@@ -1,0 +1,144 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.search.providers;
+
+import static com.cburch.logisim.gui.Strings.S;
+
+import com.cburch.logisim.circuit.SubcircuitFactory;
+import com.cburch.logisim.comp.ComponentDrawContext;
+import com.cburch.logisim.gui.search.IndexedSearchProvider;
+import com.cburch.logisim.gui.search.SearchCandidate;
+import com.cburch.logisim.gui.search.SearchContext;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.tools.AddTool;
+import com.cburch.logisim.tools.Library;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import javax.swing.Icon;
+
+/** Offers the components in the current project's visible, open library hierarchy. */
+public class AddToolSearchProvider extends IndexedSearchProvider {
+
+  @Override
+  public String getDisplayName() {
+    return S.get("searchProviderAdd");
+  }
+
+  @Override
+  public boolean isAvailable(SearchContext context) {
+    return context.project() != null;
+  }
+
+  @Override
+  protected List<SearchCandidate> buildCandidates(SearchContext context) {
+    final var project = context.project();
+    if (project == null || project.getLogisimFile() == null) return List.of();
+
+    final var candidates = new ArrayList<SearchCandidate>();
+    final Set<Library> ancestors = Collections.newSetFromMap(new IdentityHashMap<>());
+    collectFrom(
+        project.getLogisimFile(),
+        getDisplayName(),
+        project,
+        candidates,
+        ancestors,
+        true);
+    return candidates;
+  }
+
+  private static void collectFrom(
+      Library library,
+      String parentPath,
+      Project project,
+      List<SearchCandidate> candidates,
+      Set<Library> ancestors,
+      boolean projectRoot) {
+    if ((!projectRoot && library.isHidden()) || !ancestors.add(library)) return;
+    try {
+      final var path = appendPath(parentPath, displayNameOf(library));
+      for (final var tool : library.getTools()) {
+        if (tool instanceof AddTool addTool && isPlaceable(addTool, project)) {
+          candidates.add(
+              new SearchCandidate(
+                  addTool.getDisplayName(),
+                  path,
+                  new ToolIcon(addTool),
+                  "",
+                  true,
+                  () -> project.setTool(addTool)));
+        }
+      }
+      for (final var child : library.getLibraries()) {
+        collectFrom(child, path, project, candidates, ancestors, false);
+      }
+    } finally {
+      ancestors.remove(library);
+    }
+  }
+
+  private static boolean isPlaceable(AddTool tool, Project project) {
+    return !(tool.getFactory(false) instanceof SubcircuitFactory subcircuit
+        && subcircuit.getSubcircuit() == project.getCurrentCircuit());
+  }
+
+  private static String displayNameOf(Library library) {
+    final var displayName = library.getDisplayName();
+    if (displayName != null && !displayName.isBlank()) return displayName.trim();
+    final var name = library.getName();
+    return name == null ? "" : name.trim();
+  }
+
+  private static String appendPath(String parent, String child) {
+    if (child.isEmpty()) return parent;
+    return parent.isEmpty() ? child : parent + SearchCandidate.CONTEXT_SEPARATOR + child;
+  }
+
+  /** Paints an AddTool using the same scaled component icon geometry as the toolbox. */
+  private static class ToolIcon implements Icon {
+    private final AddTool tool;
+
+    ToolIcon(AddTool tool) {
+      this.tool = tool;
+    }
+
+    @Override
+    public int getIconHeight() {
+      return AppPreferences.getScaled(AppPreferences.BOX_SIZE);
+    }
+
+    @Override
+    public int getIconWidth() {
+      return AppPreferences.getScaled(AppPreferences.BOX_SIZE);
+    }
+
+    @Override
+    public void paintIcon(Component component, Graphics graphics, int x, int y) {
+      final var baseGraphics = graphics.create();
+      baseGraphics.setColor(new Color(AppPreferences.COMPONENT_ICON_COLOR.get()));
+      final var iconGraphics = baseGraphics.create();
+      try {
+        final var context =
+            new ComponentDrawContext(component, null, null, baseGraphics, iconGraphics);
+        final var border = AppPreferences.getScaled(AppPreferences.ICON_BORDER);
+        tool.paintIcon(context, x + border, y + border);
+      } finally {
+        iconGraphics.dispose();
+        baseGraphics.dispose();
+      }
+    }
+  }
+}

--- a/src/main/resources/resources/logisim/strings/gui/gui.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui.properties
@@ -810,6 +810,10 @@ searchFooter = ↑ ↓ to select · ENTER to execute · ESC to close
 #
 searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = About Logisim-evolution

--- a/src/main/resources/resources/logisim/strings/gui/gui_de.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_de.properties
@@ -811,6 +811,10 @@ hotkeyGateModifierInputSub = Eingang von Gatter entfernen
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = Über Logisim-evolution

--- a/src/main/resources/resources/logisim/strings/gui/gui_el.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_el.properties
@@ -809,6 +809,10 @@ windowToolbarLocation = Θέση Εργαλειοθήκης
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = Σχετικά με το Logisim-evolution

--- a/src/main/resources/resources/logisim/strings/gui/gui_es.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_es.properties
@@ -811,6 +811,10 @@ windowToolbarZoomfactor = Factor de zoom
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = Acerca de Logisim-evolution

--- a/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_fr.properties
@@ -810,6 +810,10 @@ hotkeyGateModifierInputSub = Supprimer l’entrée d’une porte
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = À propos de Logisim-evolution

--- a/src/main/resources/resources/logisim/strings/gui/gui_it.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_it.properties
@@ -810,6 +810,10 @@ windowToolbarZoomfactor = Fattore di zoom
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = Informazioni su Logisim-evolution

--- a/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ja.properties
@@ -809,6 +809,10 @@ windowToolbarZoomfactor = ズームファクタ
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = Logisim-evolutionについて

--- a/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_nl.properties
@@ -811,6 +811,10 @@ hotkeyGateModifierInputSub = Input aftrekken voor een poort
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = Over Logisim-evolution

--- a/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pl.properties
@@ -811,6 +811,10 @@ hotkeyGateModifierInputSub = Usuń wejście bramki
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = Informacje o Logisim-evolution

--- a/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_pt.properties
@@ -810,6 +810,10 @@ windowGridColorsReset = Resetar as cores da grade para o padrão do Logisim
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = Sobre o Logisim-evolution

--- a/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_ru.properties
@@ -811,6 +811,10 @@ hotkeyGateModifierInputSub = Удалить вход логического эл
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = О программе Logisim-evolution

--- a/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
+++ b/src/main/resources/resources/logisim/strings/gui/gui_zh.properties
@@ -811,6 +811,10 @@ hotkeyGateModifierInputSub = 减少门的输入端口数量
 #
 # ==> searchProviderMenus = Menus
 #
+# search/providers/AddToolSearchProvider.java
+#
+# ==> searchProviderAdd = Add
+#
 # start/About.java
 #
 aboutDialogTitle = 关于 Logisim-evolution

--- a/src/test/java/com/cburch/logisim/gui/search/OmniSearchDialogTest.java
+++ b/src/test/java/com/cburch/logisim/gui/search/OmniSearchDialogTest.java
@@ -1,0 +1,60 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import javax.swing.DefaultListModel;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import org.junit.jupiter.api.Test;
+
+class OmniSearchDialogTest {
+
+  @Test
+  void replacesLargeResultSetsInOneBatch() {
+    final var model = new DefaultListModel<SearchResult>();
+    model.addElement(result("old"));
+    final var additions = new AtomicInteger();
+    final var removals = new AtomicInteger();
+    final var changes = new AtomicInteger();
+    model.addListDataListener(
+        new ListDataListener() {
+          @Override
+          public void intervalAdded(ListDataEvent event) {
+            additions.incrementAndGet();
+          }
+
+          @Override
+          public void intervalRemoved(ListDataEvent event) {
+            removals.incrementAndGet();
+          }
+
+          @Override
+          public void contentsChanged(ListDataEvent event) {
+            changes.incrementAndGet();
+          }
+        });
+    final var results = IntStream.range(0, 600).mapToObj(i -> result("result " + i)).toList();
+
+    OmniSearchDialog.replaceResults(model, results);
+
+    assertEquals(600, model.size());
+    assertEquals(1, additions.get());
+    assertEquals(1, removals.get());
+    assertEquals(0, changes.get());
+  }
+
+  private static SearchResult result(String title) {
+    return SearchResult.of(SearchCandidate.of(title, "", true, () -> {}), 0);
+  }
+}

--- a/src/test/java/com/cburch/logisim/gui/search/providers/AddToolSearchProviderTest.java
+++ b/src/test/java/com/cburch/logisim/gui/search/providers/AddToolSearchProviderTest.java
@@ -1,0 +1,191 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.gui.search.providers;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.SubcircuitFactory;
+import com.cburch.logisim.file.LogisimFile;
+import com.cburch.logisim.gui.search.SearchCandidate;
+import com.cburch.logisim.gui.search.SearchContext;
+import com.cburch.logisim.gui.search.SearchProviders;
+import com.cburch.logisim.gui.search.SearchQuery;
+import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.wiring.Pin;
+import com.cburch.logisim.std.wiring.Probe;
+import com.cburch.logisim.tools.AddTool;
+import com.cburch.logisim.tools.Library;
+import com.cburch.logisim.tools.Tool;
+import java.awt.image.BufferedImage;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JPanel;
+import org.junit.jupiter.api.Test;
+
+class AddToolSearchProviderTest {
+
+  @Test
+  void isAvailableOnlyForProjectWindowsAndIsRegistered() {
+    final var provider = new AddToolSearchProvider();
+
+    assertFalse(provider.isAvailable(new SearchContext(null, null, null)));
+    assertTrue(provider.isAvailable(contextFor(mock(Project.class))));
+    assertTrue(
+        SearchProviders.getAll().stream().anyMatch(AddToolSearchProvider.class::isInstance));
+  }
+
+  @Test
+  void indexesVisibleNestedAddToolsWithTheirLibraryPathsAndIcons() {
+    final var rootTool = new AddTool(Pin.FACTORY);
+    final var leafTool = new AddTool(Probe.FACTORY);
+    final var ordinaryTool = mock(Tool.class);
+    final var leafLibrary = new TestLibrary("Leaf", List.of(leafTool, ordinaryTool), List.of());
+    final var parentLibrary = new TestLibrary("Parent", List.of(), List.of(leafLibrary));
+    final var hiddenTool = new AddTool(Pin.FACTORY);
+    final var hiddenLibrary = new TestLibrary("Hidden", List.of(hiddenTool), List.of());
+    hiddenLibrary.setHidden();
+
+    final var file = mock(LogisimFile.class);
+    when(file.getDisplayName()).thenReturn("Demo");
+    when(file.getTools()).thenReturn(List.of(rootTool));
+    when(file.getLibraries()).thenReturn(List.of(parentLibrary, hiddenLibrary));
+    final var project = mock(Project.class);
+    when(project.getLogisimFile()).thenReturn(file);
+
+    final var candidates = candidates(new AddToolSearchProvider(), project);
+
+    assertEquals(2, candidates.size());
+    assertCandidate(candidates.get(0), rootTool, "Add › Demo");
+    assertCandidate(candidates.get(1), leafTool, "Add › Demo › Parent › Leaf");
+  }
+
+  @Test
+  void activatingResultSelectsExistingToolThroughProject() {
+    final var tool = new AddTool(Pin.FACTORY);
+    final var file = mock(LogisimFile.class);
+    when(file.getDisplayName()).thenReturn("Demo");
+    when(file.getTools()).thenReturn(List.of(tool));
+    when(file.getLibraries()).thenReturn(List.of());
+    final var project = mock(Project.class);
+    when(project.getLogisimFile()).thenReturn(file);
+
+    final var candidate = candidates(new AddToolSearchProvider(), project).get(0);
+    candidate.action().run();
+
+    verify(project).setTool(tool);
+  }
+
+  @Test
+  void excludesCurrentCircuitBecauseItCannotContainItself() {
+    final var currentCircuit = mock(Circuit.class);
+    final var currentFactory = mock(SubcircuitFactory.class);
+    when(currentFactory.getSubcircuit()).thenReturn(currentCircuit);
+    final var currentTool = mock(AddTool.class);
+    when(currentTool.getFactory(false)).thenReturn(currentFactory);
+    final var otherTool = new AddTool(Pin.FACTORY);
+    final var file = mock(LogisimFile.class);
+    when(file.getDisplayName()).thenReturn("Demo");
+    when(file.getTools()).thenReturn(List.of(currentTool, otherTool));
+    when(file.getLibraries()).thenReturn(List.of());
+    final var project = mock(Project.class);
+    when(project.getLogisimFile()).thenReturn(file);
+    when(project.getCurrentCircuit()).thenReturn(currentCircuit);
+
+    final var candidates = candidates(new AddToolSearchProvider(), project);
+
+    assertEquals(1, candidates.size());
+    assertEquals(otherTool.getDisplayName(), candidates.get(0).title());
+  }
+
+  @Test
+  void rebuildsSnapshotEachTimeDialogPreparesProvider() {
+    final var first = new AddTool(Pin.FACTORY);
+    final var second = new AddTool(Probe.FACTORY);
+    final var currentTools = new AtomicReference<>(List.of(first));
+    final var file = mock(LogisimFile.class);
+    when(file.getDisplayName()).thenReturn("Demo");
+    when(file.getTools()).thenAnswer(invocation -> currentTools.get());
+    when(file.getLibraries()).thenReturn(List.of());
+    final var project = mock(Project.class);
+    when(project.getLogisimFile()).thenReturn(file);
+    final var provider = new AddToolSearchProvider();
+
+    candidates(provider, project).get(0).action().run();
+    verify(project).setTool(first);
+
+    currentTools.set(List.of(second));
+    candidates(provider, project).get(0).action().run();
+    verify(project).setTool(second);
+  }
+
+  private static List<SearchCandidate> candidates(
+      AddToolSearchProvider provider, Project project) {
+    provider.prepare(contextFor(project));
+    return provider.search(new SearchQuery("")).stream().map(result -> result.candidate()).toList();
+  }
+
+  private static SearchContext contextFor(Project project) {
+    return new SearchContext(null, null, project);
+  }
+
+  private static void assertCandidate(SearchCandidate candidate, AddTool tool, String context) {
+    assertEquals(tool.getDisplayName(), candidate.title());
+    assertEquals(context, candidate.context());
+    assertNotNull(candidate.icon());
+    assertTrue(candidate.enabled());
+    final var image = new BufferedImage(32, 32, BufferedImage.TYPE_INT_ARGB);
+    final var graphics = image.createGraphics();
+    try {
+      assertDoesNotThrow(() -> candidate.icon().paintIcon(new JPanel(), graphics, 0, 0));
+    } finally {
+      graphics.dispose();
+    }
+  }
+
+  private static class TestLibrary extends Library {
+    private final String name;
+    private final List<? extends Tool> tools;
+    private final List<Library> libraries;
+
+    TestLibrary(String name, List<? extends Tool> tools, List<Library> libraries) {
+      this.name = name;
+      this.tools = tools;
+      this.libraries = libraries;
+    }
+
+    @Override
+    public String getDisplayName() {
+      return name;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public List<Library> getLibraries() {
+      return libraries;
+    }
+
+    @Override
+    public List<? extends Tool> getTools() {
+      return tools;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a project-scoped `Add` provider to Find Action that lists placeable components from visible open libraries with their paths and icons
- activate results through the existing project tool-selection path, while excluding hidden libraries, non-add tools, and the current circuit
- batch large result-model updates so component searches remain responsive
- add localized provider/status text, release notes, and focused regression tests

## Validation

- `.\gradlew.bat test --tests 'com.cburch.logisim.gui.search.*' checkstyleMain checkstyleTest`
- `.\gradlew.bat check --rerun-tasks --no-parallel`
- `.\gradlew.bat shadowJar`
- verified all 12 locale bundles contain the new keys
- verified on Windows that `Ctrl+Shift+A` finds components, continuous `Pin` input remains responsive, and Enter selects the component for placement
- `git diff --check`

Closes #2399
