### PR TITLE
docs: update command-line option reference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,6 +99,7 @@
     * Invalid command-line option values now return a nonzero exit status.
     * Intel/Altera FPGA downloads can select an exact Quartus cable with `--fpga-cable`.
     * TTY table output includes bit widths in headers.
+    * Updated the command-line option reference to match the current interface [#1546] (@hewzhew).
     * Localized the Assembly Viewer.
   * Added and updated documentation for Telnet, FPGA Commander reports, the board editor, JAR
     libraries, wire values, transistor behavior, and unused-library save options.

--- a/src/main/resources/doc/en/html/guide/prefs/pref-cmdline.html
+++ b/src/main/resources/doc/en/html/guide/prefs/pref-cmdline.html
@@ -3,241 +3,172 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="created" content="2019-03-16T06:18:10.521000000">
-    <meta name="changed" content="2021-05-22T11:23:21.115000000">
+    <meta name="changed" content="2026-08-31T00:00:00.000000000">
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta http-equiv="Content-Language" content="en">
-    <title>
-      Command-line options
-    </title>
+    <title>Command-line options</title>
     <link rel="stylesheet" type="text/css" href="../../style.css">
   </head>
   <body>
     <div class="maindiv">
-      <h1>
-        Command-line options
-      </h1>
+      <h1>Command-line options</h1>
       <p>
-        You can configure many of Logisim's application preferences via command line options. This can be particularly useful in a laboratory of single-student computers where you want Logisim to start up the same for students every time, regardless of how previous students may have configured the program.
-      </p>
-      <p>
-        The overall command-line syntax is as follows.
+        Command-line options can select startup preferences, run a project without the graphical
+        interface, or invoke verification and FPGA workflows. The general syntax is:
       </p>
       <blockquote>
-        <pre>java -jar <i><b>jarFileName</b></i> <i>[options]</i> <i>[filenames]</i>
-</pre>
+        <pre>java -jar <i><b>jarFileName</b></i> <i>[options]</i> <i>[project-files]</i></pre>
       </blockquote>
       <p>
-        The optional additional files named on the command line will be opened as separate windows within Logisim.
-      </p>
-      <p>
-        The following example starts Logisim in its basic configuration.
+        Project files that are not consumed as option arguments are opened by Logisim-evolution.
+        Long option names are shown below; where available, the equivalent short name is shown
+        first. For example:
       </p>
       <blockquote>
-        <pre>java -jar <i><b>jarFileName</b> <b> -plain -gates shaped -locale en</b></i>
-</pre>
+        <pre>java -jar <i><b>jarFileName</b></i> --user-template plain --gates ansi --locale en</pre>
       </blockquote>
-      <p>
-        Supported options include the following.
-      </p>
+
+      <h2>General options</h2>
       <dl>
-        <dt>
-          <tt>-plain</tt>
-        </dt>
-        <dt>
-          <tt>-empty</tt>
-        </dt>
-        <dt>
-          <tt>-template <b><i>templateFile</i></b></tt>
-        </dt>
+        <dt><tt>-h, --help</tt></dt>
+        <dd><p>Displays the current command-line option summary and exits.</p></dd>
+
+        <dt><tt>-v, --version</tt></dt>
+        <dd><p>Displays version and build information and exits.</p></dd>
+
+        <dt><tt>--clear-prefs</tt></dt>
+        <dd><p>Clears saved application preferences at startup.</p></dd>
+
+        <dt><tt>-g, --gates <i>[ansi|iec]</i></tt></dt>
+        <dd><p>Selects ANSI-shaped or IEC-rectangular gate symbols.</p></dd>
+
+        <dt><tt>-m, --geometry <i>WIDTHxHEIGHT[+X+Y]</i></tt></dt>
         <dd>
           <p>
-            Configures the template for Logisim to use.
+            Sets the main-window dimensions and, when supplied, the position of its upper-left
+            corner. For example: <tt>--geometry 600x400+100+100</tt>.
           </p>
         </dd>
-        <dt>
-          <tt>-gates <i>[<b>shaped</b>|<b>rectangular</b>]</i></tt>
-        </dt>
+
+        <dt><tt>-o, --locale <i>LANGUAGE</i></tt></dt>
         <dd>
-          <p>
-            Configures which type of gate to use.
-          </p>
-        </dd>
-        <dt>
-          <tt>-locale <i><b>localeIdentifier</b></i></tt>
-        </dt>
-        <dd>
-          <p>
-            Configures which translation to use. As of this writing, the supported locales include:
-          </p>
+          <p>Selects one of the supported locale identifiers:</p>
           <table>
             <tbody>
-              <tr>
-                <td>
-                  <tt>de</tt> German
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <tt>el</tt> Greek
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <tt>en</tt> English
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <tt>es</tt> Spanish
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <tt>fr</tt> French
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <tt>pt</tt> Portugais
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <tt>ru</tt> Russian
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <tt>it</tt> Italian
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <tt>nl</tt> Dutch
-                </td>
-              </tr>
-			  <tr>
-                <td>
-                  <tt>jp</tt> Japanese
-                </td>
-              </tr>
+              <tr><td><tt>de</tt> German</td></tr>
+              <tr><td><tt>el</tt> Greek</td></tr>
+              <tr><td><tt>en</tt> English</td></tr>
+              <tr><td><tt>es</tt> Spanish</td></tr>
+              <tr><td><tt>fr</tt> French</td></tr>
+              <tr><td><tt>pt</tt> Portuguese</td></tr>
+              <tr><td><tt>ru</tt> Russian</td></tr>
+              <tr><td><tt>it</tt> Italian</td></tr>
+              <tr><td><tt>nl</tt> Dutch</td></tr>
+              <tr><td><tt>ja</tt> Japanese</td></tr>
+              <tr><td><tt>pl</tt> Polish</td></tr>
+              <tr><td><tt>zh</tt> Simplified Chinese</td></tr>
             </tbody>
           </table>
         </dd>
-        <dt>
-          <tt>-accents <i>[<b>yes</b>|<b>no</b>]</i></tt>
-        </dt>
+
+        <dt><tt>-u, --user-template <i>[empty|plain|FILE]</i></tt></dt>
         <dd>
           <p>
-            This is only relevant for languages that use characters outside the 7-bit ASCII character set; this would include languages using accented characters, and it would not include English. If <i>no</i>, characters outside the 7-bit ASCII character set are replaced with equivalents appropriate to the language; this would be useful for Java/OS combinations where such characters are not supported well.
+            Selects the empty template, the default plain template, or a readable custom template
+            file.
           </p>
         </dd>
-        <dt>
-          <tt>-clearprops</tt>
-        </dt>
+
+        <dt><tt>--no-splash</tt></dt>
+        <dd><p>Hides the splash screen at startup.</p></dd>
+
+        <dt><tt>-s, --substitute <i>LIBRARY1 LIBRARY2</i></tt></dt>
         <dd>
           <p>
-            Clear all application preferences at startup, so Logisim will act as if it were being executed on the host system for the first time.
-          </p>
-        </dd>
-        <dt>
-          <tt>-nosplash</tt>
-        </dt>
-        <dd>
-          <p>
-            Hides the initial Logisim splash screen.
-          </p>
-        </dd>
-        <dt>
-          <tt>-help</tt>
-        </dt>
-        <dd>
-          <p>
-            Displays a summary of the command line options.
-          </p>
-        </dd>
-        <dt>
-          <tt>-version</tt>
-        </dt>
-        <dd>
-          <p>
-            Displays the Logisim version number.
-          </p>
-        </dd>
-        <dt>
-          <tt>-analyze</tt>
-        </dt>
-        <dd>
-          <p>
-            Displays the combinatorial analysis menus.
-          </p>
-        </dd>
-        <dt>
-          <tt>-load <i><b>filename</b></i></tt>
-        </dt>
-        <dd>
-          <p>
-            Load an image in RAM (works only with -tty)
-          </p>
-        </dd>
-        <dt>
-          <tt>-sub <i><b>file1</b> <b>file2</b></i></tt>
-        </dt>
-        <dd>
-          <p>
-            load the file by replacing the library file (file1) with the library file (file2). More information in <a href="../verify/sub.html">Substituting libraries</a>
-          </p>
-        </dd>
-        <dt>
-          <tt>-tty</tt> [<b>table</b>|<b>speed</b>|<b>tty</b>|<b>halt</b>|<b>stats</b>]
-        </dt>
-        <dd>
-          <p>
-            Run without GUI. More information in <a href="../verify/other.html">Other verification</a>
-          </p>
-        </dd>
-        <dt>
-          <tt>-testvector <i><b>circuitname</b> <b>vectorfile</b> <b>projectfile</b></i></tt>
-        </dt>
-        <dd>
-          <p>
-            Run the <b>circuitname</b> tests in <b>projectfile</b> based on vectors in <b>vectorfile</b>. More information in <a href="../verify/test.html">Window Text Vector</a>
-          </p>
-        </dd>
-        <dt>
-          <tt>-geom <i><b>WxH</b>|<b>WxH+X+Y</b></i></tt>
-        </dt>
-        <dd>
-          <p>
-            Opens Logisim with a window dimensioned according to the parameters W (width) and H (height) or with the upper left corner positioned according to the parameters X,Y.<br>
-            Example: -geom 600x400+100+100
+            Replaces references to <i>LIBRARY1</i> with <i>LIBRARY2</i> while loading projects. See
+            <a href="../verify/sub.html">Substituting libraries</a>.
           </p>
         </dd>
       </dl>
-      <h2>
-        Undocumented Options
-      </h2>
+
+      <h2>TTY simulation options</h2>
+      <dl>
+        <dt><tt>-t, --tty <i>FORMAT[,FORMAT...]</i></tt></dt>
+        <dd>
+          <p>
+            Runs without the graphical interface. Accepted comma-separated formats are
+            <tt>table</tt>, <tt>speed</tt>, <tt>tty</tt>, <tt>halt</tt>, <tt>stats</tt>,
+            <tt>binary</tt>, <tt>hex</tt>, <tt>csv</tt>, and <tt>tabs</tt>. See
+            <a href="../verify/other.html">Other verification options</a>.
+          </p>
+        </dd>
+
+        <dt><tt>-l, --load <i>FILE [LABEL]</i></tt></dt>
+        <dd>
+          <p>
+            Loads a memory image before a TTY simulation. With a label, it applies to matching RAM
+            and ROM components; without one, it supplies the fallback image. The option may be
+            repeated for different labels and works only with <tt>--tty</tt>.
+          </p>
+        </dd>
+
+        <dt><tt>--save <i>FILE</i></tt></dt>
+        <dd>
+          <p>
+            Saves RAM contents to an image file after a TTY run. This option works only with
+            <tt>--tty</tt>.
+          </p>
+        </dd>
+
+        <dt><tt>--toplevel-circuit <i>NAME</i></tt></dt>
+        <dd><p>Selects the circuit to use as the top-level circuit.</p></dd>
+      </dl>
+
+      <h2>Verification and conversion options</h2>
+      <dl>
+        <dt><tt>-w, --test-vector <i>CIRCUIT VECTOR_FILE PROJECT_FILE</i></tt></dt>
+        <dd>
+          <p>
+            Runs <i>VECTOR_FILE</i> against <i>CIRCUIT</i> in <i>PROJECT_FILE</i>, then exits. See
+            <a href="../verify/test.html">Test vectors</a>.
+          </p>
+        </dd>
+
+        <dt><tt>-b, --test-circuit <i>CIRC_FILE</i></tt></dt>
+        <dd><p>Opens a project, runs its test bench, reports success or failure, and exits.</p></dd>
+
+        <dt><tt>-n, --new-file-format <i>INPUT OUTPUT</i></tt></dt>
+        <dd>
+          <p>
+            Opens <i>INPUT</i> as a Logisim project and writes it to <i>OUTPUT</i> using the current
+            Logisim-evolution file format.
+          </p>
+        </dd>
+      </dl>
+
+      <h2>FPGA options</h2>
       <dl>
         <dt>
-          <tt>-test-circuit <b>testCircuitPathInput</b></tt>
+          <tt>-f, --test-fpga <i>CIRC_FILE CIRCUIT BOARD [TICK_FREQUENCY] [HDLONLY]</i></tt>
         </dt>
-        <dd></dd>
-        <dt>
-          <tt>-test-fpga-implementation <b>inputpath</b> <b>Circuitimapfile</b> <b>cicuitimpname</b> <b>cicuitimpboard</b></tt>
-        </dt>
-        <dd></dd>
-        <dt>
-          <tt>-test-circ-gen <b>testCircPathInput</b> <b>testCircPathOutput</b></tt>
-        </dt>
-        <dd></dd>
-        <dt>
-          <tt>-questa<i>[<b>yes</b>|<b>no</b>]</i></tt>
-        </dt>
-        <dd></dd>
+        <dd>
+          <p>
+            Runs the FPGA implementation flow for <i>CIRCUIT</i> on <i>BOARD</i>. The optional tick
+            frequency is in hertz. <tt>HDLONLY</tt> stops after HDL generation; the two optional
+            values may be supplied in either order.
+          </p>
+        </dd>
+
+        <dt><tt>--fpga-cable <i>NAME</i></tt></dt>
+        <dd>
+          <p>
+            Selects an Intel/Altera Quartus cable by its exact reported name. This option requires
+            <tt>--test-fpga</tt> and is only valid for Intel/Altera targets.
+          </p>
+        </dd>
       </dl>
-      <p>
-        <b>Next:</b> <a href="../index.html">User's Guide</a>.
-      </p>
+
+      <p><b>Next:</b> <a href="../index.html">User's Guide</a>.</p>
     </div>
   </body>
 </html>

--- a/src/main/resources/doc/map_de.jhm
+++ b/src/main/resources/doc/map_de.jhm
@@ -76,7 +76,7 @@
 	<mapID target="prefs_layout"        url="de/html/guide/prefs/pref-layout.html" />
 	<mapID target="prefs_exp"           url="de/html/guide/prefs/pref-exp.html" />
 	<mapID target="prefs_fpga"          url="en/html/guide/prefs/pref-fpgacommander.html" />
-	<mapID target="prefs_cmdline"       url="de/html/guide/prefs/pref-cmdline.html" />
+	<mapID target="prefs_cmdline"       url="en/html/guide/prefs/pref-cmdline.html" />
 	<mapID target="opts"                url="de/html/guide/opts/index.html" />
 	<mapID target="opts_simulate"       url="de/html/guide/opts/opts-simulate.html" />
 	<mapID target="opts_toolbar"        url="de/html/guide/opts/opts-toolbar.html" />

--- a/src/main/resources/doc/map_fr.jhm
+++ b/src/main/resources/doc/map_fr.jhm
@@ -75,7 +75,7 @@
 	<mapID target="prefs_layout"        url="fr/html/guide/prefs/pref-layout.html" />
 	<mapID target="prefs_exp"           url="fr/html/guide/prefs/pref-exp.html" />
 	<mapID target="prefs_fpga"          url="en/html/guide/prefs/pref-fpgacommander.html" />
-	<mapID target="prefs_cmdline"       url="fr/html/guide/prefs/pref-cmdline.html" />
+	<mapID target="prefs_cmdline"       url="en/html/guide/prefs/pref-cmdline.html" />
 	<mapID target="opts"                url="fr/html/guide/opts/index.html" />
 	<mapID target="opts_simulate"       url="fr/html/guide/opts/opts-simulate.html" />
 	<mapID target="opts_toolbar"        url="fr/html/guide/opts/opts-toolbar.html" />

--- a/src/main/resources/doc/map_pt.jhm
+++ b/src/main/resources/doc/map_pt.jhm
@@ -75,7 +75,7 @@
 	<mapID target="prefs_layout"        url="pt/html/guide/prefs/pref-layout.html" />
 	<mapID target="prefs_exp"           url="pt/html/guide/prefs/pref-exp.html" />
 	<mapID target="prefs_fpga"          url="en/html/guide/prefs/pref-fpgacommander.html" />
-	<mapID target="prefs_cmdline"       url="pt/html/guide/prefs/pref-cmdline.html" />
+	<mapID target="prefs_cmdline"       url="en/html/guide/prefs/pref-cmdline.html" />
 	<mapID target="opts"                url="pt/html/guide/opts/index.html" />
 	<mapID target="opts_simulate"       url="pt/html/guide/opts/opts-simulate.html" />
 	<mapID target="opts_toolbar"        url="pt/html/guide/opts/opts-toolbar.html" />

--- a/src/main/resources/doc/map_ru.jhm
+++ b/src/main/resources/doc/map_ru.jhm
@@ -78,7 +78,7 @@
 	<mapID target="prefs_simulation"    url="ru/html/guide/prefs/pref-simulation.html" />
 	<mapID target="prefs_exp"           url="ru/html/guide/prefs/pref-exp.html" />
 	<mapID target="prefs_fpga"          url="ru/html/guide/prefs/pref-fpgacommander.html" />
-	<mapID target="prefs_cmdline"       url="ru/html/guide/prefs/pref-cmdline.html" />
+	<mapID target="prefs_cmdline"       url="en/html/guide/prefs/pref-cmdline.html" />
 	<mapID target="opts"                url="ru/html/guide/opts/index.html" />
 	<mapID target="opts_simulate"       url="ru/html/guide/opts/opts-simulate.html" />
 	<mapID target="opts_toolbar"        url="ru/html/guide/opts/opts-toolbar.html" />

--- a/src/main/resources/doc/zh/html/guide/prefs/pref-cmdline.html
+++ b/src/main/resources/doc/zh/html/guide/prefs/pref-cmdline.html
@@ -1,492 +1,162 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="zh">
- <head>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <meta content="2019-03-16T06:18:10.521000000" name="created"/>
-  <meta content="2023-12-12T09:31:20" name="changed" translator="gocpicnic"/>
-  <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
-  <meta content="zh" http-equiv="Content-Language"/>
-  <title>
-   <!-- Command-line options -->
-   命令行选项
-  </title>
-  <link href="../../style.css" rel="stylesheet" type="text/css"/>
- </head>
- <body>
-  <div class="maindiv">
-   <h1>
-    <!-- Command-line options -->
-    命令行选项
-   </h1>
-   <p>
-    <!-- You can configure many of Logisim's application preferences via command line options. This can be particularly useful in a laboratory of single-student computers where you want Logisim to start up the same for students every time, regardless of how previous students may have configured the program. -->
-    您可以通过命令行选项配置 Logisim-evolution 的许多应用程序首选项。 这在单学生计算机实验室中特别有用，您希望 Logisim 每次都为学生启动相同的计算机，无论以前的学生如何配置程序。
-   </p>
-   <p>
-    <!-- The overall command-line syntax is as follows. -->
-    整体命令行语法如下。
-   </p>
-   <blockquote>
-    <pre>java -jar <i><b>jarFileName</b></i> <i>[options]</i> <i>[filenames]</i>
-</pre>
-   </blockquote>
-   <p>
-    <!-- The optional additional files named on the command line will be opened as separate windows within Logisim. -->
-    命令行上命名的可选附加文件将在 Logisim-evolution 中作为单独的窗口打开。
-   </p>
-   <p>
-    <!-- The following example starts Logisim in its basic configuration. -->
-    以下示例以基本配置启动 Logisim-evolution。
-   </p>
-   <blockquote>
-    <pre>java -jar <i><b>jarFileName</b> <b> -plain -gates shaped -locale en</b></i>
-</pre>
-   </blockquote>
-   <p>
-    <!-- Supported options include the following. -->
-    支持的选项包括以下内容。
-   </p>
-   <dl>
-    <dt>
-     <tt>
-      -plain
-     </tt>
-    </dt>
-    <dt>
-     <tt>
-      -empty
-     </tt>
-    </dt>
-    <dt>
-     <!-- <tt>-template <b><i>templateFile</i></b></tt> -->
-     <tt>
-      -模板
-      <b>
-       <i>
-        templateFile
-       </i>
-      </b>
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Configures the template for Logisim to use. -->
-      配置 Logisim-evolution 使用的模板。
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -gates
-      <i>
-       [
-       <b>
-        shaped
-       </b>
-       |
-       <b>
-        rectangular
-       </b>
-       ]
-      </i>
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Configures which type of gate to use. -->
-      配置要使用的门类型。
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -locale
-      <i>
-       <b>
-        localeIdentifier
-       </b>
-      </i>
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Configures which translation to use. As of this writing, the supported locales include: -->
-      配置要使用的翻译。 截至撰写本文时，支持的区域设置包括：
-     </p>
-     <table>
-      <tbody>
-       <tr>
-        <td>
-         <tt>
-          de
-         </tt>
-         German
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <tt>
-          el
-         </tt>
-         Greek
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <tt>
-          en
-         </tt>
-         English
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <tt>
-          es
-         </tt>
-         Spanish
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <tt>
-          fr
-         </tt>
-         French
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <tt>
-          pt
-         </tt>
-         Portugais
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <tt>
-          ru
-         </tt>
-         Russian
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <tt>
-          it
-         </tt>
-         Italian
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <tt>
-          nl
-         </tt>
-         Dutch
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <tt>
-          jp
-         </tt>
-         Japanese
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dd>
-    <dt>
-     <tt>
-      -accents
-      <i>
-       [
-       <b>
-        yes
-       </b>
-       |
-       <b>
-        no
-       </b>
-       ]
-      </i>
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- This is only relevant for languages that use characters outside the 7-bit ASCII character set; this would include languages using accented characters, and it would not include English. If <i>no</i>, characters outside the 7-bit ASCII character set are replaced with equivalents appropriate to the language; this would be useful for Java/OS combinations where such characters are not supported well. -->
-      这仅与使用 7 位 ASCII 字符集之外的字符的语言相关； 这将包括使用重音字符的语言，但不包括英语。 如果
-      <i>
-       否
-      </i>
-      ，则 7 位 ASCII 字符集之外的字符将替换为适合该语言的等效字符； 这对于不能很好支持此类字符的 Java/OS 组合非常有用。
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -clearprops
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Clear all application preferences at startup, so Logisim will act as if it were being executed on the host system for the first time. -->
-      在启动时清除所有应用程序首选项，因此 Logisim-evolution 的行为就像第一次在主机系统上执行一样。
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -nosplash
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Hides the initial Logisim splash screen. -->
-      隐藏初始 Logisim-evolution 启动屏幕。
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -help
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Displays a summary of the command line options. -->
-      显示命令行选项的摘要。
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -version
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Displays the Logisim version number. -->
-      显示 Logisim-evolution 版本号。
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -analyze
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Displays the combinatorial analysis menus. -->
-      显示组合分析菜单。
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -load
-      <i>
-       <b>
-        filename
-       </b>
-      </i>
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Load an image in RAM (works only with -tty) -->
-      将图像加载到 RAM 中（仅适用于 -tty）
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -sub
-      <i>
-       <b>
-        file1
-       </b>
-       <b>
-        file2
-       </b>
-      </i>
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- load the file by replacing the library file (file1) with the library file (file2). More information in <a href="../verify/sub.html">Substituting libraries</a> -->
-      通过将库文件 (file1) 替换为库文件 (file2) 来加载文件。 更多信息请参见
-      <a href="../verify/sub.html">
-       替换库
-      </a>
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -tty
-     </tt>
-     [
-     <b>
-      table
-     </b>
-     |
-     <b>
-      speed
-     </b>
-     |
-     <b>
-      tty
-     </b>
-     |
-     <b>
-      halt
-     </b>
-     |
-     <b>
-      stats
-     </b>
-     ]
-    </dt>
-    <dd>
-     <p>
-      <!-- Run without GUI. More information in <a href="../verify/other.html">Other verification</a> -->
-      无需 GUI 即可运行。 更多信息请参阅
-      <a href="../verify/other.html">
-       其他验证
-      </a>
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -testvector
-      <i>
-       <b>
-        circuitname
-       </b>
-       <b>
-        vectorfile
-       </b>
-       <b>
-        projectfile
-       </b>
-      </i>
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Run the <b>circuitname</b> tests in <b>projectfile</b> based on vectors in <b>vectorfile</b>. More information in <a href="../verify/test.html">Window Text Vector</a> -->
-      根据
-      <b>
-       向量文件
-      </b>
-      中的向量运行
-      <b>
-       项目文件
-      </b>
-      中的
-      <b>
-       电路名称
-      </b>
-      测试。 更多信息请参见
-      <a href="../verify/test.html">
-       窗口文本向量
-      </a>
-     </p>
-    </dd>
-    <dt>
-     <tt>
-      -geom
-      <i>
-       <b>
-        WxH
-       </b>
-       |
-       <b>
-        WxH+X+Y
-       </b>
-      </i>
-     </tt>
-    </dt>
-    <dd>
-     <p>
-      <!-- Opens Logisim with a window dimensioned according to the parameters W (width) and H (height) or with the upper left corner positioned according to the parameters X,Y.<br> -->
-      打开 Logisim-evolution，其中窗口尺寸根据参数 W（宽度）和 H（高度）确定，或者左上角根据参数 X、Y 定位。
-      <br/>
-      Example: -geom 600x400+100+100
-     </p>
-    </dd>
-   </dl>
-   <h2>
-    <!-- Undocumented Options -->
-    未记录的选项
-   </h2>
-   <dl>
-    <dt>
-     <!-- <tt>-test-circuit <b>testCircuitPathInput</b></tt> -->
-     <tt>
-      -测试电路
-      <b>
-       testCircuitPathInput
-      </b>
-     </tt>
-    </dt>
-    <dd>
-    </dd>
-    <dt>
-     <tt>
-      -test-fpga-implementation
-      <b>
-       inputpath
-      </b>
-      <b>
-       Circuitimapfile
-      </b>
-      <b>
-       cicuitimpname
-      </b>
-      <b>
-       cicuitimpboard
-      </b>
-     </tt>
-    </dt>
-    <dd>
-    </dd>
-    <dt>
-     <tt>
-      -test-circ-gen
-      <b>
-       testCircPathInput
-      </b>
-      <b>
-       testCircPathOutput
-      </b>
-     </tt>
-    </dt>
-    <dd>
-    </dd>
-    <dt>
-     <tt>
-      -questa
-      <i>
-       [
-       <b>
-        yes
-       </b>
-       |
-       <b>
-        no
-       </b>
-       ]
-      </i>
-     </tt>
-    </dt>
-    <dd>
-    </dd>
-   </dl>
-   <p>
-    <!-- <b>Next:</b> <a href="../index.html">User's Guide</a>. -->
-    <b>
-     下一步：
-    </b>
-    <a href="../index.html">
-     用户指南
-    </a>
-    。
-   </p>
-  </div>
- </body>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="created" content="2019-03-16T06:18:10.521000000">
+    <meta name="changed" content="2026-08-31T00:00:00.000000000">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="zh">
+    <title>命令行选项</title>
+    <link rel="stylesheet" type="text/css" href="../../style.css">
+  </head>
+  <body>
+    <div class="maindiv">
+      <h1>命令行选项</h1>
+      <p>
+        命令行选项可用于设置启动首选项、在无图形界面的环境中运行工程，或执行验证与 FPGA
+        流程。基本语法如下：
+      </p>
+      <blockquote>
+        <pre>java -jar <i><b>jarFileName</b></i> <i>[选项]</i> <i>[工程文件]</i></pre>
+      </blockquote>
+      <p>
+        没有被选项作为参数使用的工程文件将由 Logisim-evolution 打开。下文以长选项名为主；如果
+        选项有对应的短名称，则一并列出。例如：
+      </p>
+      <blockquote>
+        <pre>java -jar <i><b>jarFileName</b></i> --user-template plain --gates ansi --locale zh</pre>
+      </blockquote>
+
+      <h2>常规选项</h2>
+      <dl>
+        <dt><tt>-h, --help</tt></dt>
+        <dd><p>显示当前命令行选项摘要，然后退出。</p></dd>
+
+        <dt><tt>-v, --version</tt></dt>
+        <dd><p>显示版本与构建信息，然后退出。</p></dd>
+
+        <dt><tt>--clear-prefs</tt></dt>
+        <dd><p>在启动时清除已保存的应用首选项。</p></dd>
+
+        <dt><tt>-g, --gates <i>[ansi|iec]</i></tt></dt>
+        <dd><p>选择 ANSI 形状或 IEC 矩形逻辑门符号。</p></dd>
+
+        <dt><tt>-m, --geometry <i>宽度x高度[+X+Y]</i></tt></dt>
+        <dd>
+          <p>
+            设置主窗口尺寸；如果提供 X、Y，还会设置窗口左上角的位置。例如：
+            <tt>--geometry 600x400+100+100</tt>。
+          </p>
+        </dd>
+
+        <dt><tt>-o, --locale <i>语言代码</i></tt></dt>
+        <dd>
+          <p>选择以下受支持的 locale 代码之一：</p>
+          <table>
+            <tbody>
+              <tr><td><tt>de</tt> 德语</td></tr>
+              <tr><td><tt>el</tt> 希腊语</td></tr>
+              <tr><td><tt>en</tt> 英语</td></tr>
+              <tr><td><tt>es</tt> 西班牙语</td></tr>
+              <tr><td><tt>fr</tt> 法语</td></tr>
+              <tr><td><tt>pt</tt> 葡萄牙语</td></tr>
+              <tr><td><tt>ru</tt> 俄语</td></tr>
+              <tr><td><tt>it</tt> 意大利语</td></tr>
+              <tr><td><tt>nl</tt> 荷兰语</td></tr>
+              <tr><td><tt>ja</tt> 日语</td></tr>
+              <tr><td><tt>pl</tt> 波兰语</td></tr>
+              <tr><td><tt>zh</tt> 简体中文</td></tr>
+            </tbody>
+          </table>
+        </dd>
+
+        <dt><tt>-u, --user-template <i>[empty|plain|文件]</i></tt></dt>
+        <dd><p>选择空模板、默认普通模板，或一个可读取的自定义模板文件。</p></dd>
+
+        <dt><tt>--no-splash</tt></dt>
+        <dd><p>启动时隐藏启动画面。</p></dd>
+
+        <dt><tt>-s, --substitute <i>库文件1 库文件2</i></tt></dt>
+        <dd>
+          <p>
+            加载工程时，用<i>库文件2</i>替换对<i>库文件1</i>的引用。参见
+            <a href="../verify/sub.html">替换库</a>。
+          </p>
+        </dd>
+      </dl>
+
+      <h2>TTY 仿真选项</h2>
+      <dl>
+        <dt><tt>-t, --tty <i>格式[,格式...]</i></tt></dt>
+        <dd>
+          <p>
+            在无图形界面的环境中运行。格式可用逗号组合，支持 <tt>table</tt>、
+            <tt>speed</tt>、<tt>tty</tt>、<tt>halt</tt>、<tt>stats</tt>、<tt>binary</tt>、
+            <tt>hex</tt>、<tt>csv</tt> 和 <tt>tabs</tt>。参见
+            <a href="../verify/other.html">其他验证选项</a>。
+          </p>
+        </dd>
+
+        <dt><tt>-l, --load <i>文件 [标签]</i></tt></dt>
+        <dd>
+          <p>
+            在 TTY 仿真前加载内存映像。指定标签时，映像用于标签匹配的 RAM 和 ROM；不指定
+            标签时，它将作为其他内存的默认映像。可以针对不同标签重复使用此选项，且只能与
+            <tt>--tty</tt> 一起使用。
+          </p>
+        </dd>
+
+        <dt><tt>--save <i>文件</i></tt></dt>
+        <dd><p>TTY 运行结束后，将 RAM 内容保存到内存映像文件。此选项只能与 <tt>--tty</tt> 一起使用。</p></dd>
+
+        <dt><tt>--toplevel-circuit <i>名称</i></tt></dt>
+        <dd><p>选择要作为顶层电路使用的电路。</p></dd>
+      </dl>
+
+      <h2>验证与转换选项</h2>
+      <dl>
+        <dt><tt>-w, --test-vector <i>电路 向量文件 工程文件</i></tt></dt>
+        <dd>
+          <p>
+            使用<i>向量文件</i>测试<i>工程文件</i>中的指定<i>电路</i>，完成后退出。参见
+            <a href="../verify/test.html">测试向量</a>。
+          </p>
+        </dd>
+
+        <dt><tt>-b, --test-circuit <i>CIRC 文件</i></tt></dt>
+        <dd><p>打开工程并运行其中的测试台，报告成功或失败，然后退出。</p></dd>
+
+        <dt><tt>-n, --new-file-format <i>输入文件 输出文件</i></tt></dt>
+        <dd>
+          <p>
+            将<i>输入文件</i>作为 Logisim 工程打开，再使用当前 Logisim-evolution 文件格式写入
+            <i>输出文件</i>。
+          </p>
+        </dd>
+      </dl>
+
+      <h2>FPGA 选项</h2>
+      <dl>
+        <dt>
+          <tt>-f, --test-fpga <i>CIRC 文件 电路 板卡 [时钟频率] [HDLONLY]</i></tt>
+        </dt>
+        <dd>
+          <p>
+            为指定<i>电路</i>和<i>板卡</i>执行 FPGA 实现流程。可选时钟频率以 Hz 为单位；
+            <tt>HDLONLY</tt> 表示生成 HDL 后停止。两个可选值可按任意顺序提供。
+          </p>
+        </dd>
+
+        <dt><tt>--fpga-cable <i>名称</i></tt></dt>
+        <dd>
+          <p>
+            按工具报告的完整名称选择 Intel/Altera Quartus 线缆。此选项必须与
+            <tt>--test-fpga</tt> 一起使用，并且仅适用于 Intel/Altera 目标。
+          </p>
+        </dd>
+      </dl>
+
+      <p><b>下一步：</b><a href="../index.html">用户指南</a>。</p>
+    </div>
+  </body>
 </html>

--- a/src/test/java/com/cburch/logisim/docs/CommandLineDocumentationTest.java
+++ b/src/test/java/com/cburch/logisim/docs/CommandLineDocumentationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.docs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cburch.logisim.Main;
+import com.cburch.logisim.gui.start.Startup;
+import com.cburch.logisim.util.LocaleManager;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CommandLineDocumentationTest {
+
+  private static final Path DOC_ROOT = Path.of("build", "resources", "main", "doc");
+  private static final Path SETTINGS =
+      Path.of("build", "resources", "main", "resources", "logisim", "settings.properties");
+  private static final Pattern HELP_OPTION =
+      Pattern.compile("(?m)^\\s*(?:-[a-z],\\s*)?--([a-z][a-z0-9-]*)(?:\\s|$)");
+  private static final Pattern DOCUMENTED_OPTION =
+      Pattern.compile("--([a-z][a-z0-9-]*)");
+  private static final Pattern DOCUMENTED_LOCALE =
+      Pattern.compile("<tr>\\s*<td>\\s*<tt>([a-z]{2})</tt>", Pattern.CASE_INSENSITIVE);
+  private static final Pattern COMMAND_LINE_MAP =
+      Pattern.compile(
+          "<mapID\\s+target=[\"']prefs_cmdline[\"']\\s+url=[\"']([^\"']+)[\"']");
+
+  private boolean originalHeadless;
+  private Locale originalLocale;
+
+  @BeforeEach
+  void recordGlobalState() {
+    originalHeadless = Main.headless;
+    originalLocale = LocaleManager.getLocale();
+  }
+
+  @AfterEach
+  void restoreGlobalState() {
+    Main.headless = originalHeadless;
+    LocaleManager.setLocale(originalLocale);
+  }
+
+  @Test
+  void documentsEveryCurrentLongOptionInEnglishAndChinese() throws Exception {
+    final var currentOptions = currentLongOptions();
+
+    assertFalse(currentOptions.isEmpty(), "No options were parsed from --help output");
+    assertEquals(currentOptions, documentedOptions("en"));
+    assertEquals(currentOptions, documentedOptions("zh"));
+  }
+
+  @Test
+  void documentsEverySupportedLocaleInEnglishAndChinese() throws Exception {
+    final var settings = new Properties();
+    try (var input = Files.newInputStream(SETTINGS)) {
+      settings.load(input);
+    }
+    final var supported =
+        new TreeSet<>(Arrays.asList(settings.getProperty("locales", "").trim().split("\\s+")));
+
+    assertFalse(supported.isEmpty(), "No locales were found in settings.properties");
+    assertEquals(supported, documentedLocales("en"));
+    assertEquals(supported, documentedLocales("zh"));
+  }
+
+  @Test
+  void usesCurrentCommandLinePagesOrEnglishFallbacks() throws Exception {
+    final var expected =
+        Map.of(
+            "de", "en/html/guide/prefs/pref-cmdline.html",
+            "en", "en/html/guide/prefs/pref-cmdline.html",
+            "fr", "en/html/guide/prefs/pref-cmdline.html",
+            "pt", "en/html/guide/prefs/pref-cmdline.html",
+            "ru", "en/html/guide/prefs/pref-cmdline.html",
+            "zh", "zh/html/guide/prefs/pref-cmdline.html");
+
+    for (final var entry : expected.entrySet()) {
+      final var map =
+          Files.readString(DOC_ROOT.resolve("map_" + entry.getKey() + ".jhm"), StandardCharsets.UTF_8);
+      final var matcher = COMMAND_LINE_MAP.matcher(map);
+      assertTrue(matcher.find(), () -> "Missing prefs_cmdline in map_" + entry.getKey() + ".jhm");
+      assertEquals(entry.getValue(), matcher.group(1), entry.getKey());
+    }
+  }
+
+  private static Set<String> currentLongOptions() {
+    final var originalOut = System.out;
+    final var output = new ByteArrayOutputStream();
+    try {
+      System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
+      assertNotNull(
+          Startup.parseArgs(new String[] {"--tty", "table", "--locale", "en", "--help"}));
+    } finally {
+      System.setOut(originalOut);
+    }
+    return matches(HELP_OPTION, output.toString(StandardCharsets.UTF_8));
+  }
+
+  private static Set<String> documentedOptions(String language) throws Exception {
+    return matches(DOCUMENTED_OPTION, commandLinePage(language));
+  }
+
+  private static Set<String> documentedLocales(String language) throws Exception {
+    return matches(DOCUMENTED_LOCALE, commandLinePage(language));
+  }
+
+  private static String commandLinePage(String language) throws Exception {
+    return Files.readString(
+        DOC_ROOT.resolve(language + "/html/guide/prefs/pref-cmdline.html"),
+        StandardCharsets.UTF_8);
+  }
+
+  private static Set<String> matches(Pattern pattern, String text) {
+    final var result = new TreeSet<String>();
+    final var matcher = pattern.matcher(text);
+    while (matcher.find()) {
+      result.add(matcher.group(1));
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary

- update the English and Simplified Chinese command-line reference to match the current parser
- route outdated German, French, Portuguese, and Russian JavaHelp entries to the current English page
- add regression coverage for documented options, supported locales, and HelpSet mappings

This changes documentation only; command-line behavior is unchanged.

## Validation

- `.\gradlew.bat test --tests com.cburch.logisim.docs.CommandLineDocumentationTest --tests com.cburch.logisim.docs.DocumentationStructureTest --tests com.cburch.logisim.docs.DocumentationGeneratorTest --tests com.cburch.logisim.docs.PackagedHelpSetTest --tests com.cburch.logisim.gui.start.StartupTest checkstyleTest --rerun-tasks --no-daemon --max-workers=1`
- `.\gradlew.bat check --rerun-tasks --no-daemon --max-workers=1`
- `git diff --check`

Part of #1546