### PR TITLE
docs: add Extra I/O component reference

### DIFF
--- a/src/main/resources/doc/de/contents.xml
+++ b/src/main/resources/doc/de/contents.xml
@@ -205,16 +205,15 @@
 			<tocitem target="bfh-BCDsevenseg" text="BCD to seven segment" image="bfh_***********" />
 		</tocitem>
 		-->
-		<!-- Input/output-Extra
 		<tocitem target="ioex" text="Input/Output-Extra">
-			<tocitem target="ioex_proggen" text="Progr. generator" image="ioex_***********" />
-			<tocitem target="ioex_switch" text="switch" image="ioex_***********" />
-			<tocitem target="ioex_buzzer" text="Buzzer" image="ioex_***********" />
-			<tocitem target="ioex_slider" text="Slider" image="ioex_***********" />
-			<tocitem target="ioex_digitalscop" text="Digital oscilloscope" image="ioex_***********" />
-			<tocitem target="ioex_plarom" text="Programmable logic array ROM" image="ioex_***********" />
+			<tocitem target="ioex_switch" text="Switch" />
+			<tocitem target="ioex_buzzer" text="Buzzer" />
+			<tocitem target="ioex_slider" text="Slider" />
+			<tocitem target="ioex_digitalscope" text="Digital Oscilloscope" />
+			<tocitem target="ioex_plarom" text="Programmable Logic Array" />
+			<tocitem target="ioex_twowayswitch" text="Two-Way Switch" />
+			<tocitem target="ioex_twopinled" text="2-Pin LED" />
 		</tocitem>
-		-->
 		<tocitem target="soc" text = "SOC library">
 			<tocitem target="nios2_sim" text ="Nios2 simulator" image="up_icon" />
 			<tocitem target="socbus" text ="SOC bus interconnect" image="socbus_icon" />

--- a/src/main/resources/doc/en/contents.xml
+++ b/src/main/resources/doc/en/contents.xml
@@ -217,6 +217,15 @@
 			<tocitem target="io_videorgb" text="Video RGB" image="icon_videorgb" />
 -->	
 		</tocitem>
+		<tocitem target="ioex" text="Input/Output-Extra">
+			<tocitem target="ioex_switch" text="Switch" />
+			<tocitem target="ioex_buzzer" text="Buzzer" />
+			<tocitem target="ioex_slider" text="Slider" />
+			<tocitem target="ioex_digitalscope" text="Digital Oscilloscope" />
+			<tocitem target="ioex_plarom" text="Programmable Logic Array" />
+			<tocitem target="ioex_twowayswitch" text="Two-Way Switch" />
+			<tocitem target="ioex_twopinled" text="2-Pin LED" />
+		</tocitem>
 		<tocitem target="ttl" text="TTL library" image="icon_ttl" />
 <!-- not documented 
 		<tocitem target="tcl" text="TCL library">
@@ -226,13 +235,6 @@
 		<tocitem target="bfh" text="BFH mega functions">
 			<tocitem target="bfh-BinairyBCD" text="Binairy to BCD" image="icon_binbcd" />
 			<tocitem target="bfh-BCDsevenseg" text="BCD to seven segment" image="icon_bcdtoseven" />
-		</tocitem>
-		<tocitem target="ioex" text="Input/Output-Extra">
-			<tocitem target="ioex_switch" text="Switch" image="icon_switch" />
-			<tocitem target="ioex_buzzer" text="Buzzer" image="icon_buzzer" />
-			<tocitem target="ioex_slider" text="Slider" image="icon_slider" />
-			<tocitem target="ioex_digitalscop" text="Digital oscilloscope" image="icon_digitalscope" />
-			<tocitem target="ioex_plarom" text="Programmable logic array ROM" image="icon_pla2" />
 		</tocitem>
 		<tocitem target="soc" text = "SOC library">
 			<tocitem target="nios2_sim" text ="Nios2 simulator" image="up_icon" />

--- a/src/main/resources/doc/en/html/libs/index.html
+++ b/src/main/resources/doc/en/html/libs/index.html
@@ -833,24 +833,24 @@
       </tbody>
     </table>		
 	 <h2>
-      <b><a href="ioextra/index.html">Input/Output Extra library</a></b>
+      <b><a href="ioextra/index.html">Input/Output-Extra Library</a></b>
     </h2>
     <table>
       <tbody>
         <tr>
           <td align="right">
-            <a href="ioextra/switch.html"><img class="iconlibs" src="../../../icons/6464/switch.png" alt="#########" border=0 height="32" width="32"></a>
+            <a href="ioextra/switch.html"><img class="iconlibs" src="../../../icons/6464/switch.png" alt="Switch icon" border=0 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
           </td>
           <td>
-            <a href="ioextra/switch.html">Swicth</a>
+            <a href="ioextra/switch.html">Switch</a>
           </td>
         </tr>
         <tr>
           <td align="right">
-            <a href="ioextra/buzzer.html"><img class="iconlibs" src="../../../icons/6464/buzzer.png" alt="#########" border=0 height="32" width="32"></a>
+            <a href="ioextra/buzzer.html"><img class="iconlibs" src="../../../icons/6464/buzzer.png" alt="Buzzer icon" border=0 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
@@ -861,7 +861,7 @@
         </tr>
         <tr>
           <td align="right">
-            <a href="ioextra/slider.html"><img class="iconlibs" src="../../../icons/6464/slider.png" alt="#########" border=0 height="32" width="32"></a>
+            <a href="ioextra/slider.html"><img class="iconlibs" src="../../../icons/6464/slider.png" alt="Slider icon" border=0 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
@@ -872,24 +872,50 @@
         </tr>
         <tr>
           <td align="right">
-            <a href="ioextra/digitalscope.html"><img class="iconlibs" src="../../../icons/6464/digitalscope.png" alt="#########" border=0 height="32" width="32"></a>
+            <a href="ioextra/digitalscope.html"><img class="iconlibs" src="../../../icons/6464/digitalscope.png" alt="Digital Oscilloscope icon" border=0 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
           </td>
           <td>
-            <a href="ioextra/digitalscope.html">Digital oscilloscope</a>
+            <a href="ioextra/digitalscope.html">Digital Oscilloscope</a>
           </td>
         </tr>
         <tr>
           <td align="right">
-            <a href="ioextra/pla.html"><img class="iconlibs" src="../../../icons/6464/pla.png" alt="#########" border=0 height="32" width="32"></a>
+            <a href="ioextra/pla.html"><img class="iconlibs" src="../../../icons/6464/pla.png" alt="Programmable Logic Array icon" border=0 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
           </td>
           <td>
-            <a href="ioextra/pla.html">pla</a>
+            <a href="ioextra/pla.html">Programmable Logic Array</a>
+          </td>
+        </tr>
+        <tr>
+          <td align="right">
+            <a href="ioextra/twowayswitch.html"><img class="iconlibs"
+                src="../../../../resources/logisim/icons/twoway.gif" alt="Two-Way Switch icon"
+                border=0 height="32" width="32"></a>
+          </td>
+          <td>
+            &nbsp;
+          </td>
+          <td>
+            <a href="ioextra/twowayswitch.html">Two-Way Switch</a>
+          </td>
+        </tr>
+        <tr>
+          <td align="right">
+            <a href="ioextra/twopinled.html"><img class="iconlibs"
+                src="../../../../resources/logisim/icons/twopinled.gif" alt="2-Pin LED icon"
+                border=0 height="32" width="32"></a>
+          </td>
+          <td>
+            &nbsp;
+          </td>
+          <td>
+            <a href="ioextra/twopinled.html">2-Pin LED</a>
           </td>
         </tr>
       </tbody>

--- a/src/main/resources/doc/en/html/libs/ioextra/buzzer.html
+++ b/src/main/resources/doc/en/html/libs/ioextra/buzzer.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="changed" content="2026-08-22T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Buzzer</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/buzzer.png" alt="Buzzer icon"
+            width="32" height="32" align="middle"> <em>Buzzer</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Input/Output-Extra</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Behavior</h2>
+      <p>
+        Produces a continuous audio waveform while <q>Enable</q> is 1. Frequencies from 20 Hz
+        through 20,000 Hz are audible. An unknown frequency uses 440 Hz; frequencies outside the
+        audible range produce no sound. Removing the component or stopping its circuit stops the
+        sound.
+      </p>
+
+      <h2>Pins</h2>
+      <dl>
+        <dt>Frequency (14 bits)</dt>
+        <dd>
+          Selects the frequency using the unit chosen by <q>Frequency</q>: Hz or decihertz
+          (0.1 Hz).
+        </dd>
+        <dt>Enable (1 bit)</dt>
+        <dd>Sound is generated only while this input is 1.</dd>
+        <dt>Volume</dt>
+        <dd>
+          Selects the amplitude from silence at 0 to the maximum at the largest value supported by
+          the configured <q>Volume Bit Width</q>.
+        </dd>
+        <dt>Duty Cycle (8 bits)</dt>
+        <dd>
+          Selects the high portion of a square-wave period from 0/256 through 255/256. An unknown
+          value uses 128/256. This input does not affect sine, triangle, sawtooth, or noise output.
+        </dd>
+      </dl>
+
+      <h2>Attributes</h2>
+      <dl>
+        <dt>Facing</dt>
+        <dd>The direction in which the component faces.</dd>
+        <dt>Select Location</dt>
+        <dd>Selects the side on which the duty-cycle input is placed.</dd>
+        <dt>Frequency</dt>
+        <dd>Selects Hz or dHz (0.1 Hz) as the frequency input unit.</dd>
+        <dt>Volume Bit Width</dt>
+        <dd>The bit width of the volume input.</dd>
+        <dt>Waveform</dt>
+        <dd>Selects sine, square, triangle, sawtooth, or noise.</dd>
+        <dt>Channel</dt>
+        <dd>Routes the sound to both stereo channels, the left channel, or the right channel.</dd>
+        <dt>Smooth Level</dt>
+        <dd>Selects how many smoothing passes are applied to non-sine waveforms.</dd>
+        <dt>Smooth Window Width</dt>
+        <dd>Selects the window width used by each smoothing pass.</dd>
+        <dt>Label</dt>
+        <dd>The text associated with the component.</dd>
+        <dt>Label Font</dt>
+        <dd>The font used to draw the label.</dd>
+      </dl>
+
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+
+      <h2>Text Tool Behavior</h2>
+      <p>Allows the label associated with the component to be edited.</p>
+
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/ioextra/digitalscope.html
+++ b/src/main/resources/doc/en/html/libs/ioextra/digitalscope.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="changed" content="2026-08-22T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Digital Oscilloscope</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/digitalscope.png"
+            alt="Digital Oscilloscope icon" width="32" height="32" align="middle">
+        <em>Digital Oscilloscope</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Input/Output-Extra</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Behavior</h2>
+      <p>
+        Records the clock and each 1-bit signal whenever the clock changes between 0 and 1. Once
+        the display is full, older samples move left as new samples are added on the right.
+        Signal changes that occur after an edge can update the most recent sample, allowing the
+        display to reflect propagation delays in the simulated circuit.
+      </p>
+      <p>
+        Recording pauses while <q>Enable</q> is 0. Setting <q>Clear</q> to 1 erases the history and
+        resets clock-edge numbering. An unknown clock is not sampled; unknown or error signal
+        values appear as gaps in their traces.
+      </p>
+
+      <h2>Pins</h2>
+      <dl>
+        <dt>Clock (1 bit)</dt>
+        <dd>The sampling clock. Both rising and falling edges add samples.</dd>
+        <dt>Signal inputs (1 bit each)</dt>
+        <dd>The signals displayed beneath the optional clock trace.</dd>
+        <dt>Enable (1 bit)</dt>
+        <dd>A value of 0 pauses recording; other values permit recording.</dd>
+        <dt>Clear (1 bit)</dt>
+        <dd>A value of 1 clears all recorded samples.</dd>
+      </dl>
+
+      <h2>Attributes</h2>
+      <dl>
+        <dt>Number of Inputs</dt>
+        <dd>Selects from 1 through 32 signal inputs.</dd>
+        <dt>Number of States</dt>
+        <dd>Selects the width of the displayed history, from 4 through 35 clock cycles.</dd>
+        <dt>Draw Clock Front Line</dt>
+        <dd>
+          Draws vertical guides at no edges, rising edges, falling edges, or both kinds of edge.
+        </dd>
+        <dt>Show Clock</dt>
+        <dd>Controls whether the clock trace and edge numbers are displayed.</dd>
+        <dt>Border Color</dt>
+        <dd>Selects the border and guide color.</dd>
+        <dt>Label</dt>
+        <dd>The text associated with the component.</dd>
+        <dt>Label Location</dt>
+        <dd>The location of the label relative to the component.</dd>
+        <dt>Label Font</dt>
+        <dd>The font used to draw the label.</dd>
+      </dl>
+
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+
+      <h2>Text Tool Behavior</h2>
+      <p>Allows the label associated with the component to be edited.</p>
+
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/ioextra/index.html
+++ b/src/main/resources/doc/en/html/libs/ioextra/index.html
@@ -3,70 +3,73 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="created" content="2018-10-23T06:18:10.521000000">
-    <meta name="changed" content="2021-05-21T06:18:42.262000000">
+    <meta name="changed" content="2026-08-22T00:00:00.000000000">
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta http-equiv="Content-Language" content="en">
-    <title>
-      Input/Output-Extra
-    </title>
+    <title>Input/Output-Extra Library</title>
     <link rel="stylesheet" type="text/css" href="../../style.css">
   </head>
   <body>
     <div class="maindiv">
-      <h1>
-        Input/Output-Extra
-      </h1>
+      <h1>Input/Output-Extra Library</h1>
       <p>
-        The Input/Output-Extra includes components that are meant to correspond to typical components found in electronics for interfacing with a user. 
+        The Input/Output-Extra library contains interactive controls, indicators, audio output,
+        signal visualization, and a programmable logic array.
       </p>
       <table>
         <tbody>
           <tr>
-            <td align="right">
-              <a href="register.html"><img class="iconlibs" src="../../../../icons/6464/switch.png" alt="#########" border=0 height="32" width="32"></a>
-            </td>
-            <td>
-              <a href="register.html">Switch</a>
-            </td>
+            <td align="right"><a href="switch.html"><img class="iconlibs"
+                src="../../../../icons/6464/switch.png" alt="Switch icon" width="32"
+                height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="switch.html">Switch</a></td>
           </tr>
           <tr>
-          <tr>
-            <td align="right">
-              <a href="register.html"><img class="iconlibs" src="../../../../icons/6464/buzzer.png" alt="#########" border=0 height="32" width="32"></a>
-            </td>
-            <td>
-              <a href="register.html">Buzzer</a>
-            </td>
+            <td align="right"><a href="buzzer.html"><img class="iconlibs"
+                src="../../../../icons/6464/buzzer.png" alt="Buzzer icon" width="32"
+                height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="buzzer.html">Buzzer</a></td>
           </tr>
           <tr>
-            <td align="right">
-              <a href="counter.html"><img class="iconlibs" src="../../../../icons/6464/slider.png" alt="#########" border=0 height="32" width="32"></a>
-            </td>
-            <td>
-              <a href="counter.html">Slider</a>
-            </td>
+            <td align="right"><a href="slider.html"><img class="iconlibs"
+                src="../../../../icons/6464/slider.png" alt="Slider icon" width="32"
+                height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="slider.html">Slider</a></td>
           </tr>
           <tr>
-            <td align="right">
-              <a href="shiftreg.html"><img class="iconlibs" src="../../../../icons/6464/digitalscope.png" alt="#########" border=0 height="32" width="32"></a>
-            </td>
-            <td>
-              <a href="shiftreg.html">Digital oscilloscopr</a>
-            </td>
+            <td align="right"><a href="digitalscope.html"><img class="iconlibs"
+                src="../../../../icons/6464/digitalscope.png" alt="Digital Oscilloscope icon"
+                width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="digitalscope.html">Digital Oscilloscope</a></td>
           </tr>
           <tr>
-            <td align="right">
-              <a href="random.html"><img class="iconlibs" src="../../../../icons/6464/pla0.png" alt="#########" border=0 height="32" width="32"></a>
-            </td>
-            <td>
-              <a href="random.html">Programmable logic array</a>
-            </td>
+            <td align="right"><a href="pla.html"><img class="iconlibs"
+                src="../../../../icons/6464/pla.png" alt="Programmable Logic Array icon"
+                width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="pla.html">Programmable Logic Array</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="twowayswitch.html"><img class="iconlibs"
+                src="../../../../../resources/logisim/icons/twoway.gif"
+                alt="Two-Way Switch icon" width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="twowayswitch.html">Two-Way Switch</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="twopinled.html"><img class="iconlibs"
+                src="../../../../../resources/logisim/icons/twopinled.gif" alt="2-Pin LED icon"
+                width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="twopinled.html">2-Pin LED</a></td>
           </tr>
         </tbody>
       </table>
-      <p>
-        <a href="../index.html">Back to <em>Library Reference</em></a>
-      </p>
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
     </div>
   </body>
 </html>

--- a/src/main/resources/doc/en/html/libs/ioextra/pla.html
+++ b/src/main/resources/doc/en/html/libs/ioextra/pla.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="changed" content="2026-08-22T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Programmable Logic Array</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/pla.png"
+            alt="Programmable Logic Array icon" width="32" height="32" align="middle">
+        <em>Programmable Logic Array</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Input/Output-Extra</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Behavior</h2>
+      <p>
+        Implements a programmable sum-of-products function. Each row in the editor is an AND
+        term. A row can select the normal or complemented form of each input bit; the second plane
+        connects selected AND terms to output OR gates. The configured matrix is stored with the
+        circuit.
+      </p>
+      <p>
+        An AND term with no selected input literal produces an error value. An output with no
+        connected AND term also produces an error value. When chip select is inactive, every
+        output bit is unknown.
+      </p>
+
+      <h2>Pins</h2>
+      <dl>
+        <dt>Input</dt>
+        <dd>A bus whose width is selected by <q>Input Bit Width</q>.</dd>
+        <dt>Output</dt>
+        <dd>A bus whose width is selected by <q>Output Bit Width</q>.</dd>
+        <dt>sel (1 bit)</dt>
+        <dd>
+          Chip select. Its active level is selected by <q>Select</q>; the default is
+          active low.
+        </dd>
+      </dl>
+
+      <h2>Attributes</h2>
+      <dl>
+        <dt>Input Bit Width</dt>
+        <dd>Selects from 1 through 32 input bits.</dd>
+        <dt>Number of And Gates</dt>
+        <dd>Selects from 1 through 32 product terms.</dd>
+        <dt>Output Bit Width</dt>
+        <dd>Selects from 1 through 32 output bits.</dd>
+        <dt>Label</dt>
+        <dd>The text associated with the component.</dd>
+        <dt>Label Font</dt>
+        <dd>The font used to draw the label.</dd>
+        <dt>Label Visible</dt>
+        <dd>Controls whether the label is displayed.</dd>
+        <dt>Contents</dt>
+        <dd>Opens the programmable matrix editor.</dd>
+        <dt>Select</dt>
+        <dd>Selects whether the chip-select input is active low or active high.</dd>
+      </dl>
+
+      <h2>Editing the Matrix</h2>
+      <p>
+        Click <q>Contents</q> in the attribute table, or use <q>Edit Contents…</q> in the
+        component's context menu. In the input plane, click the intersection with an input or its
+        complement to add or remove that literal. In the output plane, click an intersection to
+        connect or disconnect an AND term from an output. Selecting one polarity of an input
+        automatically clears the other polarity in the same term. The context menu also provides
+        <q>Clear Contents</q>.
+      </p>
+
+      <h2>Poke Tool Behavior</h2>
+      <p>None. Use the Contents attribute or the component's context menu to edit the matrix.</p>
+
+      <h2>Text Tool Behavior</h2>
+      <p>Allows the label associated with the component to be edited.</p>
+
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/ioextra/slider.html
+++ b/src/main/resources/doc/en/html/libs/ioextra/slider.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="changed" content="2026-08-22T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Slider</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/slider.png" alt="Slider icon"
+            width="32" height="32" align="middle"> <em>Slider</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Input/Output-Extra</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Behavior</h2>
+      <p>
+        Outputs an unsigned value selected by dragging the slider knob. For a width of <var>n</var>
+        bits, the output ranges from 0 through 2<sup><var>n</var></sup> − 1. The current value is
+        displayed using the selected radix.
+      </p>
+
+      <h2>Pins</h2>
+      <p>
+        The component has one output. Its width is selected by <q>Data Bits</q> and can range from
+        1 through 8 bits.
+      </p>
+
+      <h2>Attributes</h2>
+      <dl>
+        <dt>Facing</dt>
+        <dd>The direction in which the component faces.</dd>
+        <dt>Data Bits</dt>
+        <dd>The bit width of the output, from 1 through 8 bits.</dd>
+        <dt>Radix</dt>
+        <dd>The radix used to display the current value.</dd>
+        <dt>Color</dt>
+        <dd>The color used to fill the slider body.</dd>
+        <dt>Label</dt>
+        <dd>The text associated with the component.</dd>
+        <dt>Label Font</dt>
+        <dd>The font used to draw the label.</dd>
+        <dt>Label Visible</dt>
+        <dd>Controls whether the label is displayed.</dd>
+        <dt>Direction</dt>
+        <dd>
+          Selects whether values increase from left to right or from right to left. Changing this
+          attribute preserves the current value by moving the knob to the mirrored position.
+        </dd>
+      </dl>
+
+      <h2>Poke Tool Behavior</h2>
+      <p>Drag the slider knob to select the output value.</p>
+
+      <h2>Text Tool Behavior</h2>
+      <p>Allows the label associated with the component to be edited.</p>
+
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/ioextra/switch.html
+++ b/src/main/resources/doc/en/html/libs/ioextra/switch.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="changed" content="2026-08-22T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Switch</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../icons/6464/switch.png" alt="Switch icon"
+            width="32" height="32" align="middle"> <em>Switch</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Input/Output-Extra</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Behavior</h2>
+      <p>
+        Models a manually operated switch. When closed, it passes the input value to the output.
+        When open, the output is unknown. A newly placed switch is open.
+      </p>
+
+      <h2>Pins</h2>
+      <dl>
+        <dt>Input</dt>
+        <dd>An input whose width is selected by the <q>Data Bits</q> attribute.</dd>
+        <dt>Output</dt>
+        <dd>The input value when the switch is closed, or an unknown value when it is open.</dd>
+      </dl>
+
+      <h2>Attributes</h2>
+      <p>
+        When the component is selected or being added, the arrow keys alter its <q>Facing</q>
+        attribute.
+      </p>
+      <dl>
+        <dt>Facing</dt>
+        <dd>The direction from the input toward the output.</dd>
+        <dt>Data Bits</dt>
+        <dd>The bit width of the input and output.</dd>
+        <dt>Color</dt>
+        <dd>The color used to fill the switch body.</dd>
+        <dt>Label</dt>
+        <dd>The text associated with the component.</dd>
+        <dt>Label Location</dt>
+        <dd>The location of the label relative to the component.</dd>
+        <dt>Label Font</dt>
+        <dd>The font used to draw the label.</dd>
+      </dl>
+
+      <h2>Poke Tool Behavior</h2>
+      <p>Click the switch to toggle it between open and closed.</p>
+
+      <h2>Text Tool Behavior</h2>
+      <p>Allows the label associated with the component to be edited.</p>
+
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/ioextra/twopinled.html
+++ b/src/main/resources/doc/en/html/libs/ioextra/twopinled.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="changed" content="2026-08-22T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>2-Pin LED</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../../resources/logisim/icons/twopinled.gif"
+            alt="2-Pin LED icon" width="32" height="32" align="middle">
+        <em>2-Pin LED</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Input/Output-Extra</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Behavior</h2>
+      <p>
+        Models an LED with separate anode and cathode connections. It uses <q>On Color</q> only
+        when the anode is 1 and the cathode is 0. With <q>Bipolar</q> enabled, it uses
+        <q>Reverse Color</q> when the anode is 0 and the cathode is 1. All equal, unknown, or error
+        input combinations display <q>Off Color</q>.
+      </p>
+      <p>The component can also be placed in a circuit's dynamic appearance.</p>
+
+      <h2>Pins</h2>
+      <dl>
+        <dt>Anode (1 bit)</dt>
+        <dd>The LED's anode input.</dd>
+        <dt>Cathode (1 bit)</dt>
+        <dd>The LED's cathode input.</dd>
+      </dl>
+
+      <h2>Attributes</h2>
+      <dl>
+        <dt>Facing</dt>
+        <dd>Controls the orientation of the diode symbol and the anode and cathode pins.</dd>
+        <dt>On Color</dt>
+        <dd>The color displayed for forward polarity.</dd>
+        <dt>Off Color</dt>
+        <dd>The color displayed when the LED is off.</dd>
+        <dt>Bipolar</dt>
+        <dd>Enables a distinct color for reverse polarity.</dd>
+        <dt>Reverse Color</dt>
+        <dd>The color displayed for reverse polarity when <q>Bipolar</q> is enabled.</dd>
+        <dt>Label</dt>
+        <dd>The text associated with the component.</dd>
+        <dt>Label Location</dt>
+        <dd>The location of the label relative to the component.</dd>
+        <dt>Label Font</dt>
+        <dd>The font used to draw the label.</dd>
+        <dt>Label Color</dt>
+        <dd>The color used to draw the label.</dd>
+        <dt>Label Visible</dt>
+        <dd>Controls whether the label is displayed.</dd>
+      </dl>
+
+      <h2>Poke Tool Behavior</h2>
+      <p>None.</p>
+
+      <h2>Text Tool Behavior</h2>
+      <p>Allows the label associated with the component to be edited.</p>
+
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/en/html/libs/ioextra/twowayswitch.html
+++ b/src/main/resources/doc/en/html/libs/ioextra/twowayswitch.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="changed" content="2026-08-22T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Two-Way Switch</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>
+        <img class="iconlibs" src="../../../../../resources/logisim/icons/twoway.gif"
+            alt="Two-Way Switch icon" width="32" height="32" align="middle">
+        <em>Two-Way Switch</em>
+      </h1>
+      <table>
+        <tbody>
+          <tr>
+            <td><strong>Library:</strong></td>
+            <td><a href="index.html">Input/Output-Extra</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Behavior</h2>
+      <p>
+        Models a manually operated changeover switch. A newly placed component selects its first
+        branch. Clicking it alternates between the first and second branches.
+      </p>
+
+      <h2>Pins</h2>
+      <p>The pin directions depend on the <q>Switch Mode</q> attribute.</p>
+      <dl>
+        <dt>1 Input → 2 Outputs</dt>
+        <dd>
+          The common input is passed to the selected output. The unselected output is unknown.
+        </dd>
+        <dt>2 Inputs → 1 Output</dt>
+        <dd>The selected input is passed to the common output.</dd>
+      </dl>
+      <p>All three pins use the width selected by <q>Data Bits</q>.</p>
+
+      <h2>Attributes</h2>
+      <dl>
+        <dt>Switch Mode</dt>
+        <dd>Selects 1 Input → 2 Outputs or 2 Inputs → 1 Output.</dd>
+        <dt>Facing</dt>
+        <dd>The direction from the common pin toward the pair of branch pins.</dd>
+        <dt>Data Bits</dt>
+        <dd>The bit width of all three pins.</dd>
+        <dt>Color</dt>
+        <dd>The color used to fill the switch body; the default white leaves it transparent.</dd>
+        <dt>Label</dt>
+        <dd>The text associated with the component.</dd>
+        <dt>Label Location</dt>
+        <dd>The location of the label relative to the component.</dd>
+        <dt>Label Font</dt>
+        <dd>The font used to draw the label.</dd>
+      </dl>
+
+      <h2>Poke Tool Behavior</h2>
+      <p>Click the switch to select the other branch.</p>
+
+      <h2>Text Tool Behavior</h2>
+      <p>Allows the label associated with the component to be edited.</p>
+
+      <p><a href="../index.html">Back to <em>Library Reference</em></a></p>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/doc/fr/contents.xml
+++ b/src/main/resources/doc/fr/contents.xml
@@ -207,16 +207,15 @@
 			<tocitem target="bfh-BCDsevenseg" text="BCD to seven segment" image="bfh_***********" />
 		</tocitem>
 		-->
-		<!-- Input/output-Extra
 		<tocitem target="ioex" text="Input/Output-Extra">
-			<tocitem target="ioex_proggen" text="Progr. generator" image="ioex_***********" />
-			<tocitem target="ioex_switch" text="switch" image="ioex_***********" />
-			<tocitem target="ioex_buzzer" text="Buzzer" image="ioex_***********" />
-			<tocitem target="ioex_slider" text="Slider" image="ioex_***********" />
-			<tocitem target="ioex_digitalscop" text="Digital oscilloscope" image="ioex_***********" />
-			<tocitem target="ioex_plarom" text="Programmable logic array ROM" image="ioex_***********" />
+			<tocitem target="ioex_switch" text="Switch" />
+			<tocitem target="ioex_buzzer" text="Buzzer" />
+			<tocitem target="ioex_slider" text="Slider" />
+			<tocitem target="ioex_digitalscope" text="Digital Oscilloscope" />
+			<tocitem target="ioex_plarom" text="Programmable Logic Array" />
+			<tocitem target="ioex_twowayswitch" text="Two-Way Switch" />
+			<tocitem target="ioex_twopinled" text="2-Pin LED" />
 		</tocitem>
-		-->
 		<tocitem target="soc" text = "SOC library">
 			<tocitem target="nios2_sim" text ="Nios2 simulator" image="up_icon" />
 			<tocitem target="socbus" text ="SOC bus interconnect" image="socbus_icon" />

--- a/src/main/resources/doc/fr/html/libs/index.html
+++ b/src/main/resources/doc/fr/html/libs/index.html
@@ -785,63 +785,89 @@
       </tbody>
     </table>
 	 <h2>
-      <b><a href="ioextra/index.html">Librairies Entrée/Sortie (extra)</a></b>
+      <b><a href="../../../en/html/libs/ioextra/index.html">Librairies Entrée/Sortie (extra)</a></b>
     </h2>
     <table>
       <tbody>
         <tr>
           <td align="right">
-            <a href="ioextra/switch.html"><img class="iconlibs" src="../../../icons/6464/switch.png" alt="#########" border=0 height="32" width="32"></a>
+            <a href="../../../en/html/libs/ioextra/switch.html"><img class="iconlibs" src="../../../icons/6464/switch.png" alt="Switch icon" border=0 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
           </td>
           <td>
-            <a href="ioextra/switch.html">Swicth</a>
+            <a href="../../../en/html/libs/ioextra/switch.html">Switch</a>
           </td>
         </tr>
         <tr>
           <td align="right">
-            <a href="ioextra/buzzer.html"><img class="iconlibs" src="../../../icons/6464/buzzer.png" alt="#########" border=0 height="32" width="32"></a>
+            <a href="../../../en/html/libs/ioextra/buzzer.html"><img class="iconlibs" src="../../../icons/6464/buzzer.png" alt="Buzzer icon" border=0 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
           </td>
           <td>
-            <a href="ioextra/buzzer.html">Buzzer</a>
+            <a href="../../../en/html/libs/ioextra/buzzer.html">Buzzer</a>
           </td>
         </tr>
         <tr>
           <td align="right">
-            <a href="ioextra/slider.html"><img class="iconlibs" src="../../../icons/6464/slider.png" alt="#########" border=0 height="32" width="32"></a>
+            <a href="../../../en/html/libs/ioextra/slider.html"><img class="iconlibs" src="../../../icons/6464/slider.png" alt="Slider icon" border=0 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
           </td>
           <td>
-            <a href="ioextra/slider.html">Slider</a>
+            <a href="../../../en/html/libs/ioextra/slider.html">Slider</a>
           </td>
         </tr>
         <tr>
           <td align="right">
-            <a href="ioextra/digitalscope.html"><img class="iconlibs" src="../../../icons/6464/digitalscope.png" alt="#########" border=0 height="32" width="32"></a>
+            <a href="../../../en/html/libs/ioextra/digitalscope.html"><img class="iconlibs" src="../../../icons/6464/digitalscope.png" alt="Digital Oscilloscope icon" border=0 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
           </td>
           <td>
-            <a href="ioextra/digitalscope.html">Digital oscilloscope</a>
+            <a href="../../../en/html/libs/ioextra/digitalscope.html">Digital Oscilloscope</a>
           </td>
         </tr>
         <tr>
           <td align="right">
-            <a href="ioextra/pla.html"><img class="iconlibs" src="../../../icons/6464/pla.png" alt="#########" border=0 height="32" width="32"></a>
+            <a href="../../../en/html/libs/ioextra/pla.html"><img class="iconlibs" src="../../../icons/6464/pla.png" alt="Programmable Logic Array icon" border=0 height="32" width="32"></a>
           </td>
           <td>
             &nbsp;
           </td>
           <td>
-            <a href="ioextra/pla.html">pla</a>
+            <a href="../../../en/html/libs/ioextra/pla.html">Programmable Logic Array</a>
+          </td>
+        </tr>
+        <tr>
+          <td align="right">
+            <a href="../../../en/html/libs/ioextra/twowayswitch.html"><img class="iconlibs"
+                src="../../../../resources/logisim/icons/twoway.gif" alt="Two-Way Switch icon"
+                border=0 height="32" width="32"></a>
+          </td>
+          <td>
+            &nbsp;
+          </td>
+          <td>
+            <a href="../../../en/html/libs/ioextra/twowayswitch.html">Two-Way Switch</a>
+          </td>
+        </tr>
+        <tr>
+          <td align="right">
+            <a href="../../../en/html/libs/ioextra/twopinled.html"><img class="iconlibs"
+                src="../../../../resources/logisim/icons/twopinled.gif" alt="2-Pin LED icon"
+                border=0 height="32" width="32"></a>
+          </td>
+          <td>
+            &nbsp;
+          </td>
+          <td>
+            <a href="../../../en/html/libs/ioextra/twopinled.html">2-Pin LED</a>
           </td>
         </tr>
       </tbody>

--- a/src/main/resources/doc/map_de.jhm
+++ b/src/main/resources/doc/map_de.jhm
@@ -177,6 +177,14 @@
     <mapID target="io_Port_IO"          url="de/html/libs/io/Port_io.html" />
 	<mapID target="io_Repetar"          url="de/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="de/html/libs/io/videorvb.html" />
+	<mapID target="ioex"                 url="en/html/libs/ioextra/index.html" />
+	<mapID target="ioex_switch"          url="en/html/libs/ioextra/switch.html" />
+	<mapID target="ioex_buzzer"          url="en/html/libs/ioextra/buzzer.html" />
+	<mapID target="ioex_slider"          url="en/html/libs/ioextra/slider.html" />
+	<mapID target="ioex_digitalscope"    url="en/html/libs/ioextra/digitalscope.html" />
+	<mapID target="ioex_plarom"          url="en/html/libs/ioextra/pla.html" />
+	<mapID target="ioex_twowayswitch"    url="en/html/libs/ioextra/twowayswitch.html" />
+	<mapID target="ioex_twopinled"       url="en/html/libs/ioextra/twopinled.html" />
 	<mapID target="tcl"                 url="de/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="de/html/libs/tcl/reds_console.html" />
     <mapID target="tcl_generic"         url="de/html/libs/tcl/generic.html" />

--- a/src/main/resources/doc/map_en.jhm
+++ b/src/main/resources/doc/map_en.jhm
@@ -194,6 +194,14 @@
     <mapID target="io_Port_IO"          url="en/html/libs/io/Port_io.html" />
 	<mapID target="io_Repetar"          url="en/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="en/html/libs/io/videorvb.html" />
+	<mapID target="ioex"                 url="en/html/libs/ioextra/index.html" />
+	<mapID target="ioex_switch"          url="en/html/libs/ioextra/switch.html" />
+	<mapID target="ioex_buzzer"          url="en/html/libs/ioextra/buzzer.html" />
+	<mapID target="ioex_slider"          url="en/html/libs/ioextra/slider.html" />
+	<mapID target="ioex_digitalscope"    url="en/html/libs/ioextra/digitalscope.html" />
+	<mapID target="ioex_plarom"          url="en/html/libs/ioextra/pla.html" />
+	<mapID target="ioex_twowayswitch"    url="en/html/libs/ioextra/twowayswitch.html" />
+	<mapID target="ioex_twopinled"       url="en/html/libs/ioextra/twopinled.html" />
 	<mapID target="ttl"                 url="en/html/libs/ttl/index.html" />
 	<mapID target="tcl"                 url="en/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="en/html/libs/tcl/reds_console.html" />

--- a/src/main/resources/doc/map_fr.jhm
+++ b/src/main/resources/doc/map_fr.jhm
@@ -176,6 +176,14 @@
     <mapID target="io_Port_IO"          url="en/html/libs/io/Port_io.html" />	
 	<mapID target="io_Repetar"          url="en/html/libs/io/repetar.html" />	
 	<mapID target="io_videorvb"         url="en/html/libs/io/videorvb.html" />
+	<mapID target="ioex"                 url="en/html/libs/ioextra/index.html" />
+	<mapID target="ioex_switch"          url="en/html/libs/ioextra/switch.html" />
+	<mapID target="ioex_buzzer"          url="en/html/libs/ioextra/buzzer.html" />
+	<mapID target="ioex_slider"          url="en/html/libs/ioextra/slider.html" />
+	<mapID target="ioex_digitalscope"    url="en/html/libs/ioextra/digitalscope.html" />
+	<mapID target="ioex_plarom"          url="en/html/libs/ioextra/pla.html" />
+	<mapID target="ioex_twowayswitch"    url="en/html/libs/ioextra/twowayswitch.html" />
+	<mapID target="ioex_twopinled"       url="en/html/libs/ioextra/twopinled.html" />
 	<mapID target="tcl"                 url="en/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="en/html/libs/tcl/reds_console.html" />
     <mapID target="tcl_generic"         url="en/html/libs/tcl/generic.html" />

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -193,6 +193,14 @@
     <mapID target="io_Port_IO"          url="pt/html/libs/io/Port_io.html" />
 	<mapID target="io_Repetar"          url="pt/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="pt/html/libs/io/videorvb.html" />
+	<mapID target="ioex"                 url="en/html/libs/ioextra/index.html" />
+	<mapID target="ioex_switch"          url="en/html/libs/ioextra/switch.html" />
+	<mapID target="ioex_buzzer"          url="en/html/libs/ioextra/buzzer.html" />
+	<mapID target="ioex_slider"          url="en/html/libs/ioextra/slider.html" />
+	<mapID target="ioex_digitalscope"    url="en/html/libs/ioextra/digitalscope.html" />
+	<mapID target="ioex_plarom"          url="en/html/libs/ioextra/pla.html" />
+	<mapID target="ioex_twowayswitch"    url="en/html/libs/ioextra/twowayswitch.html" />
+	<mapID target="ioex_twopinled"       url="en/html/libs/ioextra/twopinled.html" />
 	<mapID target="ttl"                 url="en/html/libs/ttl/index.html" />
 	<mapID target="tcl"                 url="pt/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="pt/html/libs/tcl/reds_console.html" />

--- a/src/main/resources/doc/map_ru.jhm
+++ b/src/main/resources/doc/map_ru.jhm
@@ -189,6 +189,14 @@
 	<mapID target="io_Repetar"          url="ru/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="ru/html/libs/io/videorvb.html" />
 	<mapID target="io_videorgb"         url="ru/html/libs/io/videorvb.html" />
+	<mapID target="ioex"                 url="en/html/libs/ioextra/index.html" />
+	<mapID target="ioex_switch"          url="en/html/libs/ioextra/switch.html" />
+	<mapID target="ioex_buzzer"          url="en/html/libs/ioextra/buzzer.html" />
+	<mapID target="ioex_slider"          url="en/html/libs/ioextra/slider.html" />
+	<mapID target="ioex_digitalscope"    url="en/html/libs/ioextra/digitalscope.html" />
+	<mapID target="ioex_plarom"          url="en/html/libs/ioextra/pla.html" />
+	<mapID target="ioex_twowayswitch"    url="en/html/libs/ioextra/twowayswitch.html" />
+	<mapID target="ioex_twopinled"       url="en/html/libs/ioextra/twopinled.html" />
 	<mapID target="tcl"                 url="ru/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="ru/html/libs/tcl/redsconsole.html" />
     <mapID target="tcl_generic"         url="ru/html/libs/tcl/tclgeneric.html" />

--- a/src/main/resources/doc/map_zh.jhm
+++ b/src/main/resources/doc/map_zh.jhm
@@ -179,6 +179,14 @@
     <mapID target="io_Port_IO"          url="zh/html/libs/io/Port_io.html" />
 	<mapID target="io_Repetar"          url="zh/html/libs/io/repetar.html" />
 	<mapID target="io_videorvb"         url="zh/html/libs/io/videorvb.html" />
+	<mapID target="ioex"                 url="en/html/libs/ioextra/index.html" />
+	<mapID target="ioex_switch"          url="en/html/libs/ioextra/switch.html" />
+	<mapID target="ioex_buzzer"          url="en/html/libs/ioextra/buzzer.html" />
+	<mapID target="ioex_slider"          url="en/html/libs/ioextra/slider.html" />
+	<mapID target="ioex_digitalscope"    url="en/html/libs/ioextra/digitalscope.html" />
+	<mapID target="ioex_plarom"          url="en/html/libs/ioextra/pla.html" />
+	<mapID target="ioex_twowayswitch"    url="en/html/libs/ioextra/twowayswitch.html" />
+	<mapID target="ioex_twopinled"       url="en/html/libs/ioextra/twopinled.html" />
 	<mapID target="tcl"                 url="zh/html/libs/tcl/index.html" />
     <mapID target="tcl_reds_console"    url="zh/html/libs/tcl/reds_console.html" />
     <mapID target="tcl_generic"         url="zh/html/libs/tcl/generic.html" />

--- a/src/main/resources/doc/ru/contents.xml
+++ b/src/main/resources/doc/ru/contents.xml
@@ -230,16 +230,15 @@
 			<tocitem target="bfh-BCDsevenseg" text="BCD to seven segment" image="bfh_***********" />
 		</tocitem>
 		-->
-		<!-- Input/output-Extra
 		<tocitem target="ioex" text="Input/Output-Extra">
-			<tocitem target="ioex_proggen" text="Progr. generator" image="ioex_***********" />
-			<tocitem target="ioex_switch" text="switch" image="ioex_***********" />
-			<tocitem target="ioex_buzzer" text="Buzzer" image="ioex_***********" />
-			<tocitem target="ioex_slider" text="Slider" image="ioex_***********" />
-			<tocitem target="ioex_digitalscop" text="Digital oscilloscope" image="ioex_***********" />
-			<tocitem target="ioex_plarom" text="Programmable logic array ROM" image="ioex_***********" />
+			<tocitem target="ioex_switch" text="Switch" />
+			<tocitem target="ioex_buzzer" text="Buzzer" />
+			<tocitem target="ioex_slider" text="Slider" />
+			<tocitem target="ioex_digitalscope" text="Digital Oscilloscope" />
+			<tocitem target="ioex_plarom" text="Programmable Logic Array" />
+			<tocitem target="ioex_twowayswitch" text="Two-Way Switch" />
+			<tocitem target="ioex_twopinled" text="2-Pin LED" />
 		</tocitem>
-		-->
 		<tocitem target="soc" text = "Библиотека SoC">
 			<tocitem target="nios2_sim" text ="Имитационная модель процессора Nios2s" image="up_icon" />
 			<tocitem target="socbus" text ="Имитационная модель шины SoC" image="socbus_icon" />

--- a/src/main/resources/doc/zh/contents.xml
+++ b/src/main/resources/doc/zh/contents.xml
@@ -445,6 +445,15 @@
 
 	
 		</tocitem>
+		<tocitem target="ioex" text="Input/Output-Extra">
+			<tocitem target="ioex_switch" text="Switch" />
+			<tocitem target="ioex_buzzer" text="Buzzer" />
+			<tocitem target="ioex_slider" text="Slider" />
+			<tocitem target="ioex_digitalscope" text="Digital Oscilloscope" />
+			<tocitem target="ioex_plarom" text="Programmable Logic Array" />
+			<tocitem target="ioex_twowayswitch" text="Two-Way Switch" />
+			<tocitem target="ioex_twopinled" text="2-Pin LED" />
+		</tocitem>
 <!-- not documented 
 		<tocitem target="ttl" text="TTL">
 			<tocitem target="ttl_xxxx" text="TTL" image="icon_ttl" />
@@ -456,13 +465,6 @@
 		<tocitem target="bfh" text="BFH mega functions">
 			<tocitem target="bfh-BinairyBCD" text="Binairy to BCD" image="icon_binbcd" />
 			<tocitem target="bfh-BCDsevenseg" text="BCD to seven segment" image="icon_bcdtoseven" />
-		</tocitem>
-		<tocitem target="ioex" text="Input/Output-Extra">
-			<tocitem target="ioex_switch" text="Switch" image="icon_switch" />
-			<tocitem target="ioex_buzzer" text="Buzzer" image="icon_buzzer" />
-			<tocitem target="ioex_slider" text="Slider" image="icon_slider" />
-			<tocitem target="ioex_digitalscop" text="Digital oscilloscope" image="icon_digitalscope" />
-			<tocitem target="ioex_plarom" text="Programmable logic array ROM" image="icon_pla2" />
 		</tocitem>
 		<tocitem target="soc" text = "SOC library">
 			<tocitem target="nios2_sim" text ="Nios2 simulator" image="up_icon" />

--- a/src/main/resources/doc/zh/html/libs/index.html
+++ b/src/main/resources/doc/zh/html/libs/index.html
@@ -958,7 +958,7 @@
     <tbody>
      <tr>
       <td align="right">
-       <a href="ioextra/switch.html">
+       <a href="../../../en/html/libs/ioextra/switch.html">
         <img alt="#########" border="0" class="iconlibs" height="32" src="../../../icons/6464/switch.png" width="32"/>
        </a>
       </td>
@@ -966,14 +966,14 @@
       </td>
       <td>
        <!-- <a href="ioextra/switch.html">Swicth</a> -->
-       <a href="ioextra/switch.html">
+       <a href="../../../en/html/libs/ioextra/switch.html">
         开关
        </a>
       </td>
      </tr>
      <tr>
       <td align="right">
-       <a href="ioextra/buzzer.html">
+       <a href="../../../en/html/libs/ioextra/buzzer.html">
         <img alt="#########" border="0" class="iconlibs" height="32" src="../../../icons/6464/buzzer.png" width="32"/>
        </a>
       </td>
@@ -981,14 +981,14 @@
       </td>
       <td>
        <!-- <a href="ioextra/buzzer.html">Buzzer</a> -->
-       <a href="ioextra/buzzer.html">
+       <a href="../../../en/html/libs/ioextra/buzzer.html">
         蜂鸣器
        </a>
       </td>
      </tr>
      <tr>
       <td align="right">
-       <a href="ioextra/slider.html">
+       <a href="../../../en/html/libs/ioextra/slider.html">
         <img alt="#########" border="0" class="iconlibs" height="32" src="../../../icons/6464/slider.png" width="32"/>
        </a>
       </td>
@@ -996,14 +996,14 @@
       </td>
       <td>
        <!-- <a href="ioextra/slider.html">Slider</a> -->
-       <a href="ioextra/slider.html">
+       <a href="../../../en/html/libs/ioextra/slider.html">
         滑块
        </a>
       </td>
      </tr>
      <tr>
       <td align="right">
-       <a href="ioextra/digitalscope.html">
+       <a href="../../../en/html/libs/ioextra/digitalscope.html">
         <img alt="#########" border="0" class="iconlibs" height="32" src="../../../icons/6464/digitalscope.png" width="32"/>
        </a>
       </td>
@@ -1011,14 +1011,14 @@
       </td>
       <td>
        <!-- <a href="ioextra/digitalscope.html">Digital oscilloscope</a> -->
-       <a href="ioextra/digitalscope.html">
+       <a href="../../../en/html/libs/ioextra/digitalscope.html">
         数字示波器
        </a>
       </td>
      </tr>
      <tr>
       <td align="right">
-       <a href="ioextra/pla.html">
+       <a href="../../../en/html/libs/ioextra/pla.html">
         <img alt="#########" border="0" class="iconlibs" height="32" src="../../../icons/6464/pla.png" width="32"/>
        </a>
       </td>
@@ -1026,8 +1026,36 @@
       </td>
       <td>
        <!-- <a href="ioextra/pla.html">pla</a> -->
-       <a href="ioextra/pla.html">
+       <a href="../../../en/html/libs/ioextra/pla.html">
         PLA
+       </a>
+      </td>
+     </tr>
+     <tr>
+      <td align="right">
+       <a href="../../../en/html/libs/ioextra/twowayswitch.html">
+        <img alt="Two-Way Switch icon" border="0" class="iconlibs" height="32" src="../../../../resources/logisim/icons/twoway.gif" width="32"/>
+       </a>
+      </td>
+      <td>
+      </td>
+      <td>
+       <a href="../../../en/html/libs/ioextra/twowayswitch.html">
+        Two-Way Switch
+       </a>
+      </td>
+     </tr>
+     <tr>
+      <td align="right">
+       <a href="../../../en/html/libs/ioextra/twopinled.html">
+        <img alt="2-Pin LED icon" border="0" class="iconlibs" height="32" src="../../../../resources/logisim/icons/twopinled.gif" width="32"/>
+       </a>
+      </td>
+      <td>
+      </td>
+      <td>
+       <a href="../../../en/html/libs/ioextra/twopinled.html">
+        2-Pin LED
        </a>
       </td>
      </tr>

--- a/src/main/resources/doc/zh/html/libs/ioextra/index.html
+++ b/src/main/resources/doc/zh/html/libs/ioextra/index.html
@@ -1,98 +1,72 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="zh">
- <head>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <meta content="2018-10-23T06:18:10.521000000" name="created"/>
-  <meta content="2023-12-12T09:31:25" name="changed" translator="gocpicnic"/>
-  <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
-  <meta content="zh" http-equiv="Content-Language"/>
-  <title>
-   Input/Output-Extra
-  </title>
-  <link href="../../style.css" rel="stylesheet" type="text/css"/>
- </head>
- <body>
-  <div class="maindiv">
-   <h1>
-    Input/Output-Extra
-   </h1>
-   <p>
-    The Input/Output-Extra includes components that are meant to correspond to typical components found in electronics for interfacing with a user.
-   </p>
-   <table>
-    <tbody>
-     <tr>
-      <td align="right">
-       <a href="register.html">
-        <img alt="#########" border="0" class="iconlibs" height="32" src="../../../../icons/6464/switch.png" width="32"/>
-       </a>
-      </td>
-      <td>
-       <a href="register.html">
-        Switch
-       </a>
-      </td>
-     </tr>
-     <tr>
-      <tr>
-       <td align="right">
-        <a href="register.html">
-         <img alt="#########" border="0" class="iconlibs" height="32" src="../../../../icons/6464/buzzer.png" width="32"/>
-        </a>
-       </td>
-       <td>
-        <a href="register.html">
-         Buzzer
-        </a>
-       </td>
-      </tr>
-      <tr>
-       <td align="right">
-        <a href="counter.html">
-         <img alt="#########" border="0" class="iconlibs" height="32" src="../../../../icons/6464/slider.png" width="32"/>
-        </a>
-       </td>
-       <td>
-        <a href="counter.html">
-         Slider
-        </a>
-       </td>
-      </tr>
-      <tr>
-       <td align="right">
-        <a href="shiftreg.html">
-         <img alt="#########" border="0" class="iconlibs" height="32" src="../../../../icons/6464/digitalscope.png" width="32"/>
-        </a>
-       </td>
-       <td>
-        <a href="shiftreg.html">
-         Digital oscilloscopr
-        </a>
-       </td>
-      </tr>
-      <tr>
-       <td align="right">
-        <a href="random.html">
-         <img alt="#########" border="0" class="iconlibs" height="32" src="../../../../icons/6464/pla0.png" width="32"/>
-        </a>
-       </td>
-       <td>
-        <a href="random.html">
-         Programmable logic array
-        </a>
-       </td>
-      </tr>
-     </tr>
-    </tbody>
-   </table>
-   <p>
-    <a href="../index.html">
-     Back to
-     <em>
-      Library Reference
-     </em>
-    </a>
-   </p>
-  </div>
- </body>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="created" content="2018-10-23T06:18:10.521000000">
+    <meta name="changed" content="2026-08-22T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="zh">
+    <title>输入/输出（扩展）</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>输入/输出（扩展）</h1>
+      <p>以下组件尚无中文参考页；这些链接将打开英文参考页。</p>
+      <table>
+        <tbody>
+          <tr>
+            <td align="right"><a href="../../../../en/html/libs/ioextra/switch.html"><img
+                class="iconlibs" src="../../../../icons/6464/switch.png" alt="Switch icon"
+                width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="../../../../en/html/libs/ioextra/switch.html">Switch</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="../../../../en/html/libs/ioextra/buzzer.html"><img
+                class="iconlibs" src="../../../../icons/6464/buzzer.png" alt="Buzzer icon"
+                width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="../../../../en/html/libs/ioextra/buzzer.html">Buzzer</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="../../../../en/html/libs/ioextra/slider.html"><img
+                class="iconlibs" src="../../../../icons/6464/slider.png" alt="Slider icon"
+                width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="../../../../en/html/libs/ioextra/slider.html">Slider</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="../../../../en/html/libs/ioextra/digitalscope.html"><img
+                class="iconlibs" src="../../../../icons/6464/digitalscope.png"
+                alt="Digital Oscilloscope icon" width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="../../../../en/html/libs/ioextra/digitalscope.html">Digital Oscilloscope</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="../../../../en/html/libs/ioextra/pla.html"><img
+                class="iconlibs" src="../../../../icons/6464/pla.png"
+                alt="Programmable Logic Array icon" width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="../../../../en/html/libs/ioextra/pla.html">Programmable Logic Array</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="../../../../en/html/libs/ioextra/twowayswitch.html"><img
+                class="iconlibs" src="../../../../../resources/logisim/icons/twoway.gif"
+                alt="Two-Way Switch icon" width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="../../../../en/html/libs/ioextra/twowayswitch.html">Two-Way Switch</a></td>
+          </tr>
+          <tr>
+            <td align="right"><a href="../../../../en/html/libs/ioextra/twopinled.html"><img
+                class="iconlibs" src="../../../../../resources/logisim/icons/twopinled.gif"
+                alt="2-Pin LED icon" width="32" height="32"></a></td>
+            <td>&nbsp;</td>
+            <td><a href="../../../../en/html/libs/ioextra/twopinled.html">2-Pin LED</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <p><a href="../index.html">返回<em>库参考</em></a></p>
+    </div>
+  </body>
 </html>

--- a/src/test/java/com/cburch/logisim/docs/ExtraIoDocumentationTest.java
+++ b/src/test/java/com/cburch/logisim/docs/ExtraIoDocumentationTest.java
@@ -1,0 +1,173 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license.
+ */
+
+package com.cburch.logisim.docs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+
+class ExtraIoDocumentationTest {
+  private static final Path DOC_ROOT = Path.of("src", "main", "resources", "doc");
+  private static final Path EXTRA_IO_ROOT = DOC_ROOT.resolve("en/html/libs/ioextra");
+  private static final Path LIBRARY_SOURCE =
+      Path.of(
+          "src",
+          "main",
+          "java",
+          "com",
+          "cburch",
+          "logisim",
+          "std",
+          "io",
+          "extra",
+          "ExtraIoLibrary.java");
+  private static final Map<String, String> COMPONENT_PAGES =
+      Map.of(
+          "Switch", "switch",
+          "Buzzer", "buzzer",
+          "Slider", "slider",
+          "DigitalOscilloscope", "digitalscope",
+          "PlaRom", "pla",
+          "TwoWaySwitch", "twowayswitch",
+          "TwoPinLed", "twopinled");
+  private static final Map<String, String> TARGET_PAGES =
+      Map.of(
+          "ioex", "index",
+          "ioex_switch", "switch",
+          "ioex_buzzer", "buzzer",
+          "ioex_slider", "slider",
+          "ioex_digitalscope", "digitalscope",
+          "ioex_plarom", "pla",
+          "ioex_twowayswitch", "twowayswitch",
+          "ioex_twopinled", "twopinled");
+  private static final Pattern FACTORY_DESCRIPTION =
+      Pattern.compile("new\\s+FactoryDescription\\(\\s*(\\w+)\\.class", Pattern.DOTALL);
+
+  @Test
+  void everyRegisteredComponentHasAnEnglishReferencePage() throws Exception {
+    final var source = Files.readString(LIBRARY_SOURCE, StandardCharsets.UTF_8);
+    final var matcher = FACTORY_DESCRIPTION.matcher(source);
+    final var registeredComponents = new TreeSet<String>();
+    while (matcher.find()) {
+      registeredComponents.add(matcher.group(1));
+    }
+
+    assertEquals(
+        new TreeSet<>(COMPONENT_PAGES.keySet()),
+        registeredComponents,
+        "Update the Extra I/O reference when the registered component list changes");
+    for (final var page : COMPONENT_PAGES.values()) {
+      final var path = EXTRA_IO_ROOT.resolve(page + ".html");
+      assertTrue(Files.isRegularFile(path), () -> "Missing Extra I/O reference page " + path);
+    }
+  }
+
+  @Test
+  void englishIndexesLinkEveryReferencePage() throws Exception {
+    final var localIndex =
+        Files.readString(EXTRA_IO_ROOT.resolve("index.html"), StandardCharsets.UTF_8);
+    final var globalIndex =
+        Files.readString(DOC_ROOT.resolve("en/html/libs/index.html"), StandardCharsets.UTF_8);
+
+    for (final var page : COMPONENT_PAGES.values()) {
+      assertTrue(
+          localIndex.contains("href=\"" + page + ".html\""),
+          () -> "English Extra I/O index does not link " + page + ".html");
+      assertTrue(
+          globalIndex.contains("href=\"ioextra/" + page + ".html\""),
+          () -> "English library index does not link Extra I/O page " + page + ".html");
+    }
+  }
+
+  @Test
+  void exposedLocalizedIndexesFallBackToEnglish() throws Exception {
+    final var chineseIndex =
+        Files.readString(
+            DOC_ROOT.resolve("zh/html/libs/ioextra/index.html"), StandardCharsets.UTF_8);
+
+    for (final var page : COMPONENT_PAGES.values()) {
+      final var localFallback =
+          "href=\"../../../../en/html/libs/ioextra/" + page + ".html\"";
+      assertTrue(
+          chineseIndex.contains(localFallback),
+          () -> "Chinese Extra I/O index does not fall back to English " + page + ".html");
+      for (final var language : new String[] {"fr", "zh"}) {
+        final var globalIndex =
+            Files.readString(
+                DOC_ROOT.resolve(language + "/html/libs/index.html"), StandardCharsets.UTF_8);
+        final var globalFallback =
+            "href=\"../../../en/html/libs/ioextra/" + page + ".html\"";
+        assertTrue(
+            globalIndex.contains(globalFallback),
+            () -> language + " library index does not fall back to " + page + ".html");
+      }
+    }
+  }
+
+  @Test
+  void packagedHelpTreesExposeEveryReferencePage() throws Exception {
+    for (final var language : new String[] {"en", "de", "fr", "ru", "zh"}) {
+      final var contents = parseXml(DOC_ROOT.resolve(language + "/contents.xml"));
+      final var actualTargets = new TreeSet<String>();
+      final var items = contents.getElementsByTagName("tocitem");
+      for (var i = 0; i < items.getLength(); i++) {
+        actualTargets.add(((Element) items.item(i)).getAttribute("target"));
+      }
+
+      assertTrue(
+          actualTargets.containsAll(TARGET_PAGES.keySet()),
+          () -> language + " JavaHelp tree does not expose all Extra I/O pages");
+    }
+  }
+
+  @Test
+  void packagedHelpMapsFallBackToEnglish() throws Exception {
+    for (final var language : new String[] {"en", "de", "fr", "pt", "ru", "zh"}) {
+      final var map = parseXml(DOC_ROOT.resolve("map_" + language + ".jhm"));
+      final var actualEntries = new TreeMap<String, String>();
+      final var entries = map.getElementsByTagName("mapID");
+      for (var i = 0; i < entries.getLength(); i++) {
+        final var entry = (Element) entries.item(i);
+        actualEntries.put(entry.getAttribute("target"), entry.getAttribute("url"));
+      }
+
+      for (final var target : TARGET_PAGES.entrySet()) {
+        assertEquals(
+            "en/html/libs/ioextra/" + target.getValue() + ".html",
+            actualEntries.get(target.getKey()),
+            () -> language + " JavaHelp map has an incorrect Extra I/O fallback");
+      }
+    }
+  }
+
+  private static org.w3c.dom.Document parseXml(Path path) throws Exception {
+    final var factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setFeature(
+        "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    return factory.newDocumentBuilder().parse(path.toFile());
+  }
+}


### PR DESCRIPTION
## Summary

- add English reference pages for all seven registered Extra I/O components
- repair the Extra I/O indexes and expose the pages through packaged JavaHelp maps and trees
- add focused regression coverage for registered components, indexes, and locale fallbacks

This is the focused Extra I/O documentation slice discussed in #34.

## Testing

- .\gradlew.bat test --tests com.cburch.logisim.docs.ExtraIoDocumentationTest
- .\gradlew.bat check
- verified that relative links and image references in all eight Extra I/O pages resolve locally

NO_CHANGELOG_ENTRY