### PR TITLE
fpga: localize circuit generation diagnostics

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactory.java
@@ -126,10 +126,7 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
                 .getFactory()
                 .getHDLGenerator(thisComponent.getComponent().getAttributeSet());
         if (worker == null) {
-          // FIXME: hardcoded string
-          Reporter.report.addFatalError(
-              "INTERNAL ERROR: Cannot find the VHDL generator factory for component "
-                  + componentName);
+          Reporter.report.addFatalError(S.get("HdlMissingGeneratorFactoryError", componentName));
           return false;
         }
         if (!worker.isOnlyInlined()) {
@@ -163,11 +160,10 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
                   .getFactory()
                   .getHDLGenerator(thisCircuit.getComponent().getAttributeSet());
       if (worker == null) {
-        // FIXME: hardcoded string
         Reporter.report.addFatalError(
-            "INTERNAL ERROR: Unable to get a subcircuit VHDL generator for '"
-                + thisCircuit.getComponent().getFactory().getName()
-                + "'");
+            S.get(
+                "HdlMissingSubcircuitGeneratorError",
+                thisCircuit.getComponent().getFactory().getName()));
         return false;
       }
       hierarchy.add(
@@ -288,16 +284,15 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     /* we start with the connection of the clock sources */
     for (final var clockSource : theNetList.getClockSources()) {
       if (!clockSource.isEndConnected(0)) {
-        // FIXME: hardcoded string
-        final var msg = String.format("Clock component found with no connection, skipping: '%s'",
-                clockSource.getComponent().getAttributeSet().getValue(StdAttr.LABEL));
-        Reporter.report.addWarning(msg);
+        Reporter.report.addWarning(
+            S.get(
+                "HdlUnconnectedClockWarning",
+                clockSource.getComponent().getAttributeSet().getValue(StdAttr.LABEL)));
         continue;
       }
       final var clockNet = Hdl.getClockNetName(clockSource, 0, theNetList);
       if (clockNet.isEmpty()) {
-        // FIXME: hardcoded string
-        Reporter.report.addFatalError("INTERNAL ERROR: Cannot find clocknet!");
+        Reporter.report.addFatalError(S.get("HdlMissingClockNetError"));
       }
       final var destination = Hdl.getNetName(clockSource, 0, true, theNetList);
       final var source = theNetList.requiresGlobalClockConnection() ? TickComponentHdlGeneratorFactory.FPGA_CLOCK
@@ -453,8 +448,7 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
             }
           }
           if (map == null || compPin < 0) {
-            // FIXME: hardcoded string
-            Reporter.report.addError("BUG: did not find IOpin");
+            Reporter.report.addError(S.get("HdlMissingIoPinError"));
             continue;
           }
           if (!map.isMapped(compPin) || map.isOpenMapped(compPin)) {
@@ -494,9 +488,8 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
           } else {
             final var endId = nets.getEndIndex(componentInfo, pinLabel, false);
             if (endId < 0) {
-              // FIXME: hardcoded string
               Reporter.report.addFatalError(
-                  String.format("INTERNAL ERROR! Could not find the end-index of a sub-circuit component: '%s'", pinLabel));
+                  S.get("HdlMissingSubcircuitEndIndexError", pinLabel));
             } else {
               portMap.putAll(Hdl.getNetMap(pinLabel, true, componentInfo, endId, nets));
             }
@@ -517,9 +510,8 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
           } else {
             final var endId = nets.getEndIndex(componentInfo, pinLabel, false);
             if (endId < 0) {
-              // FIXME: hardcoded string
               Reporter.report.addFatalError(
-                      String.format("INTERNAL ERROR! Could not find the end-index of a sub-circuit component: '%s'", pinLabel));
+                  S.get("HdlMissingSubcircuitEndIndexError", pinLabel));
             } else {
               portMap.putAll(Hdl.getNetMap(pinLabel, true, componentInfo, endId, nets));
             }
@@ -539,9 +531,8 @@ public class CircuitHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
           } else {
             final var endid = nets.getEndIndex(componentInfo, pinLabel, true);
             if (endid < 0) {
-              // FIXME: hardcoded string
               Reporter.report.addFatalError(
-                      String.format("INTERNAL ERROR! Could not find the end-index of a sub-circuit component: '%s'", pinLabel));
+                  S.get("HdlMissingSubcircuitEndIndexError", pinLabel));
             } else {
               portMap.putAll(Hdl.getNetMap(pinLabel, true, componentInfo, endid, nets));
             }

--- a/src/main/resources/resources/logisim/strings/fpga/fpga.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga.properties
@@ -129,6 +129,12 @@ HdlInvalidSolderPointComponentError = INTERNAL ERROR: Component tried to index n
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+HdlMissingGeneratorFactoryError = INTERNAL ERROR: Cannot find the VHDL generator factory for component %s
+HdlMissingSubcircuitGeneratorError = INTERNAL ERROR: Unable to get a subcircuit VHDL generator for '%s'
+HdlUnconnectedClockWarning = Clock component found with no connection, skipping: '%s'
+HdlMissingClockNetError = INTERNAL ERROR: Cannot find clocknet!
+HdlMissingIoPinError = BUG: did not find IOpin
+HdlMissingSubcircuitEndIndexError = INTERNAL ERROR! Could not find the end-index of a sub-circuit component: '%s'
 HdlUnconnectedOutputPinWarning = Found an unconnected output pin, tied the pin to ground!
 HdlUnconnectedOutputBusWarning = Found an unconnected output bus pin, tied all the pin bits to ground!
 HdlUnconnectedOutputBusBitWarning = Found an unconnected output bus pin, tied bit %d to ground!

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
@@ -132,6 +132,12 @@ TopLevelNoIO = Der Toplevel „%s“ hat keine(n) Eingäng(e) und/oder keine Aus
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+# ==> HdlMissingGeneratorFactoryError =
+# ==> HdlMissingSubcircuitGeneratorError =
+# ==> HdlUnconnectedClockWarning =
+# ==> HdlMissingClockNetError =
+# ==> HdlMissingIoPinError =
+# ==> HdlMissingSubcircuitEndIndexError =
 # ==> HdlUnconnectedOutputPinWarning =
 # ==> HdlUnconnectedOutputBusWarning =
 # ==> HdlUnconnectedOutputBusBitWarning =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
@@ -129,6 +129,12 @@
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+# ==> HdlMissingGeneratorFactoryError =
+# ==> HdlMissingSubcircuitGeneratorError =
+# ==> HdlUnconnectedClockWarning =
+# ==> HdlMissingClockNetError =
+# ==> HdlMissingIoPinError =
+# ==> HdlMissingSubcircuitEndIndexError =
 # ==> HdlUnconnectedOutputPinWarning =
 # ==> HdlUnconnectedOutputBusWarning =
 # ==> HdlUnconnectedOutputBusBitWarning =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
@@ -129,6 +129,12 @@ TopLevelNoIO = El nivel superior «%s» no tiene ninguna entrada(s) y/o ninguna 
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+# ==> HdlMissingGeneratorFactoryError =
+# ==> HdlMissingSubcircuitGeneratorError =
+# ==> HdlUnconnectedClockWarning =
+# ==> HdlMissingClockNetError =
+# ==> HdlMissingIoPinError =
+# ==> HdlMissingSubcircuitEndIndexError =
 # ==> HdlUnconnectedOutputPinWarning =
 # ==> HdlUnconnectedOutputBusWarning =
 # ==> HdlUnconnectedOutputBusBitWarning =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
@@ -129,6 +129,12 @@ TopLevelNoIO = Le niveau supérieur « %s » n’a pas d’entrée(s) et/ou pa
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+# ==> HdlMissingGeneratorFactoryError =
+# ==> HdlMissingSubcircuitGeneratorError =
+# ==> HdlUnconnectedClockWarning =
+# ==> HdlMissingClockNetError =
+# ==> HdlMissingIoPinError =
+# ==> HdlMissingSubcircuitEndIndexError =
 # ==> HdlUnconnectedOutputPinWarning =
 # ==> HdlUnconnectedOutputBusWarning =
 # ==> HdlUnconnectedOutputBusBitWarning =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
@@ -129,6 +129,12 @@ TopLevelNoIO = Il livello superiore «%s» non ha ingressi e/o uscite!
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+# ==> HdlMissingGeneratorFactoryError =
+# ==> HdlMissingSubcircuitGeneratorError =
+# ==> HdlUnconnectedClockWarning =
+# ==> HdlMissingClockNetError =
+# ==> HdlMissingIoPinError =
+# ==> HdlMissingSubcircuitEndIndexError =
 # ==> HdlUnconnectedOutputPinWarning =
 # ==> HdlUnconnectedOutputBusWarning =
 # ==> HdlUnconnectedOutputBusBitWarning =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
@@ -129,6 +129,12 @@ TopLevelNoIO = トップ・レベル “%s” は入力および/または出力
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+# ==> HdlMissingGeneratorFactoryError =
+# ==> HdlMissingSubcircuitGeneratorError =
+# ==> HdlUnconnectedClockWarning =
+# ==> HdlMissingClockNetError =
+# ==> HdlMissingIoPinError =
+# ==> HdlMissingSubcircuitEndIndexError =
 # ==> HdlUnconnectedOutputPinWarning =
 # ==> HdlUnconnectedOutputBusWarning =
 # ==> HdlUnconnectedOutputBusBitWarning =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
@@ -129,6 +129,12 @@ TopLevelNoIO = Top level „%s” heeft geen ingang(en) en/of geen uitgang(en)!
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+# ==> HdlMissingGeneratorFactoryError =
+# ==> HdlMissingSubcircuitGeneratorError =
+# ==> HdlUnconnectedClockWarning =
+# ==> HdlMissingClockNetError =
+# ==> HdlMissingIoPinError =
+# ==> HdlMissingSubcircuitEndIndexError =
 # ==> HdlUnconnectedOutputPinWarning =
 # ==> HdlUnconnectedOutputBusWarning =
 # ==> HdlUnconnectedOutputBusBitWarning =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
@@ -129,6 +129,12 @@ TopLevelNoIO = Górny poziom „%s” nie ma wejścia(ów) i/lub wyjścia(ów)!
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+# ==> HdlMissingGeneratorFactoryError =
+# ==> HdlMissingSubcircuitGeneratorError =
+# ==> HdlUnconnectedClockWarning =
+# ==> HdlMissingClockNetError =
+# ==> HdlMissingIoPinError =
+# ==> HdlMissingSubcircuitEndIndexError =
 # ==> HdlUnconnectedOutputPinWarning =
 # ==> HdlUnconnectedOutputBusWarning =
 # ==> HdlUnconnectedOutputBusBitWarning =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
@@ -129,6 +129,12 @@ TopLevelNoIO = O nível superior «%s» não tem entrada(s) e/ou saída(s)!
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+# ==> HdlMissingGeneratorFactoryError =
+# ==> HdlMissingSubcircuitGeneratorError =
+# ==> HdlUnconnectedClockWarning =
+# ==> HdlMissingClockNetError =
+# ==> HdlMissingIoPinError =
+# ==> HdlMissingSubcircuitEndIndexError =
 # ==> HdlUnconnectedOutputPinWarning =
 # ==> HdlUnconnectedOutputBusWarning =
 # ==> HdlUnconnectedOutputBusBitWarning =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
@@ -129,6 +129,12 @@ TopLevelNoIO = Схема верхнего уровня «%s» не имеет �
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+# ==> HdlMissingGeneratorFactoryError =
+# ==> HdlMissingSubcircuitGeneratorError =
+# ==> HdlUnconnectedClockWarning =
+# ==> HdlMissingClockNetError =
+# ==> HdlMissingIoPinError =
+# ==> HdlMissingSubcircuitEndIndexError =
 # ==> HdlUnconnectedOutputPinWarning =
 # ==> HdlUnconnectedOutputBusWarning =
 # ==> HdlUnconnectedOutputBusBitWarning =

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
@@ -129,6 +129,12 @@ HdlInvalidSolderPointComponentError = 内部错误：元件尝试索引不存在
 #
 # circuit/CircuitHdlGeneratorFactory.java
 #
+HdlMissingGeneratorFactoryError = 内部错误：找不到元件 %s 的 VHDL 生成器工厂
+HdlMissingSubcircuitGeneratorError = 内部错误：无法获取子电路“%s”的 VHDL 生成器
+HdlUnconnectedClockWarning = 发现未连接的时钟元件，已跳过：“%s”
+HdlMissingClockNetError = 内部错误：找不到时钟网络！
+HdlMissingIoPinError = 程序错误：找不到 I/O 引脚
+HdlMissingSubcircuitEndIndexError = 内部错误：找不到子电路元件“%s”的端点索引！
 HdlUnconnectedOutputPinWarning = 发现未连接的输出引脚；已将该引脚接地！
 HdlUnconnectedOutputBusWarning = 发现未连接的输出总线引脚；已将该总线引脚的所有位接地！
 HdlUnconnectedOutputBusBitWarning = 发现未连接的输出总线引脚；已将第 %d 位接地！

--- a/src/test/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/CircuitHdlGeneratorFactoryTest.java
@@ -10,13 +10,16 @@
 package com.cburch.logisim.circuit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.cburch.logisim.TestBase;
 import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.comp.ComponentFactory;
 import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.data.MappableResourcesContainer;
 import com.cburch.logisim.fpga.designrulecheck.ConnectionEnd;
 import com.cburch.logisim.fpga.designrulecheck.ConnectionPoint;
 import com.cburch.logisim.fpga.designrulecheck.Net;
@@ -29,6 +32,9 @@ import com.cburch.logisim.fpga.hdlgenerator.Hdl;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.util.LineBuffer;
 import com.cburch.logisim.util.LocaleManager;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -74,6 +80,167 @@ class CircuitHdlGeneratorFactoryTest extends TestBase {
     } finally {
       LocaleManager.setLocale(originalLocale);
     }
+  }
+
+  @Test
+  void circuitGenerationDiagnosticsUseCurrentLocaleAndKeepSeverity() {
+    final var originalLocale = LocaleManager.getLocale();
+    try {
+      assertCircuitGenerationDiagnostics(
+          Locale.ENGLISH,
+          "INTERNAL ERROR: Cannot find the VHDL generator factory for component TestComponent",
+          "INTERNAL ERROR: Unable to get a subcircuit VHDL generator for 'TestSubcircuit'",
+          "Clock component found with no connection, skipping: 'TestClock'",
+          "INTERNAL ERROR: Cannot find clocknet!",
+          "BUG: did not find IOpin",
+          "INTERNAL ERROR! Could not find the end-index of a sub-circuit component: 'TestPin'");
+      assertCircuitGenerationDiagnostics(
+          Locale.SIMPLIFIED_CHINESE,
+          "内部错误：找不到元件 TestComponent 的 VHDL 生成器工厂",
+          "内部错误：无法获取子电路“TestSubcircuit”的 VHDL 生成器",
+          "发现未连接的时钟元件，已跳过：“TestClock”",
+          "内部错误：找不到时钟网络！",
+          "程序错误：找不到 I/O 引脚",
+          "内部错误：找不到子电路元件“TestPin”的端点索引！");
+    } finally {
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
+
+  private void assertCircuitGenerationDiagnostics(
+      Locale locale,
+      String generatorFactoryError,
+      String subcircuitGeneratorError,
+      String unconnectedClockWarning,
+      String clockNetError,
+      String ioPinError,
+      String subcircuitEndIndexError) {
+    setLocaleAndReloadBundles(locale);
+    assertMissingGeneratorFactoryError(generatorFactoryError);
+    assertMissingSubcircuitGeneratorError(subcircuitGeneratorError);
+    assertUnconnectedClockWarning(unconnectedClockWarning);
+    assertMissingClockNetError(clockNetError);
+    assertMissingIoPinError(ioPinError);
+    assertMissingSubcircuitEndIndexError(subcircuitEndIndexError);
+  }
+
+  private void assertMissingGeneratorFactoryError(String expectedError) {
+    final var reporterGui = attachReporterGui();
+    final var circuit = mock(Circuit.class);
+    final var netlist = mock(Netlist.class);
+    final var component = mock(netlistComponent.class);
+    final var circuitComponent = mock(Component.class);
+    final var componentFactory = mock(ComponentFactory.class);
+    final var attributes = mock(AttributeSet.class);
+    when(circuit.getNetList()).thenReturn(netlist);
+    when(netlist.getNormalComponents()).thenReturn(List.of(component));
+    when(component.getComponent()).thenReturn(circuitComponent);
+    when(circuitComponent.getFactory()).thenReturn(componentFactory);
+    when(circuitComponent.getAttributeSet()).thenReturn(attributes);
+    when(componentFactory.getHDLName(attributes)).thenReturn("TestComponent");
+    when(componentFactory.getHDLGenerator(attributes)).thenReturn(null);
+
+    assertFalse(
+        new CircuitHdlGeneratorFactory(circuit)
+            .generateAllHDLDescriptions(new HashSet<>(), "", new ArrayList<>()));
+    assertSingleError(reporterGui, expectedError, SimpleDrcContainer.LEVEL_FATAL);
+  }
+
+  private void assertMissingSubcircuitGeneratorError(String expectedError) {
+    final var reporterGui = attachReporterGui();
+    final var circuit = mock(Circuit.class);
+    final var netlist = mock(Netlist.class);
+    final var component = mock(netlistComponent.class);
+    final var circuitComponent = mock(Component.class);
+    final var componentFactory = mock(ComponentFactory.class);
+    final var attributes = mock(AttributeSet.class);
+    when(circuit.getNetList()).thenReturn(netlist);
+    when(netlist.getNormalComponents()).thenReturn(List.of());
+    when(netlist.getSubCircuits()).thenReturn(new ArrayList<>(List.of(component)));
+    when(component.getComponent()).thenReturn(circuitComponent);
+    when(circuitComponent.getFactory()).thenReturn(componentFactory);
+    when(circuitComponent.getAttributeSet()).thenReturn(attributes);
+    when(componentFactory.getHDLGenerator(attributes)).thenReturn(null);
+    when(componentFactory.getName()).thenReturn("TestSubcircuit");
+
+    assertFalse(
+        new CircuitHdlGeneratorFactory(circuit)
+            .generateAllHDLDescriptions(new HashSet<>(), "", new ArrayList<>()));
+    assertSingleError(reporterGui, expectedError, SimpleDrcContainer.LEVEL_FATAL);
+  }
+
+  private void assertUnconnectedClockWarning(String expectedWarning) {
+    final var reporterGui = attachReporterGui();
+    final var netlist = emptyNetlist();
+    final var clock = mock(netlistComponent.class);
+    final var circuitComponent = mock(Component.class);
+    final var attributes = mock(AttributeSet.class);
+    when(netlist.getClockSources()).thenReturn(List.of(clock));
+    when(clock.isEndConnected(0)).thenReturn(false);
+    when(clock.getComponent()).thenReturn(circuitComponent);
+    when(circuitComponent.getAttributeSet()).thenReturn(attributes);
+    when(attributes.getValue(StdAttr.LABEL)).thenReturn("TestClock");
+
+    new CircuitHdlGeneratorFactory(null).getModuleFunctionality(netlist, null);
+    assertSingleWarning(reporterGui, expectedWarning, SimpleDrcContainer.LEVEL_NORMAL);
+  }
+
+  private void assertMissingClockNetError(String expectedError) {
+    final var reporterGui = attachReporterGui();
+    final var netlist = emptyNetlist();
+    final var clock = mock(netlistComponent.class);
+    when(netlist.getClockSources()).thenReturn(List.of(clock));
+    when(netlist.requiresGlobalClockConnection()).thenReturn(true);
+    when(clock.isEndConnected(0)).thenReturn(true);
+
+    new CircuitHdlGeneratorFactory(null).getModuleFunctionality(netlist, null);
+    assertSingleError(reporterGui, expectedError, SimpleDrcContainer.LEVEL_FATAL);
+  }
+
+  private void assertMissingIoPinError(String expectedError) {
+    final var reporterGui = attachReporterGui();
+    final var netlist = mock(Netlist.class);
+    final var resources = mock(MappableResourcesContainer.class);
+    when(netlist.numberOfInOutBubbles()).thenReturn(1);
+    when(resources.getMappableResources()).thenReturn(Map.of());
+
+    new CircuitHdlGeneratorFactory(null).getPortMap(netlist, resources);
+    assertSingleError(reporterGui, expectedError, SimpleDrcContainer.LEVEL_NORMAL);
+  }
+
+  private void assertMissingSubcircuitEndIndexError(String expectedError) {
+    final var reporterGui = attachReporterGui();
+    final var netlist = mock(Netlist.class);
+    final var componentInfo = mock(netlistComponent.class);
+    final var subcircuitComponent = mock(Component.class);
+    final var subcircuitFactory = mock(SubcircuitFactory.class);
+    final var subcircuit = mock(Circuit.class);
+    final var subcircuitNetlist = mock(Netlist.class);
+    final var pin = mock(netlistComponent.class);
+    final var pinComponent = mock(Component.class);
+    final var pinAttributes = mock(AttributeSet.class);
+    when(componentInfo.getComponent()).thenReturn(subcircuitComponent);
+    when(subcircuitComponent.getFactory()).thenReturn(subcircuitFactory);
+    when(subcircuitFactory.getSubcircuit()).thenReturn(subcircuit);
+    when(subcircuit.getNetList()).thenReturn(subcircuitNetlist);
+    when(subcircuitNetlist.getNumberOfInputPorts()).thenReturn(1);
+    when(subcircuitNetlist.getInputPin(0)).thenReturn(pin);
+    when(pin.getComponent()).thenReturn(pinComponent);
+    when(pinComponent.getAttributeSet()).thenReturn(pinAttributes);
+    when(pinAttributes.getValue(StdAttr.LABEL)).thenReturn("TestPin");
+    when(netlist.getEndIndex(componentInfo, "TestPin", false)).thenReturn(-1);
+
+    new CircuitHdlGeneratorFactory(null).getPortMap(netlist, componentInfo);
+    assertSingleError(reporterGui, expectedError, SimpleDrcContainer.LEVEL_FATAL);
+  }
+
+  private Netlist emptyNetlist() {
+    final var netlist = mock(Netlist.class);
+    when(netlist.getClockSources()).thenReturn(List.of());
+    when(netlist.getAllNets()).thenReturn(List.of());
+    when(netlist.getNormalComponents()).thenReturn(List.of());
+    when(netlist.getSubCircuits()).thenReturn(new ArrayList<>());
+    return netlist;
   }
 
   private void assertUnconnectedOutputWarnings(
@@ -153,12 +320,23 @@ class CircuitHdlGeneratorFactoryTest extends TestBase {
 
   private void assertSingleSevereWarning(
       FpgaReportTabbedPane reporterGui, String expectedWarning) {
+    assertSingleWarning(reporterGui, expectedWarning, SimpleDrcContainer.LEVEL_SEVERE);
+  }
+
+  private void assertSingleWarning(
+      FpgaReportTabbedPane reporterGui, String expectedWarning, int expectedSeverity) {
     final var warning = ArgumentCaptor.forClass(Object.class);
     verify(reporterGui).addWarning(warning.capture());
     assertEquals(expectedWarning, warning.getValue().toString());
-    assertEquals(
-        SimpleDrcContainer.LEVEL_SEVERE,
-        ((SimpleDrcContainer) warning.getValue()).getSeverity());
+    assertEquals(expectedSeverity, ((SimpleDrcContainer) warning.getValue()).getSeverity());
+  }
+
+  private void assertSingleError(
+      FpgaReportTabbedPane reporterGui, String expectedError, int expectedSeverity) {
+    final var error = ArgumentCaptor.forClass(Object.class);
+    verify(reporterGui).addErrors(error.capture());
+    assertEquals(expectedError, error.getValue().toString());
+    assertEquals(expectedSeverity, ((SimpleDrcContainer) error.getValue()).getSeverity());
   }
 
   private void assertInvalidSolderPointError(Locale locale, String expectedError) {
@@ -176,11 +354,7 @@ class CircuitHdlGeneratorFactoryTest extends TestBase {
     assertEquals(
         Map.of(), CircuitHdlGeneratorFactory.getSignalMap("unused", component, 0, null));
 
-    final var error = ArgumentCaptor.forClass(Object.class);
-    verify(reporterGui).addErrors(error.capture());
-    assertEquals(expectedError, error.getValue().toString());
-    assertEquals(
-        SimpleDrcContainer.LEVEL_FATAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
+    assertSingleError(reporterGui, expectedError, SimpleDrcContainer.LEVEL_FATAL);
   }
 
   private void setLocaleAndReloadBundles(Locale locale) {


### PR DESCRIPTION
## Summary

- localize six circuit HDL-generation diagnostics used by eight reporter call sites
- preserve the existing English wording, reporter severity, control flow, and HDL-generation behavior
- add Simplified Chinese translations and standard fallback markers for the other locales
- add focused English/Chinese regression coverage through the real reporter paths, including severity checks

## Scope

This implements the proposed sixth slice from the tracking inventory in #1144 and does not close the broader localization issue. Other hard-coded FPGA diagnostics remain outside this pull request.

Tracking inventory: https://github.com/logisim-evolution/logisim-evolution/issues/1144#issuecomment-5369245087
Maintainer approval: https://github.com/logisim-evolution/logisim-evolution/issues/1144#issuecomment-5369405036

## Testing

- `.\gradlew.bat test --tests com.cburch.logisim.circuit.CircuitHdlGeneratorFactoryTest --no-daemon --rerun-tasks --max-workers=1`
- `.\gradlew.bat checkstyleMain checkstyleTest --no-daemon --rerun-tasks --max-workers=1`
- `.\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1`
- `git diff --check`
- verified that all six keys are present in all 12 FPGA locale files
- verified that none of the eight replaced diagnostics remain hard-coded in `CircuitHdlGeneratorFactory.java`