### PR TITLE
feat: add FPGA HDL support for Bit Finder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
   * Added an opt-in RAM data-bus mode where inactive output-enable drives separate outputs to high-impedance.
   * Added Real-Time Clock component.
   * Added Floating Point Constant component.
+  * Added FPGA HDL support for the Bit Finder component [#2890] (@hewzhew).
   * Added 444 RGB (12 bit) color mode to the RGB Video component.
   * Modified paste behavior to paste at current mouse location if it is on canvas.
   * Added multiline Text Tool labels using Shift+Enter or multiline clipboard text.

--- a/src/main/java/com/cburch/logisim/std/arith/BitFinder.java
+++ b/src/main/java/com/cburch/logisim/std/arith/BitFinder.java
@@ -55,17 +55,21 @@ public class BitFinder extends InstanceFactory {
           S.getter("bitFinderTypeAttr"),
           new AttributeOption[] {LOW_ONE, HIGH_ONE, LOW_ZERO, HIGH_ZERO});
 
+  static final int PRESENT = 0;
+  static final int INDEX = 1;
+  static final int INPUT = 2;
+
   public BitFinder() {
-    super(_ID, S.getter("bitFinderComponent"));
+    super(_ID, S.getter("bitFinderComponent"), new BitFinderHdlGeneratorFactory());
     setAttributes(
         new Attribute[] {StdAttr.WIDTH, TYPE}, new Object[] {BitWidth.create(8), LOW_ONE});
     setKeyConfigurator(new BitWidthConfigurator(StdAttr.WIDTH));
     setIcon(new ArithmeticIcon("?"));
   }
 
-  private int computeOutputBits(int maxBits) {
+  static int computeOutputBits(int inputWidth) {
     int outWidth = 1;
-    while ((1 << outWidth) <= maxBits) outWidth++;
+    while ((1L << outWidth) < inputWidth) outWidth++;
     return outWidth;
   }
 
@@ -77,29 +81,35 @@ public class BitFinder extends InstanceFactory {
 
   private void configurePorts(Instance instance) {
     BitWidth inWidth = instance.getAttributeValue(StdAttr.WIDTH);
-    int outWidth = computeOutputBits(inWidth.getWidth() - 1);
+    int outWidth = computeOutputBits(inWidth.getWidth());
 
     Port[] ps = new Port[3];
-    ps[0] = new Port(-20, 20, Port.OUTPUT, BitWidth.ONE);
-    ps[1] = new Port(0, 0, Port.OUTPUT, BitWidth.create(outWidth));
-    ps[2] = new Port(-40, 0, Port.INPUT, inWidth);
+    ps[PRESENT] = new Port(-20, 20, Port.OUTPUT, BitWidth.ONE);
+    ps[INDEX] = new Port(0, 0, Port.OUTPUT, BitWidth.create(outWidth));
+    ps[INPUT] = new Port(-40, 0, Port.INPUT, inWidth);
 
     Object type = instance.getAttributeValue(TYPE);
     if (type == HIGH_ZERO) {
-      ps[0].setToolTip(S.getter("bitFinderPresentTip", "0"));
-      ps[1].setToolTip(S.getter("bitFinderIndexHighTip", "0"));
+      ps[PRESENT].setToolTip(S.getter("bitFinderPresentTip", "0"));
+      ps[INDEX].setToolTip(S.getter("bitFinderIndexHighTip", "0"));
     } else if (type == LOW_ZERO) {
-      ps[0].setToolTip(S.getter("bitFinderPresentTip", "0"));
-      ps[1].setToolTip(S.getter("bitFinderIndexLowTip", "0"));
+      ps[PRESENT].setToolTip(S.getter("bitFinderPresentTip", "0"));
+      ps[INDEX].setToolTip(S.getter("bitFinderIndexLowTip", "0"));
     } else if (type == HIGH_ONE) {
-      ps[0].setToolTip(S.getter("bitFinderPresentTip", "1"));
-      ps[1].setToolTip(S.getter("bitFinderIndexHighTip", "1"));
+      ps[PRESENT].setToolTip(S.getter("bitFinderPresentTip", "1"));
+      ps[INDEX].setToolTip(S.getter("bitFinderIndexHighTip", "1"));
     } else {
-      ps[0].setToolTip(S.getter("bitFinderPresentTip", "1"));
-      ps[1].setToolTip(S.getter("bitFinderIndexLowTip", "1"));
+      ps[PRESENT].setToolTip(S.getter("bitFinderPresentTip", "1"));
+      ps[INDEX].setToolTip(S.getter("bitFinderIndexLowTip", "1"));
     }
-    ps[2].setToolTip(S.getter("bitFinderInputTip"));
+    ps[INPUT].setToolTip(S.getter("bitFinderInputTip"));
     instance.setPorts(ps);
+  }
+
+  @Override
+  public String getHDLName(AttributeSet attrs) {
+    final var inputWidth = attrs.getValue(StdAttr.WIDTH).getWidth();
+    return inputWidth < 3 ? "BitFinder_" + inputWidth + "_bit" : _ID;
   }
 
   @Override
@@ -152,10 +162,10 @@ public class BitFinder extends InstanceFactory {
   @Override
   public void propagate(InstanceState state) {
     int width = state.getAttributeValue(StdAttr.WIDTH).getWidth();
-    int outWidth = computeOutputBits(width - 1);
+    int outWidth = computeOutputBits(width);
     Object type = state.getAttributeValue(TYPE);
 
-    Value[] bits = state.getPortValue(2).getAll();
+    Value[] bits = state.getPortValue(INPUT).getAll();
     Value want;
     int i;
     if (type == HIGH_ZERO) {
@@ -186,7 +196,7 @@ public class BitFinder extends InstanceFactory {
     }
 
     int delay = outWidth * Adder.PER_DELAY;
-    state.setPort(0, present, delay);
-    state.setPort(1, index, delay);
+    state.setPort(PRESENT, present, delay);
+    state.setPort(INDEX, index, delay);
   }
 }

--- a/src/main/java/com/cburch/logisim/std/arith/BitFinderHdlGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/arith/BitFinderHdlGeneratorFactory.java
@@ -1,0 +1,241 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.arith;
+
+import com.cburch.logisim.data.AttributeOption;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.fpga.hdlgenerator.AbstractHdlGeneratorFactory;
+import com.cburch.logisim.fpga.hdlgenerator.Hdl;
+import com.cburch.logisim.fpga.hdlgenerator.HdlParameters;
+import com.cburch.logisim.instance.Port;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.util.LineBuffer;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class BitFinderHdlGeneratorFactory extends AbstractHdlGeneratorFactory {
+
+  private static final String NR_OF_INPUT_BITS_STRING = "nrOfInputBits";
+  private static final int NR_OF_INPUT_BITS_ID = -1;
+  private static final String NR_OF_INDEX_BITS_STRING = "nrOfIndexBits";
+  private static final int NR_OF_INDEX_BITS_ID = -2;
+  private static final String FIND_MODE_STRING = "findMode";
+  private static final int FIND_MODE_ID = -3;
+
+  private static final Map<AttributeOption, Integer> FIND_MODE_MAP =
+      Map.of(
+          BitFinder.LOW_ONE,
+          0,
+          BitFinder.HIGH_ONE,
+          1,
+          BitFinder.LOW_ZERO,
+          2,
+          BitFinder.HIGH_ZERO,
+          3);
+
+  public BitFinderHdlGeneratorFactory() {
+    super();
+    myParametersList
+        .add(NR_OF_INPUT_BITS_STRING, NR_OF_INPUT_BITS_ID)
+        .add(
+            NR_OF_INDEX_BITS_STRING,
+            NR_OF_INDEX_BITS_ID,
+            HdlParameters.MAP_CONSTANT,
+            1)
+        .add(
+            FIND_MODE_STRING,
+            FIND_MODE_ID,
+            HdlParameters.MAP_ATTRIBUTE_OPTION,
+            BitFinder.TYPE,
+            FIND_MODE_MAP);
+    getWiresPortsDuringHDLWriting = true;
+  }
+
+  @Override
+  public void getGenerationTimeWiresPorts(Netlist theNetlist, AttributeSet attrs) {
+    final var inputBits = attrs.getValue(StdAttr.WIDTH).getWidth();
+    final var indexBits = BitFinder.computeOutputBits(inputBits);
+
+    myPorts
+        .add(
+            Port.INPUT,
+            "inputVector",
+            inputBits == 1 ? 1 : NR_OF_INPUT_BITS_ID,
+            BitFinder.INPUT)
+        .add(Port.OUTPUT, "present", 1, BitFinder.PRESENT)
+        .add(
+            Port.OUTPUT,
+            "index",
+            indexBits == 1 ? 1 : NR_OF_INDEX_BITS_ID,
+            BitFinder.INDEX);
+
+    if (inputBits > 1) {
+      myWires
+          .addRegister("s_present", 1)
+          .addRegister("s_index", indexBits == 1 ? 1 : NR_OF_INDEX_BITS_ID);
+    }
+  }
+
+  @Override
+  protected Map<String, String> getParameterMap(AttributeSet attrs) {
+    if (attrs == null) return new TreeMap<>();
+
+    final var parameters = new TreeMap<>(super.getParameterMap(attrs));
+    parameters.put(
+        NR_OF_INDEX_BITS_STRING,
+        Integer.toString(BitFinder.computeOutputBits(attrs.getValue(StdAttr.WIDTH).getWidth())));
+    return parameters;
+  }
+
+  @Override
+  public LineBuffer getModuleFunctionality(Netlist theNetlist, AttributeSet attrs) {
+    final var inputBits = attrs.getValue(StdAttr.WIDTH).getWidth();
+    final var indexBits = BitFinder.computeOutputBits(inputBits);
+    final var contents =
+        LineBuffer.getBuffer()
+            .pair("findMode", FIND_MODE_STRING)
+            .pair("nrOfInputBits", NR_OF_INPUT_BITS_STRING)
+            .pair("nrOfIndexBits", NR_OF_INDEX_BITS_STRING)
+            .addRemarkBlock(
+                "Find modes: 0 = lowest one, 1 = highest one, "
+                    + "2 = lowest zero, 3 = highest zero");
+
+    if (inputBits == 1) {
+      if (Hdl.isVhdl()) {
+        contents.addVhdlKeywords().add(
+            """
+            present <= inputVector {{when}} {{findMode}} = 0 {{or}} {{findMode}} = 1 {{else}}
+                       {{not}} inputVector;
+            index   <= '0';
+            """);
+      } else {
+        contents.add(
+            """
+            assign present = (({{findMode}} == 0) || ({{findMode}} == 1))
+                                 ? inputVector : ~inputVector;
+            assign index = 1'b0;
+            """);
+      }
+      return contents.empty();
+    }
+
+    if (Hdl.isVhdl()) {
+      contents
+          .addVhdlKeywords()
+          .add(
+              """
+              present <= s_present;
+              index   <= s_index;
+
+              findIndex : {{process}}(inputVector) {{is}}
+                 {{variable}} found       : boolean;
+                 {{variable}} indexValue  : natural {{range}} 0 {{to}} {{nrOfInputBits}} - 1;
+                 {{variable}} targetValue : std_logic;
+              {{begin}}
+                 s_present <= '0';
+              """)
+          .add(indexBits == 1 ? "   s_index   <= '0';" : "   s_index   <= ({{others}} => '0');")
+          .add(
+              """
+                 found      := false;
+                 indexValue := 0;
+
+                 {{if}} {{findMode}} = 0 {{or}} {{findMode}} = 1 {{then}}
+                    targetValue := '1';
+                 {{else}}
+                    targetValue := '0';
+                 {{end}} {{if}};
+
+                 {{if}} {{findMode}} = 0 {{or}} {{findMode}} = 2 {{then}}
+                    {{for}} bitIndex {{in}} 0 {{to}} {{nrOfInputBits}} - 1 {{loop}}
+                       {{if}} {{not}} found {{and}} inputVector(bitIndex) = targetValue {{then}}
+                          s_present <= '1';
+                          indexValue := bitIndex;
+                          found := true;
+                       {{end}} {{if}};
+                    {{end}} {{loop}};
+                 {{else}}
+                    {{for}} bitIndex {{in}} {{nrOfInputBits}} - 1 {{downto}} 0 {{loop}}
+                       {{if}} {{not}} found {{and}} inputVector(bitIndex) = targetValue {{then}}
+                          s_present <= '1';
+                          indexValue := bitIndex;
+                          found := true;
+                       {{end}} {{if}};
+                    {{end}} {{loop}};
+                 {{end}} {{if}};
+
+                 {{if}} found {{then}}
+              """);
+      if (indexBits == 1) {
+        contents.add(
+            """
+                    {{if}} indexValue = 0 {{then}}
+                       s_index <= '0';
+                    {{else}}
+                       s_index <= '1';
+                    {{end}} {{if}};
+            """);
+      } else {
+        contents.add(
+            """
+                    s_index <= std_logic_vector(to_unsigned(indexValue, {{nrOfIndexBits}}));
+            """);
+      }
+      contents.add(
+          """
+                 {{end}} {{if}};
+              {{end}} {{process}} findIndex;
+              """);
+    } else {
+      contents.add(
+          """
+          integer bitIndex;
+
+          assign present = s_present;
+          assign index = s_index;
+
+          always @(*)
+          begin
+             s_present = 1'b0;
+          """);
+      contents.add(indexBits == 1 ? "   s_index = 1'b0;" : "   s_index = 0;");
+      contents.add(
+          """
+             if (({{findMode}} == 0) || ({{findMode}} == 2))
+                begin
+                   for (bitIndex = {{nrOfInputBits}} - 1; bitIndex >= 0; bitIndex = bitIndex - 1)
+                      begin
+                         if (inputVector[bitIndex] ==
+                             ((({{findMode}} == 0) || ({{findMode}} == 1)) ? 1'b1 : 1'b0))
+                            begin
+                               s_present = 1'b1;
+                               s_index = bitIndex;
+                            end
+                      end
+                end
+             else
+                begin
+                   for (bitIndex = 0; bitIndex < {{nrOfInputBits}}; bitIndex = bitIndex + 1)
+                      begin
+                         if (inputVector[bitIndex] ==
+                             ((({{findMode}} == 0) || ({{findMode}} == 1)) ? 1'b1 : 1'b0))
+                            begin
+                               s_present = 1'b1;
+                               s_index = bitIndex;
+                            end
+                      end
+                end
+          end
+          """);
+    }
+    return contents.empty();
+  }
+}

--- a/src/test/java/com/cburch/logisim/std/arith/BitFinderHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/std/arith/BitFinderHdlGeneratorFactoryTest.java
@@ -1,0 +1,180 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.arith;
+
+import static com.cburch.logisim.fpga.hdlgenerator.HdlText.containsIgnoringCase;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.data.AttributeOption;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
+import com.cburch.logisim.instance.StdAttr;
+import com.cburch.logisim.prefs.AppPreferences;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class BitFinderHdlGeneratorFactoryTest {
+
+  private final String originalHdlType = AppPreferences.HdlType.get();
+
+  @AfterEach
+  void restoreHdlType() {
+    AppPreferences.HdlType.set(originalHdlType);
+  }
+
+  @Test
+  void mapsAllFourFindModes() {
+    assertAll(
+        () -> assertEquals("0", parametersFor(8, BitFinder.LOW_ONE).get("findMode")),
+        () -> assertEquals("1", parametersFor(8, BitFinder.HIGH_ONE).get("findMode")),
+        () -> assertEquals("2", parametersFor(8, BitFinder.LOW_ZERO).get("findMode")),
+        () -> assertEquals("3", parametersFor(8, BitFinder.HIGH_ZERO).get("findMode")));
+  }
+
+  @Test
+  void derivesIndexWidthAcrossBoundariesAndNonPowerOfTwoInputs() {
+    assertAll(
+        () -> assertEquals(1, BitFinder.computeOutputBits(1)),
+        () -> assertEquals(1, BitFinder.computeOutputBits(2)),
+        () -> assertEquals(2, BitFinder.computeOutputBits(3)),
+        () -> assertEquals(3, BitFinder.computeOutputBits(5)),
+        () -> assertEquals(6, BitFinder.computeOutputBits(64)),
+        () -> assertEquals("3", parametersFor(5, BitFinder.LOW_ONE).get("nrOfIndexBits")),
+        () -> assertEquals("6", parametersFor(64, BitFinder.LOW_ONE).get("nrOfIndexBits")));
+  }
+
+  @Test
+  void separatesScalarPortLayoutsFromParameterizedVectorLayout() {
+    final var finder = new BitFinder();
+
+    assertAll(
+        () -> assertEquals("BitFinder_1_bit", finder.getHDLName(attributes(1, BitFinder.LOW_ONE))),
+        () -> assertEquals("BitFinder_2_bit", finder.getHDLName(attributes(2, BitFinder.LOW_ONE))),
+        () -> assertEquals(BitFinder._ID, finder.getHDLName(attributes(3, BitFinder.LOW_ONE))),
+        () -> assertEquals(BitFinder._ID, finder.getHDLName(attributes(64, BitFinder.HIGH_ZERO))));
+  }
+
+  @Test
+  void oneBitVhdlUsesScalarPortsWithoutZeroWidthVectors() {
+    final var hdl = generatedHdl(HdlGeneratorFactory.VHDL, 1, BitFinder.LOW_ONE);
+
+    assertAll(
+        () -> assertTrue(containsIgnoringCase(hdl, "inputVector : in  std_logic")),
+        () -> assertTrue(containsIgnoringCase(hdl, "index       : out std_logic")),
+        () -> assertTrue(containsIgnoringCase(hdl, "present <= inputVector")),
+        () -> assertFalse(containsIgnoringCase(hdl, "std_logic_vector( 0 downto 0 )")),
+        () -> assertFalse(containsIgnoringCase(hdl, "std_logic_vector( -1 downto 0 )")));
+  }
+
+  @Test
+  void twoBitVhdlKeepsTheIndexScalar() {
+    final var hdl = generatedHdl(HdlGeneratorFactory.VHDL, 2, BitFinder.HIGH_ONE);
+
+    assertAll(
+        () ->
+            assertTrue(
+                containsIgnoringCase(
+                    hdl,
+                    "inputVector : in  std_logic_vector( (nrOfInputBits - 1) downto 0 )")),
+        () -> assertTrue(containsIgnoringCase(hdl, "index       : out std_logic")),
+        () -> assertTrue(containsIgnoringCase(hdl, "if indexValue = 0 then")));
+  }
+
+  @Test
+  void parameterizedVhdlScansInBothDirections() {
+    final var hdl = generatedHdl(HdlGeneratorFactory.VHDL, 5, BitFinder.LOW_ZERO);
+
+    assertAll(
+        () -> assertTrue(containsIgnoringCase(hdl, "for bitIndex in 0 to nrOfInputBits - 1 loop")),
+        () ->
+            assertTrue(
+                containsIgnoringCase(
+                    hdl, "for bitIndex in nrOfInputBits - 1 downto 0 loop")),
+        () ->
+            assertTrue(
+                containsIgnoringCase(
+                    hdl,
+                    "s_index <= std_logic_vector(to_unsigned(indexValue, nrOfIndexBits));")),
+        () -> assertTrue(containsIgnoringCase(hdl, "targetValue := '0';")));
+  }
+
+  @Test
+  void oneBitVerilogUsesScalarPortsAndDirectLogic() {
+    final var hdl = generatedHdl(HdlGeneratorFactory.VERILOG, 1, BitFinder.HIGH_ZERO);
+
+    assertAll(
+        () -> assertTrue(hdl.contains("input inputVector;")),
+        () -> assertTrue(hdl.contains("output index;")),
+        () -> assertTrue(hdl.contains("assign index = 1'b0;")),
+        () -> assertFalse(hdl.contains("[-1:0]")));
+  }
+
+  @Test
+  void parameterizedVerilogSupportsTheSixtyFourBitBoundary() {
+    final var hdl = generatedHdl(HdlGeneratorFactory.VERILOG, 64, BitFinder.HIGH_ONE);
+
+    assertAll(
+        () -> assertTrue(hdl.contains("input [nrOfInputBits-1:0] inputVector;")),
+        () -> assertTrue(hdl.contains("output [nrOfIndexBits-1:0] index;")),
+        () -> assertTrue(hdl.contains("integer bitIndex;")),
+        () ->
+            assertTrue(
+                hdl.contains(
+                    "for (bitIndex = nrOfInputBits - 1; bitIndex >= 0; bitIndex = bitIndex - 1)")),
+        () ->
+            assertTrue(
+                hdl.contains(
+                    "for (bitIndex = 0; bitIndex < nrOfInputBits; bitIndex = bitIndex + 1)")),
+        () -> assertFalse(hdl.contains("!s_present")),
+        () -> assertEquals("64", parametersFor(64, BitFinder.HIGH_ONE).get("nrOfInputBits")),
+        () -> assertEquals("6", parametersFor(64, BitFinder.HIGH_ONE).get("nrOfIndexBits")));
+  }
+
+  private static Map<String, String> parametersFor(int width, AttributeOption mode) {
+    return new ExposedBitFinderHdlGeneratorFactory().parameterMap(attributes(width, mode));
+  }
+
+  private static AttributeSet attributes(int width, AttributeOption mode) {
+    final var attrs = new BitFinder().createAttributeSet();
+    attrs.setValue(StdAttr.WIDTH, BitWidth.create(width));
+    attrs.setValue(BitFinder.TYPE, mode);
+    return attrs;
+  }
+
+  private static String generatedHdl(String hdlType, int width, AttributeOption mode) {
+    AppPreferences.HdlType.set(hdlType);
+    final var attrs = attributes(width, mode);
+    final var nets = mock(Netlist.class);
+    when(nets.projName()).thenReturn("bit-finder-test");
+    final var finder = new BitFinder();
+    final var generator = new BitFinderHdlGeneratorFactory();
+    final var componentName = finder.getHDLName(attrs);
+    return String.join(
+        "\n",
+        generator.getEntity(nets, attrs, componentName))
+        + "\n"
+        + String.join("\n", generator.getArchitecture(nets, attrs, componentName));
+  }
+
+  private static class ExposedBitFinderHdlGeneratorFactory
+      extends BitFinderHdlGeneratorFactory {
+    Map<String, String> parameterMap(AttributeSet attrs) {
+      return getParameterMap(attrs);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add parameterized VHDL and Verilog generation for all four Bit Finder modes
- support the full 1-64 bit input range while keeping scalar HDL ports valid at the 1- and 2-bit boundaries
- add focused regression coverage for mode mappings, index widths, HDL structure, and boundary cases

## Testing
- `.\gradlew.bat check --no-daemon`

Closes #2890