### PR TITLE
fix(gui): prioritize logisim clipboard over system image

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/appear/Clipboard.java
+++ b/src/main/java/com/cburch/logisim/gui/appear/Clipboard.java
@@ -52,6 +52,14 @@ final class Clipboard {
   public static void set(ClipboardContents value) {
     final var old = current;
     current = value;
+    try {
+      final var sysClip = java.awt.Toolkit.getDefaultToolkit().getSystemClipboard();
+      if (sysClip.isDataFlavorAvailable(java.awt.datatransfer.DataFlavor.imageFlavor)) {
+        sysClip.setContents(new java.awt.datatransfer.StringSelection(""), null);
+      }
+    } catch (Exception e) {
+      // ignore
+    }
     propertySupport.firePropertyChange(CONTENTS_PROPERTY, old, current);
   }
 }

--- a/src/main/java/com/cburch/logisim/gui/main/Clipboard.java
+++ b/src/main/java/com/cburch/logisim/gui/main/Clipboard.java
@@ -81,6 +81,14 @@ class Clipboard {
   public static void set(Clipboard value) {
     final var old = current;
     current = value;
+    try {
+      final var sysClip = java.awt.Toolkit.getDefaultToolkit().getSystemClipboard();
+      if (sysClip.isDataFlavorAvailable(java.awt.datatransfer.DataFlavor.imageFlavor)) {
+        sysClip.setContents(new java.awt.datatransfer.StringSelection(""), null);
+      }
+    } catch (Exception e) {
+      // ignore
+    }
     propertySupport.firePropertyChange(CONTENTS_PROPERTY, old, current);
   }
 


### PR DESCRIPTION
### Description
This PR fixes an issue where an image from the system clipboard incorrectly takes priority over recently copied Logisim components when pasting.

### How to reproduce the bug (Before this PR)
1. Copy any image to system clipboard.
2. Open Logisim-evolution, select some components on the canvas, and copy them `Ctrl+C`.
3. Press Paste `Ctrl+V` on the canvas.
**Bug:** Instead of the copied components, the image from clipboard is pasted onto the canvas.

### Why it happens
When pasting, Logisim-evolution checks the system OS clipboard for an image first. However, when the user copies components inside Logisim, the application only uses its internal `Clipboard` and does not clear or overwrite the system clipboard. Because of this, the image remains in the system clipboard and intercepts all subsequent paste actions inside Logisim.

*(Note: Simply reversing the check order to prioritize Logisim's internal clipboard breaks pasting external images entirely. The ultimate solution would be to completely abandon the internal clipboard and migrate component copy/pasting to the OS system clipboard. This would also enable cross-project pasting, as requested and discussed in **Issue #1050**. However, as noted in that issue, such a migration requires a massive architectural refactor. Until that happens, this PR provides a lightweight and safe fix for the image bug).*

### How it is fixed
Instead of changing the paste priority or rewriting the core clipboard architecture, this PR fixes the root cause: 
* Whenever a user copies components inside Logisim (`Clipboard.set()`), the application now explicitly writes an empty string to the OS system clipboard.
* This automatically clear system clipboard.
* When the user pastes, no image is found in the OS clipboard, so Logisim safely pastes its internal components.
* If the user explicitly copies a new image, the system clipboard receives it, and Logisim will correctly paste that new image.
NO_TICKET NO_CHANGELOG_ENTRY NO_CHANGELOG_AUTHOR_CREDIT