### PR TITLE
Fix output-only PortIO reported as multiple drivers in FPGA netlist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,8 @@
     Verilog permits case-distinct names, and selecting no HDL permits non-HDL identifiers.
   * Fixed several HDL and FPGA generation issues, including wide Random generator HDL, PortIO bubble
     ranges, scanning I/O constraints, and Xilinx download placeholder handling.
+  * Fixed output-only Port I/O components being reported as multiple drivers during FPGA netlist
+    generation, and corrected the symmetric input-only endpoint direction [#2537] (@henriquejsza).
   * Improved project editing stability:
     * Layout zoom and scroll position are remembered separately for each circuit during a session.
     * Circuits without a remembered view initially fit the window at up to 100% zoom and are centered.

--- a/src/main/java/com/cburch/logisim/std/io/PortIo.java
+++ b/src/main/java/com/cburch/logisim/std/io/PortIo.java
@@ -300,7 +300,7 @@ public class PortIo extends InstanceFactory {
         x += dx;
         y += dy;
       }
-      if (dir == INPUT || dir == INOUTSE || dir == INOUTME) {
+      if (dir == OUTPUT || dir == INOUTSE || dir == INOUTME) {
         ps[p] = new Port(x, y, Port.INPUT, e);
         ps[p].setToolTip(S.getter("pioOutputs", range));
         p++;
@@ -315,7 +315,7 @@ public class PortIo extends InstanceFactory {
     while (n > 0) {
       final var e = Math.min(n, BitWidth.MAXWIDTH);
       String range = "[" + i + "..." + (i + e - 1) + "]";
-      if (dir == OUTPUT || dir == INOUTSE || dir == INOUTME) {
+      if (dir == INPUT || dir == INOUTSE || dir == INOUTME) {
         ps[p] = new Port(x, y, Port.OUTPUT, e);
         ps[p].setToolTip(S.getter("pioInputs", range));
         p++;

--- a/src/test/java/com/cburch/logisim/fpga/designrulecheck/NetlistDrcTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/designrulecheck/NetlistDrcTest.java
@@ -14,7 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cburch.logisim.circuit.Circuit;
 import com.cburch.logisim.circuit.CircuitMutation;
+import com.cburch.logisim.circuit.Wire;
 import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.data.BitWidth;
+import com.cburch.logisim.data.Direction;
 import com.cburch.logisim.data.Location;
 import com.cburch.logisim.file.Loader;
 import com.cburch.logisim.file.LogisimFile;
@@ -22,6 +25,8 @@ import com.cburch.logisim.fpga.hdlgenerator.HdlGeneratorFactory;
 import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.io.PortIo;
+import com.cburch.logisim.std.wiring.Constant;
 import com.cburch.logisim.std.wiring.Pin;
 import java.util.ArrayList;
 import org.junit.jupiter.api.AfterEach;
@@ -33,6 +38,37 @@ class NetlistDrcTest {
   @AfterEach
   void restoreHdlType() {
     AppPreferences.HdlType.set(originalHdlType);
+  }
+
+  @Test
+  void constantCanDriveOutputOnlyPortIoWithoutShortCircuit() {
+    final var fixture = new Fixture();
+    final var width = BitWidth.create(8);
+
+    final var constantAttrs = Constant.FACTORY.createAttributeSet();
+    constantAttrs.setValue(StdAttr.WIDTH, width);
+    constantAttrs.setValue(Constant.ATTR_VALUE, 0xffL);
+    final var constant =
+        Constant.FACTORY.createComponent(Location.create(340, 280, true), constantAttrs);
+
+    final var portFactory = new PortIo();
+    final var portAttrs = portFactory.createAttributeSet();
+    portAttrs.setValue(PortIo.ATTR_DIR, PortIo.OUTPUT);
+    portAttrs.setValue(PortIo.ATTR_SIZE, width);
+    portAttrs.setValue(StdAttr.FACING, Direction.NORTH);
+    portAttrs.setValue(StdAttr.LABEL, "interface");
+    final var portIo =
+        portFactory.createComponent(Location.create(390, 290, true), portAttrs);
+
+    add(
+        fixture.circuit,
+        constant,
+        portIo,
+        Wire.create(constant.getLocation(), portIo.getEnd(0).getLocation()));
+
+    final var result = fixture.circuit.getNetList().designRuleCheckResult(true, new ArrayList<>());
+
+    assertEquals(Netlist.DRC_PASSED, result);
   }
 
   @Test
@@ -57,9 +93,9 @@ class NetlistDrcTest {
     return Pin.FACTORY.createComponent(Location.create(x, 0, true), attrs);
   }
 
-  private static void add(Circuit circuit, Component component) {
+  private static void add(Circuit circuit, Component... components) {
     final var mutation = new CircuitMutation(circuit);
-    mutation.add(component);
+    for (final var component : components) mutation.add(component);
     mutation.execute();
   }
 

--- a/src/test/java/com/cburch/logisim/std/io/PortHdlGeneratorFactoryTest.java
+++ b/src/test/java/com/cburch/logisim/std/io/PortHdlGeneratorFactoryTest.java
@@ -46,6 +46,22 @@ class PortHdlGeneratorFactoryTest {
   }
 
   @Test
+  void outputOnlyDataEndpointIsNetlistSink() {
+    final var end = portComponent(PortIo.OUTPUT, 4).getComponent().getEnd(0);
+
+    assertTrue(end.isInput());
+    assertFalse(end.isOutput());
+  }
+
+  @Test
+  void inputOnlyDataEndpointIsNetlistSource() {
+    final var end = portComponent(PortIo.INPUT, 4).getComponent().getEnd(0);
+
+    assertFalse(end.isInput());
+    assertTrue(end.isOutput());
+  }
+
+  @Test
   void outputOnlyPortsUseOutputBubbleRange() {
     AppPreferences.HdlType.set(HdlGeneratorFactory.VHDL);
     final var nets = mock(Netlist.class);


### PR DESCRIPTION
## Summary

Output-only Port I/O components no longer trigger a false "multiple drivers (short circuit)" DRC error during FPGA netlist generation. The symmetric input-only endpoint direction is corrected at the same time.

## Root cause

In `PortIo.updatePorts()`, the data-endpoint direction guards were swapped. An `OUTPUT`-configured PortIO built a `Port.OUTPUT` end (a netlist source), while an `INPUT`-configured one built a `Port.INPUT` end. An output-only port therefore advertised itself as a driver and collided with the net actually driving it.

The fix makes an `OUTPUT`-configured port expose a `Port.INPUT` (sink) end and an `INPUT`-configured port expose a `Port.OUTPUT` (source) end, matching the existing data flow in `propagate()` while leaving INOUT endpoints, HDL generation, and map information unchanged.

## Testing

- Added a netlist DRC regression reproducing #2537 with an 8-bit Constant driving an output-only PortIO.
- Added direct output-only sink and input-only source endpoint assertions.
- Targeted run: `NetlistDrcTest` (2) + `PortHdlGeneratorFactoryTest` (5) = 7 tests, all passing.
- Full `./gradlew build -x checkstyleMain -x checkstyleTest`: passed.
- `./gradlew checkstyleMain checkstyleTest`: passed.

## Attached reproducer

With the original attachment, the log now reports `Circuit “main” passed DRC check`. The run only stops afterward because the attachment does not contain complete board I/O mappings, which is separate from this fix.

Fixes #2537
