### PR TITLE
fix: include accessibility module in packaged runtime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 * @dev (????-??-??)
   * Added Image component to insert custom bitmap images into circuits and subcircuit appearances.
   * Added contributor guidance and an online component overview for the TTL library.
+  * Fixed packaged runtimes failing to launch when Java accessibility support is configured
+    [#2398] (@hewzhew).
   * Added "Find Action" omni-search, letting menu actions be found and run by typing part of their
     name, with fuzzy and acronym matching (e.g. "expim" or "ei" find "Export Image"). It opens from
     the Help menu, from Ctrl+Shift+A (configurable under Preferences > Hotkey settings), or by

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -417,6 +417,9 @@ tasks.register("createNeededJavaModules") {
   description = "Creates a file containing the jdeps dependencies"
   dependsOn("shadowJar")
 
+  // AWT loads accessibility providers from user configuration at runtime, so jdeps cannot detect
+  // this optional module through static analysis.
+  val additionalJavaModules = listOf("jdk.accessibility")
   val libsDir = ext.get(LIBS_DIR) as String
   val shadowJarFilename = ext.get(SHADOW_JAR_FILE_NAME) as String
   val jarFileName = "${libsDir}/${shadowJarFilename}"
@@ -424,10 +427,18 @@ tasks.register("createNeededJavaModules") {
   val cmd = listOf(ext.get(JDEPS) as String, "--multi-release", "base","--print-module-deps", "--ignore-missing-deps", jarFileName)
 
   inputs.file(jarFileName)
+  inputs.property("additionalJavaModules", additionalJavaModules)
   outputs.file(outFileName)
 
   doLast {
-    val neededJavaModules = func.runCommand(cmd, "Error while finding Java dependencies with jdeps.").trim()
+    val neededJavaModules =
+        (func.runCommand(cmd, "Error while finding Java dependencies with jdeps.").split(',') +
+            additionalJavaModules)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+            .sorted()
+            .joinToString(",")
     File(outFileName).writeText(neededJavaModules)
     func.verifyFileExists(outFileName)
   }


### PR DESCRIPTION
## Summary

- include `jdk.accessibility` in the module list used for packaged runtimes because AWT can load it dynamically from user configuration and `jdeps` cannot detect it
- normalize, deduplicate, and sort the generated module list, and declare the explicit modules as a Gradle task input
- document the fix in `CHANGES.md`

## Testing

- `./gradlew.bat createNeededJavaModules`
- `./gradlew.bat check`
- compared isolated Windows `jlink` runtimes: the reported `AccessBridge` startup failure reproduces without `jdk.accessibility` and succeeds when the module is included

Closes #2398