### PR TITLE
Fix RAM losing circuit notifications after being moved

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,8 @@
     * Layout zoom and scroll position are remembered separately for each circuit during a session.
     * Circuits without a remembered view initially fit the window at up to 100% zoom and are centered.
     * Moving components preserves component state.
+    * RAM components continue to notify their circuit of memory changes after being moved [#2873]
+      (@henriquejsza).
     * Floating subcircuit inputs now propagate floating values.
     * Nested library tools resolve correctly.
     * Text label editing handles menu-shortcut actions and in-place undo/redo consistently.

--- a/src/main/java/com/cburch/logisim/std/memory/Mem.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Mem.java
@@ -52,15 +52,19 @@ public abstract class Mem extends InstanceFactory {
 
   static class MemListener implements HexModelListener {
 
-    final Instance instance;
+    private Instance instance;
 
     MemListener(Instance instance) {
       this.instance = instance;
     }
 
+    void setInstance(Instance instance) {
+      this.instance = instance;
+    }
+
     @Override
     public void bytesChanged(HexModel source, long start, long numBytes, long[] values) {
-      if (SwingUtilities.isEventDispatchThread()) instance.fireInvalidated();
+      if (instance != null && SwingUtilities.isEventDispatchThread()) instance.fireInvalidated();
     }
 
     @Override

--- a/src/main/java/com/cburch/logisim/std/memory/RamState.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamState.java
@@ -78,6 +78,7 @@ public class RamState extends MemState implements AttributeListener {
     if (value != null) {
       value.getAttributeSet().addAttributeListener(this);
     }
+    listener.setInstance(value);
   }
   
   long getCurrent(int index) {

--- a/src/test/java/com/cburch/logisim/circuit/CircuitStateTest.java
+++ b/src/test/java/com/cburch/logisim/circuit/CircuitStateTest.java
@@ -22,6 +22,9 @@ import com.cburch.logisim.file.LogisimFile;
 import com.cburch.logisim.proj.Project;
 import com.cburch.logisim.std.memory.Ram;
 import com.cburch.logisim.std.wiring.Pin;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
 
 class CircuitStateTest {
@@ -46,19 +49,51 @@ class CircuitStateTest {
   void replacementWithSameFactoryKeepsComponentState() {
     final var fixture = new Fixture();
     final var ramFactory = new Ram();
-    final var ram = ramFactory.createComponent(Location.create(100, 100, true), ramFactory.createAttributeSet());
+    final var ram =
+        ramFactory.createComponent(
+            Location.create(100, 100, true), ramFactory.createAttributeSet());
     add(fixture.circuit, ram);
 
     final var contents = ramFactory.getContents(fixture.state.getInstanceState(ram));
     contents.set(3, 0x5a);
     final var ramState = fixture.state.getData(ram);
 
-    final var movedRam = ramFactory.createComponent(Location.create(140, 100, true), ram.getAttributeSet());
+    final var movedRam =
+        ramFactory.createComponent(Location.create(140, 100, true), ram.getAttributeSet());
     replace(fixture.circuit, ram, movedRam);
 
     assertNull(fixture.state.getData(ram));
     assertSame(ramState, fixture.state.getData(movedRam));
     assertEquals(0x5a, ramFactory.getContents(fixture.state.getInstanceState(movedRam)).get(3));
+  }
+
+  @Test
+  void replacementWithSameFactoryRetargetsStateListeners() throws Exception {
+    final var fixture = new Fixture();
+    final var ramFactory = new Ram();
+    final var ram =
+        ramFactory.createComponent(
+            Location.create(100, 100, true), ramFactory.createAttributeSet());
+    add(fixture.circuit, ram);
+
+    final var contents = ramFactory.getContents(fixture.state.getInstanceState(ram));
+    final var movedRam =
+        ramFactory.createComponent(Location.create(140, 100, true), ram.getAttributeSet());
+    replace(fixture.circuit, ram, movedRam);
+
+    assertSame(contents, ramFactory.getContents(fixture.state.getInstanceState(movedRam)));
+
+    final var invalidatedComponents = new ArrayList<Component>();
+    fixture.circuit.addCircuitListener(
+        event -> {
+          if (event.getAction() == CircuitEvent.ACTION_INVALIDATE) {
+            invalidatedComponents.add((Component) event.getData());
+          }
+        });
+
+    SwingUtilities.invokeAndWait(() -> contents.set(0, contents.get(0) ^ 1));
+
+    assertEquals(List.of(movedRam), invalidatedComponents);
   }
 
   @Test


### PR DESCRIPTION
## Summary

When a RAM is moved, `CircuitState` transfers its existing `RamState` to the replacement component. `RamState` updated its attribute listener, but its memory listener still referenced the removed instance. Memory edits then fired invalidation on the old component and never reached the circuit.

Retarget the memory listener in `RamState.setRam()` and guard detached listeners. The regression test replaces a RAM, edits its contents on the EDT, and verifies that the moved component is invalidated.

## Testing

- `./gradlew test --tests 'com.cburch.logisim.circuit.CircuitStateTest'`
- `./gradlew checkstyleMain checkstyleTest`
- `./gradlew build -x checkstyleMain -x checkstyleTest`

Fixes #2873