### PR TITLE
cli: centralize TTY exit handling

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/start/Startup.java
+++ b/src/main/java/com/cburch/logisim/gui/start/Startup.java
@@ -919,13 +919,13 @@ public class Startup implements AWTEventListener {
 
   public void run() {
     if (isTty) {
+      var exitCode = TtyInterface.EXIT_FAILURE;
       try {
-        TtyInterface.run(this);
-        System.exit(0);
+        exitCode = TtyInterface.run(this);
       } catch (Exception t) {
         t.printStackTrace();
-        System.exit(-1);
       }
+      System.exit(exitCode);
     }
 
     // kick off the progress monitor

--- a/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
+++ b/src/main/java/com/cburch/logisim/gui/start/TtyInterface.java
@@ -55,6 +55,9 @@ public class TtyInterface {
   public static final int FORMAT_TABLE_CSV = 64;
   public static final int FORMAT_TABLE_BIN = 128;
   public static final int FORMAT_TABLE_HEX = 256;
+  static final int EXIT_SUCCESS = 0;
+  static final int EXIT_FAILURE = -1;
+  static final int EXIT_OSCILLATION = 1;
   static final Logger logger = LoggerFactory.getLogger(TtyInterface.class);
   private static boolean lastIsNewline = true;
 
@@ -285,7 +288,7 @@ public class TtyInterface {
     return found;
   }
 
-  public static void run(Startup args) {
+  public static int run(Startup args) {
     final var fileToOpen = args.getFilesToOpen().get(0);
     final var loader = new Loader(null);
     LogisimFile file;
@@ -293,12 +296,19 @@ public class TtyInterface {
       file = loader.openLogisimFile(fileToOpen, args.getSubstitutions());
     } catch (LoadFailedException e) {
       logger.error("{}", S.get("ttyLoadError", fileToOpen.getName()));
-      System.exit(-1);
-      return;
+      return EXIT_FAILURE;
     }
     final var proj = new Project(file);
+    try {
+      return run(args, file, proj);
+    } finally {
+      proj.getSimulator().shutDown();
+    }
+  }
+
+  private static int run(Startup args, LogisimFile file, Project proj) {
     if (args.isFpgaDownload()) {
-      if (!args.fpgaDownload(proj)) System.exit(-1);
+      if (!args.fpgaDownload(proj)) return EXIT_FAILURE;
     }
 
     final var circuitToTest = args.getCircuitToTest();
@@ -312,7 +322,7 @@ public class TtyInterface {
       displayStatistics(file, circuit);
     }
     if (format == 0) { // no simulation remaining to perform, so just exit
-      System.exit(0);
+      return EXIT_SUCCESS;
     }
 
     final var pinNames = Analyze.getPinLabels(circuit);
@@ -333,7 +343,7 @@ public class TtyInterface {
     }
     if (haltPin == null && (format & FORMAT_TABLE) != 0) {
       doTableAnalysis(proj, circuit, pinNames, format);
-      return;
+      return EXIT_SUCCESS;
     }
 
     CircuitState circState = CircuitState.createRootState(proj, circuit, Thread.currentThread());
@@ -348,32 +358,37 @@ public class TtyInterface {
           final var keys = memoriesToLoad.keySet();
           keys.removeAll(loaded);
           logger.error("{}", S.get("loadNoRamError", keys));
-          System.exit(-1);
+          return EXIT_FAILURE;
         }
       } catch (IOException e) {
         logger.error("{}: {}", S.get("loadIoError"), e.toString());
-        System.exit(-1);
+        return EXIT_FAILURE;
       }
       prop.propagate(); // propagate memory values before running simulation.
     }
 
     final var ttyFormat = args.getTtyFormat();
     final var simCode = runSimulation(circState, outputPins, haltPin, ttyFormat);
+    return finishSimulation(circState, args.getSaveFile(), simCode);
+  }
 
-    if (args.getSaveFile() != null) {
+  static int finishSimulation(CircuitState circState, File saveFile, int simCode) {
+    if (simCode == EXIT_FAILURE) return EXIT_FAILURE;
+
+    if (saveFile != null) {
       try {
-        final var saved = saveRam(circState, args.getSaveFile());
+        final var saved = saveRam(circState, saveFile);
         if (!saved) {
           logger.error("{}", S.get("saveNoRamError"));
-          System.exit(-1);
+          return EXIT_FAILURE;
         }
       } catch (IOException e) {
         logger.error("{}: {}", S.get("saveIoError"), e.toString());
-        System.exit(-1);
+        return EXIT_FAILURE;
       }
     }
 
-    System.exit(simCode);
+    return simCode;
   }
 
   private static int doTableAnalysis(Project proj, Circuit circuit, Map<Instance, String> pinLabels, int format) {
@@ -472,7 +487,8 @@ public class TtyInterface {
     return 0;
   }
 
-  private static int runSimulation(CircuitState circState, ArrayList<Instance> outputPins, Instance haltPin, int format) {
+  static int runSimulation(
+      CircuitState circState, ArrayList<Instance> outputPins, Instance haltPin, int format) {
     final var showTable = (format & FORMAT_TABLE) != 0;
     final var showSpeed = (format & FORMAT_SPEED) != 0;
     final var showTty = (format & FORMAT_TTY) != 0;
@@ -485,7 +501,7 @@ public class TtyInterface {
       final var ttyFound = prepareForTty(circState, keyboardStates);
       if (!ttyFound) {
         logger.error("{}", S.get("ttyNoTtyError"));
-        System.exit(-1);
+        return EXIT_FAILURE;
       }
       if (keyboardStates.isEmpty()) {
         keyboardStates = null;
@@ -495,7 +511,7 @@ public class TtyInterface {
       }
     }
 
-    var retCode = 0;
+    var retCode = EXIT_SUCCESS;
     long tickCount = 0;
     final var start = System.currentTimeMillis();
     var halted = false;
@@ -521,11 +537,11 @@ public class TtyInterface {
       }
 
       if (halted) {
-        retCode = 0; // normal exit
+        retCode = EXIT_SUCCESS;
         break;
       }
       if (prop.isOscillating()) {
-        retCode = 1; // abnormal exit
+        retCode = EXIT_OSCILLATION;
         break;
       }
       if (keyboardStates != null) {

--- a/src/test/java/com/cburch/logisim/gui/start/TtyInterfaceTest.java
+++ b/src/test/java/com/cburch/logisim/gui/start/TtyInterfaceTest.java
@@ -10,13 +10,30 @@
 package com.cburch.logisim.gui.start;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.circuit.CircuitState;
+import com.cburch.logisim.circuit.Propagator;
 import com.cburch.logisim.data.TestVector;
+import com.cburch.logisim.file.Loader;
+import com.cburch.logisim.file.LogisimFile;
+import com.cburch.logisim.proj.Project;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TtyInterfaceTest {
 
@@ -48,5 +65,120 @@ public class TtyInterfaceTest {
     assertEquals("x", vector.columnName[1]);
     assertEquals(4, vector.columnWidth[1].getWidth());
     assertEquals(2, vector.data.size());
+  }
+
+  @Test
+  void runReturnsFailureWhenInputCannotBeOpened() {
+    final var args = startupFor(new File(tempDir, "missing.circ"), TtyInterface.FORMAT_TABLE);
+
+    assertEquals(TtyInterface.EXIT_FAILURE, TtyInterface.run(args));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {TtyInterface.FORMAT_STATISTICS, TtyInterface.FORMAT_TABLE})
+  void analysisOnlyModesReturnSuccess(int format) {
+    final var args = startupFor(saveCircuit("analysis.circ"), format);
+
+    assertEquals(TtyInterface.EXIT_SUCCESS, TtyInterface.run(args));
+  }
+
+  @Test
+  void missingMemoryTargetReturnsFailure() {
+    final var args = startupFor(saveCircuit("load.circ"), TtyInterface.FORMAT_HALT);
+    final var loads = new HashMap<String, File>();
+    loads.put("missing", new File(tempDir, "memory.hex"));
+    when(args.getMemoryLoadFiles()).thenReturn(loads);
+
+    assertEquals(TtyInterface.EXIT_FAILURE, TtyInterface.run(args));
+  }
+
+  @Test
+  void missingTtyComponentReturnsFailure() {
+    final var args = startupFor(saveCircuit("tty.circ"), TtyInterface.FORMAT_TTY);
+
+    assertEquals(TtyInterface.EXIT_FAILURE, TtyInterface.run(args));
+  }
+
+  @Test
+  void failedFpgaDownloadReturnsFailure() {
+    final var args = startupFor(saveCircuit("fpga.circ"), TtyInterface.FORMAT_HALT);
+    when(args.isFpgaDownload()).thenReturn(true);
+    when(args.fpgaDownload(any(Project.class))).thenReturn(false);
+
+    assertEquals(TtyInterface.EXIT_FAILURE, TtyInterface.run(args));
+  }
+
+  @Test
+  void missingRamForSaveOverridesSuccessfulSimulationStatus() {
+    final var state = mock(CircuitState.class);
+    final var circuit = mock(Circuit.class);
+    when(state.getCircuit()).thenReturn(circuit);
+    when(circuit.getNonWires()).thenReturn(Set.of());
+    when(state.getSubstates()).thenReturn(Set.of());
+
+    assertEquals(
+        TtyInterface.EXIT_FAILURE,
+        TtyInterface.finishSimulation(
+            state, new File(tempDir, "memory.hex"), TtyInterface.EXIT_SUCCESS));
+  }
+
+  @Test
+  void simulationStatusIsReturnedWhenNoSaveWasRequested() {
+    assertEquals(
+        TtyInterface.EXIT_SUCCESS,
+        TtyInterface.finishSimulation(null, null, TtyInterface.EXIT_SUCCESS));
+    assertEquals(
+        TtyInterface.EXIT_OSCILLATION,
+        TtyInterface.finishSimulation(null, null, TtyInterface.EXIT_OSCILLATION));
+    assertEquals(
+        TtyInterface.EXIT_FAILURE,
+        TtyInterface.finishSimulation(null, null, TtyInterface.EXIT_FAILURE));
+  }
+
+  @Test
+  void oscillationReturnsItsExistingStatus() {
+    final var state = mock(CircuitState.class);
+    final var propagator = mock(Propagator.class);
+    when(state.getPropagator()).thenReturn(propagator);
+    when(propagator.isOscillating()).thenReturn(true);
+
+    assertEquals(
+        TtyInterface.EXIT_OSCILLATION,
+        TtyInterface.runSimulation(
+            state, new ArrayList<>(), null, TtyInterface.FORMAT_HALT));
+  }
+
+  private Startup startupFor(File circuitFile, int format) {
+    final var args = mock(Startup.class);
+    when(args.getFilesToOpen()).thenReturn(List.of(circuitFile));
+    when(args.getSubstitutions()).thenReturn(Map.of());
+    when(args.getMemoryLoadFiles()).thenReturn(new HashMap<>());
+    when(args.getTtyFormat()).thenReturn(format);
+    return args;
+  }
+
+  private File saveCircuit(String name) {
+    final var loader = new RecordingLoader();
+    final var file = LogisimFile.createNew(loader, null);
+    final var path = new File(tempDir, name);
+    assertTrue(loader.save(file, path), loader.errors());
+    return path;
+  }
+
+  private static class RecordingLoader extends Loader {
+    private final List<String> errors = new ArrayList<>();
+
+    private RecordingLoader() {
+      super(null);
+    }
+
+    private String errors() {
+      return String.join("\n", errors);
+    }
+
+    @Override
+    public void showError(String description) {
+      errors.add(description);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- make `TtyInterface` return its existing process status instead of terminating the JVM internally
- keep one TTY `System.exit` owner in `Startup` and preserve the established `0`, `-1`, and `1` results
- stop the TTY project's simulator thread before returning and add runtime-path coverage for open, statistics/table, load/save, TTY, simulation, and FPGA outcomes

This is the first behavior-preserving integration slice discussed in #1546. It does not change option combinations, parser statuses, or command-line policy.

## Testing
- `./gradlew test --tests com.cburch.logisim.gui.start.TtyInterfaceTest --no-daemon --max-workers=1`
- `./gradlew checkstyleMain checkstyleTest --no-daemon --max-workers=1`
- `./gradlew check --rerun-tasks --no-daemon --max-workers=1`
- built-JAR status matrix: statistics `0`, open failure `-1`, missing TTY `-1`, parser validation `10`
- `git diff --check`

Part of #1546