### PR TITLE
fix(fpga): preserve mappings when reopening mapper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,8 @@
     Verilog permits case-distinct names, and selecting no HDL permits non-HDL identifiers.
   * Fixed several HDL and FPGA generation issues, including wide Random generator HDL, PortIO bubble
     ranges, scanning I/O constraints, and Xilinx download placeholder handling.
+  * Fixed FPGA component mappings losing their board highlights when the mapping dialog is reopened
+    [#2933] (@hewzhew).
   * Fixed output-only Port I/O components being reported as multiple drivers during FPGA netlist
     generation, and corrected the symmetric input-only endpoint direction [#2537] (@henriquejsza).
   * Improved project editing stability:

--- a/src/main/java/com/cburch/logisim/fpga/data/MapComponent.java
+++ b/src/main/java/com/cburch/logisim/fpga/data/MapComponent.java
@@ -21,6 +21,7 @@ import com.cburch.logisim.std.io.RgbLed;
 import com.cburch.logisim.std.io.SevenSegment;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import org.w3c.dom.DOMException;
@@ -267,18 +268,42 @@ public class MapComponent {
     }
   }
 
-  public void copyMapFrom(MapComponent comp) {
+  public void copyMapFrom(
+      MapComponent comp, List<FpgaIoInformationContainer> ioComponents) {
     if (comp.nrOfPins != nrOfPins || !comp.myFactory.equals(myFactory)) {
       comp.unmap();
       return;
     }
-    maps = comp.maps;
-    opens = comp.opens;
-    constants = comp.constants;
+    maps = new ArrayList<>();
+    opens = new ArrayList<>(comp.opens);
+    constants = new ArrayList<>(comp.constants);
+    for (var i = 0; i < nrOfPins; i++) maps.add(null);
+
+    final var reboundMaps = new IdentityHashMap<MapClass, MapClass>();
     for (var i = 0; i < nrOfPins; i++) {
-      final var map = maps.get(i);
-      if (map != null) if (!map.update(this)) unmap(i);
+      final var oldMap = comp.maps.get(i);
+      if (oldMap == null) continue;
+
+      var newMap = reboundMaps.get(oldMap);
+      if (newMap == null) {
+        final var newIoComponent = findIoComponent(oldMap.getIoComp(), ioComponents);
+        if (newIoComponent == null
+            || !newIoComponent.tryMap(this, i, oldMap.getIoPin())) continue;
+        newMap = new MapClass(newIoComponent, oldMap.getIoPin());
+        reboundMaps.put(oldMap, newMap);
+      }
+      maps.set(i, newMap);
     }
+  }
+
+  private static FpgaIoInformationContainer findIoComponent(
+      FpgaIoInformationContainer oldComponent,
+      List<FpgaIoInformationContainer> ioComponents) {
+    for (final var component : ioComponents) {
+      if (component.getType().equals(oldComponent.getType())
+          && component.getRectangle().equals(oldComponent.getRectangle())) return component;
+    }
+    return null;
   }
 
   public void tryMap(CircuitMapInfo cmap, List<FpgaIoInformationContainer> IOcomps) {

--- a/src/main/java/com/cburch/logisim/fpga/data/MappableResourcesContainer.java
+++ b/src/main/java/com/cburch/logisim/fpga/data/MappableResourcesContainer.java
@@ -109,7 +109,7 @@ public class MappableResourcesContainer {
           myMappableResources.put(key, new MapComponent(key, newMappableResources.get(key)));
         } else {
           var newMap = new MapComponent(key, newMappableResources.get(key));
-          newMap.copyMapFrom(comp);
+          newMap.copyMapFrom(comp, myIOComponents);
           myMappableResources.put(key, newMap);
         }
         cur.remove(key);

--- a/src/test/java/com/cburch/logisim/fpga/data/MappableResourcesContainerTest.java
+++ b/src/test/java/com/cburch/logisim/fpga/data/MappableResourcesContainerTest.java
@@ -1,0 +1,130 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.fpga.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cburch.logisim.circuit.Circuit;
+import com.cburch.logisim.comp.Component;
+import com.cburch.logisim.comp.ComponentFactory;
+import com.cburch.logisim.data.AttributeSet;
+import com.cburch.logisim.fpga.designrulecheck.Netlist;
+import com.cburch.logisim.fpga.designrulecheck.netlistComponent;
+import com.cburch.logisim.fpga.file.BoardWriterClass;
+import com.cburch.logisim.util.XmlUtil;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MappableResourcesContainerTest {
+
+  @Test
+  void boardMappingsAreReboundWhenIoComponentsAreRefreshed() throws Exception {
+    final var board = new BoardInformation();
+    board.setBoardName("test-board");
+    board.addComponent(createOutputComponent(2));
+
+    final var key = new ArrayList<>(List.of("test-board", "output"));
+    final var container = createContainer(board, key, 2);
+    final var oldIo = container.getIoComponentInformation().getComponents().getFirst();
+    final var oldMap = container.getMappableResources().get(key);
+    assertTrue(oldMap.tryMap(1, oldIo, 1));
+
+    container.destroyIOComponentInformation();
+    container.updateIoComponents(board);
+    container.updateMappableComponents();
+
+    final var newIo = container.getIoComponentInformation().getComponents().getFirst();
+    final var newMap = container.getMappableResources().get(key);
+
+    assertNotSame(oldIo, newIo);
+    assertSame(newIo, newMap.getFpgaInfo(1));
+    assertEquals("PIN_1", newMap.getPinLocation(1));
+    assertTrue(newIo.isPinMapped(1));
+    assertSame(newMap, newIo.getPinMap(1));
+    assertEquals(1, newIo.getMapPin(1));
+  }
+
+  @Test
+  void completeMappingsKeepTheirSharedBoardPinWhenIoComponentsAreRefreshed()
+      throws Exception {
+    final var board = new BoardInformation();
+    board.setBoardName("test-board");
+    board.addComponent(createOutputComponent(4));
+
+    final var key = new ArrayList<>(List.of("test-board", "rgb-output"));
+    final var container = createContainer(board, key, 3);
+    final var oldIo = container.getIoComponentInformation().getComponents().getFirst();
+    final var oldMap = container.getMappableResources().get(key);
+    assertTrue(oldMap.tryCompleteMap(oldIo, 2));
+
+    container.destroyIOComponentInformation();
+    container.updateIoComponents(board);
+    container.updateMappableComponents();
+
+    final var newIo = container.getIoComponentInformation().getComponents().getFirst();
+    final var newMap = container.getMappableResources().get(key);
+
+    for (var pin = 0; pin < 3; pin++) {
+      assertSame(newIo, newMap.getFpgaInfo(pin));
+      assertEquals("PIN_2", newMap.getPinLocation(pin));
+    }
+    assertTrue(newMap.isCompleteMap(false));
+    assertTrue(newIo.isPinMapped(2));
+    assertSame(newMap, newIo.getPinMap(2));
+    assertEquals(0, newIo.getMapPin(2));
+  }
+
+  private static MappableResourcesContainer createContainer(
+      BoardInformation board, ArrayList<String> key, int outputCount) {
+    final var resources = new HashMap<ArrayList<String>, netlistComponent>();
+    resources.put(key, createNetlistComponent(outputCount));
+
+    final var circuit = mock(Circuit.class);
+    final var netlist = mock(Netlist.class);
+    when(circuit.getNetList()).thenReturn(netlist);
+    when(netlist.getMappableResources(anyList(), eq(true))).thenReturn(resources);
+    return new MappableResourcesContainer(board, circuit);
+  }
+
+  private static FpgaIoInformationContainer createOutputComponent(int pinCount) throws Exception {
+    final var document =
+        XmlUtil.getHardenedBuilderFactory().newDocumentBuilder().newDocument();
+    final var element = document.createElement(IoComponentTypes.SevenSegment.toString());
+    element.setAttribute(BoardWriterClass.RECT_SET_STRING, "10,20,30,40");
+    final var locations = new ArrayList<String>();
+    for (var pin = 0; pin < pinCount; pin++) {
+      locations.add("PIN_" + pin);
+    }
+    element.setAttribute(BoardWriterClass.OUTPUT_SET_STRING, String.join(",", locations));
+    element.setAttribute(BoardWriterClass.LABEL_STRING, "output");
+    return new FpgaIoInformationContainer(element);
+  }
+
+  private static netlistComponent createNetlistComponent(int outputCount) {
+    final var component = mock(Component.class);
+    when(component.getFactory()).thenReturn(mock(ComponentFactory.class));
+    when(component.getAttributeSet()).thenReturn(mock(AttributeSet.class));
+
+    final var netlistComponent = mock(netlistComponent.class);
+    when(netlistComponent.getComponent()).thenReturn(component);
+    when(netlistComponent.getMapInformationContainer())
+        .thenReturn(new ComponentMapInformationContainer(0, outputCount, 0));
+    return netlistComponent;
+  }
+}


### PR DESCRIPTION
## Summary

- rebind preserved component mappings to the refreshed board I/O clones
- retain shared-pin mappings used by complete maps
- add regression coverage for partial and shared-pin mappings across a board refresh

## Root cause

`updateIoComponents()` replaces the board I/O clones each time the mapper is opened, while `copyMapFrom()` previously kept references to the old clones. The new mapping dialog therefore had no reverse mapping state to paint or select.

## Testing

- `./gradlew test --tests com.cburch.logisim.fpga.data.MappableResourcesContainerTest`
- `./gradlew check`
- manually opened the reporter's `FPGA_write.circ`, executed mapping, cancelled and closed the download window, then repeated the flow; `/b_rst#0` and `/show#0` retained their board selection/highlight linkage on the second run

Fixes #2933