### PR TITLE
fpga: localize shared and component generator diagnostics

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactory.java
@@ -593,8 +593,7 @@ public class AbstractHdlGeneratorFactory implements HdlGeneratorFactory {
         if (myParametersList.containsKey(nrOfBits, attrs)) {
           signalSet.put(input, String.format("%s [%s-1:0]", preamble, myParametersList.get(nrOfBits, attrs)));
         } else {
-          // FIXME: hard coded String
-          Reporter.report.addFatalError("Internal Error, Parameter not present in HDL generation, your HDL code will not work!");
+          Reporter.report.addFatalError(S.get("HdlMissingParameterError"));
           return false;
         }
       } else if (nrOfBits == 0) {

--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/ToplevelHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/ToplevelHdlGeneratorFactory.java
@@ -9,6 +9,8 @@
 
 package com.cburch.logisim.fpga.hdlgenerator;
 
+import static com.cburch.logisim.fpga.Strings.S;
+
 import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.CircuitHdlGeneratorFactory;
 import com.cburch.logisim.data.AttributeSet;
@@ -354,12 +356,10 @@ public class ToplevelHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     return contents;
   }
 
-  private static Map<String, String> getToplevelWires(MapComponent component) {
+  static Map<String, String> getToplevelWires(MapComponent component) {
     final var wires = new HashMap<String, String>();
     if (component.getNrOfPins() <= 0) {
-      // FIXME: hardcoded string
-      Reporter.report.addError(
-          "BUG: Found a component with no pins. Please report this occurance!");
+      Reporter.report.addError(S.get("HdlToplevelComponentNoPinsError"));
       return wires;
     }
     for (var i = 0; i < component.getNrOfPins(); i++) {

--- a/src/main/java/com/cburch/logisim/std/bfh/BinToBcdHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/bfh/BinToBcdHdlGeneratorFactory.java
@@ -9,6 +9,8 @@
 
 package com.cburch.logisim.std.bfh;
 
+import static com.cburch.logisim.fpga.Strings.S;
+
 import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.fpga.designrulecheck.Netlist;
 import com.cburch.logisim.fpga.gui.Reporter;
@@ -162,8 +164,7 @@ public class BinToBcdHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
             .add(getAdd3Block("s_level9", 12, "s_level10", 12, "C20"));
       }
     } else {
-      // FIXME: hardcoded String
-      Reporter.report.addFatalError("Strange, this should not happen as Verilog is not yet supported!\n");
+      Reporter.report.addFatalError(S.get("HdlBinToBcdUnsupportedVerilogError"));
     }
     return contents.empty();
   }

--- a/src/main/java/com/cburch/logisim/std/wiring/BitExtenderHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/wiring/BitExtenderHdlGeneratorFactory.java
@@ -9,6 +9,8 @@
 
 package com.cburch.logisim.std.wiring;
 
+import static com.cburch.logisim.fpga.Strings.S;
+
 import com.cburch.logisim.fpga.designrulecheck.Netlist;
 import com.cburch.logisim.fpga.designrulecheck.netlistComponent;
 import com.cburch.logisim.fpga.gui.Reporter;
@@ -25,11 +27,7 @@ public class BitExtenderHdlGeneratorFactory extends InlinedHdlGeneratorFactory {
     int nrOfPins = componentInfo.nrOfEnds();
     for (int i = 1; i < nrOfPins; i++) {
       if (!componentInfo.isEndConnected(i)) {
-        // FIXME: hardcoded string
-        Reporter.report.addError(
-            String.format(
-                "Bit Extender component has floating input connection in circuit: %s",
-                circuitName));
+        Reporter.report.addError(S.get("HdlBitExtenderFloatingInputError", circuitName));
         // return empty buffer.
         return contents;
       }

--- a/src/main/resources/resources/logisim/strings/fpga/fpga.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga.properties
@@ -119,6 +119,19 @@ WorkDirWithSpaces = Your workspace directory contains spaces. Please change to a
 #
 HDLGenerator_GatedClockConnection = Component "%s" in circuit "%s" has a gated clock connection!
 HDLGenerator_NoClockConnection = Component "%s" in circuit "%s" has no clock connection!
+HdlMissingParameterError = Internal Error, Parameter not present in HDL generation, your HDL code will not work!
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+HdlToplevelComponentNoPinsError = BUG: Found a component with no pins. Please report this occurance!
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+HdlBitExtenderFloatingInputError = Bit Extender component has floating input connection in circuit: %s
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+HdlBinToBcdUnsupportedVerilogError = Strange, this should not happen as Verilog is not yet supported!\n
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_de.properties
@@ -122,6 +122,19 @@ TopLevelNoIO = Der Toplevel „%s“ hat keine(n) Eingäng(e) und/oder keine Aus
 #
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
+# ==> HdlMissingParameterError =
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+# ==> HdlToplevelComponentNoPinsError =
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+# ==> HdlBitExtenderFloatingInputError =
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+# ==> HdlBinToBcdUnsupportedVerilogError =
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_el.properties
@@ -119,6 +119,19 @@
 #
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
+# ==> HdlMissingParameterError =
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+# ==> HdlToplevelComponentNoPinsError =
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+# ==> HdlBitExtenderFloatingInputError =
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+# ==> HdlBinToBcdUnsupportedVerilogError =
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_es.properties
@@ -119,6 +119,19 @@ TopLevelNoIO = El nivel superior «%s» no tiene ninguna entrada(s) y/o ninguna 
 #
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
+# ==> HdlMissingParameterError =
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+# ==> HdlToplevelComponentNoPinsError =
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+# ==> HdlBitExtenderFloatingInputError =
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+# ==> HdlBinToBcdUnsupportedVerilogError =
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_fr.properties
@@ -119,6 +119,19 @@ TopLevelNoIO = Le niveau supérieur « %s » n’a pas d’entrée(s) et/ou pa
 #
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
+# ==> HdlMissingParameterError =
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+# ==> HdlToplevelComponentNoPinsError =
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+# ==> HdlBitExtenderFloatingInputError =
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+# ==> HdlBinToBcdUnsupportedVerilogError =
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_it.properties
@@ -119,6 +119,19 @@ TopLevelNoIO = Il livello superiore «%s» non ha ingressi e/o uscite!
 #
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
+# ==> HdlMissingParameterError =
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+# ==> HdlToplevelComponentNoPinsError =
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+# ==> HdlBitExtenderFloatingInputError =
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+# ==> HdlBinToBcdUnsupportedVerilogError =
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ja.properties
@@ -119,6 +119,19 @@ TopLevelNoIO = トップ・レベル “%s” は入力および/または出力
 #
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
+# ==> HdlMissingParameterError =
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+# ==> HdlToplevelComponentNoPinsError =
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+# ==> HdlBitExtenderFloatingInputError =
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+# ==> HdlBinToBcdUnsupportedVerilogError =
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_nl.properties
@@ -119,6 +119,19 @@ TopLevelNoIO = Top level „%s” heeft geen ingang(en) en/of geen uitgang(en)!
 #
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
+# ==> HdlMissingParameterError =
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+# ==> HdlToplevelComponentNoPinsError =
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+# ==> HdlBitExtenderFloatingInputError =
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+# ==> HdlBinToBcdUnsupportedVerilogError =
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pl.properties
@@ -119,6 +119,19 @@ TopLevelNoIO = Górny poziom „%s” nie ma wejścia(ów) i/lub wyjścia(ów)!
 #
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
+# ==> HdlMissingParameterError =
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+# ==> HdlToplevelComponentNoPinsError =
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+# ==> HdlBitExtenderFloatingInputError =
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+# ==> HdlBinToBcdUnsupportedVerilogError =
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_pt.properties
@@ -119,6 +119,19 @@ TopLevelNoIO = O nível superior «%s» não tem entrada(s) e/ou saída(s)!
 #
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
+# ==> HdlMissingParameterError =
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+# ==> HdlToplevelComponentNoPinsError =
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+# ==> HdlBitExtenderFloatingInputError =
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+# ==> HdlBinToBcdUnsupportedVerilogError =
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_ru.properties
@@ -119,6 +119,19 @@ TopLevelNoIO = Схема верхнего уровня «%s» не имеет �
 #
 # ==> HDLGenerator_GatedClockConnection =
 # ==> HDLGenerator_NoClockConnection =
+# ==> HdlMissingParameterError =
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+# ==> HdlToplevelComponentNoPinsError =
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+# ==> HdlBitExtenderFloatingInputError =
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+# ==> HdlBinToBcdUnsupportedVerilogError =
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
+++ b/src/main/resources/resources/logisim/strings/fpga/fpga_zh.properties
@@ -119,6 +119,19 @@ TopLevelNoIO = 顶层电路“%s”缺少输入和/或输出
 #
 HDLGenerator_GatedClockConnection = 元件 "%s" 在电路 "%s" 中有门控时钟连接!
 HDLGenerator_NoClockConnection = 元件 "%s" 在电路 "%s" 中没有时钟连接!
+HdlMissingParameterError = 内部错误：HDL 生成过程中缺少参数，生成的 HDL 代码将无法工作！
+#
+# hdlgenerator/ToplevelHdlGeneratorFactory.java
+#
+HdlToplevelComponentNoPinsError = 程序错误：发现一个没有引脚的元件。请报告此问题！
+#
+# std/wiring/BitExtenderHdlGeneratorFactory.java
+#
+HdlBitExtenderFloatingInputError = 电路 %s 中的位扩展器元件存在悬空输入连接
+#
+# std/bfh/BinToBcdHdlGeneratorFactory.java
+#
+HdlBinToBcdUnsupportedVerilogError = 奇怪，这不应该发生，因为尚不支持 Verilog！\n
 #
 # hdlgenerator/Hdl.java
 #

--- a/src/test/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactoryTest.java
@@ -10,12 +10,30 @@
 package com.cburch.logisim.fpga.hdlgenerator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.fpga.designrulecheck.SimpleDrcContainer;
+import com.cburch.logisim.fpga.gui.FpgaReportTabbedPane;
+import com.cburch.logisim.fpga.gui.Reporter;
+import com.cburch.logisim.instance.Port;
+import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.util.LocaleManager;
 import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class AbstractHdlGeneratorFactoryTest {
+
+  @AfterEach
+  void detachReporterGui() {
+    Reporter.report.setGuiLogger(null);
+  }
 
   @Test
   void clockWarningsUseCurrentLocaleAndKeepContext() {
@@ -42,6 +60,47 @@ class AbstractHdlGeneratorFactoryTest {
               "HDLGenerator_GatedClockConnection", "Clock", "main"));
     } finally {
       LocaleManager.setLocale(originalLocale);
+    }
+  }
+
+  @Test
+  void missingParameterErrorUsesCurrentLocaleAndKeepsFatalReturnBehavior() {
+    final var originalLocale = LocaleManager.getLocale();
+    final var originalHdlType = AppPreferences.HdlType.get();
+    try {
+      AppPreferences.HdlType.set(HdlGeneratorFactory.VERILOG);
+      assertMissingParameterError(
+          Locale.ENGLISH,
+          "Internal Error, Parameter not present in HDL generation, your HDL code will not work!");
+      assertMissingParameterError(
+          Locale.SIMPLIFIED_CHINESE,
+          "内部错误：HDL 生成过程中缺少参数，生成的 HDL 代码将无法工作！");
+    } finally {
+      AppPreferences.HdlType.set(originalHdlType);
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
+
+  private void assertMissingParameterError(Locale locale, String expectedError) {
+    LocaleManager.setLocale(locale);
+    final var reporterGui = mock(FpgaReportTabbedPane.class);
+    Reporter.report.setGuiLogger(reporterGui);
+    final var netlist = mock(Netlist.class);
+    final var attrs = mock(AttributeSet.class);
+    when(netlist.projName()).thenReturn("TestProject");
+
+    assertNull(new MissingParameterGenerator().getArchitecture(netlist, attrs, "TestComponent"));
+
+    final var error = ArgumentCaptor.forClass(Object.class);
+    verify(reporterGui).addErrors(error.capture());
+    assertEquals(expectedError, error.getValue().toString());
+    assertEquals(
+        SimpleDrcContainer.LEVEL_FATAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
+  }
+
+  private static class MissingParameterGenerator extends AbstractHdlGeneratorFactory {
+    private MissingParameterGenerator() {
+      myPorts.add(Port.INPUT, "input", -1, 0);
     }
   }
 }

--- a/src/test/java/com/cburch/logisim/fpga/hdlgenerator/ToplevelHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/hdlgenerator/ToplevelHdlGeneratorFactoryTest.java
@@ -1,0 +1,65 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.fpga.hdlgenerator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.fpga.data.MapComponent;
+import com.cburch.logisim.fpga.designrulecheck.SimpleDrcContainer;
+import com.cburch.logisim.fpga.gui.FpgaReportTabbedPane;
+import com.cburch.logisim.fpga.gui.Reporter;
+import com.cburch.logisim.util.LocaleManager;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ToplevelHdlGeneratorFactoryTest {
+
+  @AfterEach
+  void detachReporterGui() {
+    Reporter.report.setGuiLogger(null);
+  }
+
+  @Test
+  void zeroPinComponentErrorUsesCurrentLocaleAndKeepsEmptyMapBehavior() {
+    final var originalLocale = LocaleManager.getLocale();
+    try {
+      assertZeroPinComponentError(
+          Locale.ENGLISH,
+          "BUG: Found a component with no pins. Please report this occurance!");
+      assertZeroPinComponentError(
+          Locale.SIMPLIFIED_CHINESE,
+          "程序错误：发现一个没有引脚的元件。请报告此问题！");
+    } finally {
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
+
+  private void assertZeroPinComponentError(Locale locale, String expectedError) {
+    LocaleManager.setLocale(locale);
+    final var reporterGui = mock(FpgaReportTabbedPane.class);
+    Reporter.report.setGuiLogger(reporterGui);
+    final var component = mock(MapComponent.class);
+    when(component.getNrOfPins()).thenReturn(0);
+
+    assertEquals(Map.of(), ToplevelHdlGeneratorFactory.getToplevelWires(component));
+
+    final var error = ArgumentCaptor.forClass(Object.class);
+    verify(reporterGui).addErrors(error.capture());
+    assertEquals(expectedError, error.getValue().toString());
+    assertEquals(
+        SimpleDrcContainer.LEVEL_NORMAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
+  }
+}

--- a/src/test/java/com/cburch/logisim/std/bfh/BinToBcdHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/std/bfh/BinToBcdHdlGeneratorFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.bfh;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.fpga.designrulecheck.SimpleDrcContainer;
+import com.cburch.logisim.fpga.gui.FpgaReportTabbedPane;
+import com.cburch.logisim.fpga.gui.Reporter;
+import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
+import com.cburch.logisim.prefs.AppPreferences;
+import com.cburch.logisim.util.LocaleManager;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class BinToBcdHdlGeneratorFactoryTest {
+
+  @AfterEach
+  void detachReporterGui() {
+    Reporter.report.setGuiLogger(null);
+  }
+
+  @Test
+  void unsupportedVerilogErrorUsesCurrentLocaleAndKeepsBufferBehavior() {
+    final var originalLocale = LocaleManager.getLocale();
+    final var originalHdlType = AppPreferences.HdlType.get();
+    try {
+      AppPreferences.HdlType.set(HdlGeneratorFactory.VERILOG);
+      assertUnsupportedVerilogError(
+          Locale.ENGLISH,
+          "Strange, this should not happen as Verilog is not yet supported!\n");
+      assertUnsupportedVerilogError(
+          Locale.SIMPLIFIED_CHINESE,
+          "奇怪，这不应该发生，因为尚不支持 Verilog！\n");
+    } finally {
+      AppPreferences.HdlType.set(originalHdlType);
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
+
+  private void assertUnsupportedVerilogError(Locale locale, String expectedError) {
+    LocaleManager.setLocale(locale);
+    final var reporterGui = mock(FpgaReportTabbedPane.class);
+    Reporter.report.setGuiLogger(reporterGui);
+    final var attrs = mock(AttributeSet.class);
+    when(attrs.getValue(BinToBcd.ATTR_BinBits)).thenReturn(BitWidth.create(9));
+
+    assertEquals(
+        List.of(""), new BinToBcdHdlGeneratorFactory().getModuleFunctionality(null, attrs).get());
+
+    final var error = ArgumentCaptor.forClass(Object.class);
+    verify(reporterGui).addErrors(error.capture());
+    assertEquals(expectedError, error.getValue().toString());
+    assertEquals(
+        SimpleDrcContainer.LEVEL_FATAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
+  }
+}

--- a/src/test/java/com/cburch/logisim/std/wiring/BitExtenderHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/std/wiring/BitExtenderHdlGeneratorFactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.wiring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.fpga.designrulecheck.SimpleDrcContainer;
+import com.cburch.logisim.fpga.designrulecheck.netlistComponent;
+import com.cburch.logisim.fpga.gui.FpgaReportTabbedPane;
+import com.cburch.logisim.fpga.gui.Reporter;
+import com.cburch.logisim.util.LocaleManager;
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class BitExtenderHdlGeneratorFactoryTest {
+
+  @AfterEach
+  void detachReporterGui() {
+    Reporter.report.setGuiLogger(null);
+  }
+
+  @Test
+  void floatingInputErrorUsesCurrentLocaleAndKeepsEmptyBufferBehavior() {
+    final var originalLocale = LocaleManager.getLocale();
+    try {
+      assertFloatingInputError(
+          Locale.ENGLISH,
+          "Bit Extender component has floating input connection in circuit: TestCircuit");
+      assertFloatingInputError(
+          Locale.SIMPLIFIED_CHINESE,
+          "电路 TestCircuit 中的位扩展器元件存在悬空输入连接");
+    } finally {
+      LocaleManager.setLocale(originalLocale);
+    }
+  }
+
+  private void assertFloatingInputError(Locale locale, String expectedError) {
+    LocaleManager.setLocale(locale);
+    final var reporterGui = mock(FpgaReportTabbedPane.class);
+    Reporter.report.setGuiLogger(reporterGui);
+    final var component = mock(netlistComponent.class);
+    when(component.nrOfEnds()).thenReturn(2);
+    when(component.isEndConnected(1)).thenReturn(false);
+
+    assertTrue(
+        new BitExtenderHdlGeneratorFactory()
+            .getInlinedCode(null, 1L, component, "TestCircuit")
+            .isEmpty());
+
+    final var error = ArgumentCaptor.forClass(Object.class);
+    verify(reporterGui).addErrors(error.capture());
+    assertEquals(expectedError, error.getValue().toString());
+    assertEquals(
+        SimpleDrcContainer.LEVEL_NORMAL, ((SimpleDrcContainer) error.getValue()).getSeverity());
+  }
+}


### PR DESCRIPTION
## Summary

- localize four shared/component HDL-generator diagnostics across the common, top-level, Bit Extender, and Binary-to-BCD paths
- preserve the existing English wording, reporter severity, return values, and generated-buffer behavior
- add Simplified Chinese translations and standard fallback markers for the other locales
- add focused English/Chinese regression coverage through the real reporter paths, including severity and behavior checks

## Scope

This implements the proposed seventh slice from the tracking inventory in #1144 and does not close the broader localization issue. Remaining generation/download orchestration diagnostics stay outside this pull request.

Tracking inventory: https://github.com/logisim-evolution/logisim-evolution/issues/1144#issuecomment-5369245087
Maintainer approval: https://github.com/logisim-evolution/logisim-evolution/issues/1144#issuecomment-5369405036

## Testing

- `.\gradlew.bat test --tests com.cburch.logisim.fpga.hdlgenerator.AbstractHdlGeneratorFactoryTest --tests com.cburch.logisim.fpga.hdlgenerator.ToplevelHdlGeneratorFactoryTest --tests com.cburch.logisim.std.wiring.BitExtenderHdlGeneratorFactoryTest --tests com.cburch.logisim.std.bfh.BinToBcdHdlGeneratorFactoryTest --no-daemon --rerun-tasks --max-workers=1`
- `.\gradlew.bat checkstyleMain checkstyleTest --no-daemon --rerun-tasks --max-workers=1`
- `.\gradlew.bat check --no-daemon --rerun-tasks --max-workers=1` (re-run successfully after rebasing onto the latest `origin/main`)
- `git diff --check`
- verified that all four keys are represented in all 12 FPGA locale files
- verified that the four replaced production diagnostics no longer remain hard-coded