### PR TITLE
Add UI anti-aliasing preference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Added anti-aliasing preference to control anti-aliasing of UI elements (@V-Zemlyakov).
   * Set default gate shape to rectangular (IEC) for Russian locale (@V-Zemlyakov).
   * Added a new signed/unsigned option to the multiplier component.(@Diogo-Valadares)
   * Added "Show Bus Width" wire attribute to label multi-bit buses with a tick mark at Start, Center, or End (@V-Zemlyakov).

--- a/src/main/java/com/cburch/draw/toolbar/Toolbar.java
+++ b/src/main/java/com/cburch/draw/toolbar/Toolbar.java
@@ -37,6 +37,7 @@ public class Toolbar extends JPanel {
 
     computeContents();
     if (model != null) model.addToolbarModelListener(myListener);
+    com.cburch.logisim.prefs.AppPreferences.UI_ANTIALIASING.addPropertyChangeListener(myListener);
   }
 
   private void computeContents() {
@@ -100,7 +101,7 @@ public class Toolbar extends JPanel {
     }
   }
 
-  private class MyListener implements ToolbarModelListener {
+  private class MyListener implements ToolbarModelListener, java.beans.PropertyChangeListener {
     @Override
     public void toolbarAppearanceChanged(ToolbarModelEvent event) {
       repaint();
@@ -109,6 +110,11 @@ public class Toolbar extends JPanel {
     @Override
     public void toolbarContentsChanged(ToolbarModelEvent event) {
       computeContents();
+    }
+
+    @Override
+    public void propertyChange(java.beans.PropertyChangeEvent evt) {
+      repaint();
     }
   }
 }

--- a/src/main/java/com/cburch/draw/toolbar/ToolbarButton.java
+++ b/src/main/java/com/cburch/draw/toolbar/ToolbarButton.java
@@ -95,6 +95,12 @@ class ToolbarButton extends JComponent implements BaseMouseListenerContract {
     if (toolbar.getPressed() == this) {
       if (item instanceof ToolbarClickableItem clickableItem) {
         final var g2 = g.create();
+        if (g2 instanceof java.awt.Graphics2D g2d && AppPreferences.UI_ANTIALIASING.getBoolean()) {
+          g2d.setRenderingHint(
+              java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
+          g2d.setRenderingHint(
+              java.awt.RenderingHints.KEY_STROKE_CONTROL, java.awt.RenderingHints.VALUE_STROKE_PURE);
+        }
         g2.translate(BORDER, BORDER);
         clickableItem.paintPressedIcon(ToolbarButton.this, g2);
         g2.dispose();
@@ -110,6 +116,12 @@ class ToolbarButton extends JComponent implements BaseMouseListenerContract {
     }
 
     final var g2 = g.create();
+    if (g2 instanceof java.awt.Graphics2D g2d && AppPreferences.UI_ANTIALIASING.getBoolean()) {
+      g2d.setRenderingHint(
+          java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
+      g2d.setRenderingHint(
+          java.awt.RenderingHints.KEY_STROKE_CONTROL, java.awt.RenderingHints.VALUE_STROKE_PURE);
+    }
     g2.translate(BORDER, BORDER);
     item.paintIcon(ToolbarButton.this, g2);
     g2.dispose();

--- a/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
+++ b/src/main/java/com/cburch/logisim/gui/generic/ProjectExplorer.java
@@ -102,6 +102,7 @@ public class ProjectExplorer extends JTree implements LocaleListener {
 
     proj.addProjectListener(myListener);
     AppPreferences.GATE_SHAPE.addPropertyChangeListener(myListener);
+    AppPreferences.UI_ANTIALIASING.addPropertyChangeListener(myListener);
     LocaleManager.addLocaleListener(this);
     DefaultTreeCellRenderer renderer = (DefaultTreeCellRenderer) getCellRenderer();
     renderer.setClosedIcon(new TreeIcon(true));
@@ -410,7 +411,8 @@ public class ProjectExplorer extends JTree implements LocaleListener {
     //
     @Override
     public void propertyChange(PropertyChangeEvent event) {
-      if (AppPreferences.GATE_SHAPE.isSource(event)) {
+      if (AppPreferences.GATE_SHAPE.isSource(event)
+          || AppPreferences.UI_ANTIALIASING.isSource(event)) {
         ProjectExplorer.this.repaint();
       }
     }
@@ -549,6 +551,12 @@ public class ProjectExplorer extends JTree implements LocaleListener {
       // draw tool icon
       g.setColor(new Color(AppPreferences.COMPONENT_ICON_COLOR.get()));
       final var gfxIcon = g.create();
+      if (gfxIcon instanceof java.awt.Graphics2D g2d && AppPreferences.UI_ANTIALIASING.getBoolean()) {
+        g2d.setRenderingHint(
+            java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
+        g2d.setRenderingHint(
+            java.awt.RenderingHints.KEY_STROKE_CONTROL, java.awt.RenderingHints.VALUE_STROKE_PURE);
+      }
       final var context = new ComponentDrawContext(ProjectExplorer.this, null, null, g, gfxIcon);
       tool.paintIcon(
           context,
@@ -575,19 +583,27 @@ public class ProjectExplorer extends JTree implements LocaleListener {
         final var magFill = ColorUtil.getMagnifyingInterior(ProjectExplorer.this);
         final var magBorder = ColorUtil.getThemeAccentColor();
 
-        g.setColor(magFill);
-        g.fillOval(
+        final var gfxMag = g.create();
+        if (gfxMag instanceof java.awt.Graphics2D g2d && AppPreferences.UI_ANTIALIASING.getBoolean()) {
+          g2d.setRenderingHint(
+              java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
+          g2d.setRenderingHint(
+              java.awt.RenderingHints.KEY_STROKE_CONTROL, java.awt.RenderingHints.VALUE_STROKE_PURE);
+        }
+        gfxMag.setColor(magFill);
+        gfxMag.fillOval(
             x + AppPreferences.getScaled(AppPreferences.BOX_SIZE >> 2),
             y + AppPreferences.getScaled(AppPreferences.BOX_SIZE >> 2),
             AppPreferences.getScaled(AppPreferences.BOX_SIZE >> 1),
             AppPreferences.getScaled(AppPreferences.BOX_SIZE >> 1));
-        g.setColor(magBorder);
-        g.drawOval(
+        gfxMag.setColor(magBorder);
+        gfxMag.drawOval(
             x + AppPreferences.getScaled(AppPreferences.BOX_SIZE >> 2),
             y + AppPreferences.getScaled(AppPreferences.BOX_SIZE >> 2),
             AppPreferences.getScaled(AppPreferences.BOX_SIZE >> 1),
             AppPreferences.getScaled(AppPreferences.BOX_SIZE >> 1));
-        g.fillPolygon(xp, yp, xp.length);
+        gfxMag.fillPolygon(xp, yp, xp.length);
+        gfxMag.dispose();
       }
     }
   }

--- a/src/main/java/com/cburch/logisim/gui/icons/BaseIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/BaseIcon.java
@@ -60,8 +60,10 @@ public abstract class BaseIcon implements javax.swing.Icon {
   @Override
   public void paintIcon(Component comp, Graphics gfx, int x, int y) {
     final var g2 = (Graphics2D) gfx.create();
-    g2.setRenderingHint(java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
-    g2.setRenderingHint(java.awt.RenderingHints.KEY_STROKE_CONTROL, java.awt.RenderingHints.VALUE_STROKE_PURE);
+    if (AppPreferences.UI_ANTIALIASING.getBoolean()) {
+      g2.setRenderingHint(java.awt.RenderingHints.KEY_ANTIALIASING, java.awt.RenderingHints.VALUE_ANTIALIAS_ON);
+      g2.setRenderingHint(java.awt.RenderingHints.KEY_STROKE_CONTROL, java.awt.RenderingHints.VALUE_STROKE_PURE);
+    }
     g2.setColor(new Color(AppPreferences.COMPONENT_ICON_COLOR.get()));
     g2.setStroke(new BasicStroke(AppPreferences.getScaled(1)));
     g2.translate(x, y);

--- a/src/main/java/com/cburch/logisim/gui/icons/ClearIcon.java
+++ b/src/main/java/com/cburch/logisim/gui/icons/ClearIcon.java
@@ -33,7 +33,10 @@ public class ClearIcon implements Icon {
   @Override
   public void paintIcon(Component comp, Graphics gfx, int x, int y) {
     final var g2 = (Graphics2D) gfx.create();
-    g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+    if (AppPreferences.UI_ANTIALIASING.getBoolean()) {
+      g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+      g2.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+    }
     g2.translate(x, y);
     g2.setColor((comp == null) ? Color.GRAY : comp.getForeground());
     g2.setStroke(new BasicStroke(

--- a/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -91,6 +91,7 @@ class WindowOptions extends OptionsPanel {
 
     checks =
         new PrefBoolean[] {
+          new PrefBoolean(AppPreferences.UI_ANTIALIASING, S.getter("layoutAntiAliasing")),
           new PrefBoolean(AppPreferences.SHOW_TICK_RATE, S.getter("windowTickRate")),
           new PrefBoolean(
               AppPreferences.SEARCH_DOUBLE_SHIFT, S.getter("windowSearchDoubleShift")),

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -1005,6 +1005,8 @@ public class AppPreferences {
       );
   public static final PrefMonitor<Boolean> AntiAliassing =
       create(new PrefMonitorBoolean("AntiAliassing", true));
+  public static final PrefMonitor<Boolean> UI_ANTIALIASING =
+      create(new PrefMonitorBoolean("uiAntiAliasing", true));
 
   // Third party softwares preferences
   public static final PrefMonitor<String> QUESTA_PATH =


### PR DESCRIPTION
### Description
Added a new user preference to control anti-aliasing for UI elements independently from the main canvas rendering.

### Changes
* Added `UI_ANTIALIASING` setting to **Preferences > Window**.
* Applied anti-aliasing rendering hints to `ToolbarButton`, `ProjectExplorer`, and base vector icons based on the preference.
* Added a listener to update UI components immediately when the setting is changed.

### Verification
- Verified that toggling the preference updates UI elements immediately.
- Build passes cleanly (`./gradlew checkstyleMain test`).