### PR TITLE
Reenable SonarCloud runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
             - 'gradle.properties'
             - 'gradle/**/*.properties'
             - 'build.gradle.kts'
+            - '.github/workflows/build.yml'
 
     - name: "WILL BUILD STEP BE RUN?"
       run: |
@@ -68,6 +69,8 @@ jobs:
       with:
         java-version: ${{ env.JDK_VERSION }}
         distribution: ${{ env.JDK_DISTRO }}
+        # This is so Sonar has access to the full git history
+        fetch-depth: 0
     - name: Cache SonarCloud packages
       uses: actions/cache@v6
       with:
@@ -86,7 +89,5 @@ jobs:
        ./gradlew build -x checkstyleMain -x checkstyleTest
     - name: "Run SonarQube"
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      run: ([ -z $SONAR_TOKEN ] || [ -z $SONAR_HOST_URL ] || ./gradlew sonar)
+      run: ([ -z "$SONAR_TOKEN" ] || ./gradlew sonar)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Re-enabled SonarCloud analysis in the GitHub Actions build workflow (@zdimension).
   * Added anti-aliasing preference to control anti-aliasing of UI elements (@V-Zemlyakov).
   * Simplified Keyboard component buffer handling by removing redundant array-copy guards
     [#564] (@hewzhew).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,13 @@ repositories {
   mavenCentral()
 }
 
+sonar {
+  properties {
+    property("sonar.projectKey", "logisim-evolution_logisim-evolution")
+    property("sonar.organization", "logisim-evolution")
+  }
+}
+
 application {
   mainClass.set("com.cburch.logisim.Main")
   applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")


### PR DESCRIPTION
This reenables the SonarCloud runs that were first added in #1304, and closes #1954.

The token used (set as `SONAR_TOKEN`) is linked to the Logisim organization. In case someone needs it again at a later point, it's provided [here](https://sonarcloud.io/project/configuration/GitHubActions?id=logisim-evolution_logisim-evolution)