### PR TITLE
feat: add "Show Bus Width" attribute to wires with tick-mark label rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Added "Show Bus Width" wire attribute to label multi-bit buses with a tick mark at Start, Center, or End (@V-Zemlyakov).
   * Added Image component to insert custom bitmap images into circuits and subcircuit appearances.
   * Added contributor guidance and an online component overview for the TTL library.
   * Added "Find Action" omni-search, letting menu actions be found and run by typing part of their

--- a/src/main/java/com/cburch/logisim/circuit/Circuit.java
+++ b/src/main/java/com/cburch/logisim/circuit/Circuit.java
@@ -21,6 +21,7 @@ import com.cburch.logisim.comp.ComponentListener;
 import com.cburch.logisim.comp.EndData;
 import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.data.AttributeEvent;
+import com.cburch.logisim.data.AttributeOption;
 import com.cburch.logisim.data.AttributeSet;
 import com.cburch.logisim.data.BitWidth;
 import com.cburch.logisim.data.Bounds;
@@ -788,6 +789,15 @@ public class Circuit {
 
   public Set<Wire> getWires() {
     return wires.getWires();
+  }
+
+  public AttributeOption getWireBusWidthPos(Wire w) {
+    return wires.getWireBusWidthPos(w);
+  }
+
+  public void setWireBusWidthPos(Wire w, AttributeOption pos) {
+    wires.setWireBusWidthPos(w, pos);
+    fireEvent(CircuitEvent.ACTION_INVALIDATE, w);
   }
 
   public Collection<Wire> getWires(Location loc) {

--- a/src/main/java/com/cburch/logisim/circuit/CircuitMutatorImpl.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitMutatorImpl.java
@@ -117,6 +117,19 @@ class CircuitMutatorImpl implements CircuitMutator {
       DynamicElementProvider.repairDynamicElementPaths(circuit, repl);
 
       for (final var component : repl.getRemovals()) {
+        if (component instanceof Wire oldWire) {
+          final var pos = circuit.getWireBusWidthPos(oldWire);
+          if (pos != Wire.BUS_WIDTH_POS_NONE) {
+            final var additions = repl.getReplacementsFor(oldWire);
+            if (additions != null) {
+              for (final var addComp : additions) {
+                if (addComp instanceof Wire newWire) {
+                  circuit.setWireBusWidthPos(newWire, pos);
+                }
+              }
+            }
+          }
+        }
         circuit.mutatorRemove(component);
       }
       for (final var component : repl.getAdditions()) {
@@ -131,10 +144,16 @@ class CircuitMutatorImpl implements CircuitMutator {
       modified.add(circuit);
       @SuppressWarnings("unchecked")
       final var a = (Attribute<Object>) attr;
-      final var attrs = comp.getAttributeSet();
-      final var oldValue = attrs.getValue(a);
-      log.add(CircuitChange.set(circuit, comp, attr, oldValue, newValue));
-      attrs.setValue(a, newValue);
+      if (comp instanceof Wire w && Wire.BUS_WIDTH_POS_ATTR.equals(attr)) {
+        final var oldValue = circuit.getWireBusWidthPos(w);
+        log.add(CircuitChange.set(circuit, comp, attr, oldValue, newValue));
+        circuit.setWireBusWidthPos(w, (com.cburch.logisim.data.AttributeOption) newValue);
+      } else {
+        final var attrs = comp.getAttributeSet();
+        final var oldValue = attrs.getValue(a);
+        log.add(CircuitChange.set(circuit, comp, attr, oldValue, newValue));
+        attrs.setValue(a, newValue);
+      }
     }
   }
 

--- a/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitWires.java
@@ -14,6 +14,8 @@ import com.cburch.logisim.comp.ComponentDrawContext;
 import com.cburch.logisim.comp.EndData;
 import com.cburch.logisim.data.AttributeEvent;
 import com.cburch.logisim.data.AttributeListener;
+import com.cburch.logisim.data.AttributeOption;
+import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.data.BitWidth;
 import com.cburch.logisim.data.Bounds;
 import com.cburch.logisim.data.Location;
@@ -508,6 +510,19 @@ public class CircuitWires {
   private HashSet<Component> tunnels = new HashSet<>(); // Components having Tunnel factory
   private HashSet<Component> pulls = new HashSet<>(); // Components having PullResistor factory
   private HashSet<Component> components = new HashSet<>(); // other Components
+  private HashMap<Wire, AttributeOption> wireBusWidthPos = new HashMap<>();
+
+  public AttributeOption getWireBusWidthPos(Wire w) {
+    return wireBusWidthPos.getOrDefault(w, Wire.BUS_WIDTH_POS_NONE);
+  }
+
+  public void setWireBusWidthPos(Wire w, AttributeOption pos) {
+    if (pos == null || pos == Wire.BUS_WIDTH_POS_NONE) {
+      wireBusWidthPos.remove(w);
+    } else {
+      wireBusWidthPos.put(w, pos);
+    }
+  }
 
   static final Logger logger = LoggerFactory.getLogger(CircuitWires.class);
 
@@ -866,6 +881,56 @@ public class CircuitWires {
     return v;
   }
 
+  private void drawBusWidthLabel(Graphics2D g, Wire wire, WireBundle wb, Location s, Location t) {
+    final var posOption = getWireBusWidthPos(wire);
+    if (posOption == null || posOption == Wire.BUS_WIDTH_POS_NONE
+        || wb == null || !wb.isValid() || !wb.isBus()) {
+      return;
+    }
+    final var bitWidth = wb.getWidth();
+    if (bitWidth.getWidth() <= 1) {
+      return;
+    }
+    final var len = wire.getLength();
+    final var offset = Math.min(20, len / 2);
+    int px, py;
+    if (posOption == Wire.BUS_WIDTH_POS_START) {
+      if (wire.isVertical()) {
+        px = s.getX();
+        py = s.getY() + offset;
+      } else {
+        px = s.getX() + offset;
+        py = s.getY();
+      }
+    } else if (posOption == Wire.BUS_WIDTH_POS_END) {
+      if (wire.isVertical()) {
+        px = t.getX();
+        py = t.getY() - offset;
+      } else {
+        px = t.getX() - offset;
+        py = t.getY();
+      }
+    } else { // CENTER
+      px = (s.getX() + t.getX()) / 2;
+      py = (s.getY() + t.getY()) / 2;
+    }
+    final var oldFont = g.getFont();
+    final var oldColor = g.getColor();
+    final var isDark = AppPreferences.isDarkTheme(AppPreferences.LookAndFeel.get());
+    g.setColor(isDark ? new Color(200, 200, 200) : Color.DARK_GRAY);
+    GraphicsUtil.switchToWidth(g, 2);
+    g.drawLine(px - 4, py + 4, px + 4, py - 4);
+    final var label = String.valueOf(bitWidth.getWidth());
+    g.setFont(g.getFont().deriveFont(10.0f));
+    if (wire.isVertical()) {
+      GraphicsUtil.drawText(g, label, px + 6, py, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
+    } else {
+      GraphicsUtil.drawText(g, label, px, py - 6, GraphicsUtil.H_CENTER, GraphicsUtil.V_BOTTOM);
+    }
+    g.setFont(oldFont);
+    g.setColor(oldColor);
+  }
+
   void draw(ComponentDrawContext context, Collection<Component> hidden) {
     final var showState = context.getShowState();
     final var state = context.getCircuitState();
@@ -921,6 +986,8 @@ public class CircuitWires {
             g.drawLine(s.getX(), s.getY() + width, t.getX(), t.getY() + width);
           }
         }
+
+        drawBusWidthLabel(g, wire, wb, s, t);
       }
 
       for (final var loc : points.getAllLocations()) {
@@ -969,6 +1036,8 @@ public class CircuitWires {
             GraphicsUtil.switchToWidth(g, wb.isBus() ? Wire.WIDTH_BUS : Wire.WIDTH);
             g.drawLine(s.getX(), s.getY(), t.getX(), t.getY());
           }
+
+          drawBusWidthLabel(g, wire, wb, s, t);
         }
       }
 

--- a/src/main/java/com/cburch/logisim/circuit/Wire.java
+++ b/src/main/java/com/cburch/logisim/circuit/Wire.java
@@ -62,11 +62,22 @@ public final class Wire implements Component, AttributeSet, CustomHandles, Itera
   public static final double DOT_MULTIPLY_FACTOR = 1.35; // multiply factor for the intersection points
   public static final AttributeOption VALUE_HORZ = new AttributeOption("horz", S.getter("wireDirectionHorzOption"));
   public static final AttributeOption VALUE_VERT = new AttributeOption("vert", S.getter("wireDirectionVertOption"));
+  public static final AttributeOption BUS_WIDTH_POS_NONE = new AttributeOption("none", S.getter("wireBusWidthPosNoneOption"));
+  public static final AttributeOption BUS_WIDTH_POS_START = new AttributeOption("start", S.getter("wireBusWidthPosStartOption"));
+  public static final AttributeOption BUS_WIDTH_POS_CENTER = new AttributeOption("center", S.getter("wireBusWidthPosCenterOption"));
+  public static final AttributeOption BUS_WIDTH_POS_END = new AttributeOption("end", S.getter("wireBusWidthPosEndOption"));
 
   public static final Attribute<AttributeOption> DIR_ATTR = Attributes.forOption("direction", S.getter("wireDirectionAttr"), new AttributeOption[] {VALUE_HORZ, VALUE_VERT});
   public static final Attribute<Integer> LEN_ATTR = Attributes.forInteger("length", S.getter("wireLengthAttr"));
+  public static final Attribute<AttributeOption> BUS_WIDTH_POS_ATTR =
+      Attributes.forOption(
+          "buswidthpos",
+          S.getter("wireBusWidthPosAttr"),
+          new AttributeOption[] {
+            BUS_WIDTH_POS_NONE, BUS_WIDTH_POS_START, BUS_WIDTH_POS_CENTER, BUS_WIDTH_POS_END
+          });
 
-  private static final List<Attribute<?>> ATTRIBUTES = Arrays.asList(DIR_ATTR, LEN_ATTR);
+  private static final List<Attribute<?>> ATTRIBUTES = Arrays.asList(DIR_ATTR, LEN_ATTR, BUS_WIDTH_POS_ATTR);
 
   private static final Cache cache = new Cache();
 
@@ -170,7 +181,7 @@ public final class Wire implements Component, AttributeSet, CustomHandles, Itera
     java.awt.Component dest = context.getDestination();
     final var x0 = e0.getX();
     final var y0 = e0.getY();
-    dest.repaint(x0 - 5, y0 - 5, e1.getX() - x0 + 10, e1.getY() - y0 + 10);
+    dest.repaint(x0 - 30, y0 - 30, e1.getX() - x0 + 60, e1.getY() - y0 + 60);
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
@@ -160,7 +160,15 @@ public class XmlCircuitReader extends CircuitTransaction {
 
     if (!pt0.equals(pt1)) {
       // Avoid zero length wires
-      mutator.add(dest, Wire.create(pt0, pt1));
+      final var w = Wire.create(pt0, pt1);
+      mutator.add(dest, w);
+      if (elt.hasAttribute("buswidthpos")) {
+        final var posStr = elt.getAttribute("buswidthpos");
+        final var opt = Wire.BUS_WIDTH_POS_ATTR.parse(posStr);
+        if (opt != null) {
+          dest.setWireBusWidthPos(w, opt);
+        }
+      }
     }
   }
 

--- a/src/main/java/com/cburch/logisim/file/XmlWriter.java
+++ b/src/main/java/com/cburch/logisim/file/XmlWriter.java
@@ -290,7 +290,7 @@ final class XmlWriter {
       ret.appendChild(appear);
     }
     for (final var wire : circuit.getWires()) {
-      ret.appendChild(fromWire(wire));
+      ret.appendChild(fromWire(wire, circuit));
     }
     for (final var comp : circuit.getNonWires()) {
       final var elt = fromComponent(comp);
@@ -537,10 +537,14 @@ final class XmlWriter {
     return elt;
   }
 
-  Element fromWire(Wire w) {
+  Element fromWire(Wire w, Circuit circuit) {
     final var ret = doc.createElement("wire");
     ret.setAttribute("from", w.getEnd0().toString());
     ret.setAttribute("to", w.getEnd1().toString());
+    final var pos = circuit.getWireBusWidthPos(w);
+    if (pos != null && pos != Wire.BUS_WIDTH_POS_NONE) {
+      ret.setAttribute("buswidthpos", pos.getValue().toString());
+    }
     return ret;
   }
 

--- a/src/main/java/com/cburch/logisim/gui/main/AttrTableSelectionModel.java
+++ b/src/main/java/com/cburch/logisim/gui/main/AttrTableSelectionModel.java
@@ -169,7 +169,7 @@ class AttrTableSelectionModel extends AttributeSetTableModel implements Selectio
         labeler = new AutoLabel((String) value, circuit);
       }
       for (final var comp : comps) {
-        if (!(comp instanceof Wire)) {
+        if (!(comp instanceof Wire) || Wire.BUS_WIDTH_POS_ATTR.equals(attr)) {
           if (comp.getFactory() instanceof SubcircuitFactory fac) {
             if (attr.equals(CircuitAttributes.NAMED_CIRCUIT_BOX_FIXED_SIZE)
                 || attr.equals(CircuitAttributes.NAME_ATTR)) {

--- a/src/main/java/com/cburch/logisim/gui/main/SelectionAttributes.java
+++ b/src/main/java/com/cburch/logisim/gui/main/SelectionAttributes.java
@@ -15,6 +15,7 @@ import com.cburch.logisim.data.AbstractAttributeSet;
 import com.cburch.logisim.data.Attribute;
 import com.cburch.logisim.data.AttributeEvent;
 import com.cburch.logisim.data.AttributeListener;
+import com.cburch.logisim.data.AttributeOption;
 import com.cburch.logisim.util.CollectionUtil;
 import com.cburch.logisim.util.UnmodifiableList;
 import java.util.Collection;
@@ -55,25 +56,48 @@ class SelectionAttributes extends AbstractAttributeSet {
     setListening(true);
   }
 
-  private static LinkedHashMap<Attribute<Object>, Object> computeAttributes(
+  private LinkedHashMap<Attribute<Object>, Object> computeAttributes(
       Collection<Component> newSel) {
     final var attrMap = new LinkedHashMap<Attribute<Object>, Object>();
     final var sit = newSel.iterator();
     if (sit.hasNext()) {
-      final var first = sit.next().getAttributeSet();
+      final var firstComp = sit.next();
+      final var first = firstComp.getAttributeSet();
+      final var circ = canvas.getCircuit();
       for (Attribute<?> attr : first.getAttributes()) {
         @SuppressWarnings("unchecked")
         final var attrObj = (Attribute<Object>) attr;
-        attrMap.put(attrObj, first.getValue(attr));
+        Object val = first.getValue(attr);
+        if (Wire.BUS_WIDTH_POS_ATTR.equals(attr) && firstComp instanceof Wire w && circ != null) {
+          final var bw = circ.getWidth(w.getEnd0());
+          if (bw.getWidth() <= 1) {
+            continue; // Hide attribute for 1-bit
+          }
+          val = circ.getWireBusWidthPos(w);
+        }
+        attrMap.put(attrObj, val);
       }
       while (sit.hasNext()) {
-        final var next = sit.next().getAttributeSet();
+        final var nextComp = sit.next();
+        final var next = nextComp.getAttributeSet();
         final var ait = attrMap.keySet().iterator();
         while (ait.hasNext()) {
           final var attr = ait.next();
+          if (Wire.BUS_WIDTH_POS_ATTR.equals(attr) && nextComp instanceof Wire w && circ != null) {
+            final var bw = circ.getWidth(w.getEnd0());
+            if (bw.getWidth() <= 1) {
+              ait.remove();
+              continue;
+            }
+          }
           if (next.containsAttribute(attr)) {
             final var v = attrMap.get(attr);
-            if (v != null && !v.equals(next.getValue(attr))) {
+            Object nv = next.getValue(attr);
+            if (Wire.BUS_WIDTH_POS_ATTR.equals(attr) && nextComp instanceof Wire w && circ != null) {
+              nv = circ.getWireBusWidthPos(w);
+            }
+
+            if (v != null && !v.equals(nv)) {
               attrMap.put(attr, null);
             }
           } else {
@@ -85,8 +109,16 @@ class SelectionAttributes extends AbstractAttributeSet {
     return attrMap;
   }
 
-  private static boolean computeReadOnly(Collection<Component> sel, Attribute<?> attr) {
+  private boolean computeReadOnly(Collection<Component> sel, Attribute<?> attr) {
+    final var circ = canvas.getCircuit();
     for (final var comp : sel) {
+      if (attr == Wire.BUS_WIDTH_POS_ATTR && comp instanceof Wire w && circ != null) {
+        final var bitWidth = circ.getWidth(w.getEnd0());
+        if (bitWidth.getWidth() <= 1) {
+          return true;
+        }
+        continue;
+      }
       final var attrs = comp.getAttributeSet();
       if (attrs.isReadOnly(attr)) {
         return true;
@@ -96,25 +128,8 @@ class SelectionAttributes extends AbstractAttributeSet {
   }
 
   private static Set<Component> createSet(Collection<Component> comps) {
-    var includeWires = true;
-    for (final var comp : comps) {
-      if (!(comp instanceof Wire)) {
-        includeWires = false;
-        break;
-      }
-    }
-
-    if (includeWires) {
-      return new HashSet<>(comps);
-    } else {
-      final var ret = new HashSet<Component>();
-      for (final var comp : comps) {
-        if (!(comp instanceof Wire)) {
-          ret.add(comp);
-        }
-      }
-      return ret;
-    }
+    if (comps == null) return Collections.emptySet();
+    return new HashSet<>(comps);
   }
 
   private static boolean haveSameElements(Collection<Component> a, Collection<Component> b) {
@@ -196,6 +211,15 @@ class SelectionAttributes extends AbstractAttributeSet {
       return circ.getStaticAttributes().getValue(attr);
     }
 
+    if (attr == Wire.BUS_WIDTH_POS_ATTR && circ != null && selected.size() == 1) {
+      final var comp = selected.iterator().next();
+      if (comp instanceof Wire w) {
+        @SuppressWarnings("unchecked")
+        V ret = (V) circ.getWireBusWidthPos(w);
+        return ret;
+      }
+    }
+
     final var i = findIndex(attr);
     final var vs = values;
     @SuppressWarnings("unchecked")
@@ -212,6 +236,13 @@ class SelectionAttributes extends AbstractAttributeSet {
     } else if (circ != null && selected.isEmpty()) {
       return circ.getStaticAttributes().isReadOnly(attr);
     } else {
+      if (attr == Wire.BUS_WIDTH_POS_ATTR && selected.size() == 1) {
+        final var comp = selected.iterator().next();
+        if (comp instanceof Wire w && circ != null) {
+          final var width = circ.getWidth(w.getEnd0());
+          return width.getWidth() <= 1;
+        }
+      }
       int i = findIndex(attr);
       final var ro = readOnly;
       return i < 0 || i >= ro.length || ro[i];
@@ -238,13 +269,27 @@ class SelectionAttributes extends AbstractAttributeSet {
     if (selected.isEmpty() && circ != null) {
       circ.getStaticAttributes().setValue(attr, value);
     } else {
+      if (attr == Wire.BUS_WIDTH_POS_ATTR && circ != null) {
+        for (final var comp : selected) {
+          if (comp instanceof Wire w) {
+            circ.setWireBusWidthPos(w, (AttributeOption) value);
+          }
+        }
+      }
       int i = findIndex(attr);
       final var vs = values;
       if (i >= 0 && i < vs.length) {
+        final var oldVal = vs[i];
         vs[i] = value;
         for (final var comp : selected) {
-          comp.getAttributeSet().setValue(attr, value);
+          if (!(comp instanceof Wire)
+              && comp.getAttributeSet().containsAttribute(attr)) {
+            comp.getAttributeSet().setValue(attr, value);
+          }
         }
+        @SuppressWarnings("unchecked")
+        final var attrObj = (Attribute<Object>) attr;
+        fireAttributeValueChanged(attrObj, value, oldVal);
       }
     }
   }

--- a/src/main/resources/resources/logisim/strings/circuit/circuit.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = Direction
 wireDirectionHorzOption = Horizontal
 wireDirectionVertOption = Vertical
 wireLengthAttr = Length
+wireBusWidthPosAttr = Show Bus Width
+wireBusWidthPosNoneOption = None
+wireBusWidthPosStartOption = Start
+wireBusWidthPosCenterOption = Center
+wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_de.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_de.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = Richtung
 wireDirectionHorzOption = Horizontal
 wireDirectionVertOption = Vertikal
 wireLengthAttr = Länge
+# ==> wireBusWidthPosAttr = Show Bus Width
+# ==> wireBusWidthPosNoneOption = None
+# ==> wireBusWidthPosStartOption = Start
+# ==> wireBusWidthPosCenterOption = Center
+# ==> wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_el.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_el.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = Κατεύθυνση
 wireDirectionHorzOption = Οριζόντια
 wireDirectionVertOption = Κάθετα
 wireLengthAttr = Μήκος
+# ==> wireBusWidthPosAttr = Show Bus Width
+# ==> wireBusWidthPosNoneOption = None
+# ==> wireBusWidthPosStartOption = Start
+# ==> wireBusWidthPosCenterOption = Center
+# ==> wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_es.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_es.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = Dirección
 wireDirectionHorzOption = Horizontal
 wireDirectionVertOption = Vertical
 wireLengthAttr = Longitud
+# ==> wireBusWidthPosAttr = Show Bus Width
+# ==> wireBusWidthPosNoneOption = None
+# ==> wireBusWidthPosStartOption = Start
+# ==> wireBusWidthPosCenterOption = Center
+# ==> wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_fr.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_fr.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = Direction
 wireDirectionHorzOption = Horizontal
 wireDirectionVertOption = Vertical
 wireLengthAttr = Longueur
+# ==> wireBusWidthPosAttr = Show Bus Width
+# ==> wireBusWidthPosNoneOption = None
+# ==> wireBusWidthPosStartOption = Start
+# ==> wireBusWidthPosCenterOption = Center
+# ==> wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_it.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_it.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = Direzione
 wireDirectionHorzOption = Orizzontale
 wireDirectionVertOption = Verticale
 wireLengthAttr = Lunghezza
+# ==> wireBusWidthPosAttr = Show Bus Width
+# ==> wireBusWidthPosNoneOption = None
+# ==> wireBusWidthPosStartOption = Start
+# ==> wireBusWidthPosCenterOption = Center
+# ==> wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_ja.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_ja.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = 方向
 wireDirectionHorzOption = 水平方向
 wireDirectionVertOption = 垂直方向
 wireLengthAttr = 長さ
+# ==> wireBusWidthPosAttr = Show Bus Width
+# ==> wireBusWidthPosNoneOption = None
+# ==> wireBusWidthPosStartOption = Start
+# ==> wireBusWidthPosCenterOption = Center
+# ==> wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_nl.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_nl.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = Richting
 wireDirectionHorzOption = Horizontaal
 wireDirectionVertOption = Verticaal
 wireLengthAttr = Lengte
+# ==> wireBusWidthPosAttr = Show Bus Width
+# ==> wireBusWidthPosNoneOption = None
+# ==> wireBusWidthPosStartOption = Start
+# ==> wireBusWidthPosCenterOption = Center
+# ==> wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_pl.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_pl.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = Kierunek
 wireDirectionHorzOption = Poziomo
 wireDirectionVertOption = Pionowo
 wireLengthAttr = Długość
+# ==> wireBusWidthPosAttr = Show Bus Width
+# ==> wireBusWidthPosNoneOption = None
+# ==> wireBusWidthPosStartOption = Start
+# ==> wireBusWidthPosCenterOption = Center
+# ==> wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_pt.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_pt.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = Direção
 wireDirectionHorzOption = Horizontal
 wireDirectionVertOption = Vertical
 wireLengthAttr = Comprimento
+# ==> wireBusWidthPosAttr = Show Bus Width
+# ==> wireBusWidthPosNoneOption = None
+# ==> wireBusWidthPosStartOption = Start
+# ==> wireBusWidthPosCenterOption = Center
+# ==> wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_ru.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_ru.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = Направление
 wireDirectionHorzOption = Горизонтальное
 wireDirectionVertOption = Вертикальное
 wireLengthAttr = Длина
+wireBusWidthPosAttr = Показывать разрядность шины
+wireBusWidthPosNoneOption = Нет
+wireBusWidthPosStartOption = В начале
+wireBusWidthPosCenterOption = В центре
+wireBusWidthPosEndOption = В конце
 #
 # WireFactory.java
 #

--- a/src/main/resources/resources/logisim/strings/circuit/circuit_zh.properties
+++ b/src/main/resources/resources/logisim/strings/circuit/circuit_zh.properties
@@ -113,6 +113,11 @@ wireDirectionAttr = 方向
 wireDirectionHorzOption = 水平
 wireDirectionVertOption = 垂直
 wireLengthAttr = 长度
+# ==> wireBusWidthPosAttr = Show Bus Width
+# ==> wireBusWidthPosNoneOption = None
+# ==> wireBusWidthPosStartOption = Start
+# ==> wireBusWidthPosCenterOption = Center
+# ==> wireBusWidthPosEndOption = End
 #
 # WireFactory.java
 #


### PR DESCRIPTION
### Description

This PR implements the feature request from Issue #2303. 

It adds a new optional attribute **Show Bus Width** to wires. When enabled, a small diagonal tick mark and the corresponding bit-width digit are rendered on the canvas at the selected position of the wire (**Start**, **Center**, or **End**). To keep the canvas clean, this attribute is automatically hidden for standard 1-bit wires.

Resolves #2303
<img width="908" height="441" alt="wire" src="https://github.com/user-attachments/assets/068a4fd3-e918-4f29-8269-8e901bdc2016" />