### PR TITLE
docs: add missing I/O component reference pages

### DIFF
--- a/src/main/resources/doc/de/contents.xml
+++ b/src/main/resources/doc/de/contents.xml
@@ -174,12 +174,15 @@
 			<tocitem target="io_joystick" text="Joystick" image="icon_joystick" />
 			<tocitem target="io_keyboard" text="Tastatur" image="icon_keyboard" />
 			<tocitem target="io_led" text="LED" image="icon_led" />
+			<tocitem target="io_ledbar" text="LED Bar" />
 			<tocitem target="io_ledRGB" text="LED RGB" image="icon_ledRGB" />
 			<tocitem target="io_7seg" text="7-Segmentanzeige" image="icon_7seg" />
 			<tocitem target="io_hexdig" text="Hexadezimale Anzeige" image="icon_hexdig" />
 			<tocitem target="io_dotmat" text="LED-Matrix" image="icon_dotmat" />
 			<tocitem target="io_tty" text="Terminal" image="icon_tty" />
 			<tocitem target="io_telnet" text="Telnet" image="icon_telnet" />
+			<tocitem target="io_realtimeclock" text="Real-Time Clock" />
+			<tocitem target="io_matrixkeypad" text="Matrix Keypad" />
 			<tocitem target="io_Port_IO" text="Port I/O" image="icon_Port_IO" />
 			<tocitem target="io_Repetar" text="Reptar Local Bus" image="icon_repetar" />
 			<tocitem target="io_videorgb" text="Video RGB" image="icon_videorgb" />

--- a/src/main/resources/doc/de/html/libs/io/index.html
+++ b/src/main/resources/doc/de/html/libs/io/index.html
@@ -21,6 +21,8 @@ with a user.</p>
 	<td><a href="keyboard.html">Tastatur</a></td></tr>
 <tr><td align="right"><a href="led.html"><img border="0" src="../../../../icons/led.gif" width="16" height="16"></a></td>
 	<td><a href="led.html">LED</a></td></tr>
+<tr><td align="right"><a href="../../../../en/html/libs/io/ledbar.html"><img border="0" src="../../../../icons/1616/ledbar.png" width="16" height="16"></a></td>
+	<td><a href="../../../../en/html/libs/io/ledbar.html">LED Bar</a></td></tr>
 <tr><td align="right"><a href="7seg.html"><img border="0" src="../../../../icons/7seg.gif" width="16" height="16"></a></td>
 	<td><a href="7seg.html">7-Segmentanzeige</a></td></tr>
 <tr><td align="right"><a href="hexdig.html"><img border="0" src="../../../../icons/hexdig.gif" width="16" height="16"></a></td>
@@ -31,6 +33,10 @@ with a user.</p>
 	<td><a href="tty.html">Terminal</a></td></tr>
 <tr><td align="right"><a href="../../../../en/html/libs/io/telnet.html"><img border="0" src="../../../../icons/1616/telnet.png" width="16" height="16"></a></td>
 	<td><a href="../../../../en/html/libs/io/telnet.html">Telnet</a></td></tr>
+<tr><td align="right"><a href="../../../../en/html/libs/io/realtimeclock.html"><img border="0" src="../../../../../resources/logisim/icons/realtimeclock.gif" width="16" height="16"></a></td>
+	<td><a href="../../../../en/html/libs/io/realtimeclock.html">Real-Time Clock</a></td></tr>
+<tr><td align="right"><a href="../../../../en/html/libs/io/matrixkeypad.html"><img border="0" src="../../../../../resources/logisim/icons/matrixkeypad.gif" width="16" height="16"></a></td>
+	<td><a href="../../../../en/html/libs/io/matrixkeypad.html">Matrix Keypad</a></td></tr>
 </table>
 
 <p><a href="../index.html">Zurück zur <em>Bibliotheksreferenz</em></a></p>

--- a/src/main/resources/doc/en/contents.xml
+++ b/src/main/resources/doc/en/contents.xml
@@ -202,12 +202,15 @@
 			<tocitem target="io_joystick" text="Joystick" image="icon_joystick" />
 			<tocitem target="io_keyboard" text="Keyboard" image="icon_keyboard" />
 			<tocitem target="io_led" text="LED" image="icon_led" />
+			<tocitem target="io_ledbar" text="LED Bar" />
 			<tocitem target="io_ledRGB" text="LED RGB" image="icon_rgbled" />
 			<tocitem target="io_7seg" text="7-Segment Display" image="icon_7seg" />
 			<tocitem target="io_hexdig" text="Hex Digit Display" image="icon_hexdig" />
 			<tocitem target="io_dotmat" text="LED Matrix" image="icon_dotmat" />
 			<tocitem target="io_tty" text="TTY" image="icon_tty" />
 			<tocitem target="io_telnet" text="Telnet" image="icon_telnet" />
+			<tocitem target="io_realtimeclock" text="Real-Time Clock" />
+			<tocitem target="io_matrixkeypad" text="Matrix Keypad" />
 <!-- not documented 
      		<tocitem target="io_Port_IO" text="Port I/O" image="icon_Port_IO" />
 			<tocitem target="io_Repetar" text="Reptar Local Bus" image="icon_repetar" />

--- a/src/main/resources/doc/en/html/libs/io/index.html
+++ b/src/main/resources/doc/en/html/libs/io/index.html
@@ -89,14 +89,14 @@
         </tr>
         <tr>
           <td align="right">
-            <a href="./led.html"><img class="iconlibs" src="../../../../icons/6464/ledbar.png" alt="#########" border=0
+            <a href="./ledbar.html"><img class="iconlibs" src="../../../../icons/6464/ledbar.png" alt="LED Bar icon" border=0
                 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
           </td>
           <td>
-            <a href="./led.html">LED Bar</a>
+            <a href="./ledbar.html">LED Bar</a>
           </td>
         </tr>
         <tr>
@@ -169,6 +169,32 @@
           </td>
           <td>
             <a href="./telnet.html">Telnet</a>
+          </td>
+        </tr>
+        <tr>
+          <td align="right">
+            <a href="./realtimeclock.html"><img class="iconlibs"
+                src="../../../../../resources/logisim/icons/realtimeclock.gif"
+                alt="Real-Time Clock icon" border=0 height="32" width="32"></a>
+          </td>
+          <td>
+            &nbsp;
+          </td>
+          <td>
+            <a href="./realtimeclock.html">Real-Time Clock</a>
+          </td>
+        </tr>
+        <tr>
+          <td align="right">
+            <a href="./matrixkeypad.html"><img class="iconlibs"
+                src="../../../../../resources/logisim/icons/matrixkeypad.gif"
+                alt="Matrix Keypad icon" border=0 height="32" width="32"></a>
+          </td>
+          <td>
+            &nbsp;
+          </td>
+          <td>
+            <a href="./matrixkeypad.html">Matrix Keypad</a>
           </td>
         </tr>
         <tr>

--- a/src/main/resources/doc/en/html/libs/io/ledbar.html
+++ b/src/main/resources/doc/en/html/libs/io/ledbar.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="changed" content="2026-08-11T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>LED Bar</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/ledbar.png" alt="LED Bar icon"
+            width="32" height="32" align="middle"> <em>LED Bar</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Input/Output</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Behavior</h2>
+      <p>
+        Displays a horizontal row of LED segments. A segment uses the <q>On Color</q> when its
+        input is 1 and the <q>Off Color</q> when its input is 0. An unknown or error input is shown
+        using the simulator's error color.
+      </p>
+
+      <h2>Pins</h2>
+      <p>The pins depend on the <q>Input Format</q> attribute.</p>
+      <dl>
+        <dt>Separated</dt>
+        <dd>Provides one 1-bit input for each segment.</dd>
+        <dt>One Wire</dt>
+        <dd>
+          Provides one multi-bit input whose width equals the number of segments. Bit 0 controls
+          the rightmost segment.
+        </dd>
+      </dl>
+
+      <h2>Attributes</h2>
+      <dl>
+        <dt>Input Format</dt>
+        <dd>Selects between separate 1-bit inputs and one multi-bit input.</dd>
+        <dt>Segments</dt>
+        <dd>Sets the number of LED segments. The default is 8.</dd>
+        <dt>Select Location</dt>
+        <dd>Places the input pins on the bottom/left or top/right side of the component.</dd>
+        <dt>On Color</dt>
+        <dd>Selects the color of a segment whose input is 1.</dd>
+        <dt>Off Color</dt>
+        <dd>Selects the color of a segment whose input is 0.</dd>
+        <dt>Light Persistence</dt>
+        <dd>
+          Keeps a segment lit for the selected number of simulation ticks after its input becomes
+          0. A value of 0 disables persistence.
+        </dd>
+        <dt>Label</dt>
+        <dd>The text associated with the component.</dd>
+        <dt>Label Location</dt>
+        <dd>The location of the label relative to the component.</dd>
+        <dt>Label Font</dt>
+        <dd>The font used to draw the label.</dd>
+        <dt>Label Color</dt>
+        <dd>The color used to draw the label.</dd>
+        <dt>Label Visible</dt>
+        <dd>Controls whether the label is displayed.</dd>
+      </dl>
+
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+
+      <h2>Text Tool Behavior</h2>
+      <p>Allows the label associated with the component to be edited.</p>
+
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/io/matrixkeypad.html
+++ b/src/main/resources/doc/en/html/libs/io/matrixkeypad.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="changed" content="2026-08-11T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Matrix Keypad</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs"
+            src="../../../../../resources/logisim/icons/matrixkeypad.gif"
+            alt="Matrix Keypad icon" width="32" height="32" align="middle">
+        <em>Matrix Keypad</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Input/Output</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Behavior</h2>
+      <p>
+        Models a 4-by-4 matrix keypad. Pressing a key connects its row input to its column output,
+        allowing a circuit to scan the keypad in the same way as a physical row-column keypad.
+        Releasing the mouse button releases the key.
+      </p>
+      <p>The <q>Operating mode</q> attribute selects one of two electrical behaviors.</p>
+      <dl>
+        <dt>Raw Matrix</dt>
+        <dd>
+          An unpressed column is unknown. A pressed key passes the value of its row input to the
+          corresponding column output. If simultaneously pressed keys drive incompatible known
+          values into one column, that column reports an error value.
+        </dd>
+        <dt>Pmod KYPD (Internal Pull-Up)</dt>
+        <dd>
+          An unpressed column is 1. A pressed key connected to a row driven to 0 pulls its column
+          output to 0. Conflicting or erroneous row values produce an error value. This mode uses
+          the fixed Pmod KYPD labels, including 0, F, E, and D on the bottom row.
+        </dd>
+      </dl>
+
+      <h2>Pins</h2>
+      <p>
+        Four 1-bit row inputs are located along the bottom edge, and four 1-bit column outputs are
+        located along the right edge. Each key connects the row and column that intersect at its
+        position while the key is pressed.
+      </p>
+
+      <h2>Attributes</h2>
+      <dl>
+        <dt>Operating mode</dt>
+        <dd>Selects Raw Matrix or Pmod KYPD behavior as described above.</dd>
+        <dt>Display size</dt>
+        <dd>Selects the normal or large keypad appearance.</dd>
+        <dt>Key 'A', 'B', 'C', 'D', '*', and '#' Symbol</dt>
+        <dd>
+          Customizes the displayed symbols for these six keys in Raw Matrix mode. Pmod KYPD mode
+          uses fixed labels and hides these attributes.
+        </dd>
+        <dt>Label</dt>
+        <dd>The text associated with the component.</dd>
+        <dt>Label Location</dt>
+        <dd>The location of the label relative to the component.</dd>
+        <dt>Label Font</dt>
+        <dd>The font used to draw the label.</dd>
+        <dt>Label Color</dt>
+        <dd>The color used to draw the label.</dd>
+        <dt>Label Visible</dt>
+        <dd>Controls whether the label is displayed.</dd>
+      </dl>
+
+      <h2>Poke Tool Behavior</h2>
+      <p>
+        Press and hold a key to connect its row and column. The key remains pressed until the mouse
+        button is released.
+      </p>
+
+      <h2>Text Tool Behavior</h2>
+      <p>Allows the label associated with the component to be edited.</p>
+
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/io/realtimeclock.html
+++ b/src/main/resources/doc/en/html/libs/io/realtimeclock.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="changed" content="2026-08-11T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Real-Time Clock</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs"
+            src="../../../../../resources/logisim/icons/realtimeclock.gif"
+            alt="Real-Time Clock icon" width="32" height="32" align="middle">
+        <em>Real-Time Clock</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Input/Output</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Behavior</h2>
+      <p>
+        Outputs the current time since the Unix epoch, 1970-01-01 00:00:00 UTC. The value is
+        expressed in either milliseconds or seconds. The component refreshes automatically and
+        does not require a clock input.
+      </p>
+
+      <h2>Pins</h2>
+      <p>
+        The component has one 64-bit output. Its value is the current epoch time in the unit chosen
+        by the <q>Time Type</q> attribute.
+      </p>
+
+      <h2>Attributes</h2>
+      <p>
+        When the component is selected or being added, the arrow keys alter its <q>Facing</q>
+        attribute.
+      </p>
+      <dl>
+        <dt>Facing</dt>
+        <dd>The location of the output pin relative to the component.</dd>
+        <dt>Time Type</dt>
+        <dd>Selects epoch milliseconds or epoch seconds for the output.</dd>
+        <dt>Draw size</dt>
+        <dd>Selects the medium or narrow component appearance.</dd>
+      </dl>
+
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+
+      <h2>Text Tool Behavior</h2>
+      <p>None.</p>
+
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/fr/contents.xml
+++ b/src/main/resources/doc/fr/contents.xml
@@ -174,12 +174,15 @@
 			<tocitem target="io_joystick" image="icon_joystick" text="Manette"/>
 			<tocitem target="io_keyboard" image="icon_keyboard" text="Clavier"/>
 			<tocitem target="io_led" image="icon_led" text="LED"/>
+			<tocitem target="io_ledbar" text="LED Bar" />
 			<tocitem target="io_ledRGB" text="LED RVB" image="icon_led RGB" />			
 			<tocitem target="io_7seg" image="icon_7seg" text="Afficheur 7-Segments"/>
 			<tocitem target="io_hexdig" image="icon_hexdig" text="Afficheur Hexadecimal"/>
 			<tocitem target="io_dotmat" image="icon_dotmat" text="Matrice de LED"/>
 			<tocitem target="io_tty" image="icon_tty" text="TTY"/>
 			<tocitem target="io_telnet" image="icon_telnet" text="Telnet"/>
+			<tocitem target="io_realtimeclock" text="Real-Time Clock" />
+			<tocitem target="io_matrixkeypad" text="Matrix Keypad" />
 			<tocitem target="io_Port_IO" image="icon_Port_IO" text="Port I/O"  />
 			<tocitem target="io_Repetar"  image="icon_repetar" text="Reptar Local Bus"/>
 			<tocitem target="io_videorgb"  image="icon_videorgb" text="Afficheur Video RVB"/>

--- a/src/main/resources/doc/map_de.jhm
+++ b/src/main/resources/doc/map_de.jhm
@@ -166,11 +166,14 @@
 	<mapID target="io_joystick"         url="de/html/libs/io/joystick.html" />
 	<mapID target="io_keyboard"         url="de/html/libs/io/keyboard.html" />
 	<mapID target="io_led"              url="de/html/libs/io/led.html" />
+	<mapID target="io_ledbar"           url="en/html/libs/io/ledbar.html" />
 	<mapID target="io_7seg"             url="de/html/libs/io/7seg.html" />
 	<mapID target="io_hexdig"           url="de/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="de/html/libs/io/dotmat.html" />
 	<mapID target="io_tty"              url="de/html/libs/io/tty.html" />
 	<mapID target="io_telnet"           url="en/html/libs/io/telnet.html" />
+	<mapID target="io_realtimeclock"    url="en/html/libs/io/realtimeclock.html" />
+	<mapID target="io_matrixkeypad"     url="en/html/libs/io/matrixkeypad.html" />
     <mapID target="io_Port_IO"          url="de/html/libs/io/Port_io.html" />
 	<mapID target="io_Repetar"          url="de/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="de/html/libs/io/videorvb.html" />

--- a/src/main/resources/doc/map_en.jhm
+++ b/src/main/resources/doc/map_en.jhm
@@ -183,12 +183,15 @@
 	<mapID target="io_joystick"         url="en/html/libs/io/joystick.html" />
 	<mapID target="io_keyboard"         url="en/html/libs/io/keyboard.html" />
 	<mapID target="io_led"              url="en/html/libs/io/led.html" />
+	<mapID target="io_ledbar"           url="en/html/libs/io/ledbar.html" />
 	<mapID target="io_7seg"             url="en/html/libs/io/7seg.html" />
 	<mapID target="io_hexdig"           url="en/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="en/html/libs/io/dotmat.html" />
-	<mapID target="io_tty"              url="en/html/libs/io/tty.html" />	
+	<mapID target="io_tty"              url="en/html/libs/io/tty.html" />
 	<mapID target="io_telnet"           url="en/html/libs/io/telnet.html" />
-    <mapID target="io_Port_IO"          url="en/html/libs/io/Port_io.html" />	
+	<mapID target="io_realtimeclock"    url="en/html/libs/io/realtimeclock.html" />
+	<mapID target="io_matrixkeypad"     url="en/html/libs/io/matrixkeypad.html" />
+    <mapID target="io_Port_IO"          url="en/html/libs/io/Port_io.html" />
 	<mapID target="io_Repetar"          url="en/html/libs/io/repetar.html" />	
 	<mapID target="io_videorvb"         url="en/html/libs/io/videorvb.html" />
 	<mapID target="tcl"                 url="en/html/libs/tcl/index.html" />

--- a/src/main/resources/doc/map_fr.jhm
+++ b/src/main/resources/doc/map_fr.jhm
@@ -165,11 +165,14 @@
 	<mapID target="io_joystick"         url="en/html/libs/io/joystick.html" />
 	<mapID target="io_keyboard"         url="en/html/libs/io/keyboard.html" />
 	<mapID target="io_led"              url="en/html/libs/io/led.html" />
+	<mapID target="io_ledbar"           url="en/html/libs/io/ledbar.html" />
 	<mapID target="io_7seg"             url="en/html/libs/io/7seg.html" />
 	<mapID target="io_hexdig"           url="en/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="en/html/libs/io/dotmat.html" />
 	<mapID target="io_tty"              url="en/html/libs/io/tty.html" />	
 	<mapID target="io_telnet"           url="en/html/libs/io/telnet.html" />
+	<mapID target="io_realtimeclock"    url="en/html/libs/io/realtimeclock.html" />
+	<mapID target="io_matrixkeypad"     url="en/html/libs/io/matrixkeypad.html" />
     <mapID target="io_Port_IO"          url="en/html/libs/io/Port_io.html" />	
 	<mapID target="io_Repetar"          url="en/html/libs/io/repetar.html" />	
 	<mapID target="io_videorvb"         url="en/html/libs/io/videorvb.html" />

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -182,11 +182,14 @@
 	<mapID target="io_joystick"         url="pt/html/libs/io/joystick.html" />
 	<mapID target="io_keyboard"         url="pt/html/libs/io/keyboard.html" />
 	<mapID target="io_led"              url="pt/html/libs/io/led.html" />
+	<mapID target="io_ledbar"           url="en/html/libs/io/ledbar.html" />
 	<mapID target="io_7seg"             url="pt/html/libs/io/7seg.html" />
 	<mapID target="io_hexdig"           url="pt/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="pt/html/libs/io/dotmat.html" />
 	<mapID target="io_tty"              url="pt/html/libs/io/tty.html" />
 	<mapID target="io_telnet"           url="en/html/libs/io/telnet.html" />
+	<mapID target="io_realtimeclock"    url="en/html/libs/io/realtimeclock.html" />
+	<mapID target="io_matrixkeypad"     url="en/html/libs/io/matrixkeypad.html" />
     <mapID target="io_Port_IO"          url="pt/html/libs/io/Port_io.html" />
 	<mapID target="io_Repetar"          url="pt/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="pt/html/libs/io/videorvb.html" />

--- a/src/main/resources/doc/map_ru.jhm
+++ b/src/main/resources/doc/map_ru.jhm
@@ -175,6 +175,7 @@
 	<mapID target="io_joystick"         url="ru/html/libs/io/joystick.html" />
 	<mapID target="io_keyboard"         url="ru/html/libs/io/keyboard.html" />
 	<mapID target="io_led"              url="ru/html/libs/io/led.html" />
+	<mapID target="io_ledbar"           url="en/html/libs/io/ledbar.html" />
 	<mapID target="io_7seg"             url="ru/html/libs/io/7seg.html" />
 	<mapID target="io_hexdig"           url="ru/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="ru/html/libs/io/dotmat.html" />
@@ -182,6 +183,8 @@
 	<mapID target="io_ledRGB"           url="ru/html/libs/io/rgbled.html" />
 	<mapID target="io_tty"              url="ru/html/libs/io/tty.html" />
 	<mapID target="io_telnet"           url="ru/html/libs/io/telnet.html" />
+	<mapID target="io_realtimeclock"    url="en/html/libs/io/realtimeclock.html" />
+	<mapID target="io_matrixkeypad"     url="en/html/libs/io/matrixkeypad.html" />
     <mapID target="io_Port_IO"          url="ru/html/libs/io/Port_io.html" />
 	<mapID target="io_Repetar"          url="ru/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="ru/html/libs/io/videorvb.html" />

--- a/src/main/resources/doc/map_zh.jhm
+++ b/src/main/resources/doc/map_zh.jhm
@@ -167,12 +167,15 @@
 	<mapID target="io_joystick"         url="zh/html/libs/io/joystick.html" />
 	<mapID target="io_keyboard"         url="zh/html/libs/io/keyboard.html" />
 	<mapID target="io_led"              url="zh/html/libs/io/led.html" />
+	<mapID target="io_ledbar"           url="en/html/libs/io/ledbar.html" />
 	<mapID target="io_rgbled"           url="zh/html/libs/io/rgbled.html" />
 	<mapID target="io_7seg"             url="zh/html/libs/io/7seg.html" />
 	<mapID target="io_hexdig"           url="zh/html/libs/io/hexdig.html" />
 	<mapID target="io_dotmat"           url="zh/html/libs/io/dotmat.html" />
 	<mapID target="io_tty"              url="zh/html/libs/io/tty.html" />
 	<mapID target="io_telnet"           url="en/html/libs/io/telnet.html" />
+	<mapID target="io_realtimeclock"    url="en/html/libs/io/realtimeclock.html" />
+	<mapID target="io_matrixkeypad"     url="en/html/libs/io/matrixkeypad.html" />
     <mapID target="io_Port_IO"          url="zh/html/libs/io/Port_io.html" />
 	<mapID target="io_Repetar"          url="zh/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="zh/html/libs/io/videorvb.html" />

--- a/src/main/resources/doc/pt/html/libs/io/index.html
+++ b/src/main/resources/doc/pt/html/libs/io/index.html
@@ -22,6 +22,8 @@ com um usuário. </p>
 	<td><a href="keyboard.html">Teclado</a></td></tr>
 <tr><td align="right"><a href="led.html"><img border="0" src="../../../../icons/led.gif"></a></td>
 	<td><a href="led.html">LED</a></td></tr>
+<tr><td align="right"><a href="../../../../en/html/libs/io/ledbar.html"><img border="0" src="../../../../icons/1616/ledbar.png"></a></td>
+	<td><a href="../../../../en/html/libs/io/ledbar.html">LED Bar</a></td></tr>
 <tr><td align="right"><a href="7seg.html"><img border="0" src="../../../../icons/7seg.gif"></a></td>
 	<td><a href="7seg.html">Display de 7-segmentos</a></td></tr>
 <tr><td align="right"><a href="hexdig.html"><img border="0" src="../../../../icons/hexdig.gif"></a></td>
@@ -32,6 +34,10 @@ com um usuário. </p>
 	<td><a href="tty.html">TTY</a></td></tr>
 <tr><td align="right"><a href="../../../../en/html/libs/io/telnet.html"><img border="0" src="../../../../icons/1616/telnet.png"></a></td>
 	<td><a href="../../../../en/html/libs/io/telnet.html">Telnet</a></td></tr>
+<tr><td align="right"><a href="../../../../en/html/libs/io/realtimeclock.html"><img border="0" src="../../../../../resources/logisim/icons/realtimeclock.gif"></a></td>
+	<td><a href="../../../../en/html/libs/io/realtimeclock.html">Real-Time Clock</a></td></tr>
+<tr><td align="right"><a href="../../../../en/html/libs/io/matrixkeypad.html"><img border="0" src="../../../../../resources/logisim/icons/matrixkeypad.gif"></a></td>
+	<td><a href="../../../../en/html/libs/io/matrixkeypad.html">Matrix Keypad</a></td></tr>
 </table>
 
 <p><a href="../index.html">Voltar à <em>Referência para bibliotecas</em></a></p>

--- a/src/main/resources/doc/ru/contents.xml
+++ b/src/main/resources/doc/ru/contents.xml
@@ -199,12 +199,15 @@
 			<tocitem target="io_joystick" text="Джойстик" image="icon_joystick" />
 			<tocitem target="io_keyboard" text="Клавиатура" image="icon_keyboard" />
 			<tocitem target="io_led" text="Светодиод" image="icon_led" />
+			<tocitem target="io_ledbar" text="LED Bar" />
 			<tocitem target="io_ledRGB" text="RGB-светодиод" image="icon_rgbled" />
 			<tocitem target="io_7seg" text="7-сегментный индикатор" image="icon_7seg" />
 			<tocitem target="io_hexdig" text="Шестнадцатеричный индикатор" image="icon_hexdig" />
 			<tocitem target="io_dotmat" text="Светодиодная матрица" image="icon_dotmat" />
 			<tocitem target="io_tty" text="Терминал" image="icon_tty" />
 			<tocitem target="io_telnet" text="Telnet" image="icon_telnet" />
+			<tocitem target="io_realtimeclock" text="Real-Time Clock" />
+			<tocitem target="io_matrixkeypad" text="Matrix Keypad" />
 			<tocitem target="io_Port_IO" text="Порт ввода-вывода" image="icon_Port_IO" />
 			<tocitem target="io_Repetar" text="Локальная шина Reptar" image="icon_repetar" />
 			<tocitem target="io_videorgb" text="RGB видео" image="icon_videorgb" />

--- a/src/main/resources/doc/ru/html/libs/io/index.html
+++ b/src/main/resources/doc/ru/html/libs/io/index.html
@@ -67,6 +67,15 @@
 				</tr>
 				<tr>
 					<td align="right">
+						<a href="../../../../en/html/libs/io/ledbar.html"><img class="iconlibs" src="../../../../icons/6464/ledbar.png" alt="LED Bar icon" border="0" height="32" width="32"></a>
+					</td>
+					<td>&nbsp;</td>
+					<td>
+						<a href="../../../../en/html/libs/io/ledbar.html">LED Bar</a>
+					</td>
+				</tr>
+				<tr>
+					<td align="right">
 						<a href="./rgbled.html"><img class="iconlibs" src="../../../../icons/6464/rgbled.png" alt="#########" border="0" height="32" width="32"></a>
 					</td>
 					<td>&nbsp;</td>
@@ -117,6 +126,24 @@
 					<td>&nbsp;</td>
 					<td>
 						<a href="./telnet.html">Telnet</a>
+					</td>
+				</tr>
+				<tr>
+					<td align="right">
+						<a href="../../../../en/html/libs/io/realtimeclock.html"><img class="iconlibs" src="../../../../../resources/logisim/icons/realtimeclock.gif" alt="Real-Time Clock icon" border="0" height="32" width="32"></a>
+					</td>
+					<td>&nbsp;</td>
+					<td>
+						<a href="../../../../en/html/libs/io/realtimeclock.html">Real-Time Clock</a>
+					</td>
+				</tr>
+				<tr>
+					<td align="right">
+						<a href="../../../../en/html/libs/io/matrixkeypad.html"><img class="iconlibs" src="../../../../../resources/logisim/icons/matrixkeypad.gif" alt="Matrix Keypad icon" border="0" height="32" width="32"></a>
+					</td>
+					<td>&nbsp;</td>
+					<td>
+						<a href="../../../../en/html/libs/io/matrixkeypad.html">Matrix Keypad</a>
 					</td>
 				</tr>
 				<tr>

--- a/src/main/resources/doc/zh/contents.xml
+++ b/src/main/resources/doc/zh/contents.xml
@@ -414,6 +414,7 @@
 
 			<!-- <tocitem target="io_led" text="LED" image="icon_led" /> -->
 			<tocitem target="io_led" text="LED" image="icon_led" />
+			<tocitem target="io_ledbar" text="LED Bar" />
 
 			<!-- <tocitem target="io_rgbled" text="LED RGB" image="icon_rgbled" /> -->
 			<tocitem target="io_rgbled" text="RGB LED" image="icon_rgbled" />
@@ -430,8 +431,10 @@
 			<tocitem target="io_tty" text="TTY 终端" image="icon_tty" />
 
 			<tocitem target="io_telnet" text="Telnet" image="icon_telnet" />
+			<tocitem target="io_realtimeclock" text="Real-Time Clock" />
+			<tocitem target="io_matrixkeypad" text="Matrix Keypad" />
 
-     		<!-- <tocitem target="io_Port_IO" text="Port I/O" image="icon_Port_IO" /> -->
+			<!-- <tocitem target="io_Port_IO" text="Port I/O" image="icon_Port_IO" /> -->
 			<tocitem target="io_Port_IO" text="端口 IO" image="icon_Port_IO" />
 
 			<!-- <tocitem target="io_Repetar" text="Reptar Local Bus" image="icon_repetar" /> -->

--- a/src/main/resources/doc/zh/html/libs/io/index.html
+++ b/src/main/resources/doc/zh/html/libs/io/index.html
@@ -100,8 +100,22 @@
      </tr>
      <tr>
       <td align="right">
-       <a href="./ledbar.html">
-        <img alt="#########" border="0" class="iconlibs" height="32" src="../../../../icons/6464/ledbar.png" width="32"/>
+       <a href="../../../../en/html/libs/io/ledbar.html">
+        <img alt="LED Bar icon" border="0" class="iconlibs" height="32" src="../../../../icons/6464/ledbar.png" width="32"/>
+       </a>
+      </td>
+      <td>
+      </td>
+      <td>
+       <a href="../../../../en/html/libs/io/ledbar.html">
+        LED Bar
+       </a>
+      </td>
+     </tr>
+     <tr>
+      <td align="right">
+       <a href="./rgbled.html">
+        <img alt="#########" border="0" class="iconlibs" height="32" src="../../../../icons/6464/rgbled.png" width="32"/>
        </a>
       </td>
       <td>
@@ -182,6 +196,34 @@
       <td>
        <a href="../../../../en/html/libs/io/telnet.html">
         Telnet
+       </a>
+      </td>
+     </tr>
+     <tr>
+      <td align="right">
+       <a href="../../../../en/html/libs/io/realtimeclock.html">
+        <img alt="Real-Time Clock icon" border="0" class="iconlibs" height="32" src="../../../../../resources/logisim/icons/realtimeclock.gif" width="32"/>
+       </a>
+      </td>
+      <td>
+      </td>
+      <td>
+       <a href="../../../../en/html/libs/io/realtimeclock.html">
+        Real-Time Clock
+       </a>
+      </td>
+     </tr>
+     <tr>
+      <td align="right">
+       <a href="../../../../en/html/libs/io/matrixkeypad.html">
+        <img alt="Matrix Keypad icon" border="0" class="iconlibs" height="32" src="../../../../../resources/logisim/icons/matrixkeypad.gif" width="32"/>
+       </a>
+      </td>
+      <td>
+      </td>
+      <td>
+       <a href="../../../../en/html/libs/io/matrixkeypad.html">
+        Matrix Keypad
        </a>
       </td>
      </tr>

--- a/src/test/java/com/cburch/logisim/docs/IoDocumentationTest.java
+++ b/src/test/java/com/cburch/logisim/docs/IoDocumentationTest.java
@@ -14,11 +14,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class IoDocumentationTest {
   private static final Path DOC_ROOT = Path.of("src", "main", "resources", "doc");
+  private static final String[] REFERENCE_PAGES = {"ledbar", "realtimeclock", "matrixkeypad"};
 
   @ParameterizedTest
   @ValueSource(strings = {"ledbar", "realtimeclock", "matrixkeypad"})
@@ -45,11 +47,45 @@ class IoDocumentationTest {
     final var indexPath = DOC_ROOT.resolve(language + "/html/libs/io/index.html");
     final var index = Files.readString(indexPath, StandardCharsets.UTF_8);
 
-    for (final var page : new String[] {"ledbar", "realtimeclock", "matrixkeypad"}) {
+    for (final var page : REFERENCE_PAGES) {
       final var expected = "href=\"../../../../en/html/libs/io/" + page + ".html\"";
       assertTrue(
           index.contains(expected),
           () -> language + " I/O index does not fall back to English " + page + ".html");
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"de", "fr", "ru", "zh"})
+  void localizedHelpTreeIncludesReferencePages(String language) throws Exception {
+    final var contents =
+        Files.readString(DOC_ROOT.resolve(language + "/contents.xml"), StandardCharsets.UTF_8);
+
+    for (final var page : REFERENCE_PAGES) {
+      final var target = "target=\"io_" + page + "\"";
+      assertTrue(
+          contents.contains(target),
+          () -> language + " JavaHelp tree does not include target io_" + page);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"de", "fr", "ru", "zh"})
+  void localizedHelpMapFallsBackToEnglish(String language) throws Exception {
+    final var map =
+        Files.readString(DOC_ROOT.resolve("map_" + language + ".jhm"), StandardCharsets.UTF_8);
+
+    for (final var page : REFERENCE_PAGES) {
+      final var entry =
+          Pattern.compile(
+              "<mapID\\s+target=\"io_"
+                  + page
+                  + "\"\\s+url=\"en/html/libs/io/"
+                  + page
+                  + "\\.html\"\\s*/>");
+      assertTrue(
+          entry.matcher(map).find(),
+          () -> language + " JavaHelp map does not fall back to English " + page + ".html");
     }
   }
 }

--- a/src/test/java/com/cburch/logisim/docs/IoDocumentationTest.java
+++ b/src/test/java/com/cburch/logisim/docs/IoDocumentationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license.
+ */
+
+package com.cburch.logisim.docs;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class IoDocumentationTest {
+  private static final Path DOC_ROOT = Path.of("src", "main", "resources", "doc");
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ledbar", "realtimeclock", "matrixkeypad"})
+  void referencePageExists(String page) {
+    final var path = DOC_ROOT.resolve("en/html/libs/io").resolve(page + ".html");
+
+    assertTrue(Files.isRegularFile(path), () -> "Missing I/O reference page " + path);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ledbar", "realtimeclock", "matrixkeypad"})
+  void englishIndexLinksReferencePage(String page) throws Exception {
+    final var index =
+        Files.readString(DOC_ROOT.resolve("en/html/libs/io/index.html"), StandardCharsets.UTF_8);
+
+    assertTrue(
+        index.contains("href=\"./" + page + ".html\""),
+        () -> "English I/O index does not link " + page + ".html");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"de", "pt", "ru", "zh"})
+  void packagedLocaleIndexFallsBackToEnglish(String language) throws Exception {
+    final var indexPath = DOC_ROOT.resolve(language + "/html/libs/io/index.html");
+    final var index = Files.readString(indexPath, StandardCharsets.UTF_8);
+
+    for (final var page : new String[] {"ledbar", "realtimeclock", "matrixkeypad"}) {
+      final var expected = "href=\"../../../../en/html/libs/io/" + page + ".html\"";
+      assertTrue(
+          index.contains(expected),
+          () -> language + " I/O index does not fall back to English " + page + ".html");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add English reference pages for LED Bar, Real-Time Clock, and Matrix Keypad
- link all three components from the I/O library index and JavaHelp navigation, replacing the incorrect LED Bar link to the ordinary LED page
- expose the new pages from packaged localized help trees using the existing English-fallback convention
- add focused regression coverage for page presence, index links, localized navigation, and fallback maps

## Validation

- `.\gradlew.bat test --tests 'com.cburch.logisim.docs.*' checkstyleMain checkstyleTest`
- `.\gradlew.bat check --rerun-tasks --no-parallel`
- `.\gradlew.bat shadowJar`
- verified the three pages and all updated JavaHelp maps/contents are present in the packaged JAR
- verified the links through Simplified Chinese JavaHelp on Windows
- `git diff --check`

Refs #34
