### PR TITLE
Set default gate shape to rectangular (IEC) for Russian locale

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Set default gate shape to rectangular (IEC) for Russian locale (@V-Zemlyakov).
   * Added a new signed/unsigned option to the multiplier component.(@Diogo-Valadares)
   * Added "Show Bus Width" wire attribute to label multi-bit buses with a tick mark at Start, Center, or End (@V-Zemlyakov).
   * Added Image component to insert custom bitmap images into circuits and subcircuit appearances.

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -529,10 +529,16 @@ public class AppPreferences {
   public static final String SHAPE_RECTANGULAR = "rectangular"; // IEC
   // public static final String SHAPE_DIN40700 = "din40700";
 
+  private static String getDefaultGateShape() {
+    return "ru".equalsIgnoreCase(Locale.getDefault().getLanguage())
+        ? SHAPE_RECTANGULAR
+        : SHAPE_SHAPED;
+  }
+
   public static final PrefMonitor<String> GATE_SHAPE =
       create(
           new PrefMonitorStringOpts(
-              "gateShape", new String[] {SHAPE_SHAPED, SHAPE_RECTANGULAR}, SHAPE_SHAPED));
+              "gateShape", new String[] {SHAPE_SHAPED, SHAPE_RECTANGULAR}, getDefaultGateShape()));
   public static final PrefMonitor<String> LOCALE = create(new LocalePreference());
 
   // FPGA Commander Preferences


### PR DESCRIPTION
### Description
In Russian-speaking regions, engineering standards and education require rectangular (IEC) logic gate symbols. This PR improves the initial experience by setting the default gate shape to `rectangular` for new users on a `ru` locale.

### Changes
- `AppPreferences.GATE_SHAPE` now defaults to `rectangular` if the system language is `ru` (otherwise it defaults to `shaped`).
- The user's manual selection in preferences is fully preserved and overrides this default.

### Verification
- Checked clean launch on `ru` (rectangular) and `en` (shaped) locales.
- Verified that manual preference changes are saved correctly.