### PR TITLE
fix(draw): resolve ImageTool IllegalArgumentException in appearance e…

### DIFF
--- a/src/main/java/com/cburch/draw/tools/ImageTool.java
+++ b/src/main/java/com/cburch/draw/tools/ImageTool.java
@@ -17,6 +17,7 @@ import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.gui.icons.ImageIcon;
 
 import java.awt.Graphics;
+import java.util.Collections;
 import java.util.List;
 import javax.swing.Icon;
 
@@ -47,7 +48,7 @@ public class ImageTool extends RectangularTool {
 
   @Override
   public List<Attribute<?>> getAttributes() {
-    return List.of(ImageShape.SCALE_ATTR, ImageShape.LICENSE_ATTR, ImageShape.ATTRIBUTION_ATTR);
+    return Collections.emptyList();
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditHandler.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/AppearanceEditHandler.java
@@ -219,11 +219,9 @@ public class AppearanceEditHandler extends EditHandler implements SelectionListe
   public void paste() {
     if (pasteSystemClipboardImage()) return;
 
-    if (Clipboard.isEmpty()) return;
-
     final var clip = Clipboard.get();
+    if (clip == null || clip.getElements().isEmpty()) return;
     final var contents = clip.getElements();
-    if (contents.isEmpty()) return;
 
     final var add = new ArrayList<CanvasObject>(contents.size());
     for (final var obj : contents) {

--- a/src/test/java/com/cburch/draw/shapes/ImageShapeTest.java
+++ b/src/test/java/com/cburch/draw/shapes/ImageShapeTest.java
@@ -43,4 +43,10 @@ class ImageShapeTest {
     assertEquals(200, shape.getValue(ImageShape.WIDTH_ATTR));
     assertEquals(150, shape.getValue(ImageShape.HEIGHT_ATTR));
   }
+
+  @Test
+  void testImageToolAttributesIsEmptyBeforeDrawing() {
+    final var imageTool = new com.cburch.draw.tools.ImageTool(new com.cburch.draw.tools.DrawingAttributeSet());
+    assertTrue(imageTool.getAttributes().isEmpty());
+  }
 }


### PR DESCRIPTION
### Summary of Changes

1. **Fix `IllegalArgumentException` in `ImageTool`:** Resolved a crash occurring when interacting with image properties in the attribute table *before* placing the shape on the canvas (Issue #2921). Fixed by returning `Collections.emptyList()` in `ImageTool.getAttributes()`, as these properties only apply to already drawn `ImageShape` instances.
2. **Clipboard check cleanup:** Merged redundant clipboard checks in `AppearanceEditHandler.paste()` into a single condition. This addresses the feedback from @MarcinOrlowski that I accidentally missed in the previous PR (thanks again for letting it slip back then!).
3. **Testing:** Added unit test `testImageToolAttributesIsEmptyBeforeDrawing()` in `ImageShapeTest.java` to prevent regressions.

Fixes #2921
NO_CHANGELOG_ENTRY