### PR TITLE
fpga: preserve VHDL entity generics during synthesis

### DIFF
--- a/src/main/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/fpga/hdlgenerator/AbstractHdlGeneratorFactory.java
@@ -339,6 +339,22 @@ public class AbstractHdlGeneratorFactory implements HdlGeneratorFactory {
     return myParametersList.getMaps(attrs);
   }
 
+  /**
+   * Returns the VHDL generic names and declaration types used by this generator. Subclasses may
+   * override this hook when their declarations do not originate from {@link HdlParameters}.
+   */
+  protected Map<String, String> getVhdlParameterDeclarations(AttributeSet attrs) {
+    final var declarations = new TreeMap<String, String>();
+    for (final var generic : myParametersList.keySet(attrs)) {
+      declarations.put(
+          myParametersList.get(generic, attrs),
+          myParametersList.isPresentedByInteger(generic, attrs)
+              ? "{{integer}}"
+              : "std_logic_vector");
+    }
+    return declarations;
+  }
+
   @Override
   public List<String> getEntity(Netlist theNetlist, AttributeSet attrs, String componentName) {
     final var contents = LineBuffer.getHdlBuffer();
@@ -476,27 +492,25 @@ public class AbstractHdlGeneratorFactory implements HdlGeneratorFactory {
       getGenerationTimeWiresPorts(theNetlist, attrs);
     }
     contents.add(isEntity ? "{{entity}} {{1}} {{is}}" : "{{component}} {{1}}", componentName);
-    if (!myParametersList.isEmpty(attrs)) {
+    final var parameterDeclarations = getVhdlParameterDeclarations(attrs);
+    if (!parameterDeclarations.isEmpty()) {
       // first we build a list with parameters to determine the max. string length
-      final var myParameters = new HashMap<String, Boolean>();
-      for (final var generic : myParametersList.keySet(attrs)) {
-        final var parameterName = myParametersList.get(generic, attrs);
+      for (final var parameterName : parameterDeclarations.keySet()) {
         maxNameLength = Math.max(maxNameLength, parameterName.length());
-        myParameters.put(parameterName, myParametersList.isPresentedByInteger(generic, attrs));
       }
       maxNameLength += 1; // add one space after the longest one
-      final var myGenerics = new TreeSet<>(myParameters.keySet());
+      final var myGenerics = new TreeSet<>(parameterDeclarations.keySet());
       var currentGenericId = 0;
       for (final var thisGeneric : myGenerics) {
         if (currentGenericId == 0) {
           contents.add("   {{generic}} ( {{1}}{{2}}: {{3}}{{4}};", thisGeneric,
               " ".repeat(Math.max(0, maxNameLength - thisGeneric.length())),
-              myParameters.get(thisGeneric) ? "{{integer}}" : "std_logic_vector",
+              parameterDeclarations.get(thisGeneric),
               currentGenericId == (myGenerics.size() - 1) ? " )" : "");
         } else {
           contents.add("             {{1}}{{2}}: {{3}}{{4}};", thisGeneric,
               " ".repeat(Math.max(0, maxNameLength - thisGeneric.length())),
-              myParameters.get(thisGeneric) ? "{{integer}}" : "std_logic_vector",
+              parameterDeclarations.get(thisGeneric),
               currentGenericId == (myGenerics.size() - 1) ? " )" : "");
         }
         currentGenericId++;

--- a/src/main/java/com/cburch/logisim/vhdl/base/VhdlHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/vhdl/base/VhdlHdlGeneratorFactory.java
@@ -9,12 +9,15 @@
 
 package com.cburch.logisim.vhdl.base;
 
+import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.fpga.designrulecheck.Netlist;
 import com.cburch.logisim.fpga.file.FileWriter;
 import com.cburch.logisim.fpga.hdlgenerator.AbstractHdlGeneratorFactory;
 import com.cburch.logisim.fpga.hdlgenerator.Hdl;
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class VhdlHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
 
@@ -47,32 +50,33 @@ public class VhdlHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
     return contents;
   }
 
-  /* FIXME: implement the generics in the VHDL class (keeping this code for reference)
   @Override
-  public SortedMap<String, Integer> GetParameterMap(Netlist Nets, NetlistComponent ComponentInfo) {
-    AttributeSet attrs = ComponentInfo.getComponent().getAttributeSet();
-    VhdlContent content = ((VhdlEntityAttributes) attrs).getContent();
-    SortedMap<String, Integer> ParameterMap = new TreeMap<>();
-    for (Attribute<Integer> a : content.getGenericAttributes()) {
-      VhdlEntityAttributes.VhdlGenericAttribute va = (VhdlEntityAttributes.VhdlGenericAttribute) a;
-      VhdlContent.Generic g = va.getGeneric();
-      Integer v = attrs.getValue(a);
-      ParameterMap.put(g.getName(), Objects.requireNonNullElseGet(v, g::getDefaultValue));
+  protected Map<String, String> getParameterMap(AttributeSet attrs) {
+    final var parameterMap = new TreeMap<String, String>();
+    if (!(attrs instanceof VhdlEntityAttributes vhdlAttrs)) return parameterMap;
+
+    final var content = vhdlAttrs.getContent();
+    for (final Attribute<Integer> attribute : content.getGenericAttributes()) {
+      final var genericAttribute = (VhdlEntityAttributes.VhdlGenericAttribute) attribute;
+      final var generic = genericAttribute.getGeneric();
+      final var configuredValue = attrs.getValue(attribute);
+      final var value = configuredValue == null ? generic.getDefaultValue() : configuredValue;
+      parameterMap.put(
+          generic.getName(), generic.getType().equals("time") ? value + " fs" : Integer.toString(value));
     }
-    return ParameterMap;
+    return parameterMap;
   }
 
   @Override
-  public SortedMap<Integer, String> GetParameterList(AttributeSet attrs) {
-    VhdlContent content = ((VhdlEntityAttributes) attrs).getContent();
-    SortedMap<Integer, String> Parameters = new TreeMap<>();
-    int i = -1;
-    for (VhdlContent.Generic g : content.getGenerics()) {
-      Parameters.put(i--, g.getName());
+  protected Map<String, String> getVhdlParameterDeclarations(AttributeSet attrs) {
+    final var declarations = new TreeMap<String, String>();
+    if (!(attrs instanceof VhdlEntityAttributes vhdlAttrs)) return declarations;
+
+    for (final var generic : vhdlAttrs.getContent().getGenerics()) {
+      declarations.put(generic.getName(), generic.getType());
     }
-    return Parameters;
+    return declarations;
   }
-  */
 
   @Override
   public boolean isHdlSupportedTarget(AttributeSet attrs) {

--- a/src/test/java/com/cburch/logisim/vhdl/base/VhdlHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/vhdl/base/VhdlHdlGeneratorFactoryTest.java
@@ -1,0 +1,152 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.vhdl.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.data.Attribute;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.fpga.hdlgenerator.TickComponentHdlGeneratorFactory;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class VhdlHdlGeneratorFactoryTest {
+
+  @Test
+  void entityDeclarationKeepsEveryParsedGenericNameAndType() throws Exception {
+    final var content = contentWithGenerics();
+    final var attrs = new VhdlEntityAttributes(content);
+    final var netlist = mock(Netlist.class);
+    when(netlist.projName()).thenReturn("TestProject");
+
+    final var source =
+        normalized(
+            new TestVhdlHdlGeneratorFactory()
+                .getVhdlBlackBox(netlist, attrs, "generic_entry"));
+
+    assertTrue(
+        source.contains(
+            "generic ( delay : time; integer_value : integer; natural_value : natural; positive_value : positive );"),
+        source);
+  }
+
+  @Test
+  void parameterMapUsesDefaultsAndPerInstanceOverrides() throws Exception {
+    final var content = contentWithGenerics();
+    final var defaultAttrs = new VhdlEntityAttributes(content);
+    final var overriddenAttrs = new VhdlEntityAttributes(content);
+    overriddenAttrs.setValue(genericAttribute(content, "natural_value"), 42);
+    overriddenAttrs.setValue(genericAttribute(content, "delay"), 2_000_000);
+    final var generator = new TestVhdlHdlGeneratorFactory();
+
+    assertEquals(
+        Map.of(
+            "delay", "5000000 fs",
+            "integer_value", "128",
+            "natural_value", "7",
+            "positive_value", "3"),
+        generator.getTestParameterMap(defaultAttrs));
+    assertEquals(
+        Map.of(
+            "delay", "2000000 fs",
+            "integer_value", "128",
+            "natural_value", "42",
+            "positive_value", "3"),
+        generator.getTestParameterMap(overriddenAttrs));
+  }
+
+  @Test
+  void existingGeneratorParametersKeepTheirIntegerDeclarations() {
+    final var netlist = mock(Netlist.class);
+    when(netlist.projName()).thenReturn("TestProject");
+
+    final var source =
+        normalized(
+            new TestTickComponentHdlGeneratorFactory(50_000_000L, 1_000.0)
+                .getVhdlBlackBox(netlist, null, "logisimTickGenerator"));
+
+    assertTrue(
+        source.contains("generic ( nrofbits : integer; reloadvalue : integer );"), source);
+  }
+
+  private VhdlContent contentWithGenerics() throws Exception {
+    final var parser =
+        new VhdlParser(
+            """
+            entity generic_entry is
+              generic (
+                integer_value : integer := 128;
+                natural_value : natural := 7;
+                positive_value : positive := 3;
+                delay : time := 5 ns
+              );
+            end entity generic_entry;
+
+            architecture rtl of generic_entry is
+            begin
+            end architecture rtl;
+            """);
+    parser.parse();
+    final var content = new VhdlContent("generic_entry", null);
+    content.generics =
+        parser.getGenerics().stream()
+            .map(VhdlContent.Generic::new)
+            .toArray(VhdlContent.Generic[]::new);
+    return content;
+  }
+
+  private Attribute<Integer> genericAttribute(VhdlContent content, String name) {
+    return content.getGenericAttributes().stream()
+        .filter(
+            attribute ->
+                ((VhdlEntityAttributes.VhdlGenericAttribute) attribute)
+                    .getGeneric()
+                    .getName()
+                    .equals(name))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private String normalized(List<String> lines) {
+    return String.join(" ", lines)
+        .replaceAll("\\s+", " ")
+        .trim()
+        .toLowerCase(Locale.ROOT);
+  }
+
+  private static class TestVhdlHdlGeneratorFactory extends VhdlHdlGeneratorFactory {
+    private List<String> getVhdlBlackBox(
+        Netlist netlist, AttributeSet attrs, String componentName) {
+      return getVHDLBlackBox(netlist, attrs, componentName, true);
+    }
+
+    private Map<String, String> getTestParameterMap(AttributeSet attrs) {
+      return getParameterMap(attrs);
+    }
+  }
+
+  private static class TestTickComponentHdlGeneratorFactory
+      extends TickComponentHdlGeneratorFactory {
+    private TestTickComponentHdlGeneratorFactory(long clockFrequency, double tickFrequency) {
+      super(clockFrequency, tickFrequency);
+    }
+
+    private List<String> getVhdlBlackBox(
+        Netlist netlist, AttributeSet attrs, String componentName) {
+      return getVHDLBlackBox(netlist, attrs, componentName, true);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- preserve parsed VHDL generic names and declaration types in generated entity/component declarations
- emit each instance's configured generic value, falling back to the parsed default
- keep existing `HdlParameters` declarations unchanged for all other generators

## Testing
- `./gradlew test --tests com.cburch.logisim.vhdl.base.VhdlHdlGeneratorFactoryTest --no-daemon --max-workers=1`
- `./gradlew checkstyleMain checkstyleTest --no-daemon --max-workers=1`
- `./gradlew check --rerun-tasks --no-daemon --max-workers=1`
- `git diff --check`

Closes #1376