### PR TITLE
i18n: localize floating-point conversion and rounding

### DIFF
--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -146,9 +146,9 @@ fpNegatorOutputTip = 输出：输入数值的相反数
 #
 # arith/floating/FPRound.java
 #
-# ==> fpRoundComponent =
-# ==> fpRoundInputTip =
-# ==> fpRoundOutputTip =
+fpRoundComponent = 浮点数舍入器
+fpRoundInputTip = 输入：待舍入的数值
+fpRoundOutputTip = 输出：输入数值的舍入结果
 #
 # arith/floating/FPSquareRoot.java
 #
@@ -161,11 +161,11 @@ fpSubtractorComponent = 浮点数减法器
 #
 # arith/floating/FPToFP.java
 #
-# ==> fpToFpComponent =
-# ==> fpToFpDataWidthIn =
-# ==> fpToFpDataWidthOut =
-# ==> fpToFpInputTip =
-# ==> fpToFpOutputTip =
+fpToFpComponent = 浮点数转换器
+fpToFpDataWidthIn = 输入浮点数位宽
+fpToFpDataWidthOut = 输出浮点数位宽
+fpToFpInputTip = 输入：待转换的浮点数
+fpToFpOutputTip = 输出：转换后的浮点数
 #
 # arith/floating/FPToInt.java
 #
@@ -175,8 +175,8 @@ fpToIntComponent = 浮点数转整数
 fpToIntInputTip = 输入：待转换的浮点数
 fpToIntOutputTip = 输出：包含舍入后浮点值的有符号整数
 fpToIntType = 舍入模式
-# ==> rintOption =
-roundOption = 就近取整（四舍六入五留双）
+rintOption = 就近取整（中间值取偶数）
+roundOption = 就近取整
 truncateOption = 截断
 #
 # arith/floating/FPTrigonometry.java


### PR DESCRIPTION
## Summary
- localize the floating-point rounding component and its input/output tooltips
- localize floating-point-to-floating-point conversion, including input/output widths and tooltips
- distinguish round-to-nearest-ties-to-even from ordinary round-to-nearest in Chinese

This is a focused follow-up to #2566. It preserves the scope and wording guidance proposed by @lihuashiyu and discussed by @dangfan and @Harry-Chen.

## Validation
- ./gradlew.bat processResources checkstyleMain --no-daemon --max-workers=1
- full ./gradlew.bat check in a detached integration worktree with the independent #2903 test-only casing isolation
- git diff --check
- trans-tool 2.5.2 comparison against unchanged main; no new real resource errors