### PR TITLE
Make TextTool in circuit editor snap to grid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Allow Text component to snap to grid (@julianvu).
   * Added a new signed/unsigned option to the multiplier component.(@Diogo-Valadares)
   * Added "Show Bus Width" wire attribute to label multi-bit buses with a tick mark at Start, Center, or End (@V-Zemlyakov).
   * Added Image component to insert custom bitmap images into circuits and subcircuit appearances.

--- a/src/main/java/com/cburch/draw/tools/TextTool.java
+++ b/src/main/java/com/cburch/draw/tools/TextTool.java
@@ -24,6 +24,7 @@ import com.cburch.logisim.gui.icons.TextIcon;
 import java.awt.Cursor;
 import java.awt.Graphics;
 import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.util.Collections;
@@ -130,7 +131,15 @@ public class TextTool extends AbstractTool {
       }
     }
     if (!found) {
-      clicked = attrs.applyTo(new Text(mx, my, ""));
+      var x = mx;
+      var y = my;
+
+      if ((e.getModifiersEx() & InputEvent.CTRL_DOWN_MASK) != 0) {
+        x = canvas.snapX(x);
+        y = canvas.snapY(y);
+      }
+
+      clicked = attrs.applyTo(new Text(x, y, ""));
     }
 
     curText = clicked;

--- a/src/main/java/com/cburch/logisim/std/base/Text.java
+++ b/src/main/java/com/cburch/logisim/std/base/Text.java
@@ -70,7 +70,6 @@ public class Text extends InstanceFactory {
 
   private Text() {
     super(_ID, S.getter("textComponent"));
-    setShouldSnap(false);
   }
 
   private void configureLabel(Instance instance) {

--- a/src/main/java/com/cburch/logisim/tools/TextTool.java
+++ b/src/main/java/com/cburch/logisim/tools/TextTool.java
@@ -324,7 +324,8 @@ public class TextTool extends Tool implements PropertyChangeListener {
     if (caret == null) {
       if (loc.getX() < 0 || loc.getY() < 0) return;
       final var copy = (AttributeSet) attrs.clone();
-      caretComponent = Text.FACTORY.createComponent(loc, copy);
+      final var snapped = Location.create(Canvas.snapXToGrid(x), Canvas.snapYToGrid(y), false);
+      caretComponent = Text.FACTORY.createComponent(snapped, copy);
       caretCreatingText = true;
       final var editable = (TextEditable) caretComponent.getFeature(TextEditable.class);
       if (editable != null) {


### PR DESCRIPTION
This PR allows for text elements to snap to the grid so they can align with other components more easily.

Text elements in the Circuit editor snap by default. Text elements in the Appearance editor snap while holding Ctrl.

Opening existing projects does not snap any existing text elements. They will snap to the grid if moved.