### PR TITLE
fix: make project bundle library paths portable

### DIFF
--- a/src/main/java/com/cburch/logisim/file/Loader.java
+++ b/src/main/java/com/cburch/logisim/file/Loader.java
@@ -235,10 +235,11 @@ public class Loader implements LibraryLoader {
   //
   File getFileFor(String name, FileFilter filter) {
     // Determine the actual file name.
-    var file = new File(name);
+    final var normalizedName = ProjectBundlePaths.normalizeLibraryDescriptorPath(name);
+    var file = new File(normalizedName);
     if (!file.isAbsolute()) {
       final var currentDirectory = getCurrentDirectory();
-      if (currentDirectory != null) file = new File(currentDirectory, name);
+      if (currentDirectory != null) file = new File(currentDirectory, normalizedName);
     }
     while (!file.canRead()) {
       // It doesn't exist. Figure it out from the user.

--- a/src/main/java/com/cburch/logisim/file/ProjectBundlePaths.java
+++ b/src/main/java/com/cburch/logisim/file/ProjectBundlePaths.java
@@ -1,0 +1,95 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.file;
+
+import java.nio.file.Path;
+
+/** Utilities for portable and safe paths inside Logisim project bundles. */
+public final class ProjectBundlePaths {
+  private static final String ARCHIVE_SEPARATOR = "/";
+  private static final String LIBRARY_DIRECTORY =
+      Loader.LOGISIM_LIBRARY_DIR + ARCHIVE_SEPARATOR;
+
+  private ProjectBundlePaths() {}
+
+  /** Returns the portable ZIP entry name for the project bundle's library directory. */
+  public static String libraryDirectoryEntry() {
+    return LIBRARY_DIRECTORY;
+  }
+
+  /** Returns a portable ZIP entry name for a direct child of the bundle's library directory. */
+  public static String libraryEntry(String fileName) {
+    requireDirectFileName(fileName);
+    return LIBRARY_DIRECTORY + fileName;
+  }
+
+  /** Returns the portable relative descriptor for a bundled external library. */
+  public static String libraryDescriptor(String fileName, boolean fromBundledLibrary) {
+    requireDirectFileName(fileName);
+    return fromBundledLibrary
+        ? "." + ARCHIVE_SEPARATOR + fileName
+        : "." + ARCHIVE_SEPARATOR + LIBRARY_DIRECTORY + fileName;
+  }
+
+  /** Returns whether an entry is the library directory, accepting legacy Windows separators. */
+  public static boolean isLibraryDirectory(String entryName) {
+    if (entryName == null) return false;
+    final var normalized = normalizeArchiveEntry(entryName);
+    return normalized.equals(Loader.LOGISIM_LIBRARY_DIR)
+        || normalized.equals(LIBRARY_DIRECTORY);
+  }
+
+  /**
+   * Resolves a direct bundled library entry below the extraction directory.
+   *
+   * <p>Both portable forward slashes and legacy Windows backslashes are accepted. Entries outside
+   * the direct {@code library/} directory return {@code null}.
+   */
+  public static Path resolveLibraryFile(Path extractionDirectory, String entryName) {
+    if (extractionDirectory == null || entryName == null) return null;
+    final var normalized = normalizeArchiveEntry(entryName);
+    if (!normalized.startsWith(LIBRARY_DIRECTORY)) return null;
+
+    final var fileName = normalized.substring(LIBRARY_DIRECTORY.length());
+    if (!isDirectFileName(fileName)) return null;
+
+    final var libraryDirectory =
+        extractionDirectory.toAbsolutePath().normalize().resolve(Loader.LOGISIM_LIBRARY_DIR);
+    final var target = libraryDirectory.resolve(fileName).normalize();
+    return target.startsWith(libraryDirectory) ? target : null;
+  }
+
+  /** Resolves the manifest's root-level main circuit file without allowing path traversal. */
+  public static Path resolveMainFile(Path extractionDirectory, String entryName) {
+    if (extractionDirectory == null || !isDirectFileName(entryName)) return null;
+    final var directory = extractionDirectory.toAbsolutePath().normalize();
+    final var target = directory.resolve(entryName).normalize();
+    return target.startsWith(directory) ? target : null;
+  }
+
+  private static String normalizeArchiveEntry(String entryName) {
+    return entryName.replace('\\', '/');
+  }
+
+  private static boolean isDirectFileName(String fileName) {
+    return fileName != null
+        && !fileName.isEmpty()
+        && !fileName.equals(".")
+        && !fileName.equals("..")
+        && fileName.indexOf('/') < 0
+        && fileName.indexOf('\\') < 0;
+  }
+
+  private static void requireDirectFileName(String fileName) {
+    if (!isDirectFileName(fileName)) {
+      throw new IllegalArgumentException("Project bundle file name must not contain a path");
+    }
+  }
+}

--- a/src/main/java/com/cburch/logisim/file/ProjectBundlePaths.java
+++ b/src/main/java/com/cburch/logisim/file/ProjectBundlePaths.java
@@ -38,6 +38,11 @@ public final class ProjectBundlePaths {
         : "." + ARCHIVE_SEPARATOR + LIBRARY_DIRECTORY + fileName;
   }
 
+  /** Returns a portable path when reading library descriptors written on another platform. */
+  public static String normalizeLibraryDescriptorPath(String path) {
+    return path.replace('\\', '/');
+  }
+
   /** Returns whether an entry is the library directory, accepting legacy Windows separators. */
   public static boolean isLibraryDirectory(String entryName) {
     if (entryName == null) return false;

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -43,7 +43,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import java.util.regex.Pattern;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
@@ -407,9 +406,8 @@ final class XmlWriter {
         final var origFile = LibraryManager.getLibraryFilePath(file.getLoader(), desc);
         final var isJarLibrary = LibraryManager.isJarLibrary(file.getLoader(), desc);
         if (origFile != null) {
-          final var names = origFile.split(Pattern.quote(File.separator));
-          final var filename = names[names.length - 1];
-          final var newFile = LineBuffer.format("{{1}}{{2}}{{3}}", Loader.LOGISIM_LIBRARY_DIR, File.separator, filename);
+          final var filename = new File(origFile).getName();
+          final var newFile = ProjectBundlePaths.libraryEntry(filename);
           final var zipFile = file.getLoader().getZipFile();
           if (zipFile != null) {
             if (isJarLibrary) {
@@ -417,9 +415,11 @@ final class XmlWriter {
             } else {
               writeLogisimFileToZip(zipFile, origFile, newFile);
             }
-            desc = LibraryManager.getReplacementDescriptor(file.getLoader(), desc, isRecursiveCall
-                ? LineBuffer.format(".{{1}}{{2}}", File.separator, filename)
-                : LineBuffer.format(".{{1}}{{2}}{{1}}{{3}}", File.separator, Loader.LOGISIM_LIBRARY_DIR, filename));
+            desc =
+                LibraryManager.getReplacementDescriptor(
+                    file.getLoader(),
+                    desc,
+                    ProjectBundlePaths.libraryDescriptor(filename, isRecursiveCall));
           }
         }
       }

--- a/src/main/java/com/cburch/logisim/proj/ProjectActions.java
+++ b/src/main/java/com/cburch/logisim/proj/ProjectActions.java
@@ -17,6 +17,7 @@ import com.cburch.logisim.file.LoadedLibrary;
 import com.cburch.logisim.file.Loader;
 import com.cburch.logisim.file.LogisimFile;
 import com.cburch.logisim.file.LogisimFileActions;
+import com.cburch.logisim.file.ProjectBundlePaths;
 import com.cburch.logisim.generated.BuildInfo;
 import com.cburch.logisim.gui.generic.OptionPane;
 import com.cburch.logisim.gui.main.Frame;
@@ -37,6 +38,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -566,10 +568,21 @@ public final class ProjectActions {
             ret &= chooser.showOpenDialog(proj.getFrame()) == JFileChooser.APPROVE_OPTION;
             if (!ret) return ret;
             final var exportDirectory = chooser.getSelectedFile().getAbsolutePath();
-            final var mainProjectFileName = String.format("%s%s%s", exportDirectory, File.separator, bundleInfo.getMainLogisimFilename()); 
-            var filename =  mainProjectFileName;
-            if (Files.exists(Paths.get(filename)) 
-                || Files.exists(Paths.get(String.format("%s%s%s", exportDirectory, File.separator, Loader.LOGISIM_LIBRARY_DIR)))) {
+            final var extractionDirectory =
+                Paths.get(exportDirectory).toAbsolutePath().normalize();
+            final var mainProjectFile =
+                ProjectBundlePaths.resolveMainFile(
+                    extractionDirectory, bundleInfo.getMainLogisimFilename());
+            if (mainProjectFile == null) {
+              OptionPane.showMessageDialog(
+                  proj.getFrame(),
+                  S.fmt("projBundleReadError", S.get("projBundleMainNotFound")));
+              return false;
+            }
+            final var mainProjectFileName = mainProjectFile.toString();
+            var filename = mainProjectFileName;
+            final var libDir = extractionDirectory.resolve(Loader.LOGISIM_LIBRARY_DIR);
+            if (Files.exists(mainProjectFile) || Files.exists(libDir)) {
               isCorrectDirectory = false;
               OptionPane.showMessageDialog(proj.getFrame(), S.fmt("projContainsFileDir", bundleInfo.getMainLogisimFilename(), Loader.LOGISIM_LIBRARY_DIR));
             } else {
@@ -585,37 +598,32 @@ public final class ProjectActions {
               zipInput.close();
               fileOutput.close();
               final var zipFileEntries = zipFile.entries();
-              final var libDir = String.format("%s%s%s", exportDirectory, File.separator, Loader.LOGISIM_LIBRARY_DIR);
+              final var extractedLibraryFiles = new HashSet<Path>();
               while (zipFileEntries.hasMoreElements()) {
                 final var entry = zipFileEntries.nextElement();
-                if (entry.isDirectory()) {
-                  final var dirName = entry.getName();
-                  if (!dirName.equals(Loader.LOGISIM_LIBRARY_DIR)) continue;
-                  new File(String.format("%s%s%s", exportDirectory, File.separator, dirName)).mkdirs();
-                } else {
-                  final var entryName = entry.getName();
-                  if (!entryName.startsWith(String.format("%s%s", Loader.LOGISIM_LIBRARY_DIR, File.separator))) continue;
-                  if (entryName.lastIndexOf(File.separator) != entryName.indexOf(File.separator)) continue;
-                  if (!entryName.endsWith(Loader.LOGISIM_EXTENSION) 
-                      && !entryName.toLowerCase().endsWith(".jar")) {
-                    continue;
-                  }
-                  // make sure the library dir exists
-                  if (!Files.exists(Paths.get(libDir))) new File(libDir).mkdirs();
-                  filename = String.format("%s%s%s", exportDirectory, File.separator, entryName);
-                  final var testFile = new File(filename);
-                  final var testDir = new File(exportDirectory);
-                  if (!testFile.toPath().normalize().startsWith(testDir.toPath())) continue;
-                  zipInput = zipFile.getInputStream(entry);
-                  fileOutput = new FileOutputStream(filename);
-                  final var bytes = new byte[1024];
-                  var length = 0;
-                  while (((length = zipInput.read(bytes)) >= 0)) {
-                    fileOutput.write(bytes, 0, length);
-                  }
-                  fileOutput.close();
-                  zipInput.close();
+                if (ProjectBundlePaths.isLibraryDirectory(entry.getName())) {
+                  Files.createDirectories(libDir);
+                  continue;
                 }
+                final var libraryFile =
+                    ProjectBundlePaths.resolveLibraryFile(extractionDirectory, entry.getName());
+                if (libraryFile == null
+                    || !extractedLibraryFiles.add(libraryFile)
+                    || (!libraryFile.toString().endsWith(Loader.LOGISIM_EXTENSION)
+                        && !libraryFile.toString().toLowerCase().endsWith(".jar"))) {
+                  continue;
+                }
+                Files.createDirectories(libDir);
+                filename = libraryFile.toString();
+                zipInput = zipFile.getInputStream(entry);
+                fileOutput = new FileOutputStream(filename);
+                final var bytes = new byte[1024];
+                var length = 0;
+                while (((length = zipInput.read(bytes)) >= 0)) {
+                  fileOutput.write(bytes, 0, length);
+                }
+                fileOutput.close();
+                zipInput.close();
               }
               ProjectActions.doOpen(proj.getFrame().getCanvas(), proj, new File(mainProjectFileName));
             }
@@ -679,7 +687,8 @@ public final class ProjectActions {
           final var projectFile = new FileOutputStream(zipFile);
           final var projectZipFile = new ZipOutputStream(projectFile);
           ProjectBundleReadme.writeReadmeFile(projectZipFile, readmeInfo);
-          projectZipFile.putNextEntry(new ZipEntry(String.format("%s%s", Loader.LOGISIM_LIBRARY_DIR, File.separator)));
+          projectZipFile.putNextEntry(
+              new ZipEntry(ProjectBundlePaths.libraryDirectoryEntry()));
           mainFileName = chooser.getSelectedFile().getName().replace(Loader.LOGISIM_PROJECT_BUNDLE_EXTENSION, "").concat(Loader.LOGISIM_EXTENSION);
           ret &= loader.export(proj.getLogisimFile(), projectZipFile, mainFileName);
           final var info = ProjectBundleManifest.getInfoContainer(BuildInfo.displayName, mainFileName);

--- a/src/test/java/com/cburch/logisim/file/ProjectBundleExportTest.java
+++ b/src/test/java/com/cburch/logisim/file/ProjectBundleExportTest.java
@@ -1,0 +1,113 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.file;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.data.Location;
+import com.cburch.logisim.tools.AddTool;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProjectBundleExportTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void exportsPortableLibraryEntryAndDescriptor() throws Exception {
+    final var dependencyPath = tempDir.resolve("dependency.circ").toFile();
+    final var dependencyLoader = new RecordingLoader();
+    save(dependencyLoader, newProject(dependencyLoader, "Leaf"), dependencyPath);
+
+    final var mainLoader = new RecordingLoader();
+    final var mainFile = newProject(mainLoader, "Top");
+    final var dependency = mainLoader.loadLogisimLibrary(dependencyPath);
+    assertNotNull(dependency, mainLoader.errors());
+    mainFile.addLibrary(dependency);
+    final var tool = dependency.getTool("Leaf");
+    assertTrue(tool instanceof AddTool);
+    final var factory = ((AddTool) tool).getFactory();
+    final var mutation = new CircuitMutation(mainFile.getMainCircuit());
+    mutation.add(
+        factory.createComponent(Location.create(100, 100, true), factory.createAttributeSet()));
+    mutation.execute();
+    save(mainLoader, mainFile, tempDir.resolve("main.circ").toFile());
+
+    final var bundleBytes = new ByteArrayOutputStream();
+    try (var zip = new ZipOutputStream(bundleBytes)) {
+      zip.putNextEntry(new ZipEntry(ProjectBundlePaths.libraryDirectoryEntry()));
+      assertTrue(mainLoader.export(mainFile, zip, "bundle.circ"));
+    }
+
+    final Map<String, String> entries = new HashMap<>();
+    try (var zip = new ZipInputStream(new ByteArrayInputStream(bundleBytes.toByteArray()))) {
+      ZipEntry entry;
+      while ((entry = zip.getNextEntry()) != null) {
+        entries.put(entry.getName(), new String(zip.readAllBytes(), StandardCharsets.UTF_8));
+      }
+    }
+
+    assertTrue(entries.containsKey("library/"), entries.keySet().toString());
+    assertTrue(entries.containsKey("library/dependency.circ"), entries.keySet().toString());
+    assertFalse(
+        entries.keySet().stream().anyMatch(name -> name.indexOf('\\') >= 0),
+        entries.keySet().toString());
+    final var exportedMain = entries.get("bundle.circ");
+    assertNotNull(exportedMain, entries.keySet().toString());
+    assertTrue(
+        exportedMain.contains("desc=\"file#./library/dependency.circ\""), exportedMain);
+  }
+
+  private static LogisimFile newProject(RecordingLoader loader, String circuitName) {
+    final var file = LogisimFile.createNew(loader, null);
+    file.getMainCircuit().setName(circuitName);
+    return file;
+  }
+
+  private static void save(RecordingLoader loader, LogisimFile file, File path) {
+    assertTrue(loader.save(file, path), loader.errors());
+    assertFalse(loader.hasErrors(), loader.errors());
+  }
+
+  private static class RecordingLoader extends Loader {
+    private final List<String> errors = new ArrayList<>();
+
+    RecordingLoader() {
+      super(null);
+    }
+
+    String errors() {
+      return String.join("\n", errors);
+    }
+
+    boolean hasErrors() {
+      return !errors.isEmpty();
+    }
+
+    @Override
+    public void showError(String description) {
+      errors.add(description);
+    }
+  }
+}

--- a/src/test/java/com/cburch/logisim/file/ProjectBundlePathsTest.java
+++ b/src/test/java/com/cburch/logisim/file/ProjectBundlePathsTest.java
@@ -15,6 +15,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -31,6 +34,38 @@ class ProjectBundlePathsTest {
         ProjectBundlePaths.libraryDescriptor("dependency.circ", false));
     assertEquals(
         "./dependency.circ", ProjectBundlePaths.libraryDescriptor("dependency.circ", true));
+  }
+
+  @Test
+  void readsPortableAndLegacyWindowsLibraryDescriptors() {
+    assertEquals(
+        "./library/dependency.circ",
+        ProjectBundlePaths.normalizeLibraryDescriptorPath("./library/dependency.circ"));
+    assertEquals(
+        "./library/dependency.circ",
+        ProjectBundlePaths.normalizeLibraryDescriptorPath(".\\library\\dependency.circ"));
+    assertEquals(
+        "./dependency.circ",
+        ProjectBundlePaths.normalizeLibraryDescriptorPath(".\\dependency.circ"));
+  }
+
+  @Test
+  void loaderResolvesLegacyWindowsLibraryDescriptor() throws IOException {
+    final var expected = tempDir.resolve("library").resolve("dependency.circ");
+    Files.createDirectories(expected.getParent());
+    Files.createFile(expected);
+
+    final var loader =
+        new Loader(null) {
+          @Override
+          public File getCurrentDirectory() {
+            return tempDir.toFile();
+          }
+        };
+
+    assertEquals(
+        expected.toFile().getCanonicalFile(),
+        loader.getFileFor(".\\library\\dependency.circ", null).getCanonicalFile());
   }
 
   @Test

--- a/src/test/java/com/cburch/logisim/file/ProjectBundlePathsTest.java
+++ b/src/test/java/com/cburch/logisim/file/ProjectBundlePathsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProjectBundlePathsTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void writesPortableArchivePathsAndDescriptors() {
+    assertEquals("library/", ProjectBundlePaths.libraryDirectoryEntry());
+    assertEquals("library/dependency.circ", ProjectBundlePaths.libraryEntry("dependency.circ"));
+    assertEquals(
+        "./library/dependency.circ",
+        ProjectBundlePaths.libraryDescriptor("dependency.circ", false));
+    assertEquals(
+        "./dependency.circ", ProjectBundlePaths.libraryDescriptor("dependency.circ", true));
+  }
+
+  @Test
+  void acceptsPortableAndLegacyWindowsLibraryEntries() {
+    final var expected = tempDir.resolve("library").resolve("dependency.circ").toAbsolutePath();
+
+    assertEquals(
+        expected,
+        ProjectBundlePaths.resolveLibraryFile(tempDir, "library/dependency.circ"));
+    assertEquals(
+        expected,
+        ProjectBundlePaths.resolveLibraryFile(tempDir, "library\\dependency.circ"));
+    assertTrue(ProjectBundlePaths.isLibraryDirectory("library/"));
+    assertTrue(ProjectBundlePaths.isLibraryDirectory("library\\"));
+  }
+
+  @Test
+  void rejectsNestedAndEscapingLibraryEntries() {
+    assertNull(ProjectBundlePaths.resolveLibraryFile(tempDir, "other/dependency.circ"));
+    assertNull(ProjectBundlePaths.resolveLibraryFile(tempDir, "library/nested/dependency.circ"));
+    assertNull(ProjectBundlePaths.resolveLibraryFile(tempDir, "library\\..\\dependency.circ"));
+    assertNull(ProjectBundlePaths.resolveLibraryFile(tempDir, "library/.."));
+    assertNull(ProjectBundlePaths.resolveLibraryFile(tempDir, "library/"));
+    assertFalse(ProjectBundlePaths.isLibraryDirectory("library/dependency.circ"));
+  }
+
+  @Test
+  void keepsMainCircuitAtBundleRoot() {
+    assertEquals(
+        tempDir.resolve("main.circ").toAbsolutePath(),
+        ProjectBundlePaths.resolveMainFile(tempDir, "main.circ"));
+    assertNull(ProjectBundlePaths.resolveMainFile(tempDir, "../main.circ"));
+    assertNull(ProjectBundlePaths.resolveMainFile(tempDir, "nested/main.circ"));
+    assertNull(ProjectBundlePaths.resolveMainFile(tempDir, "nested\\main.circ"));
+  }
+
+  @Test
+  void refusesPathsWhenWritingBundleEntries() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ProjectBundlePaths.libraryEntry("nested/dependency.circ"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ProjectBundlePaths.libraryDescriptor("..", false));
+  }
+}


### PR DESCRIPTION
## Summary

- write project-bundle ZIP entries and bundled library descriptors with portable `/` separators
- accept both portable `/` and legacy Windows `\` entry names when extracting libraries
- keep the manifest's main circuit at the extraction root and external files as direct `library/` children, preserving zip-slip protection and ignoring duplicate normalized destinations
- add pure path-validation tests plus a real export regression test for an external `.circ` library

Fixes #2904.

## Validation

- `./gradlew test --tests com.cburch.logisim.file.ProjectBundlePathsTest --tests com.cburch.logisim.file.ProjectBundleExportTest checkstyleMain checkstyleTest`
- complete `./gradlew check` in a temporary detached integration worktree with the independent #2903 test-isolation commit: 579 tests, all checks passed
- branch-only complete suite reached all 579 tests; its only four failures were the known #2903 assertions caused by the valid persisted local `VhdlKeywordsUpperCase=false` preference
- `git diff --check`

No system preferences were changed during validation, and the temporary integration worktree was removed after the successful run.
