### PR TITLE
i18n(zh): refine Image component terminology

### DIFF
--- a/src/main/resources/resources/logisim/strings/std/std_zh.properties
+++ b/src/main/resources/resources/logisim/strings/std/std_zh.properties
@@ -291,13 +291,13 @@ imageOptimizeItem = 优化图像尺寸
 imageOptimizeConfirmTitle = 优化图像尺寸
 imageOptimizeConfirmMessage = 图像分辨率将从 %dx%d 像素压缩至 %dx%d 像素。这将显著减小电路文件大小并降低内存占用。\n\n是否继续执行？
 imageAlreadyOptimizedMessage = 图像已针对其当前尺寸 (%dx%d) 完成优化。
-imageMakeWhiteTransparentItem = 将外部背景设为透明
+imageMakeWhiteTransparentItem = 将外围白色背景设为透明
 imageChooseDialogTitle = 选择图像文件
-imageFileFilterDescription = 图像格式 (*.png, *.jpg, *.jpeg, *.gif)
-imageSourceNone = （未知）
+imageFileFilterDescription = 图像文件 (*.png, *.jpg, *.jpeg, *.gif)
+imageSourceNone = （无）
 imageLicenseAttr = 许可证
 imageLicenseUnspecifiedOpt = 未指定
-imageLicenseOtherOpt = 其它
+imageLicenseOtherOpt = 其他
 imageAttributionAttr = 来源 / 作者
 imageDataSizeAttr = 数据大小
 #


### PR DESCRIPTION
## Summary
- refine four Simplified Chinese terms for the Image component
- clarify that an empty image source means “none”
- describe the white-background transparency action more precisely
- align the file-filter and “other” wording with common project terminology

This is a small follow-up to #2925. Thank you @lihuashiyu for the original localization work.

## Testing
- `./gradlew.bat check`
- `trans-tool -l zh -ls en -b src/main/resources/resources/logisim/strings/std/std.properties` (baseline issue counts unchanged; no new errors)

NO_CHANGELOG_ENTRY