### PR TITLE
feat: add RGB444 video color mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
   * Added an opt-in RAM data-bus mode where inactive output-enable drives separate outputs to high-impedance.
   * Added Real-Time Clock component.
   * Added Floating Point Constant component.
+  * Added 444 RGB (12 bit) color mode to the RGB Video component.
   * Modified paste behavior to paste at current mouse location if it is on canvas.
   * Added multiline Text Tool labels using Shift+Enter or multiline clipboard text.
   * Fixed a regression that caused TestVector to fail when the circuit had subcircuits.

--- a/src/main/java/com/cburch/logisim/std/io/Video.java
+++ b/src/main/java/com/cburch/logisim/std/io/Video.java
@@ -72,6 +72,7 @@ class Video extends ManagedComponent implements ToolTipMaker, AttributeListener 
   static final String COLOR_RGB = "888 RGB (24 bit)";
   static final String COLOR_555_RGB = "555 RGB (15 bit)";
   static final String COLOR_565_RGB = "565 RGB (16 bit)";
+  static final String COLOR_444_RGB = "444 RGB (12 bit)";
   static final String COLOR_111_RGB = "8-Color RGB (3 bit)";
   static final String COLOR_ATARI = "Atari 2600 (7 bit)";
   static final String COLOR_XTERM16 = "XTerm16 (4 bit)";
@@ -83,6 +84,7 @@ class Video extends ManagedComponent implements ToolTipMaker, AttributeListener 
     COLOR_RGB,
     COLOR_555_RGB,
     COLOR_565_RGB,
+    COLOR_444_RGB,
     COLOR_111_RGB,
     COLOR_ATARI,
     COLOR_XTERM16,
@@ -271,6 +273,7 @@ class Video extends ManagedComponent implements ToolTipMaker, AttributeListener 
   }
 
   static final DirectColorModel rgb111 = new DirectColorModel(3, 0x4, 0x2, 0x1);
+  static final DirectColorModel rgb444 = new DirectColorModel(12, 0xF00, 0x0F0, 0x00F);
   static final DirectColorModel rgb555 = new DirectColorModel(15, 0x7C00, 0x03E0, 0x001F);
   static final DirectColorModel rgb565 = new DirectColorModel(16, 0xF800, 0x07E0, 0x001F);
   static final DirectColorModel rgb = new DirectColorModel(24, 0xFF0000, 0x00FF00, 0x0000FF);
@@ -408,6 +411,7 @@ class Video extends ManagedComponent implements ToolTipMaker, AttributeListener 
     if (model == COLOR_RGB) return rgb;
     else if (model == COLOR_555_RGB) return rgb555;
     else if (model == COLOR_565_RGB) return rgb565;
+    else if (model == COLOR_444_RGB) return rgb444;
     else if (model == COLOR_111_RGB) return rgb111;
     else if (model == COLOR_ATARI) return atari;
     else if (model == COLOR_XTERM16) return xterm16;

--- a/src/main/resources/doc/en/html/libs/io/videorvb.html
+++ b/src/main/resources/doc/en/html/libs/io/videorvb.html
@@ -80,6 +80,7 @@
 						<li><b>888 RGB (24 bit)</b> — 24-bit full color mode.</li>
 						<li><b>555 RGB (15 bit)</b> — 5 bits for each red, green, and blue channel.</li>
 						<li><b>565 RGB (16 bit)</b> — 5 bits for red, 6 bits for green, 5 bits for blue.</li>
+						<li><b>444 RGB (12 bit)</b> — 4 bits for each red, green, and blue channel.</li>
 						<li><b>8-Color RGB (3 bit)</b> — Simple 3-bit scheme (8 basic colors).</li>
 						<li><b>Atari 2600 (7 bit)</b> — Color palette of the Atari 2600 console.</li>
 						<li><b>XTerm16 (4 bit)</b> — 16 standard terminal colors.</li>

--- a/src/test/java/com/cburch/logisim/std/io/VideoColorModelTest.java
+++ b/src/test/java/com/cburch/logisim/std/io/VideoColorModelTest.java
@@ -1,0 +1,52 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Location;
+import org.junit.jupiter.api.Test;
+
+class VideoColorModelTest {
+
+  @Test
+  void rgb444ExpandsEachChannelToEightBits() {
+    final var model = Video.getColorModel(Video.COLOR_444_RGB);
+
+    assertEquals(12, model.getPixelSize());
+    assertEquals(0xFF000000, model.getRGB(0x000));
+    assertEquals(0xFFFF0000, model.getRGB(0xF00));
+    assertEquals(0xFF00FF00, model.getRGB(0x0F0));
+    assertEquals(0xFF0000FF, model.getRGB(0x00F));
+    assertEquals(0xFFAABBCC, model.getRGB(0xABC));
+  }
+
+  @Test
+  void rgb444OptionRoundTripsThroughAttributeSerialization() {
+    assertSame(Video.COLOR_444_RGB, Video.COLOR_OPTION.parse(Video.COLOR_444_RGB));
+    assertEquals(
+        Video.COLOR_444_RGB, Video.COLOR_OPTION.toStandardString(Video.COLOR_444_RGB));
+  }
+
+  @Test
+  void selectingRgb444ChangesDataPortToTwelveBits() {
+    final var attrs = Video.factory.createAttributeSet();
+    final var component =
+        Video.factory.createComponent(Location.create(100, 100, false), attrs);
+
+    assertEquals(BitWidth.create(24), component.getEnd(Video.P_DATA).getWidth());
+
+    attrs.setValue(Video.COLOR_OPTION, Video.COLOR_444_RGB);
+
+    assertEquals(BitWidth.create(12), component.getEnd(Video.P_DATA).getWidth());
+  }
+}


### PR DESCRIPTION
## Summary

- add a 444 RGB (12 bit) option to the RGB Video component
- map 4-bit red, green, and blue channels through a 12-bit DirectColorModel
- update the Data port width when RGB444 is selected
- document the new mode and add focused regression coverage

## Testing

- .\gradlew.bat test --tests com.cburch.logisim.std.io.VideoColorModelTest checkstyleMain checkstyleTest --no-daemon
- .\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1

Closes #2886