### PR TITLE
gui/UX: hide selection bounding boxes and handles when Poke Tool is active

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/main/CanvasPainter.java
+++ b/src/main/java/com/cburch/logisim/gui/main/CanvasPainter.java
@@ -17,6 +17,7 @@ import com.cburch.logisim.data.Value;
 import com.cburch.logisim.gui.generic.GridPainter;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.tools.PokeTool;
 import com.cburch.logisim.util.CollectionUtil;
 import com.cburch.logisim.util.GraphicsUtil;
 import java.awt.Color;
@@ -139,7 +140,9 @@ class CanvasPainter implements PropertyChangeListener {
     final var context = new ComponentDrawContext(canvas, circ, circState, base, g, false);
     context.setHighlightedWires(highlightedWires);
     circ.draw(context, hidden);
-    sel.draw(context, hidden);
+    if (!(proj.getTool() instanceof PokeTool)) {
+      sel.draw(context, hidden);
+    }
 
     // draw tool
     final var tool = dragTool != null ? dragTool : proj.getTool();


### PR DESCRIPTION
### Description

This is a tiny UX improvement PR (just a few lines of code) that temporarily hides selection graphics on the canvas whenever the **Poke Tool** is active.

### Summary of Changes

When components or wires are selected and the user switches to the Poke Tool to interact with the circuit:
- **Reduced Visual Noise:** Selection graphics hidden so they no longer obscure component states, UI elements, or pins.
- **Improved Simulation Focus:** Keeps the focus entirely on signal colors and interactive elements during debugging.
- **Seamless Workflow:** Users no longer need to manually deselect items (via ESC or clicking away) before poking. The previous selection is perfectly preserved and automatically reappears when switching back to the Edit/Selection tool.

### Verification
- Verified that active selection graphics disappear when switching to the Poke Tool.
- Verified that the selection is restored and visible when switching back to the Edit Tool.
NO_CHANGELOG_ENTRY