### PR TITLE
docs: add TTL contributor and library guides

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Added contributor guidance and an online component overview for the TTL library.
   * Added "Find Action" omni-search, letting menu actions be found and run by typing part of their
     name, with fuzzy and acronym matching (e.g. "expim" or "ei" find "Export Image"). It opens from
     the Help menu, from Ctrl+Shift+A (configurable under Preferences > Hotkey settings), or by

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -21,6 +21,7 @@
     * [Updating existing translation](localization.md#updating-existing-translation)
     * [Adding new translation](localization.md#adding-new-translation)
     * [Using trans-tool](localization.md#using-trans-tool)
+  * [Implementing TTL components](implementing_ttl_components.md)
   * [How to contribute](#how-to-contribute)
 
 ---

--- a/docs/implementing_ttl_components.md
+++ b/docs/implementing_ttl_components.md
@@ -1,0 +1,151 @@
+[![Logisim-evolution](img/logisim-evolution-logo.png)](https://github.com/logisim-evolution/logisim-evolution)
+
+---
+
+# Implementing TTL components #
+
+* [« Go back](developers.md)
+* **Implementing TTL components**
+  * [Before writing code](#before-writing-code)
+  * [Choose current examples](#choose-current-examples)
+  * [Define the component](#define-the-component)
+  * [Implement simulation and painting](#implement-simulation-and-painting)
+  * [Register and document the component](#register-and-document-the-component)
+  * [HDL support](#hdl-support)
+  * [Test the implementation](#test-the-implementation)
+  * [Validate the change](#validate-the-change)
+
+---
+
+This guide describes the repository-specific steps for adding a 74-series TTL component. It complements the general
+[contribution rules](../.github/CONTRIBUTING.md) and does not replace the device manufacturer's data sheet.
+
+## Before writing code ##
+
+* Open an issue and agree on the component and expected scope before implementing it.
+* Create the work on a branch from the current [`main`](https://github.com/logisim-evolution/logisim-evolution/tree/main).
+* Select an authoritative manufacturer data sheet for the exact device variant being modelled. Verify the package pinout,
+  truth table, active levels, clock edge, reset behavior, output type, and any unusual power-pin positions.
+* Cite the data sheet in the component class documentation. If sources disagree, document which source and variant the
+  simulation follows instead of silently combining them.
+
+TTL simulation in Logisim-evolution is a digital functional model. Do not claim analog characteristics, propagation times,
+fan-out limits, or electrical compatibility unless the simulator explicitly models them.
+
+## Choose current examples ##
+
+Use nearby implementations as patterns, but check every detail against the selected data sheet:
+
+* [`Ttl7400`](../src/main/java/com/cburch/logisim/std/ttl/Ttl7400.java) is a compact stateless gate example.
+* [`Ttl7493`](../src/main/java/com/cburch/logisim/std/ttl/Ttl7493.java) demonstrates a stateful counter, non-standard power
+  pins, named logical port indexes, and clock metadata.
+* [`Ttl74173`](../src/main/java/com/cburch/logisim/std/ttl/Ttl74173.java) demonstrates instance-owned register state,
+  active-low controls, and three-state outputs.
+* [`Ttl7493Test`](../src/test/java/com/cburch/logisim/std/ttl/Ttl7493Test.java) shows focused port-layout, power-pin,
+  state-transition, reset, and unknown-output tests.
+
+Prefer the smallest example with matching behavior. Older TTL classes may predate current conventions and should not be
+copied without review.
+
+## Define the component ##
+
+Place the component in `com.cburch.logisim.std.ttl` and extend
+[`AbstractTtlGate`](../src/main/java/com/cburch/logisim/std/ttl/AbstractTtlGate.java).
+
+### Stable identifier ###
+
+Declare a public `_ID` whose value is the established device number, for example `"7493"`. The identifier is serialized in
+project files, so it must be unique within the library and must never be changed after release.
+
+### Physical pins and logical ports ###
+
+Pass physical, one-based data-sheet pin numbers to the `AbstractTtlGate` constructor:
+
+* identify every output and input/output pin;
+* identify unused pins so they do not become Logisim ports;
+* provide tooltips in the same order as the resulting logical ports; and
+* use the constructor overload with explicit VCC and GND numbers when the package does not use the conventional last-pin
+  VCC and midpoint GND positions.
+
+Logical ports are zero-based and follow physical pin order after unused and power pins are omitted. When the
+**Enable Vcc and Gnd ports** attribute is enabled, GND and VCC are appended as the last two logical ports. Define named
+logical-port constants or a reviewed physical-pin conversion helper; do not pass a physical pin number directly to
+`InstanceState.getPortValue()` or `InstanceState.setPort()`.
+
+The power-pin attribute defaults to hidden for compatibility. `AbstractTtlGate` verifies exposed power inputs and drives
+declared output pins unknown when they are invalid, so focused tests must cover both hidden and exposed power modes.
+
+## Implement simulation and painting ##
+
+Implement the component's digital behavior in `propagateTtl(InstanceState)`:
+
+* read all relevant control inputs before deciding the operation;
+* preserve `Value.UNKNOWN`, error, and released-output behavior where required by the component contract;
+* use `state.setPort(port, value, delay)` for outputs and keep delays consistent with comparable TTL models; and
+* test active-low inputs, reset priority, enable/hold behavior, and clock edges explicitly rather than relying on names.
+
+State belongs to the circuit instance, never to fields on the component factory. Retrieve or initialize an `InstanceData`
+object through `InstanceState.getData()` and `InstanceState.setData()`. `TtlRegisterData` and `ClockState` provide common
+storage and edge-detection behavior for sequential devices.
+
+Implement `paintInternal()` only for the internal-structure view. Reuse `paintBase()` and the helpers in `Drawgates` where
+they match the data sheet. Painting must not contain simulation state shared across component instances.
+
+## Register and document the component ##
+
+Complete all of these integration points in the same change:
+
+1. Add a `FactoryDescription` in
+   [`TtlLibrary`](../src/main/java/com/cburch/logisim/std/ttl/TtlLibrary.java). Keep the component order deliberate.
+2. Add the `TTL<device-number>` display key and description to
+   [`std.properties`](../src/main/resources/resources/logisim/strings/std/std.properties), then use the localization tools to
+   add the corresponding key or untranslated placeholder to every `std_*.properties` bundle.
+3. Add the device and its short description to the
+   [TTL online-help overview](../src/main/resources/doc/en/html/libs/ttl/index.html). Refer users to the manufacturer's data
+   sheet for detailed behavior and electrical information.
+4. Add a concise user-visible entry under the current development section in [`CHANGES.md`](../CHANGES.md).
+
+Translate only languages you can review. The English resource bundle remains the fallback for untranslated keys.
+
+## HDL support ##
+
+HDL generation is useful but is not required for every TTL simulator contribution. Pass `null` as the generator when HDL
+support is outside the agreed issue scope.
+
+When HDL support is included, keep it reviewable alongside the simulator contract, support the repository's applicable
+VHDL and Verilog paths, and test generated ports and behavior. Sequential components may also need accurate
+`checkForGatedClocks()` and `clockPinIndex()` metadata. Java tests of generated text do not by themselves prove that an
+external synthesis tool accepts the result.
+
+## Test the implementation ##
+
+Add a focused test class under `src/test/java/com/cburch/logisim/std/ttl`. Cover the behaviors that apply to the device:
+
+* logical port count, type, location, and data-sheet pin mapping;
+* hidden and exposed VCC/GND modes, including non-standard power pins;
+* truth-table rows or representative input combinations for combinational logic;
+* clock edges, state transitions, reset priority, enables, loading, and hold behavior for sequential logic;
+* unknown, error, open-collector, or three-state output behavior; and
+* HDL metadata and generated behavior when HDL support is included.
+
+Test through the public component and `InstanceState` paths. Avoid tests that merely repeat a private helper's
+implementation.
+
+## Validate the change ##
+
+Run the focused test first, replacing the class name with the new test:
+
+```bash
+./gradlew test --tests com.cburch.logisim.std.ttl.Ttl7493Test
+```
+
+Then run compilation, Checkstyle, and the complete check suite:
+
+```bash
+./gradlew compileJava checkstyleMain checkstyleTest
+./gradlew check
+```
+
+On Windows PowerShell, use `.\gradlew.bat` instead of `./gradlew`; in Command Prompt, use `gradlew.bat`. Also run
+`git diff --check`, verify the new component manually in both power-pin modes, and confirm that the links and online-help
+entry open correctly.

--- a/src/main/resources/doc/en/contents.xml
+++ b/src/main/resources/doc/en/contents.xml
@@ -217,10 +217,8 @@
 			<tocitem target="io_videorgb" text="Video RGB" image="icon_videorgb" />
 -->	
 		</tocitem>
+		<tocitem target="ttl" text="TTL library" image="icon_ttl" />
 <!-- not documented 
-		<tocitem target="ttl" text="TTL">
-			<tocitem target="ttl_xxxx" text="TTL" image="icon_ttl" />
-		</tocitem>
 		<tocitem target="tcl" text="TCL library">
 			<tocitem target="tcl_reds_console" text="REDS console" image="icon_reds_console" />
 			<tocitem target="tcl_generic" text="Generic" image="icon_generic" />

--- a/src/main/resources/doc/en/html/libs/index.html
+++ b/src/main/resources/doc/en/html/libs/index.html
@@ -995,10 +995,22 @@
 	  </tbody>
     </table>	
     <h2>	
-	  <b><a href="tcl/index.html">Other library TTL,TCL,HDL-IP,BFH</a></b>
+	  <b>Other libraries</b>
     </h2>
     <table>
       <tbody>
+        <tr>
+          <td align="right">
+            <a href="ttl/index.html"><img class="iconlibs" src="../../../icons/6464/ttl.png"
+              alt="TTL icon" border=0 height="32" width="32"></a>
+          </td>
+          <td>
+            &nbsp;
+          </td>
+          <td>
+            <a href="ttl/index.html">TTL library</a>
+          </td>
+        </tr>
         <tr>
           <td align="right">
             <a href="tcl/redsconsole.html"><img class="iconlibs" src="../../../icons/6464/tcl.png" alt="#########" border=0 height="32" width="32"></a>

--- a/src/main/resources/doc/en/html/libs/ttl/index.html
+++ b/src/main/resources/doc/en/html/libs/ttl/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>TTL library</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>TTL library</h1>
+      <p>
+        The TTL library contains digital functional models of 74-series integrated circuits in
+        dual in-line packages. Select a model by its device number. The descriptions below match
+        the names shown in the component catalog.
+      </p>
+      <p>
+        By default, the power pins are hidden and treated as correctly powered. Enable the
+        <b class="propertie">Enable Vcc and Gnd ports</b> attribute to expose them. The
+        <b class="propertie">Show the internal structure</b> attribute displays the internal logic
+        for components that provide that view.
+      </p>
+      <p>
+        These components model digital logic, not electrical characteristics or physical timing.
+        Refer to the manufacturer's data sheet for the exact pinout, truth table, operating limits,
+        and other device-specific details.
+      </p>
+      <h2>Available models</h2>
+      <table border="1" cellpadding="4">
+        <thead>
+          <tr><th>Model</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>7400</code></td><td>quad 2-input NAND gate</td></tr>
+          <tr><td><code>7402</code></td><td>quad 2-input NOR gate (right-to-left)</td></tr>
+          <tr><td><code>7404</code></td><td>hex inverter</td></tr>
+          <tr><td><code>7408</code></td><td>quad 2-input AND gate</td></tr>
+          <tr><td><code>7410</code></td><td>triple 3-input NAND gate</td></tr>
+          <tr><td><code>7411</code></td><td>triple 3-input AND gate</td></tr>
+          <tr><td><code>7413</code></td><td>dual 4-input NAND gate(Schmitt trigger)</td></tr>
+          <tr><td><code>7414</code></td><td>hex inverter (Schmitt trigger)</td></tr>
+          <tr><td><code>7418</code></td><td>dual 4-input NAND gate(Schmitt trigger)</td></tr>
+          <tr><td><code>7419</code></td><td>hex inverter (Schmitt trigger)</td></tr>
+          <tr><td><code>7420</code></td><td>dual 4-input NAND gate</td></tr>
+          <tr><td><code>7421</code></td><td>dual 4-input AND gate</td></tr>
+          <tr><td><code>7424</code></td><td>quad 2-input NAND gate (Schmitt trigger)</td></tr>
+          <tr><td><code>7427</code></td><td>triple 3-input NOR gate</td></tr>
+          <tr><td><code>7430</code></td><td>single 8-input NAND gate</td></tr>
+          <tr><td><code>7432</code></td><td>quad 2-input OR gate</td></tr>
+          <tr><td><code>7434</code></td><td>hex buffer gate</td></tr>
+          <tr><td><code>7436</code></td><td>quad 2-input NOR gate</td></tr>
+          <tr><td><code>7438</code></td><td>quad 2-input NAND gate (open-collector)</td></tr>
+          <tr><td><code>7442</code></td><td>BCD to decimal decoder</td></tr>
+          <tr><td><code>7443</code></td><td>Excess-3 to decimal decoder</td></tr>
+          <tr><td><code>7444</code></td><td>Gray to decimal decoder</td></tr>
+          <tr><td><code>7447</code></td><td>BCD to 7-segment decoder</td></tr>
+          <tr><td><code>7451</code></td><td>dual AND-OR-INVERT gate</td></tr>
+          <tr><td><code>7454</code></td><td>Four wide AND-OR-INVERT gate</td></tr>
+          <tr><td><code>7458</code></td><td>dual AND-OR gate</td></tr>
+          <tr><td><code>7464</code></td><td>4-2-3-2 AND-OR-INVERT gate</td></tr>
+          <tr><td><code>7474</code></td><td>dual D-Flipflops with preset and clear</td></tr>
+          <tr><td><code>7476</code></td><td>dual J-K Flipflops with preset and clear</td></tr>
+          <tr><td><code>7485</code></td><td>4-bit magnitude comparator</td></tr>
+          <tr><td><code>7486</code></td><td>quad 2-input XOR gate</td></tr>
+          <tr><td><code>7487</code></td><td>4-bit True/complement, zero/one elements</td></tr>
+          <tr><td><code>7493</code></td><td>4-bit binary ripple counter</td></tr>
+          <tr><td><code>74125</code></td><td>quad bus buffer, three-state outputs, negative enable</td></tr>
+          <tr><td><code>74138</code></td><td>3-line to 8-line decoder</td></tr>
+          <tr><td><code>74139</code></td><td>Dual 2-line to 4-line decoder</td></tr>
+          <tr><td><code>74151</code></td><td>8-line to 1 line data selector</td></tr>
+          <tr><td><code>74153</code></td><td>dual 4-line to 1 line data selector</td></tr>
+          <tr><td><code>74157</code></td><td>quad 2-line to 1 line data selector</td></tr>
+          <tr><td><code>74158</code></td><td>quad 2-line to 1 line data selector, inverted output</td></tr>
+          <tr><td><code>74161</code></td><td>4-bit sync counter with async clear</td></tr>
+          <tr><td><code>74163</code></td><td>4-bit sync counter with sync clear</td></tr>
+          <tr><td><code>74164</code></td><td>8-bit serial-to-parallel shift register</td></tr>
+          <tr><td><code>74165</code></td><td>8-bit parallel-to-serial shift register</td></tr>
+          <tr><td><code>74166</code></td><td>8-bit parallel-to-serial shift register with asynchronous clear</td></tr>
+          <tr><td><code>74173</code></td><td>4-bit D-type registers with 3-state outputs</td></tr>
+          <tr><td><code>74175</code></td><td>quad D-flipflop, asynchronous reset</td></tr>
+          <tr><td><code>74181</code></td><td>arithmetic logic unit</td></tr>
+          <tr><td><code>74182</code></td><td>look-ahead carry generator</td></tr>
+          <tr><td><code>74192</code></td><td>4-bit up/down decade counter</td></tr>
+          <tr><td><code>74193</code></td><td>4-bit up/down binary counter</td></tr>
+          <tr><td><code>74194</code></td><td>4-bit bidirectional universal shift register</td></tr>
+          <tr><td><code>74240</code></td><td>octal buffers with three-state inverted outputs</td></tr>
+          <tr><td><code>74241</code></td><td>octal buffers with three-state outputs and complementary enables</td></tr>
+          <tr><td><code>74244</code></td><td>octal buffers with three-state outputs</td></tr>
+          <tr><td><code>74245</code></td><td>octal bus transceivers with three-state outputs</td></tr>
+          <tr><td><code>74266</code></td><td>quad 2-input XNOR gate (open-collector)</td></tr>
+          <tr><td><code>74273</code></td><td>octal D-Flipflop with clear</td></tr>
+          <tr><td><code>74283</code></td><td>4-bit binary full adder</td></tr>
+          <tr><td><code>74299</code></td><td>8-bit universal shift register with three-state outputs</td></tr>
+          <tr><td><code>74377</code></td><td>octal D-Flipflop with enable</td></tr>
+          <tr><td><code>74381</code></td><td>arithmetic logic unit (ALU)</td></tr>
+          <tr><td><code>74541</code></td><td>Octal buffers with three-state outputs</td></tr>
+          <tr><td><code>74670</code></td><td>4-by-4 register file with three-state outputs</td></tr>
+          <tr><td><code>747266</code></td><td>quad 2-input XNOR gate</td></tr>
+        </tbody>
+      </table>
+      <p><b>Back to</b> <a href="../index.html">Library Reference</a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/map_en.jhm
+++ b/src/main/resources/doc/map_en.jhm
@@ -192,8 +192,9 @@
 	<mapID target="io_realtimeclock"    url="en/html/libs/io/realtimeclock.html" />
 	<mapID target="io_matrixkeypad"     url="en/html/libs/io/matrixkeypad.html" />
     <mapID target="io_Port_IO"          url="en/html/libs/io/Port_io.html" />
-	<mapID target="io_Repetar"          url="en/html/libs/io/repetar.html" />	
+	<mapID target="io_Repetar"          url="en/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="en/html/libs/io/videorvb.html" />
+	<mapID target="ttl"                 url="en/html/libs/ttl/index.html" />
 	<mapID target="tcl"                 url="en/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="en/html/libs/tcl/reds_console.html" />
     <mapID target="tcl_generic"         url="en/html/libs/tcl/generic.html" />

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -193,6 +193,7 @@
     <mapID target="io_Port_IO"          url="pt/html/libs/io/Port_io.html" />
 	<mapID target="io_Repetar"          url="pt/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="pt/html/libs/io/videorvb.html" />
+	<mapID target="ttl"                 url="en/html/libs/ttl/index.html" />
 	<mapID target="tcl"                 url="pt/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="pt/html/libs/tcl/reds_console.html" />
     <mapID target="tcl_generic"         url="pt/html/libs/tcl/generic.html" />


### PR DESCRIPTION
## Summary

- add a repository-specific contributor guide for implementing TTL components
- add an English online-help overview of all 65 currently registered TTL models
- link the new documentation from the developer guide, Library Reference, and JavaHelp table of contents

## Validation

- verified all 65 registered models match the English localization keys and descriptions
- verified the new local links and JavaHelp map targets
- `./gradlew test --tests "com.cburch.logisim.docs.*"`
- Markdown lint
- `git diff --check`

Closes #2877