### PR TITLE
feat(macOS): Introduce native file dialog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # Changes #
 
 * @dev (????-??-??)
+  * Added native macOS file dialogs for open and save operations with standard file filtering support (@V-Zemlyakov).
   * Re-enabled SonarCloud analysis in the GitHub Actions build workflow (@zdimension).
   * Added anti-aliasing preference to control anti-aliasing of UI elements (@V-Zemlyakov).
   * Simplified Keyboard component buffer handling by removing redundant array-copy guards

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -799,27 +799,35 @@ tasks.register("createApp") {
     )
     func.runCommand(params, "Error while creating the .app directory.")
 
-    if ("x86_64".equals(arch)) {
-      val pListFilename = "${appDirName}/Contents/Info.plist"
-      val tempPList = "${dest}/Info.plist"
-      func.runCommand(listOf(
-          "awk",
-          "{print >\"${tempPList}\"};"
-              + "/NSHighResolutionCapable/{"
-              + "print \"  <string>true</string>\" >\"${tempPList}\";"
-              + "print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"${tempPList}\""
-              + "}",
-          pListFilename,
-      ), "Error while patching Info.plist file.")
+    val languages = listOf("de", "el", "en", "es", "fr", "it", "ja", "nl", "pl", "pt", "ru", "zh")
+    val langXml = languages.joinToString("") { "<string>$it</string>" }
+    val pListFilename = "${appDirName}/Contents/Info.plist"
+    val tempPList = "${dest}/Info.plist"
+    func.runCommand(listOf(
+        "awk",
+        "{print >\"${tempPList}\"};"
+            + "/NSHighResolutionCapable/{"
+            + "print \"  <string>true</string>\" >\"${tempPList}\";"
+            + "print \"  <key>CFBundleLocalizations</key>\" >\"${tempPList}\";"
+            + "print \"  <array>${langXml}</array>\" >\"${tempPList}\";"
+            + "print \"  <key>NSSupportsAutomaticGraphicsSwitching</key>\" >\"${tempPList}\""
+            + "}",
+        pListFilename,
+    ), "Error while patching Info.plist file.")
 
-      func.runCommand(listOf(
-          "mv", tempPList, pListFilename
-      ), "Error while moving Info.plist into the .app directory.")
+    func.runCommand(listOf(
+        "mv", tempPList, pListFilename
+    ), "Error while moving Info.plist into the .app directory.")
 
-      func.runCommand(listOf(
-          "codesign", "--force", "--sign", "-", appDirName
-      ), "Error while executing: codesign")
+    for (lang in languages) {
+      val lprojDir = File("${appDirName}/Contents/Resources/${lang}.lproj")
+      lprojDir.mkdirs()
+      File(lprojDir, "InfoPlist.strings").writeText("/* Localized Bundle */\n")
     }
+
+    func.runCommand(listOf(
+        "codesign", "--force", "--sign", "-", appDirName
+    ), "Error while executing: codesign")
   }
 }
 

--- a/src/main/java/com/cburch/logisim/util/JFileChoosers.java
+++ b/src/main/java/com/cburch/logisim/util/JFileChoosers.java
@@ -52,6 +52,85 @@ public final class JFileChoosers {
       }
       return super.getSelectedFile();
     }
+
+    @Override
+    public int showOpenDialog(java.awt.Component parent) {
+      if (MacCompatibility.isRunningOnMac()) {
+        final var file = showMacFileDialog(parent, java.awt.FileDialog.LOAD);
+        if (file != null) {
+          setSelectedFile(file);
+          return APPROVE_OPTION;
+        }
+        return CANCEL_OPTION;
+      }
+      return super.showOpenDialog(parent);
+    }
+
+    @Override
+    public int showSaveDialog(java.awt.Component parent) {
+      if (MacCompatibility.isRunningOnMac()) {
+        final var file = showMacFileDialog(parent, java.awt.FileDialog.SAVE);
+        if (file != null) {
+          setSelectedFile(file);
+          return APPROVE_OPTION;
+        }
+        return CANCEL_OPTION;
+      }
+      return super.showSaveDialog(parent);
+    }
+
+    private File showMacFileDialog(java.awt.Component parent, int mode) {
+      java.awt.Window parentWindow = null;
+      if (parent instanceof java.awt.Window win) {
+        parentWindow = win;
+      } else if (parent != null) {
+        parentWindow = javax.swing.SwingUtilities.getWindowAncestor(parent);
+      }
+
+      var title = getDialogTitle();
+      if (title == null) {
+        final var key = (mode == java.awt.FileDialog.LOAD)
+            ? "FileChooser.openDialogTitleText"
+            : "FileChooser.saveDialogTitleText";
+        title = javax.swing.UIManager.getString(key);
+      }
+      final java.awt.FileDialog fileDialog;
+      if (parentWindow instanceof java.awt.Frame frame) {
+        fileDialog = new java.awt.FileDialog(frame, title, mode);
+      } else if (parentWindow instanceof java.awt.Dialog dialog) {
+        fileDialog = new java.awt.FileDialog(dialog, title, mode);
+      } else {
+        fileDialog = new java.awt.FileDialog((java.awt.Frame) null, title, mode);
+      }
+
+      final var curDir = getCurrentDirectory();
+      if (curDir != null) {
+        fileDialog.setDirectory(curDir.getAbsolutePath());
+      }
+      final var selFile = getSelectedFile();
+      if (selFile != null) {
+        fileDialog.setFile(selFile.getName());
+      }
+
+      final var filter = getFileFilter();
+      if (filter != null && filter != getAcceptAllFileFilter()) {
+        fileDialog.setFilenameFilter((dir, name) -> {
+          final var f = new File(dir, name);
+          return f.isDirectory() || filter.accept(f);
+        });
+      }
+
+      fileDialog.setVisible(true);
+
+      if (fileDialog.getFile() != null) {
+        final var selected = new File(fileDialog.getDirectory(), fileDialog.getFile());
+        if (selected.getParentFile() != null) {
+          setCurrentDirectory(selected.getParentFile());
+        }
+        return selected;
+      }
+      return null;
+    }
   }
 
   public static JFileChooser create() {


### PR DESCRIPTION
### Description
This PR significantly improves the user experience on macOS by replacing the legacy Java JFileChooser with native macOS file dialogs for all open/save operations. 

### Main Feature: Native File Dialogs
* Adapted standard `FilenameFilter` logic to correctly display file types and allow directory navigation inside the native interface.
* *Note on filtering:* Unlike the standard `JFileChooser` on Windows/Linux (which provides an "All files" dropdown), the macOS native dialog strictly enforces the applied file extension filter to keep the view clean.
* *Future consideration:* If requested, a configuration option can be added to `AppPreferences` later to allow users to toggle back to the legacy `JFileChooser`.

### Supporting macOS Build Fixes
To ensure the native dialogs display in the correct system language and the app bundle runs correctly on modern Apple hardware, the following build fixes were included:
* **Localization:** `build.gradle.kts` now dynamically creates `<locale>.lproj` directories and registers `CFBundleLocalizations` in `Info.plist`. This ensures macOS natively recognizes supported languages and translates the file dialog buttons properly.
* **Apple Silicon (arm64):** Removed the `x86_64` architecture restriction for `Info.plist` patching and code-signing. The script now unconditionally executes `codesign --force --sign -` for all architectures so the modified `.app` bundle runs natively on arm64 without being flagged as "damaged".
NO_TICKET