### PR TITLE
docs: document project bundle file actions

### DIFF
--- a/src/main/resources/doc/en/html/guide/menu/file.html
+++ b/src/main/resources/doc/en/html/guide/menu/file.html
@@ -74,6 +74,22 @@
           </p>
         </dd>
         <dt>
+          <strong>Extract and open project bundle...</strong>
+        </dt>
+        <dd>
+          <p>
+            Extracts a Logisim-evolution project bundle (<b class="tkeybd">.lsebdl</b>) into a directory and opens its main circuit. If the bundle contains a README, Logisim-evolution displays it before asking where to extract the circuit and its bundled libraries.
+          </p>
+        </dd>
+        <dt>
+          <strong>Export project bundle...</strong>&nbsp;&nbsp;<b class="tkeybd">Ctrl-Shift-E</b>
+        </dt>
+        <dd>
+          <p>
+            Packages the current circuit and its external circuit or JAR libraries into a portable Logisim-evolution project bundle (<b class="tkeybd">.lsebdl</b>). Before creating the bundle, Logisim-evolution lets you add optional README information for its recipient.
+          </p>
+        </dd>
+        <dt>
           <strong>Export Image...</strong>
         </dt>
         <dd>


### PR DESCRIPTION
## Summary
- document **Extract and open project bundle...** in the File menu guide
- document **Export project bundle...**, its default shortcut, and bundled contents
- explain the optional README step and `.lsebdl` format

## Validation
- parsed the updated page successfully with `xmllint --html --noout`
- verified balanced `dt`/`dd` entries and all local links

Closes #1213.
