### PR TITLE
fix(draw): correct transposed comparisons in Line.matches()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,8 @@
   * Added a default text-tool color preference and synchronized string-option preference updates.
   * Component tree can now be filtered. Any part of the name matches, and multiple words match in any order.
   * Added a Github Action check ensuring PRs also provide updated changel(@MarcinOrlowski).
+  * Fixed `Line.matches()` comparing transposed coordinates, causing identical lines to be treated
+    as different and some different lines as identical [#2939] (@henriquejsza).
   * Many other bug fixes.
 
 * v4.1.0 (2026-02-15)

--- a/src/main/java/com/cburch/draw/shapes/Line.java
+++ b/src/main/java/com/cburch/draw/shapes/Line.java
@@ -133,8 +133,8 @@ public class Line extends AbstractCanvasObject {
   public boolean matches(CanvasObject other) {
     return (other instanceof Line that)
            ? this.x0 == that.x0
-              && this.y0 == that.x1
-              && this.x1 == that.y0
+              && this.y0 == that.y0
+              && this.x1 == that.x1
               && this.y1 == that.y1
               && this.strokeWidth == that.strokeWidth
               && this.strokeColor.equals(that.strokeColor)

--- a/src/test/java/com/cburch/draw/shapes/LineTest.java
+++ b/src/test/java/com/cburch/draw/shapes/LineTest.java
@@ -1,0 +1,32 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.draw.shapes;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class LineTest {
+
+  @Test
+  void matchesReturnsTrueForIdenticalLines() {
+    final var line = new Line(0, 1, 2, 3);
+    final var copy = new Line(0, 1, 2, 3);
+    assertTrue(line.matches(copy));
+  }
+
+  @Test
+  void matchesReturnsFalseForTransposedCoordinates() {
+    final var line = new Line(0, 1, 2, 3);
+    final var transposed = new Line(0, 2, 1, 3);
+    assertFalse(line.matches(transposed));
+  }
+}


### PR DESCRIPTION
## Summary

Correct `Line.matches()` to compare `y0` with `y0` and `x1` with `x1`. Add regression tests for identical lines and lines with transposed `y0`/`x1` coordinates, and document the fix in `CHANGES.md`.

## Root cause

`Line.matches()` crossed `y0` and `x1` between the two instances. This rejected identical lines and accepted certain lines with different coordinates. `matchesHashCode()` already uses the coordinates in positional order and does not need to change.

## Testing

- `./gradlew --no-daemon test --tests 'com.cburch.draw.shapes.LineTest' --rerun-tasks`
- `./gradlew --no-daemon checkstyleMain checkstyleTest --rerun-tasks`
- `./gradlew --no-daemon build -x checkstyleMain -x checkstyleTest --rerun-tasks`
- `npx --yes markdownlint-cli@0.49.0 --config .markdownlint.yaml CHANGES.md`
- `git diff --check`

Fixes #2939
