### PR TITLE
io: remove redundant keyboard buffer guards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * @dev (????-??-??)
   * Added anti-aliasing preference to control anti-aliasing of UI elements (@V-Zemlyakov).
+  * Simplified Keyboard component buffer handling by removing redundant array-copy guards
+    [#564] (@hewzhew).
   * Set default gate shape to rectangular (IEC) for Russian locale (@V-Zemlyakov).
   * Added a new signed/unsigned option to the multiplier component.(@Diogo-Valadares)
   * Added "Show Bus Width" wire attribute to label multi-bit buses with a tick mark at Start, Center, or End (@V-Zemlyakov).

--- a/src/main/java/com/cburch/logisim/std/io/KeyboardData.java
+++ b/src/main/java/com/cburch/logisim/std/io/KeyboardData.java
@@ -54,7 +54,7 @@ class KeyboardData implements InstanceData, Cloneable {
     final var len = bufferLength;
     final var pos = cursorPos;
     if (pos >= len) return false;
-    if (len >= pos + 1) System.arraycopy(buf, pos + 1, buf, pos, len - (pos + 1));
+    System.arraycopy(buf, pos + 1, buf, pos, len - (pos + 1));
     bufferLength = len - 1;
     str = null;
     dispValid = false;
@@ -66,7 +66,7 @@ class KeyboardData implements InstanceData, Cloneable {
     final var len = bufferLength;
     if (len == 0) return '\0';
     final var ret = buf[0];
-    if (len >= 1) System.arraycopy(buf, 1, buf, 0, len - 1);
+    System.arraycopy(buf, 1, buf, 0, len - 1);
     bufferLength = len - 1;
     final var pos = cursorPos;
     if (pos > 0) cursorPos = pos - 1;
@@ -116,7 +116,7 @@ class KeyboardData implements InstanceData, Cloneable {
     final var len = bufferLength;
     if (len >= buf.length) return false;
     final var pos = cursorPos;
-    if (len >= pos) System.arraycopy(buf, pos, buf, pos + 1, len - pos);
+    System.arraycopy(buf, pos, buf, pos + 1, len - pos);
     buf[pos] = value;
     bufferLength = len + 1;
     cursorPos = pos + 1;

--- a/src/test/java/com/cburch/logisim/std/io/KeyboardDataTest.java
+++ b/src/test/java/com/cburch/logisim/std/io/KeyboardDataTest.java
@@ -1,0 +1,80 @@
+/*
+ * Logisim-evolution - digital logic design tool and simulator
+ * Copyright by the Logisim-evolution developers
+ *
+ * https://github.com/logisim-evolution/
+ *
+ * This is free software released under GNU GPLv3 license
+ */
+
+package com.cburch.logisim.std.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class KeyboardDataTest {
+
+  @Test
+  void insertHandlesBeginningMiddleEndAndCapacityBoundary() {
+    final var data = keyboardData("ac", 3);
+
+    assertTrue(data.setCursor(1));
+    assertTrue(data.insert('b'));
+    assertEquals("abc", data.toString());
+    assertEquals(2, data.getCursorPosition());
+    assertFalse(data.insert('x'));
+    assertEquals("abc", data.toString());
+
+    data.clear();
+    assertTrue(data.insert('b'));
+    assertTrue(data.setCursor(0));
+    assertTrue(data.insert('a'));
+    assertTrue(data.setCursor(2));
+    assertTrue(data.insert('c'));
+    assertEquals("abc", data.toString());
+  }
+
+  @Test
+  void deleteHandlesBeginningMiddleEndAndEmptyTailCopy() {
+    final var data = keyboardData("abcd", 4);
+
+    assertTrue(data.setCursor(1));
+    assertTrue(data.delete());
+    assertEquals("acd", data.toString());
+
+    assertTrue(data.setCursor(0));
+    assertTrue(data.delete());
+    assertEquals("cd", data.toString());
+
+    assertTrue(data.setCursor(1));
+    assertTrue(data.delete());
+    assertEquals("c", data.toString());
+    assertFalse(data.delete());
+    assertEquals("c", data.toString());
+  }
+
+  @Test
+  void dequeueHandlesEmptySingleAndMultipleCharacters() {
+    final var data = keyboardData("abc", 3);
+    assertTrue(data.setCursor(2));
+
+    assertEquals('a', data.dequeue());
+    assertEquals("bc", data.toString());
+    assertEquals(1, data.getCursorPosition());
+
+    assertEquals('b', data.dequeue());
+    assertEquals('c', data.dequeue());
+    assertEquals("", data.toString());
+    assertEquals(0, data.getCursorPosition());
+    assertEquals('\0', data.dequeue());
+  }
+
+  private static KeyboardData keyboardData(String value, int capacity) {
+    final var data = new KeyboardData(capacity);
+    for (final var character : value.toCharArray()) assertTrue(data.insert(character));
+    return data;
+  }
+}


### PR DESCRIPTION
## Description

Remove three redundant guards around `System.arraycopy` calls in `KeyboardData`. The existing method preconditions already guarantee valid indices, and zero-length copies are well-defined, so the guards do not affect behavior.

Add focused regression tests covering insertion at the beginning, middle, and end; full-capacity rejection; deletion including zero-length tail copies; and dequeue behavior.

This addresses the remaining explicitly deferred cleanup identified in #564.

## Testing

- `./gradlew check`
- 638 tests completed with 0 failures, 0 errors, and 0 skipped

Closes #564.